### PR TITLE
Add /nix

### DIFF
--- a/data/security-lists.toml
+++ b/data/security-lists.toml
@@ -198,6 +198,12 @@ proc = [
     "/var/run",
 ]
 
+# NixOS / Nix package manager
+# All Nix-managed binaries and libraries live in /nix/store
+nix = [
+    "/nix",
+]
+
 [system_read_paths.macos]
 # macOS executables and libraries
 executables = [

--- a/src/config/security_lists.rs
+++ b/src/config/security_lists.rs
@@ -115,6 +115,8 @@ pub struct LinuxSystemPaths {
     pub devices: Vec<String>,
     #[serde(default)]
     pub proc: Vec<String>,
+    #[serde(default)]
+    pub nix: Vec<String>,
 }
 
 /// macOS-specific system paths
@@ -200,6 +202,7 @@ impl SecurityLists {
             paths.extend(self.system_read_paths.linux.terminfo.iter().cloned());
             paths.extend(self.system_read_paths.linux.devices.iter().cloned());
             paths.extend(self.system_read_paths.linux.proc.iter().cloned());
+            paths.extend(self.system_read_paths.linux.nix.iter().cloned());
         }
 
         #[cfg(target_os = "macos")]


### PR DESCRIPTION
All Nix-managed binaries and libraries live in `/nix/store`

`nix = [
    "/nix",
`

Fixes: #19  