### PR TITLE
fix: correct broken documentation links

### DIFF
--- a/docs/cli/clients/claude-code.mdx
+++ b/docs/cli/clients/claude-code.mdx
@@ -90,7 +90,7 @@ Then run with secrets:
 nono run --profile claude-code --secrets anthropic_api_key -- claude
 ```
 
-See [Secrets Management](/usage/secrets) for full documentation.
+See [Secrets Management](/cli/usage/secrets) for full documentation.
 
 ### Restrict to Specific Projects
 
@@ -197,7 +197,7 @@ nono run --profile claude-code --allow ~/other-project -- claude
 nono run --profile claude-code --net-block -- claude
 ```
 
-See [Security Profiles](/security/profiles) for details on profile format and precedence rules.
+See [Security Profiles](/cli/security/profiles) for details on profile format and precedence rules.
 
 ## Automatic Hook Integration
 

--- a/docs/cli/clients/openclaw.mdx
+++ b/docs/cli/clients/openclaw.mdx
@@ -68,7 +68,7 @@ nono run --profile openclaw-strict --secrets -- openclaw gateway
 Custom profiles override built-in profiles of the same name. If you create `~/.config/nono/profiles/openclaw.toml`, it will be used instead of the built-in.
 </Note>
 
-See [Security Profiles](/security/profiles) for the full profile format reference.
+See [Security Profiles](/cli/security/profiles) for the full profile format reference.
 
 ## Security Tips
 
@@ -120,7 +120,7 @@ The secrets are loaded from the keystore and injected as `$TELEGRAM_BOT_TOKEN` a
 Secrets are loaded **before** the sandbox is applied, then zeroized from nono's memory after `exec()`. The sandboxed process cannot access the keystore directly - it only receives the specific secrets you authorized.
 </Note>
 
-See [Secrets Management](/usage/secrets) for complete documentation on storing and managing secrets.
+See [Secrets Management](/cli/usage/secrets) for complete documentation on storing and managing secrets.
 
 ### Limit Agent Filesystem Access
 
@@ -231,4 +231,4 @@ docker run -v $(pwd):/work my-openclaw-image \
   nono run --profile openclaw -- openclaw gateway
 ```
 
-See [nono vs Containers](/security/vs-containers) for a detailed comparison.
+See [nono vs Containers](/cli/security/containers) for a detailed comparison.

--- a/docs/cli/clients/opencode.mdx
+++ b/docs/cli/clients/opencode.mdx
@@ -83,7 +83,7 @@ Then run:
 nono run --profile opencode --secrets openai_api_key -- opencode
 ```
 
-See [Secrets Management](/usage/secrets) for full documentation.
+See [Secrets Management](/cli/usage/secrets) for full documentation.
 
 ### Read-Only Mode
 
@@ -111,4 +111,4 @@ nono run --profile opencode --allow ~/shared-libs -- opencode
 nono run --profile opencode --net-block -- opencode
 ```
 
-See [Security Profiles](/security/profiles) for details on profile format and precedence rules.
+See [Security Profiles](/cli/security/profiles) for details on profile format and precedence rules.

--- a/docs/cli/clients/quickstart.mdx
+++ b/docs/cli/clients/quickstart.mdx
@@ -9,9 +9,9 @@ nono works with any CLI tool, but these guides walk through setup and best pract
 
 | Client | Profile | Network | Description |
 |--------|---------|---------|-------------|
-| [Claude Code](/clients/claude-code) | `claude-code` | Allowed | Anthropic's CLI coding agent |
-| [OpenCode](/clients/opencode) | `opencode` | Allowed | Open-source AI coding assistant |
-| [OpenClaw](/clients/openclaw) | `openclaw` | Allowed | Multi-channel AI agent platform |
+| [Claude Code](/cli/clients/claude-code) | `claude-code` | Allowed | Anthropic's CLI coding agent |
+| [OpenCode](/cli/clients/opencode) | `opencode` | Allowed | Open-source AI coding assistant |
+| [OpenClaw](/cli/clients/openclaw) | `openclaw` | Allowed | Multi-channel AI agent platform |
 
 ## Quick Start
 
@@ -42,7 +42,7 @@ nono is agent-agnostic. If your tool isn't listed here, you can run it directly 
 nono run --allow . -- my-agent
 ```
 
-Or create a custom profile. See [Security Profiles](/security/profiles) for the profile format and how to create your own.
+Or create a custom profile. See [Security Profiles](/cli/security/profiles) for the profile format and how to create your own.
 
 ## What the Sandbox Does
 
@@ -54,4 +54,4 @@ When you run a client through nono:
 4. All child processes inherit the same restrictions
 5. The sandbox cannot be escaped or expanded at runtime
 
-See [Security Model](/security/index) for full details.
+See [Security Model](/cli/security/index) for full details.

--- a/docs/cli/getting_started/installation.mdx
+++ b/docs/cli/getting_started/installation.mdx
@@ -22,20 +22,20 @@ We are in the process of packaging nono for popular Linux distributions. In the 
 
 ## Building from Source
 
-See the [Development Guide](/development) for instructions on building nono from source.
+See the [Development Guide](/cli/development) for instructions on building nono from source.
 
 ## Where next?
 
 I expect you want to get going with nono and a coding agent. Here are some of the current documented clients
-- [Claude Code](/clients/claude-code.md)
-- [OpenClaw](/clients/openclaw.md)
-- [OpenCode](/clients/opencode.md)
+- [Claude Code](/cli/clients/claude-code)
+- [OpenClaw](/cli/clients/openclaw)
+- [OpenCode](/cli/clients/opencode)
 
 <Note>
   If there is an Agent you want supported please open an issue or PR to add it! Its fairly straightforward to add new ones, and we will be adding more over time.
 </Note>
 
-Alternatively, you can check out the [Usage](/usage) guide to learn how to use nono.
+Alternatively, you can check out the [Usage](/cli/usage) guide to learn how to use nono.
 
 ## Platform Support
 

--- a/docs/cli/security/containers.mdx
+++ b/docs/cli/security/containers.mdx
@@ -256,6 +256,6 @@ Do you need a different OS or runtime?
 
 ## Next Steps
 
-- [Security Model](index.mdx) - Understanding nono's guarantees
-- [Profiles](/security/profiles) - Pre-configured sandboxes for common agents
-- [Installation](/getting_started/installation) - Get started with nono
+- [Security Model](/cli/security) - Understanding nono's guarantees
+- [Profiles](/cli/security/profiles) - Pre-configured sandboxes for common agents
+- [Installation](/cli/getting_started/installation) - Get started with nono

--- a/docs/cli/security/index.mdx
+++ b/docs/cli/security/index.mdx
@@ -117,6 +117,6 @@ nono applies the sandbox and immediately exec()s into the target command.
 
 ## Next Steps
 
-- [macOS Seatbelt](seatbelt.md) - How nono uses Seatbelt on macOS
-- [Linux Landlock](landlock.md) - How nono uses Landlock on Linux
-- [Why OS-Level Controls](vs-application.md) - Why kernel enforcement beats application-level controls
+- [macOS Seatbelt](/cli/security/seatbelt) - How nono uses Seatbelt on macOS
+- [Linux Landlock](/cli/security/landlock) - How nono uses Landlock on Linux
+- [Why OS-Level Controls](/cli/security/application) - Why kernel enforcement beats application-level controls

--- a/docs/cli/security/profiles.mdx
+++ b/docs/cli/security/profiles.mdx
@@ -97,7 +97,7 @@ To use secrets from a profile, add the `--secrets` flag:
 nono run --profile my-agent --secrets -- my-command
 ```
 
-See [Secrets Management](/usage/secrets) for details on storing secrets in the keystore.
+See [Secrets Management](/cli/usage/secrets) for details on storing secrets in the keystore.
 
 ### Hooks Section
 
@@ -210,7 +210,7 @@ script = "nono-hook.sh"
 - `interactive = true` preserves TTY for Claude's terminal UI
 - Hooks auto-install to `~/.claude/hooks/` for sandbox-aware error handling
 
-See [Claude Code client guide](/clients/claude-code) for full details.
+See [Claude Code client guide](/cli/clients/claude-code) for full details.
 
 ---
 

--- a/docs/cli/security/seatbelt.mdx
+++ b/docs/cli/security/seatbelt.mdx
@@ -211,6 +211,6 @@ Some macOS security features interact with code signing. Building nono from sour
 ## References
 
 - [Apple Sandbox Design Guide](https://developer.apple.com/library/archive/documentation/Security/Conceptual/AppSandboxDesignGuide/)
-- [sandbox_init man page](https://developer.apple.com/library/archive/documentation/Darwin/Reference/ManPages/man3/sandbox_init.3.html)
+- [sandbox_init man page](https://keith.github.io/xcode-man-pages/sandbox_init.3.html)
 - [XNU source code](https://github.com/apple-oss-distributions/xnu)
 - [Apple Sandbox Guide (reverse engineering)](https://reverse.put.as/wp-content/uploads/2011/09/Apple-Sandbox-Guide-v1.0.pdf)

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -252,7 +252,7 @@ Secrets are:
 - Auto-named by uppercasing: `openai_api_key` becomes `$OPENAI_API_KEY`
 - Zeroized from memory after `exec()`
 
-See [Secrets Management](secrets.md) for full documentation on storing and using secrets.
+See [Secrets Management](/cli/usage/secrets) for full documentation on storing and using secrets.
 
 ### Profile Options
 
@@ -486,4 +486,4 @@ nono run \
 
 ## Examples
 
-See the [Examples](examples.md) page for common usage patterns.
+See the [Examples](/cli/usage/examples) page for common usage patterns.

--- a/docs/cli/usage/index.mdx
+++ b/docs/cli/usage/index.mdx
@@ -176,7 +176,7 @@ nono run --allow . --secrets openai_api_key -- my-agent
 
 Secrets are loaded **before** the sandbox is applied, so the sandboxed process cannot access the keystore directly - only the specific secrets you authorize.
 
-See [Secrets Management](secrets.md) for full documentation.
+See [Secrets Management](/cli/usage/secrets) for full documentation.
 
 ## Sensitive Paths
 
@@ -193,6 +193,6 @@ Use `nono why --path <path> --op read` to check if a specific path is blocked an
 
 ## Next Steps
 
-- [CLI Reference](flags.md) - Complete flag documentation
-- [Secrets Management](secrets.md) - Secure API key loading from system keystore
-- [Examples](examples.md) - Common usage patterns
+- [CLI Reference](/cli/usage/flags) - Complete flag documentation
+- [Secrets Management](/cli/usage/secrets) - Secure API key loading from system keystore
+- [Examples](/cli/usage/examples) - Common usage patterns

--- a/docs/cli/usage/secrets.mdx
+++ b/docs/cli/usage/secrets.mdx
@@ -494,5 +494,5 @@ systemctl --user start gnome-keyring
 
 ## Next Steps
 
-- [CLI Reference](/usage/flags) - Complete flag documentation
-- [Profiles](/security/profiles) - Profile system overview
+- [CLI Reference](/cli/usage/flags) - Complete flag documentation
+- [Profiles](/cli/security/profiles) - Profile system overview


### PR DESCRIPTION
## Summary
- Fix all internal doc links across 12 files under `docs/cli/`
- Fix `.md`/`.mdx` extensions to extensionless paths (Mintlify convention)
- Add `/cli/` prefix to all internal links for nested docs structure
- Fix stale `vs-application`/`vs-containers` references to match actual filenames
- Replace dead Apple sandbox_init man page URL with Keith Ammon mirror

## Files changed
- `docs/cli/getting_started/installation.mdx`
- `docs/cli/security/index.mdx`
- `docs/cli/security/containers.mdx`
- `docs/cli/security/seatbelt.mdx`
- `docs/cli/security/profiles.mdx`
- `docs/cli/usage/flags.mdx`
- `docs/cli/usage/index.mdx`
- `docs/cli/usage/secrets.mdx`
- `docs/cli/clients/quickstart.mdx`
- `docs/cli/clients/claude-code.mdx`
- `docs/cli/clients/opencode.mdx`
- `docs/cli/clients/openclaw.mdx`

## Test plan
- [x] Verified no remaining `.md`/`.mdx` extension references in link targets
- [x] Verified no remaining links missing `/cli/` prefix
- [x] Verified no stale `vs-application`/`vs-containers` references
- [x] Tested locally with `mintlify dev`