### PR TITLE
fix: include RemoveDir in Landlock write access for atomic dir rename()

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,10 +195,9 @@ nono run --allow . --block-command my-dangerous-tool -- my-script.sh
 
 nono applies kernel-level protections that limit destructive operations:
 
-- **File deletion blocked outside granted paths** - `unlink`/`rmdir` syscalls are blocked for system paths like `/tmp`, `/dev`, and any path not explicitly granted with `--allow` or `--write`
-- **Directory deletion blocked everywhere** - `rmdir` is blocked even within granted write paths (Linux: `RemoveDir` excluded from Landlock rules; macOS: global `deny file-write-unlink` with targeted overrides for file deletion only)
+- **File and directory deletion blocked outside granted paths** - `unlink`/`rmdir` syscalls are blocked for system paths like `/tmp`, `/dev`, and any path not explicitly granted with `--allow` or `--write`
 
-Within paths you explicitly grant write access to (`--allow` or `--write`), file creation, modification, and deletion are permitted - this is necessary for normal file operations like atomic writes.
+Within paths you explicitly grant write access to (`--allow` or `--write`), file creation, modification, and deletion (including directory deletion) are permitted - this is necessary for normal file operations like atomic writes and directory renames.
 
 ```bash
 # File deletion blocked in system paths (even with --allow-command rm)
@@ -240,7 +239,7 @@ nono follows a capability-based security model with defense-in-depth:
 
 1. **Command validation** - Dangerous commands (rm, dd, chmod, etc.) are blocked before execution
 2. **Sandbox applied** - OS-level restrictions are applied (irreversible)
-3. **Kernel enforcement** - Directory deletion blocked everywhere; file deletion blocked outside granted write paths
+3. **Kernel enforcement** - File and directory deletion blocked outside granted write paths
 4. **Command executed** - The command runs with only granted capabilities
 5. **All children inherit** - Subprocesses also run under restrictions
 6. **Key isolation** - Secrets are injected securely and cannot be accessed outside the sandbox

--- a/docs/security/landlock.mdx
+++ b/docs/security/landlock.mdx
@@ -71,11 +71,12 @@ AccessFs::MakeFifo
 AccessFs::MakeBlock
 AccessFs::MakeSym
 AccessFs::RemoveFile  // File deletion (needed for atomic writes)
+AccessFs::RemoveDir   // Directory deletion (needed for rename() on directories)
 AccessFs::Refer       // Rename/hard link across directories (ABI v2+)
 AccessFs::Truncate    // ABI v3+
 ```
 
-Note: `RemoveDir` is intentionally excluded for safety - directory deletion is blocked even within writable paths.
+Note: `RemoveFile` and `RemoveDir` are both included because `rename()` requires removal rights on the source. This enables atomic write patterns (write to `.tmp` then rename to target) for both files and directories.
 
 ### Full Access (`--allow`)
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -133,9 +133,9 @@ pub struct SandboxArgs {
     pub read: Vec<PathBuf>,
 
     /// Directories to allow write-only access (recursive).
-    /// Write access includes: creating files/dirs, modifying content, deleting files,
-    /// renaming/moving files (atomic writes), and truncating files.
-    /// Note: Directory deletion is NOT included for safety.
+    /// Write access includes: creating files/dirs, modifying content, deleting files
+    /// and directories, renaming/moving files and directories (atomic writes),
+    /// and truncating files.
     #[arg(long, short = 'w', value_name = "DIR")]
     pub write: Vec<PathBuf>,
 

--- a/tests/integration/test_fs_access.sh
+++ b/tests/integration/test_fs_access.sh
@@ -68,6 +68,25 @@ expect_success "can write to nested path in granted directory" \
     "$NONO_BIN" run --allow "$TMPDIR/allowed" -- sh -c "echo 'nested' > '$TMPDIR/allowed/nested/deep/written.txt'"
 
 # =============================================================================
+# Directory Rename (atomic directory rename via RemoveDir permission)
+# =============================================================================
+
+echo ""
+echo "--- Directory Rename ---"
+
+# Create source directory with content for rename test
+mkdir -p "$TMPDIR/allowed/rename_src"
+echo "rename content" > "$TMPDIR/allowed/rename_src/data.txt"
+
+expect_success "rename directory within granted writable path" \
+    "$NONO_BIN" run --allow "$TMPDIR/allowed" --allow-command mv -- mv "$TMPDIR/allowed/rename_src" "$TMPDIR/allowed/rename_dst"
+
+# Verify the rename actually happened
+run_test "renamed directory exists at destination" 0 test -d "$TMPDIR/allowed/rename_dst"
+run_test "renamed directory content preserved" 0 test -f "$TMPDIR/allowed/rename_dst/data.txt"
+run_test "source directory no longer exists" 1 test -d "$TMPDIR/allowed/rename_src"
+
+# =============================================================================
 # Read-only vs Write-only Access
 # =============================================================================
 


### PR DESCRIPTION
Fixes #96

This PR adds `AccessFs::RemoveDir` to the Landlock flags, which is necessary for atomic writes and renames of directories.

Previously, `rename`ing directories would not work. This was problematic build tools like cargo for example, which directory `rename()` for incremental build cache.

Security: Allowing this doesn't change the security profile for nono notably, as removing files and mkdir were already allowed. 