### PR TITLE
Add `/nix` and `/run` to macOS default read paths for Nix Darwin

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -211,7 +211,9 @@
           "/Applications",
           "/cores",
           "/opt",
-          "/Volumes"
+          "/Volumes",
+          "/run",
+          "/nix"
         ]
       },
       "symlink_pairs": {


### PR DESCRIPTION
Add `/nix` and `/run` read paths to `system_read_macos` policy group so Nix Darwin users can reach executables managed by nix-darwin. Matches the existing Linux policy which already includes both paths.