### PR TITLE
docs: fix broken Development Guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ We are in the process of packaging nono for popular Linux distributions. In the 
 
 ### Building from Source
 
-See the [Development Guide](development/index.md) for instructions on building nono from source.
+See the [Development Guide](https://docs.nono.sh/development) for instructions on building nono from source.
 
 ## Supported Clients
 


### PR DESCRIPTION
Hi! Thanks for this awesome project.

I wanted to build from source locally and was going to follow the instructions in the README, but the link returned a 404. I found the instructions on the website, though. I thought I’d open a PR to fix this, but if you’d prefer something else, just let me know and I’ll close it.

Thanks again!