### PR TITLE
fix: skip unreadable directories during trust scan

### DIFF
--- a/crates/nono/src/trust/policy.rs
+++ b/crates/nono/src/trust/policy.rs
@@ -276,10 +276,25 @@ fn find_files_recursive(
         return Ok(());
     }
 
-    let entries = std::fs::read_dir(dir).map_err(NonoError::Io)?;
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+            tracing::debug!(
+                "Skipping unreadable directory {}: {}",
+                dir.display(),
+                e
+            );
+            return Ok(());
+        }
+        Err(e) => return Err(NonoError::Io(e)),
+    };
 
     for entry in entries {
-        let entry = entry.map_err(NonoError::Io)?;
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => continue,
+            Err(e) => return Err(NonoError::Io(e)),
+        };
         let path = entry.path();
 
         // Use std::fs::metadata (stat) instead of entry.file_type (lstat)
@@ -884,6 +899,31 @@ mod tests {
         let files = find_instruction_files(&policy, dir.path()).unwrap();
         assert_eq!(files.len(), 1);
         assert!(files[0].to_string_lossy().contains("SKILLS.md"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn find_instruction_files_skips_unreadable_dirs() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        // Create a matching file at root level
+        std::fs::write(dir.path().join("SKILLS.md"), "content").unwrap();
+        // Create a subdirectory with mode 000 (unreadable)
+        let blocked = dir.path().join("shadow");
+        std::fs::create_dir(&blocked).unwrap();
+        std::fs::write(blocked.join("CLAUDE.md"), "secret").unwrap();
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let policy = make_policy(Enforcement::Deny, vec![], vec![]);
+        let files = find_instruction_files(&policy, dir.path()).unwrap();
+
+        // Should find the root-level file but not error on the blocked directory
+        assert_eq!(files.len(), 1);
+        assert!(files[0].to_string_lossy().contains("SKILLS.md"));
+
+        // Restore permissions so tempdir cleanup succeeds
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o755)).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- The pre-exec trust scanner (`find_files_recursive`) fatally errors when encountering a directory with restricted permissions (e.g., mode `000`)
- `std::fs::read_dir()` returns `EACCES` on such directories, which was propagated as a fatal `NonoError::Io` via `?`, aborting the entire sandbox launch
- This is inconsistent with the existing handling on line 289 where metadata errors on individual files are gracefully skipped with `continue`

## Fix
- Handle `PermissionDenied` errors from `read_dir()` by logging a debug message and returning `Ok(())` (skip the directory)
- Handle `PermissionDenied` errors from entry iteration with `continue`
- All other I/O errors remain fatal

## How to reproduce
```bash
# Create a directory with mode 000 somewhere under your working directory
mkdir -p /tmp/test-project/subdir
chmod 000 /tmp/test-project/subdir

# Trust scan hits the unreadable directory and fatally errors
nono run --profile claude-code --workdir /tmp/test-project --allow-cwd -- echo hello
# ERROR: I/O error: Permission denied (os error 13)

# Clean up
chmod 755 /tmp/test-project/subdir
```

## Test plan
- [x] Added regression test `find_instruction_files_skips_unreadable_dirs` that creates a mode-000 subdirectory and verifies `find_instruction_files()` succeeds
- [x] All 33 existing trust policy tests pass
- [x] Clippy clean with `-D warnings -D clippy::unwrap_used`

🤖 Generated with [Claude Code](https://claude.com/claude-code)