### PR TITLE
Replace environment variable introspection with advisory API

### DIFF
--- a/docs/development/testing.mdx
+++ b/docs/development/testing.mdx
@@ -134,7 +134,7 @@ Tests unusual scenarios and boundary conditions.
 | Symlinks | Symlink traversal within allowed paths |
 | Symlink Escapes | Symlinks to sensitive paths are blocked |
 | Path Variations | Relative paths, `..` references, spaces, special characters |
-| Environment Variables | `NONO_ACTIVE`, `NONO_ALLOWED`, `NONO_BLOCKED`, `NONO_NET`, `NONO_HELP` |
+| Capability Queries | `nono why --self` for sandbox introspection, `NONO_CAP_FILE` env var |
 | Non-existent Paths | Proper error handling for missing paths |
 | Dry Run Mode | `--dry-run` shows sandbox info without executing |
 | Mixed Permissions | Combining `--read` and `--write` directories |

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -18,10 +18,13 @@ Command fails with "Permission denied" or "Operation not permitted" errors.
    nono run --allow . --dry-run -- command
    ```
 
-2. **Check environment variables inside the sandbox**:
+2. **Query capabilities from inside the sandbox**:
    ```bash
-   nono run --allow . -- sh -c 'echo "Allowed: $NONO_ALLOWED"'
-   nono run --allow . -- sh -c 'echo "Blocked: $NONO_BLOCKED"'
+   # Check if a specific path is accessible
+   nono run --allow . -- nono why --self --path /tmp --op write --json
+
+   # Human-readable output
+   nono run --allow . -- nono why --self --path ~/.ssh --op read
    ```
 
 3. **Run with verbose logging**:
@@ -74,10 +77,10 @@ Commands like `curl`, `wget`, or API calls fail with connection errors.
    nono run --allow . -- curl https://example.com
    ```
 
-2. **Check if you're actually in nono sandbox**:
+2. **Check if network is allowed from inside the sandbox**:
    ```bash
-   nono run --allow . -- sh -c 'echo $NONO_NET'
-   # Should print "allowed" (default)
+   nono run --allow . -- nono why --self --host example.com --json
+   # Should show {"status":"allowed",...}
    ```
 
 3. **Test network outside nono**:
@@ -200,8 +203,9 @@ Child processes always inherit sandbox restrictions. If you're seeing this:
 
 1. **Verify the parent is sandboxed**:
    ```bash
-   nono run --allow . -- sh -c 'echo $NONO_ACTIVE'
-   # Should print "1"
+   # The --self flag only works inside a sandbox
+   nono run --allow . -- nono why --self --path /etc --op read
+   # Should show current sandbox capabilities
    ```
 
 2. **Check if you're testing correctly**:
@@ -235,26 +239,35 @@ There is minimal overhead from sandbox initialization (microseconds). If you're 
 
 ---
 
-## Using Environment Variables for Debugging
+## Using `nono why --self` for Debugging
 
-When running inside nono, these variables are set:
+When running inside a nono sandbox, you can query your own capabilities using `nono why --self`:
 
 ```bash
-# Check if running under nono
-nono run --allow . -- sh -c 'echo $NONO_ACTIVE'
+# Check if a path would be readable
+nono run --allow . -- nono why --self --path ~/.ssh --op read
+# Output: DENIED - sensitive_path (SSH keys and config)
 
-# See what paths are allowed
-nono run --allow . -- sh -c 'echo $NONO_ALLOWED'
+# Check if a path would be writable
+nono run --allow . -- nono why --self --path ./src --op write
+# Output: ALLOWED - Granted by: --allow .
 
-# See what paths are blocked (sensitive)
-nono run --allow . -- sh -c 'echo $NONO_BLOCKED'
+# JSON output for programmatic use (useful for AI agents)
+nono run --allow . -- nono why --self --path /tmp --op write --json
+# {"status":"denied","reason":"not_in_allowed_paths","suggestion":"--write /tmp"}
 
 # Check network status
-nono run --allow . -- sh -c 'echo $NONO_NET'
+nono run --allow . -- nono why --self --host api.openai.com
+# Output: ALLOWED - network allowed by default
 
-# Get help text for requesting more access
-nono run --allow . -- sh -c 'echo $NONO_HELP'
+# Check network when blocked
+nono run --allow . --net-block -- nono why --self --host api.openai.com
+# Output: DENIED - network_blocked
 ```
+
+<Note>
+The `--self` flag reads the sandbox state from `NONO_CAP_FILE`, which is the only environment variable nono sets. This is designed for programmatic introspection by AI agents rather than debugging via shell variables.
+</Note>
 
 ---
 

--- a/docs/usage/examples.mdx
+++ b/docs/usage/examples.mdx
@@ -47,19 +47,43 @@ nono run --allow ./workspace -- my-ai-agent
 
 ```bash
 # Check a sensitive path
-nono why ~/.ssh/id_rsa
-# Output: BLOCKED: ~/.ssh/id_rsa is a sensitive path
+nono why --path ~/.ssh/id_rsa --op read
+# Output: DENIED - sensitive_path (SSH keys and config)
 
-# Check with suggestions
-nono why -s ~/.aws
-# Output includes: nono run --read ~/.aws -- <command>
+# JSON output for programmatic use
+nono why --json --path ~/.aws --op read
+# {"status":"denied","reason":"sensitive_path","category":"AWS credentials",...}
 ```
 
-### Check a project directory
+### Check with capability context
 
 ```bash
-nono why -s ./my-project
-# Shows what flags would grant access
+# Would ./src be writable if we use --allow .?
+nono why --path ./src --op write --allow .
+# Output: ALLOWED - Granted by: --allow .
+
+# Check against a profile
+nono why --path ./src --op read --profile claude-code
+```
+
+### Query from inside a sandbox
+
+```bash
+# AI agents can query their own capabilities
+nono run --allow . -- nono why --self --path /tmp --op write --json
+# {"status":"denied","reason":"not_in_allowed_paths",...}
+```
+
+### Check network access
+
+```bash
+# Network is allowed by default
+nono why --host api.openai.com --port 443
+# Output: ALLOWED - network allowed by default
+
+# Check with network blocked
+nono why --host api.openai.com --net-block
+# Output: DENIED - network_blocked
 ```
 
 ## Build Tools

--- a/docs/usage/flags.mdx
+++ b/docs/usage/flags.mdx
@@ -15,7 +15,7 @@ Suppress all nono output (banner, summary, status messages). Only the executed c
 
 ```bash
 nono -s run --allow . -- my-agent
-nono --silent why ~/.ssh/id_rsa
+nono --silent why --path ~/.ssh/id_rsa --op read
 ```
 
 ## Commands
@@ -30,10 +30,12 @@ nono run [OPTIONS] -- <COMMAND> [ARGS...]
 
 ### `nono why`
 
-Check why a path would be blocked or allowed.
+Check why a path or network operation would be allowed or denied. Designed for both human debugging and programmatic use by AI agents.
 
 ```bash
-nono why [OPTIONS] <PATH>
+nono why --path <PATH> --op <OP> [OPTIONS]
+nono why --host <HOST> [--port <PORT>] [OPTIONS]
+nono why --self --path <PATH> --op <OP> [OPTIONS]  # Inside sandbox
 ```
 
 ### `nono setup`
@@ -227,23 +229,84 @@ nono run --config ./nono.toml -- command
 
 ## `nono why` Options
 
-### `<PATH>` (required)
+The `why` command checks why a path or network operation would be allowed or denied. It's designed for both human debugging and programmatic use by AI agents.
 
-The path to check.
+### `--path`
 
-```bash
-nono why ~/.ssh/id_rsa
-nono why ./my-project
-```
-
-### `--suggest`
-
-Show what flags would grant access to this path.
+The filesystem path to check.
 
 ```bash
-nono why --suggest ~/.aws
-# Output includes suggested nono run flags
+nono why --path ~/.ssh/id_rsa --op read
+nono why --path ./my-project --op write
 ```
+
+### `--op`
+
+The operation to check: `read`, `write`, or `readwrite`. Defaults to `read` if not specified.
+
+```bash
+nono why --path ./src --op read
+nono why --path ./output --op write
+nono why --path ./data --op readwrite
+```
+
+### `--host`
+
+Network host to check (instead of `--path`).
+
+```bash
+nono why --host api.openai.com --port 443
+```
+
+### `--port`
+
+Network port (default: 443). Used with `--host`.
+
+```bash
+nono why --host example.com --port 8080
+```
+
+### `--json`
+
+Output JSON instead of human-readable format. Useful for programmatic use by AI agents.
+
+```bash
+nono why --json --path ~/.ssh --op read
+# {"status":"denied","reason":"sensitive_path","category":"SSH keys and config",...}
+```
+
+### `--self`
+
+Query current sandbox state from inside a sandboxed process. This allows agents to introspect their own capabilities.
+
+```bash
+# Inside a sandbox:
+nono why --self --path /tmp --op write --json
+```
+
+### Capability Context Options
+
+When checking paths outside a sandbox, you can simulate a capability context:
+
+```bash
+# Check if ./src would be writable with --allow .
+nono why --path ./src --op write --allow .
+
+# Check against a profile
+nono why --path ~/.config --op read --profile claude-code
+```
+
+Available context flags:
+- `--allow`, `-a` - Directories with read+write access
+- `--read`, `-r` - Directories with read-only access
+- `--write`, `-w` - Directories with write-only access
+- `--allow-file` - Single files with read+write access
+- `--read-file` - Single files with read-only access
+- `--write-file` - Single files with write-only access
+- `--net-block` - Block network access
+- `--profile`, `-p` - Use a named profile
+- `--workdir` - Working directory for `$WORKDIR` expansion
+- `--trust-unsigned` - Trust unsigned user profiles
 
 ## `nono setup` Options
 

--- a/docs/usage/index.mdx
+++ b/docs/usage/index.mdx
@@ -13,7 +13,7 @@ nono provides two main commands:
 | Command | Description |
 |---------|-------------|
 | `nono run` | Run a command inside the sandbox |
-| `nono why` | Check why a path would be blocked or allowed |
+| `nono why` | Check why a path/network operation would be allowed or denied |
 | `nono setup` | Sets up profiles (openclaw, claude etc) |
 
 ## Running Commands (`nono run`)
@@ -36,27 +36,43 @@ nono run --allow . -- claude
 
 ## Checking Path Access (`nono why`)
 
+The `why` command checks if a path or network operation would be allowed or denied. It's designed for both human debugging and programmatic use by AI agents.
+
 ```bash
-nono why [OPTIONS] <PATH>
+nono why --path <PATH> --op <OP> [OPTIONS]
+nono why --host <HOST> [--port <PORT>] [OPTIONS]
+nono why --self --path <PATH> --op <OP> [OPTIONS]  # Inside sandbox
 ```
 
 ### Examples
 
 ```bash
 # Check if a sensitive path would be blocked
-nono why ~/.ssh/id_rsa
-# Output: BLOCKED: ~/.ssh/id_rsa is a sensitive path
+nono why --path ~/.ssh/id_rsa --op read
+# Output: DENIED - sensitive_path (SSH keys and config)
 
-# Check with suggestions for granting access
-nono why -s ./my-project
-# Output includes: nono run --allow ./my-project -- <command>
+# Check with capability context
+nono why --path ./src --op write --allow .
+# Output: ALLOWED - Granted by: --allow .
+
+# JSON output for AI agents
+nono why --json --path ~/.aws --op read
+# {"status":"denied","reason":"sensitive_path","category":"AWS credentials",...}
+
+# From inside a sandbox, query own capabilities
+nono run --allow . -- nono why --self --path /tmp --op write --json
 ```
 
 ### Options
 
 | Flag | Description |
 |------|-------------|
-| `-s`, `--suggest` | Show flags needed to grant access |
+| `--path` | Filesystem path to check |
+| `--op` | Operation: `read`, `write`, or `readwrite` (default: `read`) |
+| `--host` | Network host to check (instead of `--path`) |
+| `--port` | Network port (default: 443) |
+| `--json` | Output JSON for programmatic use |
+| `--self` | Query current sandbox state (inside sandbox) |
 
 ## Understanding Permissions
 
@@ -104,20 +120,25 @@ nono run --allow . --net-block -- cargo build
 4. **Execute** - nono exec()s into your command, inheriting the sandbox
 5. **Enforce** - Kernel blocks any unauthorized access attempts
 
-## Environment Variables
+## Querying Sandbox Capabilities
 
-When running inside nono, these environment variables are set:
+When running inside a nono sandbox, processes can query their own capabilities using `nono why --self`:
 
-| Variable | Description |
-|----------|-------------|
-| `NONO_ACTIVE` | Set to `1` when running under nono |
-| `NONO_ALLOWED` | Colon-separated list of allowed paths |
-| `NONO_NET` | `allowed` or `blocked` |
-| `NONO_BLOCKED` | Colon-separated list of blocked sensitive paths |
-| `NONO_HELP` | Help text for requesting additional access |
-| `NONO_CONTEXT` | Full explanation of sandbox state for AI agents |
+```bash
+# Check if a path is accessible
+nono why --self --path /tmp --op write --json
+# {"status":"denied","reason":"not_in_allowed_paths","suggestion":"--write /tmp"}
 
-These help sandboxed applications (especially AI agents) provide better error messages when access is denied.
+# Check network access
+nono why --self --host api.openai.com
+# ALLOWED - network allowed by default
+```
+
+This is particularly useful for AI agents - when an operation fails, the agent can call `nono why --self` to get a structured JSON response explaining why and how to fix it.
+
+<Note>
+The only environment variable nono sets is `NONO_CAP_FILE`, which points to the capability state file. Use `nono why --self` instead of parsing environment variables directly.
+</Note>
 
 ## Secrets Management
 
@@ -146,7 +167,7 @@ The following paths are always blocked by default to protect credentials:
 - `~/.zshrc`, `~/.bashrc`, `~/.profile` - Shell configs (often contain secrets)
 - `~/.npmrc`, `~/.git-credentials` - Package manager tokens
 
-Use `nono why <path>` to check if a specific path is blocked and why.
+Use `nono why --path <path> --op read` to check if a specific path is blocked and why.
 
 ## Next Steps
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -207,7 +207,7 @@ pub fn user_state_dir() -> Option<PathBuf> {
 // These provide access to embedded config data without requiring full config loading
 // ============================================================================
 
-/// Get all sensitive paths from embedded config (for NONO_BLOCKED env var)
+/// Get all sensitive paths from embedded config
 pub fn get_sensitive_paths() -> Vec<String> {
     match embedded::load_security_lists() {
         Ok(lists) => lists.all_sensitive_paths().into_iter().collect(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -96,6 +96,16 @@ pub enum NonoError {
         current: u64,
         attempted: u64,
     },
+
+    // Environment variable validation errors
+    #[error("Environment variable '{var}' validation failed: {reason}")]
+    EnvVarValidation { var: String, reason: String },
+
+    #[error("Capability state file validation failed: {reason}")]
+    CapFileValidation { reason: String },
+
+    #[error("Capability state file too large: {size} bytes (max: {max} bytes)")]
+    CapFileTooLarge { size: u64, max: u64 },
 }
 
 pub type Result<T> = std::result::Result<T, NonoError>;

--- a/src/profile/builtin.rs
+++ b/src/profile/builtin.rs
@@ -90,8 +90,13 @@ fn opencode() -> Profile {
             signature: None,
         },
         filesystem: FilesystemConfig {
-            allow: vec!["$WORKDIR".to_string()],
-            read: vec!["$HOME/.opencode".to_string()],
+            allow: vec![
+                "$WORKDIR".to_string(),
+                "$HOME/.config/opencode".to_string(),
+                "$HOME/.cache/opencode".to_string(),
+                "$HOME/.local/share/opencode".to_string(),
+            ],
+            read: vec![],
             write: vec![],
             allow_file: vec![],
             read_file: vec![],

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,0 +1,567 @@
+//! Query API for checking if operations would be allowed
+//!
+//! This module provides the Advisory API that lets agents pre-check if operations
+//! will be allowed before attempting them. When an agent encounters a permission
+//! error, it can call `nono query` to get a structured JSON response explaining
+//! why and how to fix it.
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+use crate::capability::{CapabilitySet, FsAccess};
+use crate::config;
+use crate::error::{NonoError, Result};
+
+/// Result of a query operation
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "status")]
+pub enum QueryResult {
+    /// Operation would be allowed
+    #[serde(rename = "allowed")]
+    Allowed {
+        /// Why it's allowed
+        reason: AllowReason,
+        /// What granted the permission
+        granted_by: String,
+    },
+    /// Operation would be denied
+    #[serde(rename = "denied")]
+    Denied {
+        /// Why it's denied
+        reason: DenyReason,
+        /// Category of sensitive path (if applicable)
+        #[serde(skip_serializing_if = "Option::is_none")]
+        category: Option<String>,
+        /// Suggested flag to allow this operation
+        suggestion: String,
+    },
+    /// Not running inside a nono sandbox
+    #[serde(rename = "not_sandboxed")]
+    NotSandboxed {
+        /// Explanation message
+        message: String,
+    },
+}
+
+/// Reason why an operation is allowed
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum AllowReason {
+    /// Explicitly granted via --allow, --read, or --write
+    ExplicitGrant,
+    /// Within the working directory ($WORKDIR)
+    WithinWorkdir,
+    /// System path allowed for executables
+    SystemPath,
+    /// Network allowed by default
+    NetworkAllowedByDefault,
+}
+
+/// Reason why an operation is denied
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum DenyReason {
+    /// Path is in the sensitive paths list
+    SensitivePath,
+    /// Path is not in the list of allowed paths
+    NotInAllowedPaths,
+    /// Network access is blocked
+    NetworkBlocked,
+}
+
+/// Query if a path operation would be allowed
+///
+/// Checks the path against:
+/// 1. Sensitive paths list (always denied unless explicitly overridden)
+/// 2. Granted capabilities from CLI args or profile
+///
+/// # Errors
+/// Returns `NonoError::EnvVarValidation` if tilde expansion is needed but HOME is missing or invalid
+pub fn query_path(path: &Path, op: FsAccess, caps: &CapabilitySet) -> Result<QueryResult> {
+    let path_str = path.display().to_string();
+
+    // First check sensitive paths - these are blocked by default
+    if let Some(category) = config::check_sensitive_path(&path_str) {
+        return Ok(QueryResult::Denied {
+            reason: DenyReason::SensitivePath,
+            category: Some(category.to_string()),
+            // SECURITY: Do not call path.is_file() here - it leaks metadata about denied paths
+            // (reveals whether path exists and its type). Always use directory-level flags.
+            suggestion: suggest_flag(path, op),
+        });
+    }
+
+    // Expand ~ in path for comparison
+    // SECURITY: Validate HOME environment variable before use
+    // Per security guidelines: "Validate environment variables before use.
+    // Never assume HOME, TMPDIR, or other env vars are set or trustworthy."
+    let expanded_path_str = if path_str.starts_with("~/") || path_str == "~" {
+        let home = std::env::var("HOME").map_err(|_| NonoError::EnvVarValidation {
+            var: "HOME".to_string(),
+            reason: "not set (required for tilde expansion)".to_string(),
+        })?;
+
+        // Validate HOME is an absolute path
+        if !Path::new(&home).is_absolute() {
+            return Err(NonoError::EnvVarValidation {
+                var: "HOME".to_string(),
+                reason: format!("must be an absolute path, got: {}", home),
+            });
+        }
+
+        if path_str.starts_with("~/") {
+            path_str.replacen('~', &home, 1)
+        } else {
+            home
+        }
+    } else {
+        path_str.clone()
+    };
+
+    // Convert to Path for secure component-based comparison
+    // SECURITY: Using Path::starts_with() instead of String::starts_with()
+    // to prevent path traversal attacks like "/homeevil" matching "/home"
+    let expanded_path = Path::new(&expanded_path_str);
+    let query_path = Path::new(&path_str);
+
+    // Check against granted capabilities
+    for cap in &caps.fs {
+        // Check if the path matches or is under the capability path
+        // SECURITY: Path::starts_with() compares path components, not strings
+        // e.g., Path("/homeevil").starts_with("/home") == false
+        //       String "/homeevil".starts_with("/home") == true (VULNERABLE!)
+        let matches = if cap.is_file {
+            // File capability - exact match only
+            expanded_path == cap.resolved
+        } else {
+            // Directory capability - path is under this directory
+            // Check both resolved (canonicalized) and original paths
+            expanded_path == cap.resolved
+                || expanded_path.starts_with(&cap.resolved)
+                || query_path == cap.original
+                || query_path.starts_with(&cap.original)
+        };
+
+        if matches && access_allows(&cap.access, op) {
+            return Ok(QueryResult::Allowed {
+                reason: AllowReason::ExplicitGrant,
+                granted_by: format!(
+                    "--{} {}",
+                    access_to_flag(&cap.access),
+                    cap.original.display()
+                ),
+            });
+        }
+    }
+
+    // Not allowed
+    Ok(QueryResult::Denied {
+        reason: DenyReason::NotInAllowedPaths,
+        category: None,
+        // SECURITY: Do not call path.is_file() here - it leaks metadata about denied paths
+        suggestion: suggest_flag(path, op),
+    })
+}
+
+/// Query if network access would be allowed
+pub fn query_network(_host: &str, _port: u16, caps: &CapabilitySet) -> QueryResult {
+    if caps.net_block {
+        QueryResult::Denied {
+            reason: DenyReason::NetworkBlocked,
+            category: None,
+            suggestion: "remove --net-block flag".to_string(),
+        }
+    } else {
+        QueryResult::Allowed {
+            reason: AllowReason::NetworkAllowedByDefault,
+            granted_by: "network allowed by default".to_string(),
+        }
+    }
+}
+
+/// Check if a capability's access level allows the requested operation
+fn access_allows(cap_access: &FsAccess, requested: FsAccess) -> bool {
+    match (cap_access, requested) {
+        // ReadWrite allows anything
+        (FsAccess::ReadWrite, _) => true,
+        // Read allows Read
+        (FsAccess::Read, FsAccess::Read) => true,
+        // Write allows Write
+        (FsAccess::Write, FsAccess::Write) => true,
+        // Otherwise denied
+        _ => false,
+    }
+}
+
+/// Convert access level to CLI flag name
+fn access_to_flag(access: &FsAccess) -> &'static str {
+    match access {
+        FsAccess::Read => "read",
+        FsAccess::Write => "write",
+        FsAccess::ReadWrite => "allow",
+    }
+}
+
+/// Generate a suggestion for how to allow an operation
+///
+/// SECURITY: This function deliberately does NOT check if the path is a file or directory
+/// to avoid metadata leaks. Calling path.is_file() on denied paths would reveal whether
+/// they exist and their type, violating the security principle:
+/// "Metadata leaks: Even denying file content, allowing metadata reveals file existence"
+///
+/// We always suggest directory-level flags (--read, --write, --allow) which work for
+/// both files and directories, preventing information disclosure about denied paths.
+fn suggest_flag(path: &Path, op: FsAccess) -> String {
+    let flag = match op {
+        FsAccess::Read => "--read",
+        FsAccess::Write => "--write",
+        FsAccess::ReadWrite => "--allow",
+    };
+    format!("{} {}", flag, path.display())
+}
+
+/// Print a query result in human-readable format
+pub fn print_result(result: &QueryResult) {
+    match result {
+        QueryResult::Allowed { reason, granted_by } => {
+            println!("ALLOWED");
+            println!("  Reason: {:?}", reason);
+            println!("  Granted by: {}", granted_by);
+        }
+        QueryResult::Denied {
+            reason,
+            category,
+            suggestion,
+        } => {
+            println!("DENIED");
+            println!("  Reason: {:?}", reason);
+            if let Some(cat) = category {
+                println!("  Category: {}", cat);
+            }
+            println!("  Suggestion: {}", suggestion);
+        }
+        QueryResult::NotSandboxed { message } => {
+            println!("NOT SANDBOXED");
+            println!("  {}", message);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_query_sensitive_path() {
+        let caps = CapabilitySet::default();
+        let result = query_path(Path::new("~/.ssh/id_rsa"), FsAccess::Read, &caps)
+            .expect("query should succeed");
+
+        match result {
+            QueryResult::Denied {
+                reason: DenyReason::SensitivePath,
+                category: Some(_),
+                ..
+            } => {}
+            _ => panic!("Expected sensitive path denial, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_query_not_allowed_path() {
+        let caps = CapabilitySet::default();
+        let result = query_path(Path::new("/tmp/some/file"), FsAccess::Read, &caps)
+            .expect("query should succeed");
+
+        match result {
+            QueryResult::Denied {
+                reason: DenyReason::NotInAllowedPaths,
+                category: None,
+                ..
+            } => {}
+            _ => panic!("Expected not-in-allowed-paths denial, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_query_network_allowed() {
+        let caps = CapabilitySet::default();
+        let result = query_network("api.openai.com", 443, &caps);
+
+        match result {
+            QueryResult::Allowed {
+                reason: AllowReason::NetworkAllowedByDefault,
+                ..
+            } => {}
+            _ => panic!("Expected network allowed, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_query_network_blocked() {
+        let caps = CapabilitySet {
+            net_block: true,
+            ..Default::default()
+        };
+
+        let result = query_network("api.openai.com", 443, &caps);
+
+        match result {
+            QueryResult::Denied {
+                reason: DenyReason::NetworkBlocked,
+                ..
+            } => {}
+            _ => panic!("Expected network blocked, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_access_allows() {
+        // ReadWrite allows anything
+        assert!(access_allows(&FsAccess::ReadWrite, FsAccess::Read));
+        assert!(access_allows(&FsAccess::ReadWrite, FsAccess::Write));
+        assert!(access_allows(&FsAccess::ReadWrite, FsAccess::ReadWrite));
+
+        // Read only allows Read
+        assert!(access_allows(&FsAccess::Read, FsAccess::Read));
+        assert!(!access_allows(&FsAccess::Read, FsAccess::Write));
+        assert!(!access_allows(&FsAccess::Read, FsAccess::ReadWrite));
+
+        // Write only allows Write
+        assert!(access_allows(&FsAccess::Write, FsAccess::Write));
+        assert!(!access_allows(&FsAccess::Write, FsAccess::Read));
+        assert!(!access_allows(&FsAccess::Write, FsAccess::ReadWrite));
+    }
+
+    #[test]
+    fn test_suggest_flag() {
+        // SECURITY: All suggestions use directory-level flags to avoid metadata leaks
+        assert_eq!(
+            suggest_flag(Path::new("./src"), FsAccess::Read),
+            "--read ./src"
+        );
+        assert_eq!(
+            suggest_flag(Path::new("./file.txt"), FsAccess::Write),
+            "--write ./file.txt"
+        );
+        assert_eq!(
+            suggest_flag(Path::new("./dir"), FsAccess::ReadWrite),
+            "--allow ./dir"
+        );
+    }
+
+    /// SECURITY REGRESSION TEST
+    /// Ensures Path::starts_with() is used instead of String::starts_with()
+    /// to prevent path traversal attacks.
+    ///
+    /// With string comparison: "/homeevil".starts_with("/home") == true (VULNERABLE!)
+    /// With path comparison:   Path("/homeevil").starts_with("/home") == false (SECURE)
+    #[test]
+    fn test_path_component_comparison_security() {
+        use crate::capability::FsCapability;
+        use std::path::PathBuf;
+
+        // Create a capability for /home
+        let mut caps = CapabilitySet::default();
+        caps.fs.push(FsCapability {
+            original: PathBuf::from("/home"),
+            resolved: PathBuf::from("/home"),
+            access: FsAccess::ReadWrite,
+            is_file: false,
+        });
+
+        // /home/user should be allowed (legitimate child path)
+        let result = query_path(Path::new("/home/user"), FsAccess::Read, &caps)
+            .expect("query should succeed");
+        assert!(
+            matches!(result, QueryResult::Allowed { .. }),
+            "Expected /home/user to be allowed under /home capability"
+        );
+
+        // /homeevil should NOT be allowed (not a child, just similar prefix)
+        // This is the security vulnerability we're preventing
+        let result = query_path(Path::new("/homeevil"), FsAccess::Read, &caps)
+            .expect("query should succeed");
+        assert!(
+            matches!(
+                result,
+                QueryResult::Denied {
+                    reason: DenyReason::NotInAllowedPaths,
+                    ..
+                }
+            ),
+            "SECURITY VULNERABILITY: /homeevil should NOT match /home capability! Got {:?}",
+            result
+        );
+
+        // /home-evil should also NOT be allowed
+        let result = query_path(Path::new("/home-evil"), FsAccess::Read, &caps)
+            .expect("query should succeed");
+        assert!(
+            matches!(
+                result,
+                QueryResult::Denied {
+                    reason: DenyReason::NotInAllowedPaths,
+                    ..
+                }
+            ),
+            "SECURITY VULNERABILITY: /home-evil should NOT match /home capability! Got {:?}",
+            result
+        );
+
+        // /home itself should be allowed (exact match)
+        let result =
+            query_path(Path::new("/home"), FsAccess::Read, &caps).expect("query should succeed");
+        assert!(
+            matches!(result, QueryResult::Allowed { .. }),
+            "Expected /home to be allowed with /home capability"
+        );
+    }
+
+    /// SECURITY TEST: Validate HOME environment variable
+    /// Per security guidelines: "Validate environment variables before use.
+    /// Never assume HOME, TMPDIR, or other env vars are set or trustworthy."
+    ///
+    /// Note: This test modifies global environment variables, so it must run serially
+    #[test]
+    #[ignore] // Run with: cargo test -- --ignored --test-threads=1
+    fn test_home_validation() {
+        use std::env;
+
+        let caps = CapabilitySet::default();
+
+        // Save original HOME
+        let original_home = env::var("HOME").ok();
+
+        // Test 1: HOME not set - should fail when tilde expansion is needed
+        env::remove_var("HOME");
+        let result = query_path(Path::new("~/test"), FsAccess::Read, &caps);
+        match &result {
+            Err(NonoError::EnvVarValidation { var, reason }) => {
+                assert_eq!(var, "HOME");
+                assert!(
+                    reason.contains("not set"),
+                    "Expected 'not set' in reason, got: {}",
+                    reason
+                );
+            }
+            _ => panic!(
+                "Expected HOME validation error when not set, got {:?}",
+                result
+            ),
+        }
+
+        // Test 2: HOME is relative path - should fail
+        env::set_var("HOME", "relative/path");
+        let result = query_path(Path::new("~/test"), FsAccess::Read, &caps);
+        match &result {
+            Err(NonoError::EnvVarValidation { var, reason }) => {
+                assert_eq!(var, "HOME");
+                assert!(
+                    reason.contains("absolute path"),
+                    "Expected 'absolute path' in reason, got: {}",
+                    reason
+                );
+            }
+            _ => panic!(
+                "Expected HOME validation error for relative path, got {:?}",
+                result
+            ),
+        }
+
+        // Test 3: Paths without tilde should work even if HOME is invalid
+        env::set_var("HOME", "invalid");
+        let result = query_path(Path::new("/tmp/test"), FsAccess::Read, &caps);
+        assert!(
+            result.is_ok(),
+            "Paths without tilde should not require valid HOME"
+        );
+
+        // Restore original HOME
+        if let Some(home) = original_home {
+            env::set_var("HOME", home);
+        } else {
+            env::remove_var("HOME");
+        }
+    }
+
+    /// SECURITY REGRESSION TEST: Metadata leak prevention
+    ///
+    /// Verifies that query_path does NOT leak metadata about denied paths.
+    /// Per security guidelines: "Metadata leaks: Even denying file content,
+    /// allowing metadata reveals file existence, size, and timestamps."
+    ///
+    /// This test ensures that:
+    /// 1. Suggestions for denied paths use directory-level flags (--read, --write, --allow)
+    /// 2. The suggestion format is identical for files, directories, and non-existent paths
+    /// 3. No filesystem access (path.is_file(), path.exists(), etc.) is performed on denied paths
+    #[test]
+    fn test_no_metadata_leak_on_denied_paths() {
+        let caps = CapabilitySet::default();
+
+        // Test 1: Sensitive path (file) - should use directory-level flag
+        let result = query_path(Path::new("~/.ssh/id_rsa"), FsAccess::Read, &caps)
+            .expect("query should succeed");
+        match result {
+            QueryResult::Denied { suggestion, .. } => {
+                // Should suggest --read, NOT --read-file (which would reveal it's a file)
+                assert!(
+                    suggestion.starts_with("--read "),
+                    "Expected --read flag for denied path, got: {}",
+                    suggestion
+                );
+                assert!(
+                    !suggestion.contains("--read-file"),
+                    "METADATA LEAK: Suggestion reveals path is a file: {}",
+                    suggestion
+                );
+            }
+            _ => panic!("Expected denial for sensitive path"),
+        }
+
+        // Test 2: Non-existent path - should use same format (no metadata disclosure)
+        let result = query_path(
+            Path::new("/nonexistent/path/that/does/not/exist"),
+            FsAccess::Write,
+            &caps,
+        )
+        .expect("query should succeed");
+        match result {
+            QueryResult::Denied { suggestion, .. } => {
+                // Should suggest --write (directory-level), same as if it were a real path
+                assert!(
+                    suggestion.starts_with("--write "),
+                    "Expected --write flag for denied path, got: {}",
+                    suggestion
+                );
+                assert!(
+                    !suggestion.contains("--write-file"),
+                    "METADATA LEAK: Suggestion format differs for non-existent path: {}",
+                    suggestion
+                );
+            }
+            _ => panic!("Expected denial for non-existent path"),
+        }
+
+        // Test 3: Existing directory - verify same format as files
+        // Using /etc which exists on all Unix systems
+        let result = query_path(Path::new("/etc"), FsAccess::ReadWrite, &caps)
+            .expect("query should succeed");
+        match result {
+            QueryResult::Denied { suggestion, .. } => {
+                // Should suggest --allow (directory-level)
+                assert!(
+                    suggestion.starts_with("--allow "),
+                    "Expected --allow flag for denied path, got: {}",
+                    suggestion
+                );
+                assert!(
+                    !suggestion.contains("--allow-file"),
+                    "Should not use file-specific flag: {}",
+                    suggestion
+                );
+            }
+            _ => panic!("Expected denial for /etc"),
+        }
+    }
+}

--- a/src/sandbox_state.rs
+++ b/src/sandbox_state.rs
@@ -1,0 +1,701 @@
+//! Sandbox state persistence for `nono query --self`
+//!
+//! When nono runs a command, it writes the capability state to a temp file
+//! and passes the path via NONO_CAP_FILE. This allows sandboxed processes
+//! to query their own capabilities using `nono query --self`.
+
+use serde::{Deserialize, Serialize};
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+use tracing::debug;
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+
+use crate::capability::{CapabilitySet, FsAccess, FsCapability};
+use crate::error::{NonoError, Result};
+
+/// Sandbox state stored for `nono query --self`
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SandboxState {
+    /// Filesystem capabilities
+    pub fs: Vec<FsCapState>,
+    /// Whether network is blocked
+    pub net_blocked: bool,
+    /// Commands explicitly allowed
+    pub allowed_commands: Vec<String>,
+    /// Commands explicitly blocked
+    pub blocked_commands: Vec<String>,
+}
+
+/// Serializable filesystem capability state
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FsCapState {
+    /// Original path as specified
+    pub original: String,
+    /// Resolved absolute path
+    pub path: String,
+    /// Access level: "read", "write", or "readwrite"
+    pub access: String,
+    /// Whether this is a single file (vs directory)
+    pub is_file: bool,
+}
+
+impl SandboxState {
+    /// Create sandbox state from a CapabilitySet
+    pub fn from_caps(caps: &CapabilitySet) -> Self {
+        Self {
+            fs: caps
+                .fs
+                .iter()
+                .map(|c| FsCapState {
+                    original: c.original.display().to_string(),
+                    path: c.resolved.display().to_string(),
+                    access: match c.access {
+                        FsAccess::Read => "read".to_string(),
+                        FsAccess::Write => "write".to_string(),
+                        FsAccess::ReadWrite => "readwrite".to_string(),
+                    },
+                    is_file: c.is_file,
+                })
+                .collect(),
+            net_blocked: caps.net_block,
+            allowed_commands: caps.allowed_commands.clone(),
+            blocked_commands: caps.blocked_commands.clone(),
+        }
+    }
+
+    /// Convert back to a CapabilitySet
+    ///
+    /// Note: This creates a "reconstructed" capability set that may not
+    /// have all the validation of the original (paths may not exist anymore).
+    pub fn to_caps(&self) -> CapabilitySet {
+        let mut caps = CapabilitySet::new();
+
+        for fs_cap in &self.fs {
+            let access = match fs_cap.access.as_str() {
+                "read" => FsAccess::Read,
+                "write" => FsAccess::Write,
+                "readwrite" => FsAccess::ReadWrite,
+                _ => FsAccess::Read, // Default to read for unknown
+            };
+
+            // Create capability without validation (path may not exist in sandbox)
+            let cap = FsCapability {
+                original: PathBuf::from(&fs_cap.original),
+                resolved: PathBuf::from(&fs_cap.path),
+                access,
+                is_file: fs_cap.is_file,
+            };
+            caps.fs.push(cap);
+        }
+
+        caps.net_block = self.net_blocked;
+        caps.allowed_commands = self.allowed_commands.clone();
+        caps.blocked_commands = self.blocked_commands.clone();
+
+        caps
+    }
+
+    /// Write sandbox state to a file with secure permissions
+    ///
+    /// # Security
+    /// This function implements multiple defenses against temp file attacks:
+    /// - Uses `create_new(true)` to fail if file exists (prevents symlink attacks)
+    /// - Sets `mode(0o600)` for owner-only read/write permissions (Unix)
+    /// - Atomic write operation (no TOCTOU window)
+    ///
+    /// # Errors
+    /// Returns error if:
+    /// - File already exists (prevents symlink attack)
+    /// - Serialization fails
+    /// - File creation fails
+    /// - Write operation fails
+    pub fn write_to_file(&self, path: &std::path::Path) -> Result<()> {
+        let json = serde_json::to_string_pretty(self).map_err(|e| {
+            NonoError::ConfigParse(format!("Failed to serialize sandbox state: {}", e))
+        })?;
+
+        // SECURITY: Use OpenOptions with create_new(true) to prevent symlink attacks
+        // If an attacker pre-creates a symlink at this path, create_new will fail
+        // rather than following the symlink and writing to the target.
+        #[cfg(unix)]
+        let mut file = OpenOptions::new()
+            .create_new(true) // Fail if exists - prevents symlink attack
+            .write(true)
+            .mode(0o600) // Owner-only read/write (prevents info disclosure)
+            .open(path)
+            .map_err(|e| NonoError::ConfigWrite {
+                path: path.to_path_buf(),
+                source: e,
+            })?;
+
+        // Non-Unix platforms: Still use create_new for symlink protection
+        // but can't set permissions at creation time
+        #[cfg(not(unix))]
+        let mut file = OpenOptions::new()
+            .create_new(true) // Fail if exists - prevents symlink attack
+            .write(true)
+            .open(path)
+            .map_err(|e| NonoError::ConfigWrite {
+                path: path.to_path_buf(),
+                source: e,
+            })?;
+
+        // Write atomically
+        file.write_all(json.as_bytes())
+            .map_err(|e| NonoError::ConfigWrite {
+                path: path.to_path_buf(),
+                source: e,
+            })?;
+
+        Ok(())
+    }
+}
+
+/// Maximum size for capability state files (1 MB is more than enough)
+const MAX_CAP_FILE_SIZE: u64 = 1_048_576;
+
+/// Validate the NONO_CAP_FILE path for security
+///
+/// This function implements defense-in-depth validation to prevent:
+/// - Arbitrary file read via malicious env var
+/// - Symlink attacks
+/// - Path traversal attacks
+/// - Excessively large files (DoS)
+fn validate_cap_file_path(path_str: &str) -> Result<PathBuf> {
+    // Security check: Path must be absolute
+    let path = PathBuf::from(path_str);
+    if !path.is_absolute() {
+        return Err(NonoError::EnvVarValidation {
+            var: "NONO_CAP_FILE".to_string(),
+            reason: "path must be absolute".to_string(),
+        });
+    }
+
+    // Security check: Canonicalize to prevent symlink attacks
+    // This resolves symlinks and validates the path exists
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| NonoError::CapFileValidation {
+            reason: format!("failed to canonicalize path: {}", e),
+        })?;
+
+    // Security check: Must be in system temp directory
+    // This prevents reading arbitrary files on the system
+    // Note: On macOS, /tmp is a symlink to /private/tmp or /var/folders/...
+    // so we must canonicalize the temp dir for comparison
+    let temp_dir =
+        std::env::temp_dir()
+            .canonicalize()
+            .map_err(|e| NonoError::CapFileValidation {
+                reason: format!("failed to canonicalize temp directory: {}", e),
+            })?;
+
+    if !canonical.starts_with(&temp_dir) {
+        return Err(NonoError::CapFileValidation {
+            reason: format!(
+                "path must be in temp directory ({}), got: {}",
+                temp_dir.display(),
+                canonical.display()
+            ),
+        });
+    }
+
+    // Security check: Must match expected naming pattern
+    // Expected format: /tmp/.nono-<pid>.json
+    let file_name = canonical
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| NonoError::CapFileValidation {
+            reason: "invalid file name".to_string(),
+        })?;
+
+    if !file_name.starts_with(".nono-") || !file_name.ends_with(".json") {
+        return Err(NonoError::CapFileValidation {
+            reason: format!(
+                "file name must match pattern .nono-*.json, got: {}",
+                file_name
+            ),
+        });
+    }
+
+    // Security check: File size must be reasonable
+    let metadata = std::fs::metadata(&canonical).map_err(|e| NonoError::CapFileValidation {
+        reason: format!("failed to read file metadata: {}", e),
+    })?;
+
+    if metadata.len() > MAX_CAP_FILE_SIZE {
+        return Err(NonoError::CapFileTooLarge {
+            size: metadata.len(),
+            max: MAX_CAP_FILE_SIZE,
+        });
+    }
+
+    // Security check: Must be a regular file (not a directory, device, etc.)
+    if !metadata.is_file() {
+        return Err(NonoError::CapFileValidation {
+            reason: "path must be a regular file".to_string(),
+        });
+    }
+
+    Ok(canonical)
+}
+
+/// Load sandbox state from NONO_CAP_FILE environment variable
+///
+/// Returns None if not running inside a nono sandbox (env var not set).
+///
+/// # Security
+/// This function implements comprehensive validation to prevent:
+/// - Arbitrary file read attacks via malicious NONO_CAP_FILE values
+/// - Symlink attacks through path canonicalization
+/// - Path traversal by requiring /tmp prefix
+/// - DoS via file size limits
+///
+/// All validation failures are treated as fatal errors (not silent None returns)
+/// to ensure security issues are visible and auditable.
+pub fn load_sandbox_state() -> Option<SandboxState> {
+    // Not running in sandbox if env var not set - this is the only case that returns None
+    let cap_file_str = std::env::var("NONO_CAP_FILE").ok()?;
+
+    // All validation failures beyond this point are security-relevant and should not be silent
+    // We use expect() here because a validation failure indicates either:
+    // 1. An attack attempt (malicious env var)
+    // 2. A bug in nono (incorrect path set by parent process)
+    // Both cases should terminate rather than silently failing
+    let validated_path = validate_cap_file_path(&cap_file_str).unwrap_or_else(|e| {
+        eprintln!("SECURITY: NONO_CAP_FILE validation failed: {}", e);
+        eprintln!("SECURITY: This may indicate an attack attempt or a bug in nono");
+        std::process::exit(1);
+    });
+
+    // Read and parse the capability state
+    let content = std::fs::read_to_string(&validated_path).unwrap_or_else(|e| {
+        eprintln!("Error reading capability state file: {}", e);
+        std::process::exit(1);
+    });
+
+    let state: SandboxState = serde_json::from_str(&content).unwrap_or_else(|e| {
+        eprintln!("Error parsing capability state file: {}", e);
+        std::process::exit(1);
+    });
+
+    Some(state)
+}
+
+/// Check if we're running inside a nono sandbox
+#[allow(dead_code)]
+pub fn is_sandboxed() -> bool {
+    std::env::var("NONO_CAP_FILE").is_ok()
+}
+
+/// Get the path to the capability state file (for cleanup)
+#[allow(dead_code)]
+pub fn get_cap_file_path() -> Option<String> {
+    std::env::var("NONO_CAP_FILE").ok()
+}
+
+/// Check if a process with the given PID is currently running
+///
+/// # Platform Support
+/// - Unix: Uses kill(pid, 0) to check process existence
+/// - Non-Unix: Always returns true (conservative - keeps files)
+///
+/// # Security
+/// This function is used to determine if a state file is stale.
+/// Returning true when uncertain is safe (keeps files), but may leak disk space.
+#[cfg(unix)]
+fn is_process_running(pid: u32) -> bool {
+    use nix::sys::signal::kill;
+    use nix::unistd::Pid;
+
+    // Send signal 0 (None) to check if process exists
+    // Signal 0 is a special case that checks process existence without sending a signal
+    let nix_pid = Pid::from_raw(pid as i32);
+    match kill(nix_pid, None) {
+        Ok(()) => true,                         // Process exists
+        Err(nix::errno::Errno::ESRCH) => false, // No such process - safe to delete
+        Err(nix::errno::Errno::EPERM) => true,  // Process exists but permission denied
+        _ => true,                              // Unknown error - conservative, keep file
+    }
+}
+
+#[cfg(not(unix))]
+fn is_process_running(_pid: u32) -> bool {
+    // On non-Unix platforms, we can't reliably check process existence.
+    // Be conservative and assume the process is still running.
+    // This means state files may accumulate on Windows, but won't break functionality.
+    true
+}
+
+/// Clean up stale sandbox state files from previous nono runs
+///
+/// This function is called on each nono invocation to remove state files
+/// where the corresponding process is no longer running. This prevents:
+/// - Disk space exhaustion from accumulated state files
+/// - Information disclosure from old capability data
+/// - Forensic analysis from historical sandbox configurations
+///
+/// # Security
+/// - Only deletes files matching .nono-*.json pattern in temp directory
+/// - Validates PID existence before deletion
+/// - Skips files with invalid naming (prevents accidental deletion)
+/// - Logs but doesn't fail on individual file errors (best-effort cleanup)
+///
+/// # Errors
+/// Individual file deletion errors are logged but don't cause the function to fail.
+/// This ensures nono continues to work even if some cleanup fails.
+pub fn cleanup_stale_state_files() {
+    let temp_dir = std::env::temp_dir();
+
+    // Read directory entries
+    let entries = match std::fs::read_dir(&temp_dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            // Can't read temp dir - log and skip cleanup
+            // This is not fatal as it only affects cleanup
+            debug!("Failed to read temp directory for cleanup: {}", e);
+            return;
+        }
+    };
+
+    let current_pid = std::process::id();
+    let mut cleaned_count = 0;
+    let mut skipped_count = 0;
+
+    for entry in entries.flatten() {
+        let file_name = match entry.file_name().to_str() {
+            Some(name) => name.to_string(),
+            None => continue, // Skip non-UTF8 filenames
+        };
+
+        // Only process files matching .nono-*.json pattern
+        if !file_name.starts_with(".nono-") || !file_name.ends_with(".json") {
+            continue;
+        }
+
+        // Extract PID from filename: .nono-<pid>.json
+        let pid_str = file_name
+            .trim_start_matches(".nono-")
+            .trim_end_matches(".json");
+
+        let pid = match pid_str.parse::<u32>() {
+            Ok(p) => p,
+            Err(_) => {
+                // Invalid PID format - skip this file
+                debug!("Skipping state file with invalid PID: {}", file_name);
+                continue;
+            }
+        };
+
+        // Never delete our own state file (we might create it later)
+        if pid == current_pid {
+            continue;
+        }
+
+        // Check if the process is still running
+        if is_process_running(pid) {
+            skipped_count += 1;
+            continue;
+        }
+
+        // Process is dead - safe to delete the state file
+        let file_path = temp_dir.join(&file_name);
+        match std::fs::remove_file(&file_path) {
+            Ok(()) => {
+                debug!("Cleaned up stale state file for PID {}: {}", pid, file_name);
+                cleaned_count += 1;
+            }
+            Err(e) => {
+                // Log but don't fail - best effort cleanup
+                debug!("Failed to remove stale state file {}: {}", file_name, e);
+            }
+        }
+    }
+
+    if cleaned_count > 0 {
+        debug!(
+            "Cleanup complete: removed {} stale state file(s), {} active",
+            cleaned_count, skipped_count
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_sandbox_state_roundtrip() {
+        let mut caps = CapabilitySet::new();
+        caps.net_block = true;
+        caps.allowed_commands = vec!["pip".to_string()];
+
+        let state = SandboxState::from_caps(&caps);
+        assert!(state.net_blocked);
+        assert_eq!(state.allowed_commands, vec!["pip"]);
+
+        let restored = state.to_caps();
+        assert!(restored.net_block);
+        assert_eq!(restored.allowed_commands, vec!["pip"]);
+    }
+
+    #[test]
+    fn test_sandbox_state_write_and_read() {
+        let dir = tempdir().expect("Failed to create temp dir");
+        let file_path = dir.path().join("test_state.json");
+
+        let mut caps = CapabilitySet::new();
+        caps.net_block = true;
+
+        let state = SandboxState::from_caps(&caps);
+        state
+            .write_to_file(&file_path)
+            .expect("Failed to write state");
+
+        // Read it back
+        let content = std::fs::read_to_string(&file_path).expect("Failed to read file");
+        let loaded: SandboxState = serde_json::from_str(&content).expect("Failed to parse state");
+
+        assert!(loaded.net_blocked);
+    }
+
+    #[test]
+    fn test_fs_cap_state_access_parsing() {
+        let state = SandboxState {
+            fs: vec![
+                FsCapState {
+                    original: "./src".to_string(),
+                    path: "/home/user/src".to_string(),
+                    access: "read".to_string(),
+                    is_file: false,
+                },
+                FsCapState {
+                    original: "./out".to_string(),
+                    path: "/home/user/out".to_string(),
+                    access: "write".to_string(),
+                    is_file: false,
+                },
+                FsCapState {
+                    original: "./data".to_string(),
+                    path: "/home/user/data".to_string(),
+                    access: "readwrite".to_string(),
+                    is_file: false,
+                },
+            ],
+            net_blocked: false,
+            allowed_commands: vec![],
+            blocked_commands: vec![],
+        };
+
+        let caps = state.to_caps();
+        assert_eq!(caps.fs.len(), 3);
+        assert_eq!(caps.fs[0].access, FsAccess::Read);
+        assert_eq!(caps.fs[1].access, FsAccess::Write);
+        assert_eq!(caps.fs[2].access, FsAccess::ReadWrite);
+    }
+
+    // Security tests for validate_cap_file_path
+
+    #[test]
+    fn test_validate_cap_file_rejects_relative_path() {
+        let result = validate_cap_file_path("relative/path.json");
+        assert!(result.is_err());
+        match result {
+            Err(NonoError::EnvVarValidation { var, reason }) => {
+                assert_eq!(var, "NONO_CAP_FILE");
+                assert!(reason.contains("absolute"));
+            }
+            _ => panic!("Expected EnvVarValidation error"),
+        }
+    }
+
+    #[test]
+    fn test_validate_cap_file_rejects_nonexistent_path() {
+        let result = validate_cap_file_path("/tmp/.nono-99999999.json");
+        assert!(result.is_err());
+        match result {
+            Err(NonoError::CapFileValidation { reason }) => {
+                assert!(reason.contains("canonicalize"));
+            }
+            _ => panic!("Expected CapFileValidation error"),
+        }
+    }
+
+    #[test]
+    fn test_validate_cap_file_rejects_outside_tmp() {
+        // Try to read /etc/passwd (would fail on canonicalization, but shows intent)
+        let result = validate_cap_file_path("/etc/passwd");
+        assert!(result.is_err());
+        // This will fail on canonicalization or /tmp check depending on whether file exists
+    }
+
+    #[test]
+    fn test_validate_cap_file_rejects_wrong_naming_pattern() {
+        // Create a file in /tmp but with wrong name
+        let file_path = std::env::temp_dir().join("wrong_name.json");
+        std::fs::write(&file_path, "{}").expect("Failed to create test file");
+
+        let result = validate_cap_file_path(file_path.to_str().unwrap_or_default());
+        std::fs::remove_file(&file_path).ok(); // Cleanup
+
+        assert!(result.is_err());
+        match result {
+            Err(NonoError::CapFileValidation { reason }) => {
+                assert!(reason.contains("pattern") || reason.contains(".nono-"));
+            }
+            _ => panic!("Expected CapFileValidation error"),
+        }
+    }
+
+    #[test]
+    fn test_validate_cap_file_rejects_too_large_file() {
+        // Create a file larger than MAX_CAP_FILE_SIZE
+        let file_path = std::env::temp_dir().join(".nono-test-large.json");
+
+        // Create a 2MB file (larger than 1MB limit)
+        let large_content = vec![b'x'; 2_097_152];
+        std::fs::write(&file_path, large_content).expect("Failed to create large test file");
+
+        let result = validate_cap_file_path(file_path.to_str().unwrap_or_default());
+        std::fs::remove_file(&file_path).ok(); // Cleanup
+
+        assert!(result.is_err());
+        match result {
+            Err(NonoError::CapFileTooLarge { size, max }) => {
+                assert!(size > max);
+                assert_eq!(max, MAX_CAP_FILE_SIZE);
+            }
+            _ => panic!("Expected CapFileTooLarge error, got: {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_validate_cap_file_accepts_valid_path() {
+        // Create a valid capability file in /tmp
+        let file_path = std::env::temp_dir().join(".nono-test-12345.json");
+        let test_state = SandboxState {
+            fs: vec![],
+            net_blocked: true,
+            allowed_commands: vec![],
+            blocked_commands: vec![],
+        };
+
+        let json = serde_json::to_string(&test_state).expect("Failed to serialize");
+        std::fs::write(&file_path, json).expect("Failed to write test file");
+
+        let result = validate_cap_file_path(file_path.to_str().unwrap_or_default());
+        std::fs::remove_file(&file_path).ok(); // Cleanup
+
+        assert!(
+            result.is_ok(),
+            "Valid path should be accepted: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_validate_cap_file_rejects_directory() {
+        // Create a directory with the right naming pattern
+        let dir_path = std::env::temp_dir().join(".nono-test-dir.json");
+        std::fs::create_dir(&dir_path).expect("Failed to create test directory");
+
+        let result = validate_cap_file_path(dir_path.to_str().unwrap_or_default());
+        std::fs::remove_dir(&dir_path).ok(); // Cleanup
+
+        assert!(result.is_err());
+        match result {
+            Err(NonoError::CapFileValidation { reason }) => {
+                assert!(reason.contains("regular file"));
+            }
+            _ => panic!("Expected CapFileValidation error"),
+        }
+    }
+
+    // Security tests for write_to_file
+
+    #[test]
+    #[cfg(unix)]
+    fn test_write_sets_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().expect("Failed to create temp dir");
+        let file_path = dir.path().join(".nono-test-perms.json");
+
+        let state = SandboxState {
+            fs: vec![],
+            net_blocked: true,
+            allowed_commands: vec![],
+            blocked_commands: vec![],
+        };
+
+        state
+            .write_to_file(&file_path)
+            .expect("Failed to write state");
+
+        // Verify file permissions are 0o600 (owner read/write only)
+        let metadata = std::fs::metadata(&file_path).expect("Failed to read metadata");
+        let mode = metadata.permissions().mode() & 0o777;
+
+        assert_eq!(
+            mode, 0o600,
+            "File should have 0o600 permissions (owner-only), got: 0o{:o}",
+            mode
+        );
+    }
+
+    #[test]
+    fn test_write_prevents_symlink_attack() {
+        let dir = tempdir().expect("Failed to create temp dir");
+        let file_path = dir.path().join(".nono-test-symlink.json");
+
+        // Pre-create file (simulating symlink attack)
+        std::fs::write(&file_path, "malicious").expect("Failed to create decoy");
+
+        let state = SandboxState {
+            fs: vec![],
+            net_blocked: true,
+            allowed_commands: vec![],
+            blocked_commands: vec![],
+        };
+
+        // Should fail due to create_new(true)
+        let result = state.write_to_file(&file_path);
+        assert!(
+            result.is_err(),
+            "write_to_file must fail when file exists (symlink protection)"
+        );
+
+        // Verify original content unchanged
+        let content = std::fs::read_to_string(&file_path).expect("Failed to read");
+        assert_eq!(content, "malicious", "Original file must not be modified");
+    }
+
+    #[test]
+    fn test_write_prevents_toctou_race() {
+        let dir = tempdir().expect("Failed to create temp dir");
+        let file_path = dir.path().join(".nono-test-toctou.json");
+
+        let state = SandboxState {
+            fs: vec![],
+            net_blocked: true,
+            allowed_commands: vec![],
+            blocked_commands: vec![],
+        };
+
+        // First write succeeds
+        state
+            .write_to_file(&file_path)
+            .expect("First write should succeed");
+
+        // Second write fails (prevents TOCTOU)
+        let result = state.write_to_file(&file_path);
+        assert!(
+            result.is_err(),
+            "Second write must fail (prevents TOCTOU races)"
+        );
+    }
+}


### PR DESCRIPTION
This replaces the NONO_* environment variables (`NONO_ACTIVE, NONO_ALLOWED, NONO_BLOCKED, NONO_NET, NONO_HELP, NONO_CONTEXT`) with a structured query API that enables AI agents to pre-check if operations will be allowed before attempting them. Instead of parsing environment variables, sandboxed processes now call `nono why --self` to get a programmatic JSON response explaining why an operation is allowed or denied.

The old `nono why <path>` command is re-implemented with a more powerful interface that supports filesystem path queries (`--path` and `--op`), network queries (`--host` and `--port`), JSON output for programmatic use, and the ability to query current sandbox state from inside the sandbox with `--self`. Capability context can be provided via the existing flags (--allow, --read, --write, --profile, etc.) to check what would be allowed under different configurations.

The sandbox state is now written to a temp file and passed via `NONO_CAP_FILE`, which allows `nono why --self` to reconstruct the capability set from inside the sandbox and answer questions about what operations are allowed.