### PR TITLE
Fix broken internal doc links across CLI docs

### DIFF
--- a/docs/cli/clients/claude-code.mdx
+++ b/docs/cli/clients/claude-code.mdx
@@ -90,7 +90,7 @@ Then run with secrets:
 nono run --profile claude-code --secrets anthropic_api_key -- claude
 ```
 
-See [Secrets Management](/cli/usage/secrets) for full documentation.
+See [Secrets Management](/cli/features/secrets) for full documentation.
 
 ### Restrict to Specific Projects
 
@@ -197,7 +197,7 @@ nono run --profile claude-code --allow ~/other-project -- claude
 nono run --profile claude-code --net-block -- claude
 ```
 
-See [Security Profiles](/cli/security/profiles) for details on profile format and precedence rules.
+See [Security Profiles](/cli/features/profiles-groups) for details on profile format and precedence rules.
 
 ## Automatic Hook Integration
 

--- a/docs/cli/clients/openclaw.mdx
+++ b/docs/cli/clients/openclaw.mdx
@@ -68,7 +68,7 @@ nono run --profile openclaw-strict --secrets -- openclaw gateway
 Custom profiles override built-in profiles of the same name. If you create `~/.config/nono/profiles/openclaw.toml`, it will be used instead of the built-in.
 </Note>
 
-See [Security Profiles](/cli/security/profiles) for the full profile format reference.
+See [Security Profiles](/cli/features/profiles-groups) for the full profile format reference.
 
 ## Security Tips
 
@@ -120,7 +120,7 @@ The secrets are loaded from the keystore and injected as `$TELEGRAM_BOT_TOKEN` a
 Secrets are loaded **before** the sandbox is applied, then zeroized from nono's memory after `exec()`. The sandboxed process cannot access the keystore directly - it only receives the specific secrets you authorized.
 </Note>
 
-See [Secrets Management](/cli/usage/secrets) for complete documentation on storing and managing secrets.
+See [Secrets Management](/cli/features/secrets) for complete documentation on storing and managing secrets.
 
 ### Limit Agent Filesystem Access
 
@@ -231,4 +231,4 @@ docker run -v $(pwd):/work my-openclaw-image \
   nono run --profile openclaw -- openclaw gateway
 ```
 
-See [nono vs Containers](/cli/security/containers) for a detailed comparison.
+See [nono vs Containers](/cli/internals/containers) for a detailed comparison.

--- a/docs/cli/clients/opencode.mdx
+++ b/docs/cli/clients/opencode.mdx
@@ -83,7 +83,7 @@ Then run:
 nono run --profile opencode --secrets openai_api_key -- opencode
 ```
 
-See [Secrets Management](/cli/usage/secrets) for full documentation.
+See [Secrets Management](/cli/features/secrets) for full documentation.
 
 ### Read-Only Mode
 
@@ -111,4 +111,4 @@ nono run --profile opencode --allow ~/shared-libs -- opencode
 nono run --profile opencode --net-block -- opencode
 ```
 
-See [Security Profiles](/cli/security/profiles) for details on profile format and precedence rules.
+See [Security Profiles](/cli/features/profiles-groups) for details on profile format and precedence rules.

--- a/docs/cli/clients/quickstart.mdx
+++ b/docs/cli/clients/quickstart.mdx
@@ -42,7 +42,7 @@ nono is agent-agnostic. If your tool isn't listed here, you can run it directly 
 nono run --allow-cwd -- my-agent
 ```
 
-Or create a custom profile. See [Security Profiles](/cli/security/profiles) for the profile format and how to create your own.
+Or create a custom profile. See [Security Profiles](/cli/features/profiles-groups) for the profile format and how to create your own.
 
 ## What the Sandbox Does
 
@@ -54,4 +54,4 @@ When you run a client through nono:
 4. All child processes inherit the same restrictions
 5. The sandbox cannot be escaped or expanded at runtime
 
-See [Security Model](/cli/security) for full details.
+See [Security Model](/cli/internals/security-model) for full details.

--- a/docs/cli/development/index.mdx
+++ b/docs/cli/development/index.mdx
@@ -8,7 +8,7 @@ This section covers development topics for contributors and maintainers of nono.
 ## Topics
 
 <CardGroup cols={2}>
-  <Card title="Testing" icon="vial" href="/development/testing">
+  <Card title="Testing" icon="vial" href="/cli/development/testing">
     Integration test suites, running tests locally, and CI pipeline
   </Card>
 </CardGroup>

--- a/docs/cli/getting_started/installation.mdx
+++ b/docs/cli/getting_started/installation.mdx
@@ -20,7 +20,7 @@ We are in the process of packaging nono for popular Linux distributions. In the 
 
 ## Building from Source
 
-See the [Development Guide](/cli/development) for instructions on building nono from source.
+See the [Development Guide](/cli/development/index) for instructions on building nono from source.
 
 ## Platform Support
 

--- a/docs/cli/internals/containers.mdx
+++ b/docs/cli/internals/containers.mdx
@@ -256,6 +256,6 @@ Do you need a different OS or runtime?
 
 ## Next Steps
 
-- [Security Model](index.mdx) - Understanding nono's guarantees
-- [Profiles](/security/profiles) - Pre-configured sandboxes for common agents
-- [Installation](/getting_started/installation) - Get started with nono
+- [Security Model](/cli/internals/index) - Understanding nono's guarantees
+- [Profiles](/cli/features/profiles-groups) - Pre-configured sandboxes for common agents
+- [Installation](/cli/getting_started/installation) - Get started with nono

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -256,7 +256,7 @@ Secrets are:
 - Auto-named by uppercasing: `openai_api_key` becomes `$OPENAI_API_KEY`
 - Zeroized from memory after `exec()`
 
-See [Secrets Management](/cli/usage/secrets) for full documentation on storing and using secrets.
+See [Secrets Management](/cli/features/secrets) for full documentation on storing and using secrets.
 
 ### Profile Options
 


### PR DESCRIPTION
## Summary

Several CLI doc pages contained hrefs using old paths (`/cli/security/*`, `/cli/usage/secrets`) that no longer exist after the CLI section was reorganized to use `cli/internals/*` and `cli/features/*`.

- `/cli/usage/secrets` → `/cli/features/secrets` (claude-code, openclaw, opencode, flags)
- `/cli/security/profiles` → `/cli/features/profiles-groups` (claude-code, openclaw, opencode, clients/quickstart)
- `/cli/security/containers` → `/cli/internals/containers` (openclaw)
- `/cli/security` → `/cli/internals/security-model` (clients/quickstart)
- `/development/testing` → `/cli/development/testing` (development/index — missing `cli/` prefix)
- `/cli/development` → `/cli/development/index` (installation)
- `index.mdx`, `/security/profiles`, `/getting_started/installation` → proper absolute paths (internals/containers)

## Test plan

- [ ] Verify all "See also" links in client pages resolve correctly
- [ ] Verify the "Testing" card in development/index resolves correctly
- [ ] Verify "Next Steps" links at bottom of containers.mdx resolve correctly