### PR TITLE
fix(security): prevent path collision bypass in macOS sandbox

### DIFF
--- a/tests/integration/test_sensitive_paths.sh
+++ b/tests/integration/test_sensitive_paths.sh
@@ -273,7 +273,11 @@ if [[ -d ~/.ssh ]]; then
         "$NONO_BIN" run --read "$COLLISION_DIR_SSH" --allow "$TMPDIR" -- ls ~/.ssh/
 
     if [[ -f ~/.ssh/id_rsa ]] || [[ -f ~/.ssh/id_ed25519 ]]; then
-        KEY_FILE=$(ls ~/.ssh/id_rsa 2>/dev/null || ls ~/.ssh/id_ed25519 2>/dev/null)
+        if [[ -f ~/.ssh/id_rsa ]]; then
+            KEY_FILE=~/.ssh/id_rsa
+        else
+            KEY_FILE=~/.ssh/id_ed25519
+        fi
         expect_failure "~/.sshfoo grant does NOT allow reading SSH keys" \
             "$NONO_BIN" run --read "$COLLISION_DIR_SSH" --allow "$TMPDIR" -- cat "$KEY_FILE"
     fi


### PR DESCRIPTION
The `user_granted` check used string-based `starts_with()` to determine if a capability path matched a sensitive path. This allowed attackers to bypass sensitive path protections by creating directories with matching prefixes (e.g., `~/.sshfoo` would match `~/.ssh` check).

Changed to path-component-aware comparison requiring either exact match or path separator after the sensitive path prefix. Also added trailing slash normalization to handle edge cases like "/foo/" vs "/foo".

Unit tests added (`src/sandbox/macos.rs`):
- test_path_collision_bypass_blocked
- test_exact_sensitive_path_grant_allows_access
- test_child_path_grant_allows_access
- test_unrelated_path_does_not_affect_sensitive
- test_multiple_collision_attempts_blocked
- test_trailing_slash_normalization

Integration tests added (`tests/integration/test_sensitive_paths.sh`):
- ~/.sshfoo grant does NOT bypass `~/.ssh` protection
- ~/.awsbackup grant does NOT bypass`~/.aws` protection
- Collision directories themselves remain accessible when granted