### PR TITLE
fix(nono): correct file type check to enable character devices

### DIFF
--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -138,7 +138,7 @@ impl FsCapability {
         })?;
 
         // Verify type on the already-resolved path (no TOCTOU: same inode)
-        if !resolved.is_file() {
+        if resolved.is_dir() {
             return Err(NonoError::ExpectedFile(path.to_path_buf()));
         }
 


### PR DESCRIPTION
Fixes #137

Allows character devices to be used with `--allow-file` (previously unable to be used in either `allow-file` or `allow`). Landlock correctly sandboxes them, it's just that the rust precheck was overeager.