### PR TITLE
Remove platform specific nix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Output styling
 colored = "3"
 rand = "0.8"
-nix = "0.29"
 
 # Path resolution (for async-signal-safe exec)
 which = "7"


### PR DESCRIPTION
When Dependabot updates nix, it's likely only updating ONE of these entries (probably just the general one to 0.31.1), leaving the platform-specific entries at 0.29. This causes two different versions of nix to be compiled.