### PR TITLE
feat: support Unix domain sockets in file capabilities

### DIFF
--- a/data/profiles/claude-code-secretive.toml
+++ b/data/profiles/claude-code-secretive.toml
@@ -1,0 +1,89 @@
+# Claude Code + Secretive (SSH keys in Secure Enclave)
+#
+# For users who store SSH keys in macOS Secure Enclave via Secretive
+# (https://github.com/maxgoedjen/secretive) and want git commit signing
+# to work inside the nono sandbox.
+#
+# Install:
+#   mkdir -p ~/.config/nono/profiles
+#   cp data/profiles/claude-code-secretive.toml ~/.config/nono/profiles/
+#
+# Usage:
+#   nono run --profile claude-code-secretive --trust-unsigned --allow-cwd -- claude
+#
+# --trust-unsigned is required for all user profiles (profile signing is not
+# yet implemented, see roadmap). The flag acknowledges you trust this file.
+#
+# Prerequisite:
+#   Disable Claude Code's built-in sandbox so nono is the sole enforcer.
+
+interactive = true
+
+[meta]
+name = "claude-code-secretive"
+version = "1.0.0"
+description = "Claude Code with Secretive SSH agent (Secure Enclave signing)"
+author = "community"
+
+[workdir]
+access = "readwrite"
+
+[filesystem]
+allow = [
+    # Claude Code state (debug logs, projects, settings)
+    "$HOME/.claude",
+
+    # git signing creates temp buffers in $TMPDIR (e.g. .git_signing_buffer_tmp*)
+    "$TMPDIR",
+]
+
+read = [
+    # Secretive public keys — git reads these for commit signing verification
+    "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/PublicKeys",
+]
+
+write = []
+
+allow_file = [
+    # Claude Code settings
+    "$HOME/.claude.json",
+
+    # SSH known_hosts — git/ssh may need to append new host keys
+    "$HOME/.ssh/known_hosts",
+]
+
+read_file = [
+    # macOS Keychain for Claude OAuth authentication
+    "$HOME/Library/Keychains/login.keychain-db",
+
+    # Git configuration (gpg.format = ssh, user.signingKey, etc.)
+    "$HOME/.gitconfig",
+
+    # SSH config (IdentityAgent pointing to Secretive socket)
+    "$HOME/.ssh/config",
+
+    # Secretive agent socket — a Unix domain socket, not a regular file.
+    # Requires the socket capability fix (is_dir() check instead of is_file()).
+    # Connecting uses (allow network-outbound) which nono grants by default.
+    "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh",
+
+    # Global gitignore — git reads this during operations
+    "$HOME/.gitignore",
+
+    # allowed_signers for commit signature verification.
+    # git may look in either location depending on gpg.ssh.allowedSignersFile config.
+    "$HOME/.ssh/allowed_signers",
+    "$HOME/.config/git/allowed_signers",
+]
+
+write_file = []
+
+[network]
+block = false
+
+[secrets]
+
+[hooks.claude-code]
+event = "PostToolUseFailure"
+matcher = "Read|Write|Edit|Bash"
+script = "nono-hook.sh"

--- a/docs/clients/claude-code.mdx
+++ b/docs/clients/claude-code.mdx
@@ -162,6 +162,29 @@ Claude Code installs a VS Code extension on startup. The built-in profile alread
 
 Claude Code reads git configuration for repository operations. The built-in profile already grants read access to `~/.gitconfig` and `~/.gitignore_global`. No additional flags are needed for git operations.
 
+## Secretive (SSH Keys in Secure Enclave)
+
+If you use [Secretive](https://github.com/maxgoedjen/secretive) to store SSH keys in the macOS Secure Enclave, git commit signing (`git commit -S`) needs access to the Secretive agent socket. A community profile is provided at `data/profiles/claude-code-secretive.toml`.
+
+**Install the profile:**
+```bash
+mkdir -p ~/.config/nono/profiles
+cp data/profiles/claude-code-secretive.toml ~/.config/nono/profiles/
+```
+
+**Usage:**
+```bash
+nono run --profile claude-code-secretive --trust-unsigned --allow-cwd -- claude
+```
+
+The profile extends the standard Claude Code profile with:
+- **Read access** to `~/.gitconfig` and `~/.ssh/config` (git signing configuration)
+- **Read access** to the Secretive agent socket (`~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh`)
+- **Read+write access** to `~/.ssh/known_hosts` (SSH may append new host keys)
+
+<Note>
+The Secretive socket is a Unix domain socket, not a regular file. nono v0.4+ supports granting capabilities on sockets directly, so only the socket itself is exposed — not the entire container directory.
+</Note>
 ## Overriding Profile Settings
 
 CLI flags always take precedence over profile settings:

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -79,7 +79,7 @@ impl<'a> DiagnosticFormatter<'a> {
                     FsAccess::Write => "write",
                     FsAccess::ReadWrite => "read+write",
                 };
-                let kind = if cap.is_file { "file" } else { "dir" };
+                let kind = cap.kind_label();
                 lines.push(format!(
                     "[nono]     {} ({}, {})",
                     cap.resolved.display(),

--- a/src/output.rs
+++ b/src/output.rs
@@ -48,7 +48,7 @@ pub fn print_capabilities(caps: &CapabilitySet, silent: bool) {
     if !caps.fs.is_empty() {
         eprintln!("  {}", "Filesystem:".white());
         for cap in &caps.fs {
-            let kind = if cap.is_file { "file" } else { "dir" };
+            let kind = cap.kind_label();
             let access_str = format!("{}", cap.access);
             let access_colored = match cap.access {
                 crate::capability::FsAccess::Read => access_str.green(),


### PR DESCRIPTION
## Summary

- **Fix `FsCapability::new_file()` to accept Unix domain sockets**, FIFOs, and device files by checking `is_dir()` instead of `is_file()`. The directory-vs-non-directory distinction is what matters for sandbox rule generation (`subpath` vs `literal`), not the specific file type.
- **Fix `process_profile_paths()`** with the same `is_dir()` check — both code paths were gating on `is_file()`.
- **Add `kind_label()` method** to display `(socket)`, `(fifo)`, `(device)` instead of generic `(file)` in capabilities output and diagnostics.
- **Add community profile `claude-code-secretive.toml`** for users who store SSH keys in macOS Secure Enclave via [Secretive](https://github.com/maxgoedjen/secretive) and want git commit signing inside the nono sandbox.
- **Document Secretive setup** in `docs/clients/claude-code.mdx`.

## Motivation

Secretive exposes SSH keys via a Unix domain socket at `~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh`. Before this change, specifying that socket in a profile's `read_file` list was silently skipped because `std::path::Path::is_file()` returns `false` for sockets. The only workaround was granting access to the parent `Data/` directory, which also contains symlinks to `~/Desktop`, `~/Downloads`, etc. — far too broad.

## Test plan

- [x] Unit test `test_fs_capability_unix_socket` — creates a real Unix socket via `UnixListener::bind()` and verifies `new_file()` accepts it
- [x] All 124 existing tests pass, clippy clean (`-D warnings -D clippy::unwrap_used`), fmt clean
- [x] End-to-end: signed commit via Secretive works inside nono sandbox (`git commit --allow-empty -S -m "test"` → `Good "git" signature`)
- [x] Socket displays as `(socket)` in capabilities output

🤖 Generated with [Claude Code](https://claude.com/claude-code)