### PR TITLE
feat(learn): add macOS learn mode via Seatbelt report-mode

### DIFF
--- a/crates/nono-cli/Cargo.toml
+++ b/crates/nono-cli/Cargo.toml
@@ -58,6 +58,7 @@ keyring = { version = "3", features = ["sync-secret-service"] }
 [target.'cfg(target_os = "macos")'.dependencies]
 nix = { version = "0.31", features = ["process", "signal", "fs", "user"] }
 keyring = { version = "3", features = ["apple-native"] }
+dns-lookup = "2"
 
 [build-dependencies]
 toml = "1.0"

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -24,7 +24,7 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
-    /// Trace a command to discover required filesystem paths (Linux only)
+    /// Trace a command to discover required filesystem paths
     #[command(trailing_var_arg = true)]
     #[command(after_help = "EXAMPLES:
     # Discover paths needed by a command

--- a/crates/nono-cli/src/learn/linux.rs
+++ b/crates/nono-cli/src/learn/linux.rs
@@ -1,228 +1,23 @@
-//! Learn mode: trace file accesses to discover required paths
-//!
-//! Uses strace to monitor a command's file system accesses and produces
-//! a list of paths that would need to be allowed in a nono profile.
+//! Linux learn mode implementation using strace
 
+use super::{FileAccess, NetworkAccess, NetworkAccessKind};
 use crate::cli::LearnArgs;
+use crate::profile;
 use nono::{NonoError, Result};
-use std::collections::BTreeSet;
-use std::net::IpAddr;
-use std::path::PathBuf;
-
-#[cfg(target_os = "linux")]
-use crate::profile::{self, Profile};
-#[cfg(target_os = "linux")]
-use std::collections::{HashMap, HashSet};
-#[cfg(target_os = "linux")]
+use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
-#[cfg(target_os = "linux")]
-use std::path::Path;
-#[cfg(target_os = "linux")]
 use std::process::{Command, Stdio};
-#[cfg(target_os = "linux")]
 use tracing::{debug, info, warn};
 
-/// Result of learning file access patterns
-#[derive(Debug)]
-pub struct LearnResult {
-    /// Paths that need read access
-    pub read_paths: BTreeSet<PathBuf>,
-    /// Paths that need write access
-    pub write_paths: BTreeSet<PathBuf>,
-    /// Paths that need read+write access
-    pub readwrite_paths: BTreeSet<PathBuf>,
-    /// Paths that were accessed but are already covered by system paths
-    pub system_covered: BTreeSet<PathBuf>,
-    /// Paths that were accessed but are already covered by profile
-    pub profile_covered: BTreeSet<PathBuf>,
-    /// Outbound network connections observed
-    pub outbound_connections: Vec<NetworkConnectionSummary>,
-    /// Listening ports observed
-    pub listening_ports: Vec<NetworkConnectionSummary>,
-}
-
-impl LearnResult {
-    #[cfg(target_os = "linux")]
-    fn new() -> Self {
-        Self {
-            read_paths: BTreeSet::new(),
-            write_paths: BTreeSet::new(),
-            readwrite_paths: BTreeSet::new(),
-            system_covered: BTreeSet::new(),
-            profile_covered: BTreeSet::new(),
-            outbound_connections: Vec::new(),
-            listening_ports: Vec::new(),
-        }
-    }
-
-    /// Check if any paths were discovered
-    pub fn has_paths(&self) -> bool {
-        !self.read_paths.is_empty()
-            || !self.write_paths.is_empty()
-            || !self.readwrite_paths.is_empty()
-    }
-
-    /// Check if any network activity was observed
-    pub fn has_network_activity(&self) -> bool {
-        !self.outbound_connections.is_empty() || !self.listening_ports.is_empty()
-    }
-
-    /// Format as JSON fragment for profile
-    pub fn to_json(&self) -> String {
-        let allow: Vec<String> = self
-            .readwrite_paths
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect();
-        let read: Vec<String> = self
-            .read_paths
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect();
-        let write: Vec<String> = self
-            .write_paths
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect();
-
-        let outbound: Vec<serde_json::Value> = self
-            .outbound_connections
-            .iter()
-            .map(|c| {
-                let mut obj = serde_json::json!({
-                    "addr": c.endpoint.addr.to_string(),
-                    "port": c.endpoint.port,
-                    "count": c.count,
-                });
-                if let Some(ref hostname) = c.endpoint.hostname {
-                    obj["hostname"] = serde_json::Value::String(hostname.clone());
-                }
-                obj
-            })
-            .collect();
-
-        let listening: Vec<serde_json::Value> = self
-            .listening_ports
-            .iter()
-            .map(|c| {
-                let mut obj = serde_json::json!({
-                    "addr": c.endpoint.addr.to_string(),
-                    "port": c.endpoint.port,
-                    "count": c.count,
-                });
-                if let Some(ref hostname) = c.endpoint.hostname {
-                    obj["hostname"] = serde_json::Value::String(hostname.clone());
-                }
-                obj
-            })
-            .collect();
-
-        let fragment = serde_json::json!({
-            "filesystem": {
-                "allow": allow,
-                "read": read,
-                "write": write
-            },
-            "network": {
-                "outbound": outbound,
-                "listening": listening
-            }
-        });
-
-        serde_json::to_string_pretty(&fragment).unwrap_or_else(|_| "{}".to_string())
-    }
-
-    /// Format as human-readable summary
-    pub fn to_summary(&self) -> String {
-        let mut lines = Vec::new();
-
-        if !self.read_paths.is_empty() {
-            lines.push("Read access needed:".to_string());
-            for path in &self.read_paths {
-                lines.push(format!("  {}", path.display()));
-            }
-        }
-
-        if !self.write_paths.is_empty() {
-            lines.push("Write access needed:".to_string());
-            for path in &self.write_paths {
-                lines.push(format!("  {}", path.display()));
-            }
-        }
-
-        if !self.readwrite_paths.is_empty() {
-            lines.push("Read+Write access needed:".to_string());
-            for path in &self.readwrite_paths {
-                lines.push(format!("  {}", path.display()));
-            }
-        }
-
-        if !self.system_covered.is_empty() {
-            lines.push(format!(
-                "\n({} paths already covered by system defaults)",
-                self.system_covered.len()
-            ));
-        }
-
-        if !self.profile_covered.is_empty() {
-            lines.push(format!(
-                "({} paths already covered by profile)",
-                self.profile_covered.len()
-            ));
-        }
-
-        // Network sections
-        if !self.outbound_connections.is_empty() {
-            if !lines.is_empty() {
-                lines.push(String::new());
-            }
-            lines.push("Outbound connections:".to_string());
-            for conn in &self.outbound_connections {
-                lines.push(format_network_summary(conn));
-            }
-        }
-
-        if !self.listening_ports.is_empty() {
-            if !lines.is_empty() {
-                lines.push(String::new());
-            }
-            lines.push("Listening ports:".to_string());
-            for conn in &self.listening_ports {
-                lines.push(format_network_summary(conn));
-            }
-        }
-
-        if lines.is_empty() {
-            lines.push("No additional paths needed.".to_string());
-        }
-
-        lines.join("\n")
-    }
-}
-
-/// Format a single network connection summary line
-fn format_network_summary(conn: &NetworkConnectionSummary) -> String {
-    let count_str = if conn.count > 1 {
-        format!(" ({}x)", conn.count)
-    } else {
-        String::new()
-    };
-
-    if let Some(ref hostname) = conn.endpoint.hostname {
-        format!(
-            "  {} ({}):{}{}",
-            hostname, conn.endpoint.addr, conn.endpoint.port, count_str
-        )
-    } else {
-        format!(
-            "  {}:{}{}",
-            conn.endpoint.addr, conn.endpoint.port, count_str
-        )
-    }
+/// Unified type for parsed strace accesses
+#[derive(Debug, Clone)]
+enum TracedAccess {
+    File(FileAccess),
+    Network(NetworkAccess),
+    DnsQuery(String),
 }
 
 /// Check if strace is available
-#[cfg(target_os = "linux")]
 fn check_strace() -> Result<()> {
     match Command::new("strace").arg("--version").output() {
         Ok(output) if output.status.success() => Ok(()),
@@ -232,17 +27,8 @@ fn check_strace() -> Result<()> {
     }
 }
 
-/// Run learn mode (non-Linux stub)
-#[cfg(not(target_os = "linux"))]
-pub fn run_learn(_args: &LearnArgs) -> Result<LearnResult> {
-    Err(NonoError::LearnError(
-        "nono learn is only available on Linux (requires strace)".to_string(),
-    ))
-}
-
 /// Run learn mode (Linux implementation)
-#[cfg(target_os = "linux")]
-pub fn run_learn(args: &LearnArgs) -> Result<LearnResult> {
+pub fn run_learn(args: &LearnArgs) -> Result<super::LearnResult> {
     check_strace()?;
 
     // Load profile if specified
@@ -257,70 +43,18 @@ pub fn run_learn(args: &LearnArgs) -> Result<LearnResult> {
         run_strace(&args.command, args.timeout)?;
 
     // Process and categorize file paths
-    let mut result = process_accesses(raw_file_accesses, profile.as_ref(), args.all)?;
+    let mut result = super::process_accesses(raw_file_accesses, profile.as_ref(), args.all)?;
 
     // Process network accesses with forward DNS correlation
     let (outbound, listening) =
-        process_network_accesses(raw_network_accesses, dns_queries, !args.no_rdns);
+        super::process_network_accesses(raw_network_accesses, dns_queries, !args.no_rdns);
     result.outbound_connections = outbound;
     result.listening_ports = listening;
 
     Ok(result)
 }
 
-/// Represents a file access from strace
-#[cfg(target_os = "linux")]
-#[derive(Debug, Clone)]
-struct FileAccess {
-    path: PathBuf,
-    is_write: bool,
-}
-
-/// Kind of network access observed via strace
-#[cfg(target_os = "linux")]
-#[derive(Debug, Clone)]
-enum NetworkAccessKind {
-    Connect,
-    Bind,
-}
-
-/// A single network access observed via strace
-#[cfg(target_os = "linux")]
-#[derive(Debug, Clone)]
-struct NetworkAccess {
-    addr: IpAddr,
-    port: u16,
-    kind: NetworkAccessKind,
-    /// Hostname from the most recent DNS query (timing-based correlation)
-    queried_hostname: Option<String>,
-}
-
-/// A resolved network endpoint with optional reverse DNS hostname
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct NetworkEndpoint {
-    pub addr: IpAddr,
-    pub port: u16,
-    pub hostname: Option<String>,
-}
-
-/// Summary of connections to a single endpoint (with count)
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct NetworkConnectionSummary {
-    pub endpoint: NetworkEndpoint,
-    pub count: usize,
-}
-
-/// Unified type for parsed strace accesses
-#[cfg(target_os = "linux")]
-#[derive(Debug, Clone)]
-enum TracedAccess {
-    File(FileAccess),
-    Network(NetworkAccess),
-    DnsQuery(String),
-}
-
 /// Run strace on the command and collect file accesses, network accesses, and DNS queries
-#[cfg(target_os = "linux")]
 fn run_strace(
     command: &[String],
     timeout: Option<u64>,
@@ -431,7 +165,6 @@ fn run_strace(
 ///
 /// strace prefixes multi-process lines with `[pid NNNNN] `. Returns None
 /// for single-process traces (no prefix).
-#[cfg(target_os = "linux")]
 fn extract_strace_pid(line: &str) -> Option<u32> {
     let trimmed = line.trim_start();
     let rest = trimmed.strip_prefix("[pid ")?;
@@ -440,7 +173,6 @@ fn extract_strace_pid(line: &str) -> Option<u32> {
 }
 
 /// Parse a single strace line to extract file or network access
-#[cfg(target_os = "linux")]
 fn parse_strace_line(line: &str) -> Option<TracedAccess> {
     // strace output format examples:
     // openat(AT_FDCWD, "/etc/passwd", O_RDONLY|O_CLOEXEC) = 3
@@ -501,13 +233,12 @@ fn parse_strace_line(line: &str) -> Option<TracedAccess> {
     }
 
     Some(TracedAccess::File(FileAccess {
-        path: PathBuf::from(path),
+        path: std::path::PathBuf::from(path),
         is_write,
     }))
 }
 
 /// Extract path from strace syscall line
-#[cfg(target_os = "linux")]
 fn extract_path_from_syscall(line: &str, syscall: &str) -> Option<String> {
     // Find the opening paren after syscall
     let start_idx = line.find(&format!("{}(", syscall))?;
@@ -547,7 +278,6 @@ fn extract_path_from_syscall(line: &str, syscall: &str) -> Option<String> {
 ///
 /// Invalid or incomplete escape sequences are passed through literally
 /// to avoid data loss.
-#[cfg(target_os = "linux")]
 fn unescape_strace_string(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
     let mut chars = s.chars().peekable();
@@ -634,7 +364,6 @@ fn unescape_strace_string(s: &str) -> String {
 }
 
 /// Determine if a syscall represents a write access
-#[cfg(target_os = "linux")]
 fn is_write_access(line: &str, syscall: &str) -> bool {
     match syscall {
         "creat" | "mkdir" | "unlink" | "rename" => true,
@@ -649,155 +378,7 @@ fn is_write_access(line: &str, syscall: &str) -> bool {
     }
 }
 
-/// Process raw accesses into categorized result
-#[cfg(target_os = "linux")]
-fn process_accesses(
-    accesses: Vec<FileAccess>,
-    profile: Option<&Profile>,
-    show_all: bool,
-) -> Result<LearnResult> {
-    let mut result = LearnResult::new();
-
-    // Get system paths that are already allowed (from policy.json groups)
-    let loaded_policy = crate::policy::load_embedded_policy()?;
-    let system_read_paths = crate::policy::get_system_read_paths(&loaded_policy);
-    let system_read_set: HashSet<&str> = system_read_paths.iter().map(|s| s.as_str()).collect();
-
-    // Get profile paths if available
-    let profile_paths: HashSet<String> = if let Some(prof) = profile {
-        let mut paths = HashSet::new();
-        paths.extend(prof.filesystem.allow.iter().cloned());
-        paths.extend(prof.filesystem.read.iter().cloned());
-        paths.extend(prof.filesystem.write.iter().cloned());
-        paths
-    } else {
-        HashSet::new()
-    };
-
-    // Track unique paths (canonicalized where possible)
-    let mut seen_paths: HashSet<PathBuf> = HashSet::new();
-
-    for access in accesses {
-        // Try to canonicalize, fall back to original
-        let canonical = access.path.canonicalize().unwrap_or(access.path.clone());
-
-        // Skip if we've seen this path
-        if seen_paths.contains(&canonical) {
-            continue;
-        }
-        seen_paths.insert(canonical.clone());
-
-        // Check if covered by system paths
-        if is_covered_by_set(&canonical, &system_read_set)? {
-            if show_all {
-                result.system_covered.insert(canonical);
-            }
-            continue;
-        }
-
-        // Check if covered by profile
-        if is_covered_by_profile(&canonical, &profile_paths)? {
-            if show_all {
-                result.profile_covered.insert(canonical);
-            }
-            continue;
-        }
-
-        // Categorize by access type
-        // Collapse to parent directories for cleaner output
-        let collapsed = collapse_to_parent(&canonical);
-
-        if access.is_write {
-            // Check if already in read, upgrade to readwrite
-            if result.read_paths.contains(&collapsed) {
-                result.read_paths.remove(&collapsed);
-                result.readwrite_paths.insert(collapsed);
-            } else if !result.readwrite_paths.contains(&collapsed) {
-                result.write_paths.insert(collapsed);
-            }
-        } else {
-            // Read access
-            if result.write_paths.contains(&collapsed) {
-                result.write_paths.remove(&collapsed);
-                result.readwrite_paths.insert(collapsed);
-            } else if !result.readwrite_paths.contains(&collapsed) {
-                result.read_paths.insert(collapsed);
-            }
-        }
-    }
-
-    Ok(result)
-}
-
-/// Check if a path is covered by a set of allowed paths
-#[cfg(target_os = "linux")]
-fn is_covered_by_set(path: &Path, allowed: &HashSet<&str>) -> Result<bool> {
-    for allowed_path in allowed {
-        let allowed_expanded = expand_home(allowed_path)?;
-        if let Ok(allowed_canonical) = std::fs::canonicalize(&allowed_expanded) {
-            if path.starts_with(&allowed_canonical) {
-                return Ok(true);
-            }
-        }
-        // Also check without canonicalization for paths that may not exist
-        let allowed_path_buf = PathBuf::from(&allowed_expanded);
-        if path.starts_with(&allowed_path_buf) {
-            return Ok(true);
-        }
-    }
-    Ok(false)
-}
-
-/// Check if a path is covered by profile paths
-#[cfg(target_os = "linux")]
-fn is_covered_by_profile(path: &Path, profile_paths: &HashSet<String>) -> Result<bool> {
-    for profile_path in profile_paths {
-        let expanded = expand_home(profile_path)?;
-        if let Ok(canonical) = std::fs::canonicalize(&expanded) {
-            if path.starts_with(&canonical) {
-                return Ok(true);
-            }
-        }
-        let path_buf = PathBuf::from(&expanded);
-        if path.starts_with(&path_buf) {
-            return Ok(true);
-        }
-    }
-    Ok(false)
-}
-
-/// Expand ~ to home directory
-#[cfg(target_os = "linux")]
-fn expand_home(path: &str) -> Result<String> {
-    use crate::config;
-
-    if path.starts_with('~') {
-        let home = config::validated_home()?;
-        return Ok(path.replacen('~', &home, 1));
-    }
-    if path.starts_with("$HOME") {
-        let home = config::validated_home()?;
-        return Ok(path.replacen("$HOME", &home, 1));
-    }
-    Ok(path.to_string())
-}
-
-/// Collapse a file path to its parent directory for cleaner output
-#[cfg(target_os = "linux")]
-fn collapse_to_parent(path: &Path) -> PathBuf {
-    // Don't collapse if it's already a directory
-    if path.is_dir() {
-        return path.to_path_buf();
-    }
-
-    // Collapse files to their parent directory
-    path.parent()
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| path.to_path_buf())
-}
-
 /// Extract a substring between a prefix and suffix
-#[cfg(target_os = "linux")]
 fn extract_between<'a>(s: &'a str, prefix: &str, suffix: &str) -> Option<&'a str> {
     let start = s.find(prefix)?;
     let after = &s[start + prefix.len()..];
@@ -806,8 +387,9 @@ fn extract_between<'a>(s: &'a str, prefix: &str, suffix: &str) -> Option<&'a str
 }
 
 /// Parse a network syscall (connect or bind) from strace output
-#[cfg(target_os = "linux")]
 fn parse_network_syscall(line: &str, kind: NetworkAccessKind) -> Option<NetworkAccess> {
+    use std::net::IpAddr;
+
     // Skip Unix domain sockets — local IPC, not network
     if line.contains("sa_family=AF_UNIX") || line.contains("sa_family=AF_LOCAL") {
         return None;
@@ -848,7 +430,6 @@ fn parse_network_syscall(line: &str, kind: NetworkAccessKind) -> Option<NetworkA
 ///
 /// Only processes sendto calls to port 53 (DNS). Extracts the query
 /// hostname from the DNS wire format in the buffer argument.
-#[cfg(target_os = "linux")]
 fn parse_dns_sendto(line: &str) -> Option<String> {
     // Only interested in DNS (port 53)
     if !line.contains("htons(53)") {
@@ -872,7 +453,6 @@ fn parse_dns_sendto(line: &str) -> Option<String> {
 ///
 /// In strace output, quotes inside the buffer are C-escaped as `\"`, so we
 /// must extract and unescape the buffer before parsing the JSON.
-#[cfg(target_os = "linux")]
 fn parse_resolved_sendto(line: &str) -> Option<String> {
     // Quick filter: ResolveHostname is plain ASCII, visible in raw strace output
     if !line.contains("ResolveHostname") {
@@ -910,7 +490,6 @@ fn parse_resolved_sendto(line: &str) -> Option<String> {
 /// For `sendto(fd, "BUFFER", len, ...)`, extracts BUFFER from the second arg.
 /// For `sendmsg(fd, {msg_name=..., msg_iov=[{iov_base="BUFFER", ...}], ...})`,
 /// extracts BUFFER from the iov_base field.
-#[cfg(target_os = "linux")]
 fn extract_sendto_buffer(line: &str) -> Option<String> {
     // Determine where to start looking for the quoted buffer
     let search_start = if let Some(pos) = line.find("iov_base=") {
@@ -948,7 +527,6 @@ fn extract_sendto_buffer(line: &str) -> Option<String> {
 ///
 /// Reuses the char-level unescaping from `unescape_strace_string` and
 /// converts each char back to its byte value (all values are 0–255).
-#[cfg(target_os = "linux")]
 fn unescape_strace_bytes(s: &str) -> Vec<u8> {
     unescape_strace_string(s).chars().map(|c| c as u8).collect()
 }
@@ -958,7 +536,6 @@ fn unescape_strace_bytes(s: &str) -> Vec<u8> {
 /// Expects at least the 12-byte DNS header followed by the question section.
 /// Returns the queried hostname (e.g., "example.com") or None if the data
 /// is malformed or truncated.
-#[cfg(target_os = "linux")]
 fn parse_dns_query_hostname(data: &[u8]) -> Option<String> {
     // Minimum: 12-byte header + at least 1 label byte
     if data.len() < 13 {
@@ -1016,154 +593,11 @@ fn parse_dns_query_hostname(data: &[u8]) -> Option<String> {
     Some(labels.join("."))
 }
 
-/// Process raw network accesses into categorized summaries.
-///
-/// Uses forward DNS correlation from captured DNS queries to map IPs to
-/// hostnames. Falls back to reverse DNS for unmatched IPs when `resolve_dns`
-/// is true.
-#[cfg(target_os = "linux")]
-fn process_network_accesses(
-    accesses: Vec<NetworkAccess>,
-    dns_queries: Vec<String>,
-    resolve_dns: bool,
-) -> (Vec<NetworkConnectionSummary>, Vec<NetworkConnectionSummary>) {
-    let mut connect_counts: HashMap<(IpAddr, u16), usize> = HashMap::new();
-    let mut bind_counts: HashMap<(IpAddr, u16), usize> = HashMap::new();
-
-    for access in &accesses {
-        let key = (access.addr, access.port);
-        match access.kind {
-            NetworkAccessKind::Connect => {
-                *connect_counts.entry(key).or_insert(0) += 1;
-            }
-            NetworkAccessKind::Bind => {
-                *bind_counts.entry(key).or_insert(0) += 1;
-            }
-        }
-    }
-
-    // Build IP → hostname mapping using three strategies (in priority order):
-    // 1. Timing-based: hostname attached directly from preceding DNS query
-    // 2. Forward DNS: resolve captured hostnames to IPs
-    // 3. Reverse DNS: lookup IP → hostname as last resort
-    let hostnames = if resolve_dns {
-        // Strategy 1: Use hostnames attached during tracing (timing correlation)
-        let mut map: HashMap<IpAddr, String> = HashMap::new();
-        for access in &accesses {
-            if let Some(ref hostname) = access.queried_hostname {
-                map.entry(access.addr).or_insert_with(|| hostname.clone());
-            }
-        }
-
-        // Strategy 2: Forward DNS for IPs not covered by timing correlation
-        let all_ips: HashSet<IpAddr> = accesses.iter().map(|a| a.addr).collect();
-        let unresolved_after_timing: HashSet<IpAddr> = all_ips
-            .iter()
-            .filter(|ip| !map.contains_key(ip))
-            .copied()
-            .collect();
-
-        if !unresolved_after_timing.is_empty() && !dns_queries.is_empty() {
-            let forward = resolve_forward_dns(&dns_queries);
-            for (ip, hostname) in forward {
-                map.entry(ip).or_insert(hostname);
-            }
-        }
-
-        // Strategy 3: Reverse DNS for anything still unresolved
-        let unresolved_after_forward: HashSet<IpAddr> = all_ips
-            .iter()
-            .filter(|ip| !map.contains_key(ip))
-            .copied()
-            .collect();
-
-        if !unresolved_after_forward.is_empty() {
-            let reverse = resolve_reverse_dns(&unresolved_after_forward);
-            map.extend(reverse);
-        }
-
-        map
-    } else {
-        HashMap::new()
-    };
-
-    let build_summaries =
-        |counts: &HashMap<(IpAddr, u16), usize>| -> Vec<NetworkConnectionSummary> {
-            let mut summaries: Vec<NetworkConnectionSummary> = counts
-                .iter()
-                .map(|(&(addr, port), &count)| NetworkConnectionSummary {
-                    endpoint: NetworkEndpoint {
-                        addr,
-                        port,
-                        hostname: hostnames.get(&addr).cloned(),
-                    },
-                    count,
-                })
-                .collect();
-            summaries.sort();
-            summaries
-        };
-
-    (
-        build_summaries(&connect_counts),
-        build_summaries(&bind_counts),
-    )
-}
-
-/// Resolve captured DNS query hostnames to IPs via forward DNS lookup.
-///
-/// For each hostname the traced program queried, resolves it to its current
-/// IPs to build an IP→hostname mapping. This gives the actual hostname the
-/// program intended to reach (e.g., "google.com") rather than infrastructure
-/// names from reverse DNS (e.g., "jr-in-f100.1e100.net").
-#[cfg(target_os = "linux")]
-fn resolve_forward_dns(hostnames: &[String]) -> HashMap<IpAddr, String> {
-    let mut result = HashMap::new();
-    let unique: HashSet<&String> = hostnames.iter().collect();
-
-    for hostname in unique {
-        match dns_lookup::lookup_host(hostname) {
-            Ok(ips) => {
-                for ip in ips {
-                    // First hostname to resolve to this IP wins
-                    result.entry(ip).or_insert_with(|| hostname.clone());
-                }
-            }
-            Err(e) => {
-                debug!("Forward DNS lookup failed for {}: {}", hostname, e);
-            }
-        }
-    }
-
-    result
-}
-
-/// Resolve IP addresses to hostnames via reverse DNS (fallback)
-#[cfg(target_os = "linux")]
-fn resolve_reverse_dns(ips: &HashSet<IpAddr>) -> HashMap<IpAddr, String> {
-    let mut result = HashMap::new();
-
-    for &ip in ips {
-        match dns_lookup::lookup_addr(&ip) {
-            Ok(hostname) => {
-                // Skip if the hostname is just the IP address stringified
-                if hostname != ip.to_string() {
-                    result.insert(ip, hostname);
-                }
-            }
-            Err(e) => {
-                debug!("Reverse DNS lookup failed for {}: {}", ip, e);
-            }
-        }
-    }
-
-    result
-}
-
-#[cfg(all(test, target_os = "linux"))]
+#[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     /// Helper to extract FileAccess from TracedAccess
     fn expect_file_access(traced: Option<TracedAccess>) -> FileAccess {
@@ -1230,48 +664,6 @@ mod tests {
         assert!(!is_write_access("openat(..., O_RDONLY, ...)", "openat"));
         assert!(is_write_access("creat(...)", "creat"));
         assert!(is_write_access("mkdir(...)", "mkdir"));
-    }
-
-    #[test]
-    fn test_expand_home() {
-        // Save original HOME to restore after test (avoid polluting other parallel tests)
-        let original_home = std::env::var("HOME").ok();
-
-        std::env::set_var("HOME", "/home/test");
-        assert_eq!(expand_home("~/foo").expect("valid home"), "/home/test/foo");
-        assert_eq!(
-            expand_home("$HOME/bar").expect("valid home"),
-            "/home/test/bar"
-        );
-        assert_eq!(
-            expand_home("/absolute/path").expect("no expansion needed"),
-            "/absolute/path"
-        );
-
-        // Restore original HOME
-        if let Some(home) = original_home {
-            std::env::set_var("HOME", home);
-        }
-    }
-
-    #[test]
-    fn test_collapse_to_parent() {
-        // For a file that doesn't exist, collapse to parent
-        let path = PathBuf::from("/some/dir/file.txt");
-        let collapsed = collapse_to_parent(&path);
-        assert_eq!(collapsed, PathBuf::from("/some/dir"));
-    }
-
-    #[test]
-    fn test_learn_result_to_json() {
-        let mut result = LearnResult::new();
-        result.read_paths.insert(PathBuf::from("/some/read/path"));
-        result.write_paths.insert(PathBuf::from("/some/write/path"));
-
-        let json = result.to_json();
-        assert!(json.contains("filesystem"));
-        assert!(json.contains("/some/read/path"));
-        assert!(json.contains("/some/write/path"));
     }
 
     #[test]
@@ -1342,6 +734,7 @@ mod tests {
 
     #[test]
     fn test_parse_connect_ipv4() {
+        use std::net::IpAddr;
         let line = r#"connect(3, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("93.184.216.34")}, 16) = 0"#;
         let access = expect_network_access(parse_strace_line(line));
         assert_eq!(access.addr, "93.184.216.34".parse::<IpAddr>().unwrap());
@@ -1351,6 +744,7 @@ mod tests {
 
     #[test]
     fn test_parse_connect_ipv6() {
+        use std::net::IpAddr;
         let line = r#"connect(3, {sa_family=AF_INET6, sin6_port=htons(443), sin6_flowinfo=htonl(0), inet_pton(AF_INET6, "2606:2800:220:1:248:1893:25c8:1946"), sin6_scope_id=0}, 28) = 0"#;
         let access = expect_network_access(parse_strace_line(line));
         assert_eq!(
@@ -1372,6 +766,7 @@ mod tests {
 
     #[test]
     fn test_parse_bind_ipv4() {
+        use std::net::IpAddr;
         let line = r#"bind(4, {sa_family=AF_INET, sin_port=htons(8080), sin_addr=inet_addr("0.0.0.0")}, 16) = 0"#;
         let access = expect_network_access(parse_strace_line(line));
         assert_eq!(access.addr, "0.0.0.0".parse::<IpAddr>().unwrap());
@@ -1381,6 +776,7 @@ mod tests {
 
     #[test]
     fn test_parse_bind_ipv6() {
+        use std::net::IpAddr;
         let line = r#"bind(4, {sa_family=AF_INET6, sin6_port=htons(3000), sin6_flowinfo=htonl(0), inet_pton(AF_INET6, "::"), sin6_scope_id=0}, 28) = 0"#;
         let access = expect_network_access(parse_strace_line(line));
         assert_eq!(access.addr, "::".parse::<IpAddr>().unwrap());
@@ -1390,6 +786,7 @@ mod tests {
 
     #[test]
     fn test_parse_connect_failed() {
+        use std::net::IpAddr;
         // Failed connections should still be captured — they reveal intent
         let line = r#"connect(3, {sa_family=AF_INET, sin_port=htons(80), sin_addr=inet_addr("10.0.0.1")}, 16) = -1 ECONNREFUSED (Connection refused)"#;
         let access = expect_network_access(parse_strace_line(line));
@@ -1428,123 +825,6 @@ mod tests {
     }
 
     #[test]
-    fn test_network_dedup() {
-        // Duplicate endpoints should be merged with count
-        let accesses = vec![
-            NetworkAccess {
-                addr: "93.184.216.34".parse().unwrap(),
-                port: 443,
-                kind: NetworkAccessKind::Connect,
-                queried_hostname: None,
-            },
-            NetworkAccess {
-                addr: "93.184.216.34".parse().unwrap(),
-                port: 443,
-                kind: NetworkAccessKind::Connect,
-                queried_hostname: None,
-            },
-            NetworkAccess {
-                addr: "93.184.216.34".parse().unwrap(),
-                port: 443,
-                kind: NetworkAccessKind::Connect,
-                queried_hostname: None,
-            },
-        ];
-
-        let (outbound, listening) = process_network_accesses(accesses, vec![], false);
-        assert_eq!(outbound.len(), 1);
-        assert_eq!(outbound[0].count, 3);
-        assert!(listening.is_empty());
-    }
-
-    #[test]
-    fn test_learn_result_network_json() {
-        let mut result = LearnResult::new();
-        result.outbound_connections.push(NetworkConnectionSummary {
-            endpoint: NetworkEndpoint {
-                addr: "93.184.216.34".parse().unwrap(),
-                port: 443,
-                hostname: Some("example.com".to_string()),
-            },
-            count: 5,
-        });
-        result.listening_ports.push(NetworkConnectionSummary {
-            endpoint: NetworkEndpoint {
-                addr: "0.0.0.0".parse().unwrap(),
-                port: 3000,
-                hostname: None,
-            },
-            count: 1,
-        });
-
-        let json = result.to_json();
-        assert!(json.contains("\"network\""));
-        assert!(json.contains("\"outbound\""));
-        assert!(json.contains("\"listening\""));
-        assert!(json.contains("93.184.216.34"));
-        assert!(json.contains("443"));
-        assert!(json.contains("example.com"));
-        assert!(json.contains("0.0.0.0"));
-        assert!(json.contains("3000"));
-    }
-
-    #[test]
-    fn test_learn_result_network_summary() {
-        let mut result = LearnResult::new();
-        result.outbound_connections.push(NetworkConnectionSummary {
-            endpoint: NetworkEndpoint {
-                addr: "93.184.216.34".parse().unwrap(),
-                port: 443,
-                hostname: Some("example.com".to_string()),
-            },
-            count: 12,
-        });
-        result.listening_ports.push(NetworkConnectionSummary {
-            endpoint: NetworkEndpoint {
-                addr: "0.0.0.0".parse().unwrap(),
-                port: 3000,
-                hostname: None,
-            },
-            count: 1,
-        });
-
-        let summary = result.to_summary();
-        assert!(summary.contains("Outbound connections:"));
-        assert!(summary.contains("example.com (93.184.216.34):443 (12x)"));
-        assert!(summary.contains("Listening ports:"));
-        assert!(summary.contains("0.0.0.0:3000"));
-        // Count of 1 should NOT show "(1x)"
-        assert!(!summary.contains("(1x)"));
-    }
-
-    #[test]
-    fn test_has_network_activity() {
-        let mut result = LearnResult::new();
-        assert!(!result.has_network_activity());
-
-        result.outbound_connections.push(NetworkConnectionSummary {
-            endpoint: NetworkEndpoint {
-                addr: "10.0.0.1".parse().unwrap(),
-                port: 80,
-                hostname: None,
-            },
-            count: 1,
-        });
-        assert!(result.has_network_activity());
-
-        let mut result2 = LearnResult::new();
-        result2.listening_ports.push(NetworkConnectionSummary {
-            endpoint: NetworkEndpoint {
-                addr: "0.0.0.0".parse().unwrap(),
-                port: 8080,
-                hostname: None,
-            },
-            count: 1,
-        });
-        assert!(result2.has_network_activity());
-    }
-
-    #[test]
     fn test_extract_between() {
         assert_eq!(extract_between("htons(443)", "htons(", ")"), Some("443"));
         assert_eq!(
@@ -1560,34 +840,6 @@ mod tests {
         // AF_LOCAL is an alias for AF_UNIX, should also be ignored
         let line = r#"connect(3, {sa_family=AF_LOCAL, sun_path="/tmp/socket"}, 110) = 0"#;
         assert!(parse_strace_line(line).is_none());
-    }
-
-    #[test]
-    fn test_format_network_summary_with_hostname() {
-        let conn = NetworkConnectionSummary {
-            endpoint: NetworkEndpoint {
-                addr: "93.184.216.34".parse().unwrap(),
-                port: 443,
-                hostname: Some("example.com".to_string()),
-            },
-            count: 5,
-        };
-        let line = format_network_summary(&conn);
-        assert_eq!(line, "  example.com (93.184.216.34):443 (5x)");
-    }
-
-    #[test]
-    fn test_format_network_summary_without_hostname() {
-        let conn = NetworkConnectionSummary {
-            endpoint: NetworkEndpoint {
-                addr: "10.0.0.1".parse().unwrap(),
-                port: 8080,
-                hostname: None,
-            },
-            count: 1,
-        };
-        let line = format_network_summary(&conn);
-        assert_eq!(line, "  10.0.0.1:8080");
     }
 
     // --- DNS query parsing tests ---
@@ -1700,6 +952,7 @@ mod tests {
 
     #[test]
     fn test_dns_timing_correlation_maps_hostname() {
+        use super::super::{NetworkAccess, NetworkAccessKind};
         // Simulate: program queried "example.com", then connected to an IP.
         // The queried_hostname attached during tracing should map directly.
         let accesses = vec![NetworkAccess {
@@ -1710,7 +963,7 @@ mod tests {
         }];
         let dns_queries = vec!["example.com".to_string()];
 
-        let (outbound, _) = process_network_accesses(accesses, dns_queries, true);
+        let (outbound, _) = super::super::process_network_accesses(accesses, dns_queries, true);
         assert_eq!(outbound.len(), 1);
         // Timing correlation attaches the hostname directly — no DNS lookup needed
         assert_eq!(

--- a/crates/nono-cli/src/learn/macos.rs
+++ b/crates/nono-cli/src/learn/macos.rs
@@ -1,0 +1,580 @@
+//! macOS learn mode implementation using Seatbelt report-mode
+//!
+//! Uses `(allow (with report) default)` Seatbelt profile — allows all ops
+//! but logs each to kernel log. The parent reads kernel log events via
+//! `log stream` to discover the traced process's file and network accesses.
+
+use super::{FileAccess, NetworkAccess, NetworkAccessKind};
+use crate::cli::LearnArgs;
+use crate::profile;
+use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
+use nix::unistd::{execvp, fork, ForkResult};
+use nono::{NonoError, Result};
+use std::ffi::{CStr, CString};
+use std::io::{BufRead, BufReader};
+use std::net::IpAddr;
+use std::os::raw::c_char;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::ptr;
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+use tracing::debug;
+
+// FFI bindings to macOS sandbox API
+// Same declarations as in crates/nono/src/sandbox/macos.rs
+extern "C" {
+    fn sandbox_init(profile: *const c_char, flags: u64, errorbuf: *mut *mut c_char) -> i32;
+    fn sandbox_free_error(errorbuf: *mut c_char);
+}
+
+/// Parsed event from seatbelt log stream
+#[derive(Debug)]
+enum TracedEvent {
+    File(FileAccess),
+    Network(NetworkAccess),
+}
+
+/// Run learn mode (macOS implementation)
+pub fn run_learn(args: &LearnArgs) -> Result<super::LearnResult> {
+    // Load profile if specified
+    let profile = if let Some(ref profile_name) = args.profile {
+        Some(profile::load_profile(profile_name)?)
+    } else {
+        None
+    };
+
+    // Resolve target program path before fork for a clear error message
+    if args.command.is_empty() {
+        return Err(NonoError::NoCommand);
+    }
+    let program = which::which(&args.command[0])
+        .map_err(|_| NonoError::LearnError(format!("Command not found: {}", args.command[0])))?;
+
+    let program_path = program
+        .to_str()
+        .ok_or_else(|| NonoError::LearnError("Program path contains invalid UTF-8".to_string()))?;
+
+    // Prepare CStrings before fork (async-signal-safety)
+    let sandbox_profile_cstr =
+        CString::new("(version 1)(allow (with report) default)").map_err(|e| {
+            NonoError::LearnError(format!("Failed to create sandbox profile CString: {}", e))
+        })?;
+
+    let program_cstr = CString::new(program_path)
+        .map_err(|e| NonoError::LearnError(format!("Invalid program path: {}", e)))?;
+
+    let args_cstrs: Vec<CString> = args
+        .command
+        .iter()
+        .map(|a| {
+            CString::new(a.as_str())
+                .map_err(|e| NonoError::LearnError(format!("Invalid argument '{}': {}", a, e)))
+        })
+        .collect::<Result<_>>()?;
+
+    // Start log stream process before fork so it captures all child events
+    let mut log_child = start_log_stream()?;
+
+    let log_stdout = log_child
+        .stdout
+        .take()
+        .ok_or_else(|| NonoError::LearnError("Failed to get log stream stdout".to_string()))?;
+
+    let mut log_reader = BufReader::new(log_stdout);
+
+    // Wait for the log stream header line to confirm it's running
+    let mut header = String::new();
+    log_reader
+        .read_line(&mut header)
+        .map_err(|e| NonoError::LearnError(format!("Failed to read log stream header: {}", e)))?;
+
+    // SAFETY: fork() is called before spawning any threads in this function.
+    // All CStrings are prepared above for async-signal-safety in the child.
+    let child_pid = match unsafe { fork() }
+        .map_err(|e| NonoError::LearnError(format!("fork() failed: {}", e)))?
+    {
+        ForkResult::Child => {
+            // Child process: apply sandbox then exec
+            // SAFETY: Only async-signal-safe operations after fork.
+            // All CStrings were prepared before fork.
+            unsafe {
+                let mut err_ptr: *mut c_char = ptr::null_mut();
+                if sandbox_init(sandbox_profile_cstr.as_ptr(), 0, &mut err_ptr) != 0 {
+                    if !err_ptr.is_null() {
+                        sandbox_free_error(err_ptr);
+                    }
+                    nix::libc::_exit(126);
+                }
+
+                let args_refs: Vec<&CStr> = args_cstrs.iter().map(|c| c.as_c_str()).collect();
+
+                // execvp replaces the process image; returns only on error
+                let _ = execvp(program_cstr.as_c_str(), &args_refs);
+                nix::libc::_exit(127);
+            }
+        }
+        ForkResult::Parent { child } => child,
+    };
+
+    // Parent process: spawn reader thread to collect log events
+    let (tx, rx) = mpsc::channel::<String>();
+    let reader_thread = thread::spawn(move || {
+        for line in log_reader.lines() {
+            match line {
+                Ok(line) => {
+                    if tx.send(line).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let start = Instant::now();
+    let timeout_duration = args.timeout.map(Duration::from_secs);
+
+    let mut file_accesses: Vec<FileAccess> = Vec::new();
+    let mut network_accesses: Vec<NetworkAccess> = Vec::new();
+
+    // Poll waitpid and drain event channel until child exits
+    loop {
+        // Drain available events
+        while let Ok(line) = rx.try_recv() {
+            if let Some(event) = parse_seatbelt_log_line(&line) {
+                match event {
+                    TracedEvent::File(fa) => file_accesses.push(fa),
+                    TracedEvent::Network(na) => network_accesses.push(na),
+                }
+            }
+        }
+
+        // Check if child has exited
+        match waitpid(child_pid, Some(WaitPidFlag::WNOHANG)) {
+            Ok(WaitStatus::Exited(_, _)) | Ok(WaitStatus::Signaled(_, _, _)) => break,
+            Ok(_) => {} // Still running
+            Err(e) => {
+                debug!("waitpid error: {}", e);
+                break;
+            }
+        }
+
+        // Check timeout
+        if let Some(timeout) = timeout_duration {
+            if start.elapsed() > timeout {
+                let _ = nix::sys::signal::kill(child_pid, nix::sys::signal::Signal::SIGTERM);
+                let _ = waitpid(child_pid, None);
+                break;
+            }
+        }
+
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    // Drain window: allow remaining log events to arrive after child exits
+    thread::sleep(Duration::from_millis(100));
+    while let Ok(line) = rx.try_recv() {
+        if let Some(event) = parse_seatbelt_log_line(&line) {
+            match event {
+                TracedEvent::File(fa) => file_accesses.push(fa),
+                TracedEvent::Network(na) => network_accesses.push(na),
+            }
+        }
+    }
+
+    // Shut down log stream
+    let _ = log_child.kill();
+    let _ = log_child.wait();
+    let _ = reader_thread.join();
+
+    // Warn if no events were captured — most likely a privilege issue
+    if file_accesses.is_empty() && network_accesses.is_empty() {
+        eprintln!(
+            "warning: no events captured from log stream \
+             — ensure your user is in the admin group"
+        );
+    }
+
+    // Process and categorize file paths (shared cross-platform code)
+    let mut result = super::process_accesses(file_accesses, profile.as_ref(), args.all)?;
+
+    // Process network accesses (no DNS queries on macOS — mDNSResponder handles DNS
+    // outside our sandbox, so forward DNS correlation is unavailable)
+    let (outbound, listening) =
+        super::process_network_accesses(network_accesses, vec![], !args.no_rdns);
+    result.outbound_connections = outbound;
+    result.listening_ports = listening;
+
+    Ok(result)
+}
+
+/// Start a `log stream` process filtered to Seatbelt kernel events
+fn start_log_stream() -> Result<Child> {
+    // Match both file and network sandbox report events
+    let predicate = r#"process == "kernel" AND message CONTAINS "Sandbox: " AND (message CONTAINS " allow file-" OR message CONTAINS " allow network-")"#;
+
+    Command::new("log")
+        .args(["stream", "--level", "debug", "--predicate", predicate])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| {
+            NonoError::LearnError(format!(
+                "Failed to start log stream (requires admin privileges): {}",
+                e
+            ))
+        })
+}
+
+/// Parse a seatbelt log line into a TracedEvent.
+///
+/// Log line format (from `log stream`):
+/// ```text
+/// 2024-01-15 10:30:45.123456+0000  0x1234  Default  0x0  0  0  kernel: (Sandbox) Sandbox: bash(12345) allow file-read-data /usr/lib/libSystem.B.dylib
+/// ```
+///
+/// The function extracts the operation and path/address from the "Sandbox: " portion.
+fn parse_seatbelt_log_line(line: &str) -> Option<TracedEvent> {
+    // Find "Sandbox: " marker
+    let marker = "Sandbox: ";
+    let idx = line.find(marker)?;
+    let after_marker = &line[idx + marker.len()..];
+
+    // Skip "processname(pid) " — find ") " to locate where the action starts
+    let paren_close = after_marker.find(") ")?;
+    let rest = &after_marker[paren_close + 2..];
+
+    // Must start with "allow " (report mode always logs allows)
+    let rest = rest.strip_prefix("allow ")?;
+
+    // Split into operation and optional path/address
+    let (operation, path_part) = match rest.find(' ') {
+        Some(space_idx) => {
+            let op = &rest[..space_idx];
+            let path = rest[space_idx + 1..].trim();
+            (op, if path.is_empty() { None } else { Some(path) })
+        }
+        None => (rest.trim(), None),
+    };
+
+    // File operations
+    if operation.starts_with("file-") {
+        let path_str = path_part?;
+        if path_str.is_empty() {
+            return None;
+        }
+        // Any file-write-* operation requires write access: file-write-data,
+        // file-write-create, file-write-unlink, file-write-truncate,
+        // file-write-mode, file-write-xattr, file-write-owner, file-write-times, etc.
+        let is_write = operation.starts_with("file-write-");
+        return Some(TracedEvent::File(FileAccess {
+            path: PathBuf::from(path_str),
+            is_write,
+        }));
+    }
+
+    // Network operations
+    if operation == "network-outbound" || operation == "network-bind" {
+        let kind = if operation == "network-outbound" {
+            NetworkAccessKind::Connect
+        } else {
+            NetworkAccessKind::Bind
+        };
+
+        // Network entries may include "*:port" or "addr:port"; skip Unix socket paths
+        if let Some(addr_str) = path_part {
+            if let Some(na) = parse_network_address(addr_str, kind) {
+                return Some(TracedEvent::Network(na));
+            }
+        }
+        // Network event without parseable address (e.g., mDNSResponder socket) — skip
+        return None;
+    }
+
+    None
+}
+
+/// Parse a network address string from a seatbelt log event.
+///
+/// Handles formats:
+/// - `*:port` (wildcard address)
+/// - `addr:port` (specific IPv4, e.g. `93.184.216.34:443`)
+/// - `addr:port` (IPv6 without brackets, e.g. `::1:443` where `::1` is the
+///   address and `443` is the port — Seatbelt does not use `[addr]:port` notation)
+///
+/// The last `:` in the string is used as the addr/port separator (via `rfind`).
+/// This works for both IPv4 and compact IPv6 notation.
+///
+/// Returns None for Unix socket paths (start with `/`) or unparseable strings.
+fn parse_network_address(addr_str: &str, kind: NetworkAccessKind) -> Option<NetworkAccess> {
+    // Unix socket paths start with '/' — not network addresses
+    if addr_str.starts_with('/') {
+        return None;
+    }
+
+    // Find the last ':' to split address from port
+    let colon_idx = addr_str.rfind(':')?;
+    let addr_part = &addr_str[..colon_idx];
+    let port_str = &addr_str[colon_idx + 1..];
+
+    let port: u16 = port_str.parse().ok()?;
+    if port == 0 {
+        return None;
+    }
+
+    let addr: IpAddr = if addr_part == "*" {
+        // Wildcard: use unspecified address
+        "0.0.0.0".parse().ok()?
+    } else {
+        addr_part.parse().ok()?
+    };
+
+    Some(NetworkAccess {
+        addr,
+        port,
+        kind,
+        queried_hostname: None,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn parse_file(line: &str) -> FileAccess {
+        match parse_seatbelt_log_line(line) {
+            Some(TracedEvent::File(fa)) => fa,
+            other => panic!("Expected File event, got {:?}", other),
+        }
+    }
+
+    fn parse_network(line: &str) -> NetworkAccess {
+        match parse_seatbelt_log_line(line) {
+            Some(TracedEvent::Network(na)) => na,
+            other => panic!("Expected Network event, got {:?}", other),
+        }
+    }
+
+    const LOG_PREFIX: &str =
+        "2024-01-15 10:30:45.123456+0000  0x1234  Default  0x0  0  0  kernel: (Sandbox) ";
+
+    fn make_line(msg: &str) -> String {
+        format!("{}{}", LOG_PREFIX, msg)
+    }
+
+    #[test]
+    fn test_parse_file_read_data() {
+        let line =
+            make_line("Sandbox: bash(12345) allow file-read-data /usr/lib/libSystem.B.dylib");
+        let fa = parse_file(&line);
+        assert_eq!(fa.path, PathBuf::from("/usr/lib/libSystem.B.dylib"));
+        assert!(!fa.is_write);
+    }
+
+    #[test]
+    fn test_parse_file_read_metadata() {
+        let line = make_line("Sandbox: bash(12345) allow file-read-metadata /usr/bin/ls");
+        let fa = parse_file(&line);
+        assert_eq!(fa.path, PathBuf::from("/usr/bin/ls"));
+        assert!(!fa.is_write);
+    }
+
+    #[test]
+    fn test_parse_file_write_create() {
+        let line = make_line("Sandbox: bash(12345) allow file-write-create /tmp/output.txt");
+        let fa = parse_file(&line);
+        assert_eq!(fa.path, PathBuf::from("/tmp/output.txt"));
+        assert!(fa.is_write);
+    }
+
+    #[test]
+    fn test_parse_file_write_data() {
+        let line = make_line("Sandbox: bash(12345) allow file-write-data /tmp/output.txt");
+        let fa = parse_file(&line);
+        assert_eq!(fa.path, PathBuf::from("/tmp/output.txt"));
+        assert!(fa.is_write);
+    }
+
+    #[test]
+    fn test_parse_file_write_unlink_is_write() {
+        // file-write-unlink (deletion) requires write access
+        let line = make_line("Sandbox: bash(12345) allow file-write-unlink /tmp/old.txt");
+        let fa = parse_file(&line);
+        assert!(fa.is_write);
+    }
+
+    #[test]
+    fn test_parse_file_write_ops_are_writes() {
+        // All file-write-* operations must be classified as writes
+        let write_ops = [
+            "file-write-data",
+            "file-write-create",
+            "file-write-unlink",
+            "file-write-truncate",
+            "file-write-mode",
+            "file-write-xattr",
+            "file-write-owner",
+            "file-write-times",
+            "file-write-setugid",
+        ];
+        for op in &write_ops {
+            let line = make_line(&format!("Sandbox: bash(12345) allow {} /tmp/file.txt", op));
+            let fa = parse_file(&line);
+            assert!(fa.is_write, "expected is_write=true for op={}", op);
+        }
+    }
+
+    #[test]
+    fn test_parse_network_outbound_mdns() {
+        // mDNSResponder is a Unix socket path → should not parse as network address
+        let line =
+            make_line("Sandbox: curl(12345) allow network-outbound /private/var/run/mDNSResponder");
+        assert!(parse_seatbelt_log_line(&line).is_none());
+    }
+
+    #[test]
+    fn test_parse_network_outbound_tcp() {
+        let line = make_line("Sandbox: curl(12345) allow network-outbound *:443");
+        let na = parse_network(&line);
+        assert_eq!(na.port, 443);
+        assert!(matches!(na.kind, NetworkAccessKind::Connect));
+    }
+
+    #[test]
+    fn test_parse_network_bind() {
+        let line = make_line("Sandbox: node(12345) allow network-bind *:8080");
+        let na = parse_network(&line);
+        assert_eq!(na.port, 8080);
+        assert!(matches!(na.kind, NetworkAccessKind::Bind));
+    }
+
+    #[test]
+    fn test_parse_network_outbound_with_ip() {
+        let line = make_line("Sandbox: curl(12345) allow network-outbound 93.184.216.34:443");
+        let na = parse_network(&line);
+        assert_eq!(na.addr, "93.184.216.34".parse::<IpAddr>().unwrap());
+        assert_eq!(na.port, 443);
+        assert!(matches!(na.kind, NetworkAccessKind::Connect));
+    }
+
+    #[test]
+    fn test_parse_no_sandbox_marker() {
+        let line = "Some random log line without sandbox info";
+        assert!(parse_seatbelt_log_line(line).is_none());
+    }
+
+    #[test]
+    fn test_parse_network_no_path_skipped() {
+        // Network event with no address info — should be skipped
+        let line = make_line("Sandbox: curl(12345) allow network-outbound");
+        assert!(parse_seatbelt_log_line(&line).is_none());
+    }
+
+    #[test]
+    fn test_parse_network_port_zero_skipped() {
+        let line = make_line("Sandbox: curl(12345) allow network-outbound *:0");
+        assert!(parse_seatbelt_log_line(&line).is_none());
+    }
+
+    #[test]
+    fn test_parse_network_address_wildcard() {
+        let na = parse_network_address("*:443", NetworkAccessKind::Connect).unwrap();
+        assert_eq!(na.addr, "0.0.0.0".parse::<IpAddr>().unwrap());
+        assert_eq!(na.port, 443);
+    }
+
+    #[test]
+    fn test_parse_network_address_unix_socket() {
+        assert!(parse_network_address(
+            "/private/var/run/mDNSResponder",
+            NetworkAccessKind::Connect
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn test_parse_network_address_invalid() {
+        assert!(parse_network_address("notanaddress", NetworkAccessKind::Connect).is_none());
+        assert!(parse_network_address("", NetworkAccessKind::Connect).is_none());
+    }
+
+    // --- IPv6 network tests (equivalent of test_parse_connect_ipv6 / test_parse_bind_ipv6) ---
+
+    #[test]
+    fn test_parse_network_outbound_ipv6_loopback() {
+        // Seatbelt logs IPv6 addresses as addr:port using rfind(':') to split
+        let line = make_line("Sandbox: curl(12345) allow network-outbound ::1:443");
+        let na = parse_network(&line);
+        assert_eq!(na.addr, "::1".parse::<IpAddr>().unwrap());
+        assert_eq!(na.port, 443);
+        assert!(matches!(na.kind, NetworkAccessKind::Connect));
+    }
+
+    #[test]
+    fn test_parse_network_bind_ipv6_any() {
+        // IPv6 bind on all interfaces
+        let line = make_line("Sandbox: node(12345) allow network-bind :::8080");
+        let na = parse_network(&line);
+        assert_eq!(na.addr, "::".parse::<IpAddr>().unwrap());
+        assert_eq!(na.port, 8080);
+        assert!(matches!(na.kind, NetworkAccessKind::Bind));
+    }
+
+    #[test]
+    fn test_parse_network_outbound_ipv6_with_addr() {
+        // Specific IPv6 address
+        let line = make_line("Sandbox: curl(12345) allow network-outbound 2001:db8::1:443");
+        let na = parse_network(&line);
+        assert_eq!(na.addr, "2001:db8::1".parse::<IpAddr>().unwrap());
+        assert_eq!(na.port, 443);
+        assert!(matches!(na.kind, NetworkAccessKind::Connect));
+    }
+
+    // --- Regression: multiple file operations in one pass ---
+    // (equivalent of test_existing_file_parsing_unchanged in linux.rs)
+
+    #[test]
+    fn test_existing_file_parsing_unchanged() {
+        let cases = [
+            ("file-read-data", "/etc/hosts", false),
+            ("file-read-metadata", "/usr/bin/ls", false),
+            ("file-write-create", "/tmp/newdir", true),
+            ("file-write-data", "/tmp/file.txt", true),
+            ("file-write-unlink", "/tmp/old.txt", true),
+            ("file-write-truncate", "/tmp/file.txt", true),
+        ];
+
+        for (op, path, expected_write) in &cases {
+            let line = make_line(&format!("Sandbox: bash(12345) allow {} {}", op, path));
+            let fa = parse_file(&line);
+            assert_eq!(fa.path, PathBuf::from(path), "path mismatch for op={}", op);
+            assert_eq!(
+                fa.is_write, *expected_write,
+                "is_write mismatch for op={}",
+                op
+            );
+        }
+    }
+
+    // --- Unix-socket / AF_LOCAL skipped via full log line ---
+    // (equivalent of test_parse_connect_af_local_ignored in linux.rs,
+    //  complementing test_parse_network_address_unix_socket which only tests
+    //  the address parser directly)
+
+    #[test]
+    fn test_parse_network_outbound_unix_socket_skipped() {
+        // A Unix socket path that looks network-ish should still be skipped
+        let line = make_line("Sandbox: curl(12345) allow network-outbound /var/run/varlink.socket");
+        assert!(parse_seatbelt_log_line(&line).is_none());
+    }
+
+    #[test]
+    fn test_parse_network_outbound_private_path_skipped() {
+        // Any absolute path for network-outbound should be skipped (it's a socket file)
+        let line = make_line("Sandbox: curl(12345) allow network-outbound /private/tmp/sock");
+        assert!(parse_seatbelt_log_line(&line).is_none());
+    }
+}

--- a/crates/nono-cli/src/learn/mod.rs
+++ b/crates/nono-cli/src/learn/mod.rs
@@ -1,0 +1,817 @@
+//! Learn mode: trace file accesses to discover required paths
+//!
+//! Uses platform-specific tracing to monitor a command's filesystem and network
+//! accesses and produces a list of paths that would need to be allowed in a nono profile.
+//!
+//! - Linux: strace
+//! - macOS: Seatbelt report-mode + log stream
+
+use crate::cli::LearnArgs;
+use crate::profile::Profile;
+use nono::Result;
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::net::IpAddr;
+use std::path::{Path, PathBuf};
+use tracing::debug;
+
+#[cfg(target_os = "linux")]
+mod linux;
+
+#[cfg(target_os = "macos")]
+mod macos;
+
+// ============================================================================
+// Shared types
+// ============================================================================
+
+/// Represents a file access from tracing
+#[derive(Debug, Clone)]
+pub(crate) struct FileAccess {
+    pub path: PathBuf,
+    pub is_write: bool,
+}
+
+/// Kind of network access observed
+#[derive(Debug, Clone)]
+pub(crate) enum NetworkAccessKind {
+    Connect,
+    Bind,
+}
+
+/// A single network access observed
+#[derive(Debug, Clone)]
+pub(crate) struct NetworkAccess {
+    pub addr: IpAddr,
+    pub port: u16,
+    pub kind: NetworkAccessKind,
+    /// Hostname from the most recent DNS query (timing-based correlation)
+    pub queried_hostname: Option<String>,
+}
+
+/// A resolved network endpoint with optional reverse DNS hostname
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct NetworkEndpoint {
+    pub addr: IpAddr,
+    pub port: u16,
+    pub hostname: Option<String>,
+}
+
+/// Summary of connections to a single endpoint (with count)
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct NetworkConnectionSummary {
+    pub endpoint: NetworkEndpoint,
+    pub count: usize,
+}
+
+/// Result of learning file access patterns
+#[derive(Debug)]
+pub struct LearnResult {
+    /// Paths that need read access
+    pub read_paths: BTreeSet<PathBuf>,
+    /// Paths that need write access
+    pub write_paths: BTreeSet<PathBuf>,
+    /// Paths that need read+write access
+    pub readwrite_paths: BTreeSet<PathBuf>,
+    /// Paths that were accessed but are already covered by system paths
+    pub system_covered: BTreeSet<PathBuf>,
+    /// Paths that were accessed but are already covered by profile
+    pub profile_covered: BTreeSet<PathBuf>,
+    /// Outbound network connections observed
+    pub outbound_connections: Vec<NetworkConnectionSummary>,
+    /// Listening ports observed
+    pub listening_ports: Vec<NetworkConnectionSummary>,
+}
+
+impl LearnResult {
+    pub(crate) fn new() -> Self {
+        Self {
+            read_paths: BTreeSet::new(),
+            write_paths: BTreeSet::new(),
+            readwrite_paths: BTreeSet::new(),
+            system_covered: BTreeSet::new(),
+            profile_covered: BTreeSet::new(),
+            outbound_connections: Vec::new(),
+            listening_ports: Vec::new(),
+        }
+    }
+
+    /// Check if any paths were discovered
+    pub fn has_paths(&self) -> bool {
+        !self.read_paths.is_empty()
+            || !self.write_paths.is_empty()
+            || !self.readwrite_paths.is_empty()
+    }
+
+    /// Check if any network activity was observed
+    pub fn has_network_activity(&self) -> bool {
+        !self.outbound_connections.is_empty() || !self.listening_ports.is_empty()
+    }
+
+    /// Format as JSON fragment for profile
+    pub fn to_json(&self) -> String {
+        let allow: Vec<String> = self
+            .readwrite_paths
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect();
+        let read: Vec<String> = self
+            .read_paths
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect();
+        let write: Vec<String> = self
+            .write_paths
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect();
+
+        let outbound: Vec<serde_json::Value> = self
+            .outbound_connections
+            .iter()
+            .map(|c| {
+                let mut obj = serde_json::json!({
+                    "addr": c.endpoint.addr.to_string(),
+                    "port": c.endpoint.port,
+                    "count": c.count,
+                });
+                if let Some(ref hostname) = c.endpoint.hostname {
+                    obj["hostname"] = serde_json::Value::String(hostname.clone());
+                }
+                obj
+            })
+            .collect();
+
+        let listening: Vec<serde_json::Value> = self
+            .listening_ports
+            .iter()
+            .map(|c| {
+                let mut obj = serde_json::json!({
+                    "addr": c.endpoint.addr.to_string(),
+                    "port": c.endpoint.port,
+                    "count": c.count,
+                });
+                if let Some(ref hostname) = c.endpoint.hostname {
+                    obj["hostname"] = serde_json::Value::String(hostname.clone());
+                }
+                obj
+            })
+            .collect();
+
+        let fragment = serde_json::json!({
+            "filesystem": {
+                "allow": allow,
+                "read": read,
+                "write": write
+            },
+            "network": {
+                "outbound": outbound,
+                "listening": listening
+            }
+        });
+
+        serde_json::to_string_pretty(&fragment).unwrap_or_else(|e| {
+            tracing::warn!("Failed to serialize learn result to JSON: {}", e);
+            "{}".to_string()
+        })
+    }
+
+    /// Format as human-readable summary
+    pub fn to_summary(&self) -> String {
+        let mut lines = Vec::new();
+
+        if !self.read_paths.is_empty() {
+            lines.push("Read access needed:".to_string());
+            for path in &self.read_paths {
+                lines.push(format!("  {}", path.display()));
+            }
+        }
+
+        if !self.write_paths.is_empty() {
+            lines.push("Write access needed:".to_string());
+            for path in &self.write_paths {
+                lines.push(format!("  {}", path.display()));
+            }
+        }
+
+        if !self.readwrite_paths.is_empty() {
+            lines.push("Read+Write access needed:".to_string());
+            for path in &self.readwrite_paths {
+                lines.push(format!("  {}", path.display()));
+            }
+        }
+
+        if !self.system_covered.is_empty() {
+            lines.push(format!(
+                "\n({} paths already covered by system defaults)",
+                self.system_covered.len()
+            ));
+        }
+
+        if !self.profile_covered.is_empty() {
+            lines.push(format!(
+                "({} paths already covered by profile)",
+                self.profile_covered.len()
+            ));
+        }
+
+        // Network sections
+        if !self.outbound_connections.is_empty() {
+            if !lines.is_empty() {
+                lines.push(String::new());
+            }
+            lines.push("Outbound connections:".to_string());
+            for conn in &self.outbound_connections {
+                lines.push(format_network_summary(conn));
+            }
+        }
+
+        if !self.listening_ports.is_empty() {
+            if !lines.is_empty() {
+                lines.push(String::new());
+            }
+            lines.push("Listening ports:".to_string());
+            for conn in &self.listening_ports {
+                lines.push(format_network_summary(conn));
+            }
+        }
+
+        if lines.is_empty() {
+            lines.push("No additional paths needed.".to_string());
+        }
+
+        lines.join("\n")
+    }
+}
+
+/// Format a single network connection summary line
+fn format_network_summary(conn: &NetworkConnectionSummary) -> String {
+    let count_str = if conn.count > 1 {
+        format!(" ({}x)", conn.count)
+    } else {
+        String::new()
+    };
+
+    if let Some(ref hostname) = conn.endpoint.hostname {
+        format!(
+            "  {} ({}):{}{}",
+            hostname, conn.endpoint.addr, conn.endpoint.port, count_str
+        )
+    } else {
+        format!(
+            "  {}:{}{}",
+            conn.endpoint.addr, conn.endpoint.port, count_str
+        )
+    }
+}
+
+// ============================================================================
+// Cross-platform dispatcher
+// ============================================================================
+
+/// Run learn mode
+#[cfg(target_os = "linux")]
+pub fn run_learn(args: &LearnArgs) -> Result<LearnResult> {
+    linux::run_learn(args)
+}
+
+/// Run learn mode
+#[cfg(target_os = "macos")]
+pub fn run_learn(args: &LearnArgs) -> Result<LearnResult> {
+    macos::run_learn(args)
+}
+
+/// Run learn mode (unsupported platform stub)
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub fn run_learn(_args: &LearnArgs) -> Result<LearnResult> {
+    use nono::NonoError;
+    Err(NonoError::LearnError(
+        "nono learn is not supported on this platform".to_string(),
+    ))
+}
+
+// ============================================================================
+// Shared helpers (used by both Linux and macOS implementations)
+// ============================================================================
+
+/// Process raw file accesses into categorized result
+pub(crate) fn process_accesses(
+    accesses: Vec<FileAccess>,
+    profile: Option<&Profile>,
+    show_all: bool,
+) -> Result<LearnResult> {
+    let mut result = LearnResult::new();
+
+    // Get system paths that are already allowed (from policy.json groups)
+    let loaded_policy = crate::policy::load_embedded_policy()?;
+    let system_read_paths = crate::policy::get_system_read_paths(&loaded_policy);
+    let system_read_set: HashSet<&str> = system_read_paths.iter().map(|s| s.as_str()).collect();
+
+    // Get profile paths if available
+    let profile_paths: HashSet<String> = if let Some(prof) = profile {
+        let mut paths = HashSet::new();
+        paths.extend(prof.filesystem.allow.iter().cloned());
+        paths.extend(prof.filesystem.read.iter().cloned());
+        paths.extend(prof.filesystem.write.iter().cloned());
+        paths
+    } else {
+        HashSet::new()
+    };
+
+    // Merge accesses by canonical path, upgrading to write if any access is a write.
+    // This prevents the same canonical path seen first as read then as write from
+    // having the write silently dropped.
+    let mut merged: HashMap<PathBuf, bool> = HashMap::new(); // canonical → is_write
+    for access in accesses {
+        let canonical = access.path.canonicalize().unwrap_or(access.path);
+        let entry = merged.entry(canonical).or_insert(false);
+        if access.is_write {
+            *entry = true;
+        }
+    }
+
+    for (canonical, is_write) in merged {
+        // Check if covered by system paths
+        if is_covered_by_set(&canonical, &system_read_set)? {
+            if show_all {
+                result.system_covered.insert(canonical);
+            }
+            continue;
+        }
+
+        // Check if covered by profile
+        if is_covered_by_profile(&canonical, &profile_paths)? {
+            if show_all {
+                result.profile_covered.insert(canonical);
+            }
+            continue;
+        }
+
+        // Categorize by access type
+        // Collapse to parent directories for cleaner output
+        let collapsed = collapse_to_parent(&canonical);
+
+        if is_write {
+            // Check if already in read, upgrade to readwrite
+            if result.read_paths.contains(&collapsed) {
+                result.read_paths.remove(&collapsed);
+                result.readwrite_paths.insert(collapsed);
+            } else if !result.readwrite_paths.contains(&collapsed) {
+                result.write_paths.insert(collapsed);
+            }
+        } else {
+            // Read access
+            if result.write_paths.contains(&collapsed) {
+                result.write_paths.remove(&collapsed);
+                result.readwrite_paths.insert(collapsed);
+            } else if !result.readwrite_paths.contains(&collapsed) {
+                result.read_paths.insert(collapsed);
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// Check if a path is covered by a set of allowed paths
+pub(crate) fn is_covered_by_set(path: &Path, allowed: &HashSet<&str>) -> Result<bool> {
+    for allowed_path in allowed {
+        let allowed_expanded = expand_home(allowed_path)?;
+        if let Ok(allowed_canonical) = std::fs::canonicalize(&allowed_expanded) {
+            if path.starts_with(&allowed_canonical) {
+                return Ok(true);
+            }
+        }
+        // Also check without canonicalization for paths that may not exist
+        let allowed_path_buf = PathBuf::from(&allowed_expanded);
+        if path.starts_with(&allowed_path_buf) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Check if a path is covered by profile paths
+pub(crate) fn is_covered_by_profile(path: &Path, profile_paths: &HashSet<String>) -> Result<bool> {
+    for profile_path in profile_paths {
+        let expanded = expand_home(profile_path)?;
+        if let Ok(canonical) = std::fs::canonicalize(&expanded) {
+            if path.starts_with(&canonical) {
+                return Ok(true);
+            }
+        }
+        let path_buf = PathBuf::from(&expanded);
+        if path.starts_with(&path_buf) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Expand ~ to home directory
+///
+/// Only expands `~` when it appears as a complete prefix: `~` alone or `~/...`.
+/// A `~` embedded mid-path (e.g. `/path/with~tilde`) is left unchanged.
+pub(crate) fn expand_home(path: &str) -> Result<String> {
+    use crate::config;
+
+    // Only expand '~' as a leading component: "~" or "~/..."
+    if path == "~" || path.starts_with("~/") {
+        let home = config::validated_home()?;
+        return Ok(format!("{}{}", home, &path[1..]));
+    }
+    // Only expand "$HOME" as a leading component: "$HOME" or "$HOME/..."
+    if path == "$HOME" || path.starts_with("$HOME/") {
+        let home = config::validated_home()?;
+        return Ok(format!("{}{}", home, &path[5..]));
+    }
+    Ok(path.to_string())
+}
+
+/// Collapse a file path to its parent directory for cleaner output
+pub(crate) fn collapse_to_parent(path: &Path) -> PathBuf {
+    // Don't collapse if it's already a directory
+    if path.is_dir() {
+        return path.to_path_buf();
+    }
+
+    // Collapse files to their parent directory
+    path.parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| path.to_path_buf())
+}
+
+/// Process raw network accesses into categorized summaries.
+///
+/// Uses forward DNS correlation from captured DNS queries to map IPs to
+/// hostnames. Falls back to reverse DNS for unmatched IPs when `resolve_dns`
+/// is true.
+pub(crate) fn process_network_accesses(
+    accesses: Vec<NetworkAccess>,
+    dns_queries: Vec<String>,
+    resolve_dns: bool,
+) -> (Vec<NetworkConnectionSummary>, Vec<NetworkConnectionSummary>) {
+    let mut connect_counts: HashMap<(IpAddr, u16), usize> = HashMap::new();
+    let mut bind_counts: HashMap<(IpAddr, u16), usize> = HashMap::new();
+
+    for access in &accesses {
+        let key = (access.addr, access.port);
+        match access.kind {
+            NetworkAccessKind::Connect => {
+                *connect_counts.entry(key).or_insert(0) += 1;
+            }
+            NetworkAccessKind::Bind => {
+                *bind_counts.entry(key).or_insert(0) += 1;
+            }
+        }
+    }
+
+    // Build IP → hostname mapping using three strategies (in priority order):
+    // 1. Timing-based: hostname attached directly from preceding DNS query
+    // 2. Forward DNS: resolve captured hostnames to IPs
+    // 3. Reverse DNS: lookup IP → hostname as last resort
+    let hostnames = if resolve_dns {
+        // Strategy 1: Use hostnames attached during tracing (timing correlation)
+        let mut map: HashMap<IpAddr, String> = HashMap::new();
+        for access in &accesses {
+            if let Some(ref hostname) = access.queried_hostname {
+                map.entry(access.addr).or_insert_with(|| hostname.clone());
+            }
+        }
+
+        // Strategy 2: Forward DNS for IPs not covered by timing correlation
+        let all_ips: HashSet<IpAddr> = accesses.iter().map(|a| a.addr).collect();
+        let unresolved_after_timing: HashSet<IpAddr> = all_ips
+            .iter()
+            .filter(|ip| !map.contains_key(ip))
+            .copied()
+            .collect();
+
+        if !unresolved_after_timing.is_empty() && !dns_queries.is_empty() {
+            let forward = resolve_forward_dns(&dns_queries);
+            for (ip, hostname) in forward {
+                map.entry(ip).or_insert(hostname);
+            }
+        }
+
+        // Strategy 3: Reverse DNS for anything still unresolved
+        let unresolved_after_forward: HashSet<IpAddr> = all_ips
+            .iter()
+            .filter(|ip| !map.contains_key(ip))
+            .copied()
+            .collect();
+
+        if !unresolved_after_forward.is_empty() {
+            let reverse = resolve_reverse_dns(&unresolved_after_forward);
+            map.extend(reverse);
+        }
+
+        map
+    } else {
+        HashMap::new()
+    };
+
+    let build_summaries =
+        |counts: &HashMap<(IpAddr, u16), usize>| -> Vec<NetworkConnectionSummary> {
+            let mut summaries: Vec<NetworkConnectionSummary> = counts
+                .iter()
+                .map(|(&(addr, port), &count)| NetworkConnectionSummary {
+                    endpoint: NetworkEndpoint {
+                        addr,
+                        port,
+                        hostname: hostnames.get(&addr).cloned(),
+                    },
+                    count,
+                })
+                .collect();
+            summaries.sort();
+            summaries
+        };
+
+    (
+        build_summaries(&connect_counts),
+        build_summaries(&bind_counts),
+    )
+}
+
+/// Resolve captured DNS query hostnames to IPs via forward DNS lookup.
+///
+/// For each hostname the traced program queried, resolves it to its current
+/// IPs to build an IP→hostname mapping. This gives the actual hostname the
+/// program intended to reach (e.g., "google.com") rather than infrastructure
+/// names from reverse DNS (e.g., "jr-in-f100.1e100.net").
+fn resolve_forward_dns(hostnames: &[String]) -> HashMap<IpAddr, String> {
+    let mut result = HashMap::new();
+    let unique: HashSet<&String> = hostnames.iter().collect();
+
+    for hostname in unique {
+        match dns_lookup::lookup_host(hostname) {
+            Ok(ips) => {
+                for ip in ips {
+                    // First hostname to resolve to this IP wins
+                    result.entry(ip).or_insert_with(|| hostname.clone());
+                }
+            }
+            Err(e) => {
+                debug!("Forward DNS lookup failed for {}: {}", hostname, e);
+            }
+        }
+    }
+
+    result
+}
+
+/// Resolve IP addresses to hostnames via reverse DNS (fallback)
+fn resolve_reverse_dns(ips: &HashSet<IpAddr>) -> HashMap<IpAddr, String> {
+    let mut result = HashMap::new();
+
+    for &ip in ips {
+        match dns_lookup::lookup_addr(&ip) {
+            Ok(hostname) => {
+                // Skip if the hostname is just the IP address stringified
+                if hostname != ip.to_string() {
+                    result.insert(ip, hostname);
+                }
+            }
+            Err(e) => {
+                debug!("Reverse DNS lookup failed for {}: {}", ip, e);
+            }
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_learn_result_to_json() {
+        let mut result = LearnResult::new();
+        result.read_paths.insert(PathBuf::from("/some/read/path"));
+        result.write_paths.insert(PathBuf::from("/some/write/path"));
+
+        let json = result.to_json();
+        assert!(json.contains("filesystem"));
+        assert!(json.contains("/some/read/path"));
+        assert!(json.contains("/some/write/path"));
+    }
+
+    #[test]
+    fn test_expand_home() {
+        // RAII guard: restores HOME even if the test panics
+        struct HomeGuard(Option<String>);
+        impl Drop for HomeGuard {
+            fn drop(&mut self) {
+                match &self.0 {
+                    Some(home) => std::env::set_var("HOME", home),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+        }
+        let _guard = HomeGuard(std::env::var("HOME").ok());
+
+        std::env::set_var("HOME", "/home/test");
+        assert_eq!(expand_home("~/foo").expect("valid home"), "/home/test/foo");
+        assert_eq!(expand_home("~").expect("tilde alone"), "/home/test");
+        assert_eq!(
+            expand_home("$HOME/bar").expect("valid home"),
+            "/home/test/bar"
+        );
+        assert_eq!(expand_home("$HOME").expect("HOME alone"), "/home/test");
+        assert_eq!(
+            expand_home("/absolute/path").expect("no expansion needed"),
+            "/absolute/path"
+        );
+        // Tilde not at position 0+/ boundary must not be expanded
+        assert_eq!(
+            expand_home("/path/with~tilde").expect("mid-path tilde unchanged"),
+            "/path/with~tilde"
+        );
+    }
+
+    #[test]
+    fn test_collapse_to_parent() {
+        // For a file that doesn't exist, collapse to parent
+        let path = PathBuf::from("/some/dir/file.txt");
+        let collapsed = collapse_to_parent(&path);
+        assert_eq!(collapsed, PathBuf::from("/some/dir"));
+    }
+
+    #[test]
+    fn test_learn_result_network_json() {
+        let mut result = LearnResult::new();
+        result.outbound_connections.push(NetworkConnectionSummary {
+            endpoint: NetworkEndpoint {
+                addr: "93.184.216.34".parse().unwrap(),
+                port: 443,
+                hostname: Some("example.com".to_string()),
+            },
+            count: 5,
+        });
+        result.listening_ports.push(NetworkConnectionSummary {
+            endpoint: NetworkEndpoint {
+                addr: "0.0.0.0".parse().unwrap(),
+                port: 3000,
+                hostname: None,
+            },
+            count: 1,
+        });
+
+        let json = result.to_json();
+        assert!(json.contains("\"network\""));
+        assert!(json.contains("\"outbound\""));
+        assert!(json.contains("\"listening\""));
+        assert!(json.contains("93.184.216.34"));
+        assert!(json.contains("443"));
+        assert!(json.contains("example.com"));
+        assert!(json.contains("0.0.0.0"));
+        assert!(json.contains("3000"));
+    }
+
+    #[test]
+    fn test_learn_result_network_summary() {
+        let mut result = LearnResult::new();
+        result.outbound_connections.push(NetworkConnectionSummary {
+            endpoint: NetworkEndpoint {
+                addr: "93.184.216.34".parse().unwrap(),
+                port: 443,
+                hostname: Some("example.com".to_string()),
+            },
+            count: 12,
+        });
+        result.listening_ports.push(NetworkConnectionSummary {
+            endpoint: NetworkEndpoint {
+                addr: "0.0.0.0".parse().unwrap(),
+                port: 3000,
+                hostname: None,
+            },
+            count: 1,
+        });
+
+        let summary = result.to_summary();
+        assert!(summary.contains("Outbound connections:"));
+        assert!(summary.contains("example.com (93.184.216.34):443 (12x)"));
+        assert!(summary.contains("Listening ports:"));
+        assert!(summary.contains("0.0.0.0:3000"));
+        // Count of 1 should NOT show "(1x)"
+        assert!(!summary.contains("(1x)"));
+    }
+
+    #[test]
+    fn test_has_network_activity() {
+        let mut result = LearnResult::new();
+        assert!(!result.has_network_activity());
+
+        result.outbound_connections.push(NetworkConnectionSummary {
+            endpoint: NetworkEndpoint {
+                addr: "10.0.0.1".parse().unwrap(),
+                port: 80,
+                hostname: None,
+            },
+            count: 1,
+        });
+        assert!(result.has_network_activity());
+
+        let mut result2 = LearnResult::new();
+        result2.listening_ports.push(NetworkConnectionSummary {
+            endpoint: NetworkEndpoint {
+                addr: "0.0.0.0".parse().unwrap(),
+                port: 8080,
+                hostname: None,
+            },
+            count: 1,
+        });
+        assert!(result2.has_network_activity());
+    }
+
+    #[test]
+    fn test_format_network_summary_with_hostname() {
+        let conn = NetworkConnectionSummary {
+            endpoint: NetworkEndpoint {
+                addr: "93.184.216.34".parse().unwrap(),
+                port: 443,
+                hostname: Some("example.com".to_string()),
+            },
+            count: 5,
+        };
+        let line = format_network_summary(&conn);
+        assert_eq!(line, "  example.com (93.184.216.34):443 (5x)");
+    }
+
+    #[test]
+    fn test_format_network_summary_without_hostname() {
+        let conn = NetworkConnectionSummary {
+            endpoint: NetworkEndpoint {
+                addr: "10.0.0.1".parse().unwrap(),
+                port: 8080,
+                hostname: None,
+            },
+            count: 1,
+        };
+        let line = format_network_summary(&conn);
+        assert_eq!(line, "  10.0.0.1:8080");
+    }
+
+    #[test]
+    fn test_process_accesses_read_then_write_upgrades() {
+        // The same canonical path accessed first as read then as write must NOT have
+        // the write silently dropped (previous dedup bug: seen_paths keyed on canonical
+        // caused the second access to be skipped entirely).
+        //
+        // Use a path that is guaranteed not to be in any system read group so it
+        // passes through the coverage filter.
+        let accesses = vec![
+            FileAccess {
+                path: PathBuf::from("/nonexistent_nono_test_upgrade/dir/file.txt"),
+                is_write: false,
+            },
+            FileAccess {
+                path: PathBuf::from("/nonexistent_nono_test_upgrade/dir/file.txt"),
+                is_write: true,
+            },
+        ];
+        let result = process_accesses(accesses, None, false).expect("process_accesses failed");
+        let collapsed = PathBuf::from("/nonexistent_nono_test_upgrade/dir");
+        // The path must appear with write access, not only as a read
+        assert!(
+            !result.read_paths.contains(&collapsed),
+            "path must not remain read-only after write access"
+        );
+        assert!(
+            result.write_paths.contains(&collapsed) || result.readwrite_paths.contains(&collapsed),
+            "path must be in write_paths or readwrite_paths"
+        );
+    }
+
+    #[test]
+    fn test_network_dedup() {
+        // Duplicate endpoints should be merged with count
+        let accesses = vec![
+            NetworkAccess {
+                addr: "93.184.216.34".parse().unwrap(),
+                port: 443,
+                kind: NetworkAccessKind::Connect,
+                queried_hostname: None,
+            },
+            NetworkAccess {
+                addr: "93.184.216.34".parse().unwrap(),
+                port: 443,
+                kind: NetworkAccessKind::Connect,
+                queried_hostname: None,
+            },
+            NetworkAccess {
+                addr: "93.184.216.34".parse().unwrap(),
+                port: 443,
+                kind: NetworkAccessKind::Connect,
+                queried_hostname: None,
+            },
+        ];
+
+        let (outbound, listening) = process_network_accesses(accesses, vec![], false);
+        assert_eq!(outbound.len(), 1);
+        assert_eq!(outbound[0].count, 3);
+        assert!(listening.is_empty());
+    }
+}

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -117,6 +117,16 @@ fn run_learn(args: LearnArgs, silent: bool) -> Result<()> {
         eprintln!();
     }
 
+    #[cfg(target_os = "macos")]
+    if !silent {
+        eprintln!(
+            "{}",
+            "NOTE: On macOS, nono learn requires admin group membership to read kernel logs."
+                .yellow()
+        );
+        eprintln!();
+    }
+
     eprintln!("nono learn - Tracing file accesses and network activity...\n");
 
     let result = learn::run_learn(&args)?;

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -735,8 +735,7 @@ pub fn get_dangerous_commands(policy: &Policy) -> HashSet<String> {
 ///
 /// Collects `allow.read` entries from all platform-matching groups. Paths are
 /// returned unexpanded (with `~` and `$TMPDIR` intact) for caller to expand.
-/// Used by learn mode (Linux only).
-#[cfg(target_os = "linux")]
+/// Used by learn mode.
 pub fn get_system_read_paths(policy: &Policy) -> Vec<String> {
     let mut result = Vec::new();
 


### PR DESCRIPTION
This is kind of gross, but seems work work for me. Not sure if it fits with your goals for the project - as mentioned in #170, maybe `dylib` is a better approach?

- Parent starts `log stream` filtered to kernel Sandbox events
- Forks child, which applies `(allow (with report) default)` then exec()s the target — allows all ops but logs each to the kernel log
- Parent drains log events via mpsc channel while polling waitpid
- Seatbelt sandbox is inherited across exec(), so all child processes are traced including SIP-protected binaries