### PR TITLE
docs: replace --allow . with --allow-cwd in run/shell examples

### DIFF
--- a/crates/nono-cli/README.md
+++ b/crates/nono-cli/README.md
@@ -44,7 +44,7 @@ nono run --allow-cwd --net-block -- command
 nono run --profile claude-code -- claude
 
 # Start an interactive shell inside the sandbox
-nono shell --allow .
+nono shell --allow-cwd
 
 # Check why a path would be blocked
 nono why --path ~/.ssh/id_rsa --op read


### PR DESCRIPTION
## Summary

Partial fix for #121

Replaces `--allow .` with `--allow-cwd` in the nono-cli README (`nono shell` example).

### Scope limitation

`--allow-cwd` defaults to **read-only** access when no profile is specified (see `main.rs:795`), whereas `--allow .` grants **read+write**. Because of this semantic difference, most docs and CLI help examples are left unchanged — replacing them would silently downgrade access in the examples.

A broader replacement across all docs/CLI help text should be revisited once there's a decision on whether `--allow-cwd` should default to read+write without a profile, or whether the examples should use `--allow-cwd` with an explicit profile.

### What's not changed (and why)

- **CLI help text** (`cli.rs`) — examples show `--allow .` for read+write CWD access, which `--allow-cwd` alone wouldn't provide
- **`nono why` examples** — `why` doesn't support `--allow-cwd`; it uses `--allow .` for capability context simulation
- **`--allow ./path`** — specific subdirectories, not CWD references
- **Unit tests** — test `--allow` flag parsing

## Files changed

- `crates/nono-cli/README.md` — `nono shell --allow .` → `nono shell --allow-cwd`

## Test plan

- [x] `cargo build` succeeds
- [x] Change is docs-only (README), no functional impact