### PR TITLE
fix link to development guide in Installation docs page

### DIFF
--- a/docs/getting_started/installation.mdx
+++ b/docs/getting_started/installation.mdx
@@ -22,7 +22,7 @@ We are in the process of packaging nono for popular Linux distributions. In the 
 
 ## Building from Source
 
-See the [Development Guide](development/index.mdx) for instructions on building nono from source.
+See the [Development Guide](/development) for instructions on building nono from source.
 
 ## Where next?
 


### PR DESCRIPTION
fix for broken link in https://docs.nono.sh/getting_started/installation#building-from-source, which points to https://docs.nono.sh/getting_started/development/index.md (which doesn't exist)