### PR TITLE
feat!: add AccessMode::Interactive, restrict IoctlDev to TTY devices

### DIFF
--- a/bindings/c/include/nono.h
+++ b/bindings/c/include/nono.h
@@ -24,6 +24,8 @@
 
 #define NONO_ACCESS_MODE_READ_WRITE 2
 
+#define NONO_ACCESS_MODE_INTERACTIVE 3
+
 /**
  * Sentinel value returned on error (NULL pointer, out-of-bounds index).
  */

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -14,6 +14,7 @@ use std::os::raw::c_char;
 pub const NONO_ACCESS_MODE_READ: u32 = 0;
 pub const NONO_ACCESS_MODE_WRITE: u32 = 1;
 pub const NONO_ACCESS_MODE_READ_WRITE: u32 = 2;
+pub const NONO_ACCESS_MODE_INTERACTIVE: u32 = 3;
 /// Sentinel value returned on error (NULL pointer, out-of-bounds index).
 pub const NONO_ACCESS_MODE_INVALID: u32 = u32::MAX;
 
@@ -25,6 +26,7 @@ pub fn validate_access_mode(raw: u32) -> Option<nono::AccessMode> {
         NONO_ACCESS_MODE_READ => Some(nono::AccessMode::Read),
         NONO_ACCESS_MODE_WRITE => Some(nono::AccessMode::Write),
         NONO_ACCESS_MODE_READ_WRITE => Some(nono::AccessMode::ReadWrite),
+        NONO_ACCESS_MODE_INTERACTIVE => Some(nono::AccessMode::Interactive),
         _ => None,
     }
 }
@@ -36,6 +38,8 @@ pub fn access_mode_to_raw(mode: nono::AccessMode) -> u32 {
         nono::AccessMode::Read => NONO_ACCESS_MODE_READ,
         nono::AccessMode::Write => NONO_ACCESS_MODE_WRITE,
         nono::AccessMode::ReadWrite => NONO_ACCESS_MODE_READ_WRITE,
+        nono::AccessMode::Interactive => NONO_ACCESS_MODE_INTERACTIVE,
+        _ => NONO_ACCESS_MODE_INVALID,
     }
 }
 

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -335,8 +335,10 @@ pub struct RunArgs {
 
     /// Preserve TTY for interactive apps (e.g., Claude Code, vim, htop).
     /// Without this flag, nono monitors output which can break interactive UIs.
-    #[arg(long = "exec")]
-    pub direct_exec: bool,
+    /// Also upgrades TTY device paths to Interactive access mode (adds IoctlDev
+    /// on Linux Landlock V5+). WARNING: this weakens isolation for TTY devices.
+    #[arg(long = "interactive", short = 'i', alias = "exec")]
+    pub interactive: bool,
 
     /// Enable atomic rollback snapshots for the session.
     /// Takes content-addressable snapshots of writable directories so you

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -2022,7 +2022,8 @@ fn open_canonical_path_no_symlinks(
     let flags = match access {
         nono::AccessMode::Read => libc::O_RDONLY,
         nono::AccessMode::Write => libc::O_WRONLY,
-        nono::AccessMode::ReadWrite => libc::O_RDWR,
+        nono::AccessMode::ReadWrite | nono::AccessMode::Interactive => libc::O_RDWR,
+        _ => libc::O_RDWR,
     } | libc::O_NOFOLLOW
         | libc::O_CLOEXEC;
 
@@ -2104,7 +2105,7 @@ mod tests {
     #[test]
     fn test_exec_strategy_supervised_selection() {
         // Verify the strategy selection logic from main.rs:
-        // interactive || direct_exec -> Direct
+        // interactive -> Direct
         // supervised -> Supervised
         // else -> Monitor
         let strategy = ExecStrategy::Supervised;

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -72,7 +72,7 @@ fn run() -> Result<()> {
                 args.sandbox,
                 args.command,
                 args.no_diagnostics,
-                args.direct_exec,
+                args.interactive,
                 args.rollback,
                 args.supervised,
                 args.no_rollback_prompt,
@@ -308,7 +308,7 @@ fn run_sandbox(
     args: SandboxArgs,
     command: Vec<String>,
     no_diagnostics: bool,
-    direct_exec: bool,
+    interactive_cli: bool,
     rollback: bool,
     supervised: bool,
     no_rollback_prompt: bool,
@@ -442,15 +442,20 @@ fn run_sandbox(
     let mut proxy_credentials = prepared.proxy_credentials.clone();
     proxy_credentials.extend(args.proxy_credential.clone());
 
+    // Upgrade TTY device paths to Interactive when interactive mode is active
+    let is_interactive = prepared.interactive || interactive_cli;
+    if is_interactive {
+        prepared.caps.upgrade_tty_to_interactive();
+    }
+
     execute_sandboxed(
         program,
         cmd_args,
         prepared.caps,
         prepared.secrets,
         ExecutionFlags {
-            interactive: prepared.interactive,
+            interactive: is_interactive,
             no_diagnostics,
-            direct_exec,
             rollback,
             supervised,
             no_rollback_prompt,
@@ -498,7 +503,10 @@ fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
         return Ok(());
     }
 
-    let prepared = prepare_sandbox(&args.sandbox, silent)?;
+    let mut prepared = prepare_sandbox(&args.sandbox, silent)?;
+
+    // Shell is always interactive - upgrade TTY device paths
+    prepared.caps.upgrade_tty_to_interactive();
 
     if !silent {
         eprintln!(
@@ -517,7 +525,6 @@ fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
         ExecutionFlags {
             interactive: true,
             no_diagnostics: true,
-            direct_exec: false,
             rollback: false,
             supervised: false,
             no_rollback_prompt: false,
@@ -544,7 +551,6 @@ fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
 struct ExecutionFlags {
     interactive: bool,
     no_diagnostics: bool,
-    direct_exec: bool,
     rollback: bool,
     supervised: bool,
     no_rollback_prompt: bool,
@@ -588,7 +594,7 @@ struct ExecutionFlags {
 fn select_execution_strategy(flags: &ExecutionFlags) -> exec_strategy::ExecStrategy {
     if flags.rollback || flags.supervised || flags.proxy_active {
         exec_strategy::ExecStrategy::Supervised
-    } else if flags.interactive || flags.direct_exec {
+    } else if flags.interactive {
         exec_strategy::ExecStrategy::Direct
     } else {
         exec_strategy::ExecStrategy::Monitor
@@ -871,7 +877,10 @@ fn execute_sandboxed(
                     .iter()
                     .filter(|c| {
                         !c.is_file
-                            && matches!(c.access, AccessMode::Write | AccessMode::ReadWrite)
+                            && matches!(
+                                c.access,
+                                AccessMode::Write | AccessMode::ReadWrite | AccessMode::Interactive
+                            )
                             && matches!(c.source, nono::CapabilitySource::User)
                     })
                     .map(|c| c.resolved.clone())

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -94,6 +94,8 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
                 AccessMode::Read => access_str.green(),
                 AccessMode::Write => access_str.yellow(),
                 AccessMode::ReadWrite => access_str.truecolor(204, 102, 0), // orange
+                AccessMode::Interactive => access_str.cyan(),
+                _ => access_str.white(),
             };
 
             if verbose > 0 {
@@ -396,6 +398,8 @@ pub fn prompt_cwd_sharing(cwd: &Path, access: &AccessMode) -> Result<bool> {
         AccessMode::Read => access_str.green(),
         AccessMode::Write => access_str.yellow(),
         AccessMode::ReadWrite => access_str.truecolor(204, 102, 0),
+        AccessMode::Interactive => access_str.cyan(),
+        _ => access_str.white(),
     };
 
     eprintln!(

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -503,7 +503,12 @@ pub fn apply_macos_login_keychain_exception(caps: &mut CapabilitySet) {
         .fs_capabilities()
         .iter()
         .filter(|cap| cap.is_file)
-        .filter(|cap| matches!(cap.access, AccessMode::Read | AccessMode::ReadWrite))
+        .filter(|cap| {
+            matches!(
+                cap.access,
+                AccessMode::Read | AccessMode::ReadWrite | AccessMode::Interactive
+            )
+        })
         .map(|cap| cap.resolved.clone())
         .filter(|path| is_login_db(path))
         .filter_map(|path| {
@@ -558,7 +563,12 @@ pub fn apply_unlink_overrides(caps: &mut CapabilitySet) {
     let writable_paths: Vec<PathBuf> = caps
         .fs_capabilities()
         .iter()
-        .filter(|cap| matches!(cap.access, AccessMode::Write | AccessMode::ReadWrite))
+        .filter(|cap| {
+            matches!(
+                cap.access,
+                AccessMode::Write | AccessMode::ReadWrite | AccessMode::Interactive
+            )
+        })
         .filter(|cap| !cap.is_file)
         .map(|cap| cap.resolved.clone())
         .collect();

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -491,7 +491,7 @@ pub struct Profile {
     pub hooks: HooksConfig,
     #[serde(default, alias = "undo")]
     pub rollback: RollbackConfig,
-    /// App has interactive UI that needs TTY preserved (implies --exec mode)
+    /// App has interactive UI that needs TTY preserved (implies --interactive mode)
     #[serde(default)]
     pub interactive: bool,
 }

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -100,7 +100,8 @@ pub fn query_path(path: &Path, requested: AccessMode, caps: &CapabilitySet) -> R
 
         let sufficient = matches!(
             (cap.access, requested),
-            (AccessMode::ReadWrite, _)
+            (AccessMode::Interactive, _)
+                | (AccessMode::ReadWrite, _)
                 | (AccessMode::Read, AccessMode::Read)
                 | (AccessMode::Write, AccessMode::Write)
         );

--- a/crates/nono-cli/src/sandbox_state.rs
+++ b/crates/nono-cli/src/sandbox_state.rs
@@ -54,6 +54,8 @@ impl SandboxState {
                         AccessMode::Read => "read".to_string(),
                         AccessMode::Write => "write".to_string(),
                         AccessMode::ReadWrite => "readwrite".to_string(),
+                        AccessMode::Interactive => "interactive".to_string(),
+                        _ => "readwrite".to_string(),
                     },
                     is_file: c.is_file,
                 })
@@ -79,6 +81,7 @@ impl SandboxState {
                 "read" => AccessMode::Read,
                 "write" => AccessMode::Write,
                 "readwrite" => AccessMode::ReadWrite,
+                "interactive" => AccessMode::Interactive,
                 other => {
                     return Err(NonoError::ConfigParse(format!(
                         "invalid access mode in sandbox state: {other}"

--- a/crates/nono-cli/src/terminal_approval.rs
+++ b/crates/nono-cli/src/terminal_approval.rs
@@ -123,6 +123,8 @@ fn format_access_mode(access: &AccessMode) -> &'static str {
         AccessMode::Read => "read-only",
         AccessMode::Write => "write-only",
         AccessMode::ReadWrite => "read+write",
+        AccessMode::Interactive => "interactive (read+write+ioctl)",
+        _ => "unknown",
     }
 }
 

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -46,6 +46,7 @@ impl std::fmt::Display for CapabilitySource {
 }
 
 /// Filesystem access mode
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AccessMode {
     /// Read-only access
@@ -54,6 +55,11 @@ pub enum AccessMode {
     Write,
     /// Read and write access
     ReadWrite,
+    /// ReadWrite + device ioctl: for TTY/PTY devices needing terminal operations.
+    /// On Linux (Landlock V5+), adds IoctlDev. On macOS, same as ReadWrite
+    /// (Seatbelt handles ioctl separately). WARNING: IoctlDev permits ALL ioctl
+    /// commands on device nodes, which weakens isolation.
+    Interactive,
 }
 
 impl std::fmt::Display for AccessMode {
@@ -62,6 +68,7 @@ impl std::fmt::Display for AccessMode {
             AccessMode::Read => write!(f, "read"),
             AccessMode::Write => write!(f, "write"),
             AccessMode::ReadWrite => write!(f, "read+write"),
+            AccessMode::Interactive => write!(f, "interactive"),
         }
     }
 }
@@ -744,13 +751,24 @@ impl CapabilitySet {
                     false
                 } else {
                     // Same source category: highest access wins
-                    cap.access == AccessMode::ReadWrite && existing.access != AccessMode::ReadWrite
+                    // Interactive > ReadWrite > Read/Write
+                    (cap.access == AccessMode::Interactive
+                        && existing.access != AccessMode::Interactive)
+                        || (cap.access == AccessMode::ReadWrite
+                            && !matches!(
+                                existing.access,
+                                AccessMode::ReadWrite | AccessMode::Interactive
+                            ))
                 };
 
                 // Merge complementary access modes (Read + Write = ReadWrite).
+                // Interactive absorbs all other modes.
                 // When two entries from the same source category have different
                 // non-ReadWrite modes, upgrade the kept entry to ReadWrite.
                 let merged_access = match (existing.access, cap.access) {
+                    (AccessMode::Interactive, _) | (_, AccessMode::Interactive) => {
+                        Some(AccessMode::Interactive)
+                    }
                     (AccessMode::Read, AccessMode::Write)
                     | (AccessMode::Write, AccessMode::Read) => Some(AccessMode::ReadWrite),
                     _ => None,
@@ -798,6 +816,41 @@ impl CapabilitySet {
         to_remove.reverse();
         for idx in to_remove {
             self.fs.remove(idx);
+        }
+    }
+
+    /// Upgrade TTY/PTY device paths to `AccessMode::Interactive`.
+    ///
+    /// Scans existing filesystem capabilities and promotes paths matching
+    /// `/dev/tty` or `/dev/pts` to `Interactive` access mode, which adds
+    /// `IoctlDev` on Linux (Landlock V5+) for terminal operations.
+    ///
+    /// **User intent protection**: Entries with `CapabilitySource::User` are
+    /// never modified. If a user explicitly set `/dev/tty` to `Read`, that
+    /// choice is respected.
+    ///
+    /// This method is idempotent: calling it multiple times produces the same result.
+    pub fn upgrade_tty_to_interactive(&mut self) {
+        let tty_path = Path::new("/dev/tty");
+        let pts_path = Path::new("/dev/pts");
+
+        for cap in &mut self.fs {
+            // Never override explicit user intent
+            if matches!(cap.source, CapabilitySource::User) {
+                continue;
+            }
+            // Already Interactive, nothing to do
+            if cap.access == AccessMode::Interactive {
+                continue;
+            }
+            // Check if this is a TTY/PTY device path
+            let is_tty = cap.resolved == tty_path
+                || cap.resolved.starts_with(pts_path)
+                || cap.original == tty_path
+                || cap.original.starts_with(pts_path);
+            if is_tty {
+                cap.access = AccessMode::Interactive;
+            }
         }
     }
 
@@ -1407,5 +1460,145 @@ mod tests {
         let summary = caps.summary();
         assert!(summary.contains("tcp connect ports: 443"));
         assert!(summary.contains("tcp bind ports: 8080"));
+    }
+
+    #[test]
+    fn test_access_mode_interactive_display() {
+        assert_eq!(AccessMode::Interactive.to_string(), "interactive");
+    }
+
+    #[test]
+    fn test_dedup_interactive_absorbs_read() {
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/dev/tty"),
+            resolved: PathBuf::from("/dev/tty"),
+            access: AccessMode::Interactive,
+            is_file: true,
+            source: CapabilitySource::System,
+        });
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/dev/tty"),
+            resolved: PathBuf::from("/dev/tty"),
+            access: AccessMode::Read,
+            is_file: true,
+            source: CapabilitySource::System,
+        });
+        caps.deduplicate();
+        assert_eq!(caps.fs_capabilities().len(), 1);
+        assert_eq!(caps.fs_capabilities()[0].access, AccessMode::Interactive);
+    }
+
+    #[test]
+    fn test_dedup_interactive_absorbs_readwrite() {
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/dev/tty"),
+            resolved: PathBuf::from("/dev/tty"),
+            access: AccessMode::ReadWrite,
+            is_file: true,
+            source: CapabilitySource::System,
+        });
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/dev/tty"),
+            resolved: PathBuf::from("/dev/tty"),
+            access: AccessMode::Interactive,
+            is_file: true,
+            source: CapabilitySource::System,
+        });
+        caps.deduplicate();
+        assert_eq!(caps.fs_capabilities().len(), 1);
+        assert_eq!(caps.fs_capabilities()[0].access, AccessMode::Interactive);
+    }
+
+    #[test]
+    fn test_dedup_read_write_merge_to_interactive_when_interactive_present() {
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/dev/tty"),
+            resolved: PathBuf::from("/dev/tty"),
+            access: AccessMode::Read,
+            is_file: true,
+            source: CapabilitySource::System,
+        });
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/dev/tty"),
+            resolved: PathBuf::from("/dev/tty"),
+            access: AccessMode::Interactive,
+            is_file: true,
+            source: CapabilitySource::System,
+        });
+        caps.deduplicate();
+        assert_eq!(caps.fs_capabilities().len(), 1);
+        assert_eq!(caps.fs_capabilities()[0].access, AccessMode::Interactive);
+    }
+
+    #[test]
+    fn test_upgrade_tty_to_interactive() {
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/dev/tty"),
+            resolved: PathBuf::from("/dev/tty"),
+            access: AccessMode::ReadWrite,
+            is_file: true,
+            source: CapabilitySource::System,
+        });
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/dev/pts"),
+            resolved: PathBuf::from("/dev/pts"),
+            access: AccessMode::Read,
+            is_file: false,
+            source: CapabilitySource::Group("tty".to_string()),
+        });
+        caps.upgrade_tty_to_interactive();
+        assert_eq!(caps.fs_capabilities()[0].access, AccessMode::Interactive);
+        assert_eq!(caps.fs_capabilities()[1].access, AccessMode::Interactive);
+    }
+
+    #[test]
+    fn test_upgrade_tty_leaves_non_tty_unchanged() {
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/usr"),
+            resolved: PathBuf::from("/usr"),
+            access: AccessMode::Read,
+            is_file: false,
+            source: CapabilitySource::System,
+        });
+        caps.upgrade_tty_to_interactive();
+        assert_eq!(caps.fs_capabilities()[0].access, AccessMode::Read);
+    }
+
+    #[test]
+    fn test_upgrade_tty_preserves_user_intent() {
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/dev/tty"),
+            resolved: PathBuf::from("/dev/tty"),
+            access: AccessMode::Read,
+            is_file: true,
+            source: CapabilitySource::User,
+        });
+        caps.upgrade_tty_to_interactive();
+        // User explicitly set Read on /dev/tty - must NOT be upgraded
+        assert_eq!(caps.fs_capabilities()[0].access, AccessMode::Read);
+    }
+
+    #[test]
+    fn test_upgrade_tty_idempotent() {
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/dev/tty"),
+            resolved: PathBuf::from("/dev/tty"),
+            access: AccessMode::ReadWrite,
+            is_file: true,
+            source: CapabilitySource::System,
+        });
+        caps.upgrade_tty_to_interactive();
+        let first = caps.fs_capabilities()[0].access;
+        caps.upgrade_tty_to_interactive();
+        let second = caps.fs_capabilities()[0].access;
+        assert_eq!(first, second);
+        assert_eq!(first, AccessMode::Interactive);
     }
 }

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -424,6 +424,7 @@ fn access_str(access: AccessMode) -> &'static str {
         AccessMode::Read => "read",
         AccessMode::Write => "write",
         AccessMode::ReadWrite => "read+write",
+        AccessMode::Interactive => "interactive",
     }
 }
 

--- a/crates/nono/src/query.rs
+++ b/crates/nono/src/query.rs
@@ -91,7 +91,8 @@ impl QueryContext {
             if covers {
                 let sufficient = matches!(
                     (cap.access, requested),
-                    (AccessMode::ReadWrite, _)
+                    (AccessMode::Interactive, _)
+                        | (AccessMode::ReadWrite, _)
                         | (AccessMode::Read, AccessMode::Read)
                         | (AccessMode::Write, AccessMode::Write)
                 );

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -50,7 +50,11 @@ pub fn support_info() -> SupportInfo {
 /// most applications for safe config updates.
 fn access_to_landlock(access: AccessMode, _abi: ABI) -> BitFlags<AccessFs> {
     match access {
-        AccessMode::Read => AccessFs::ReadFile | AccessFs::ReadDir | AccessFs::Execute,
+        AccessMode::Read => {
+            // Read access includes basic file/dir reading and execution.
+            // IoctlDev is NOT included here; use Interactive for TTY paths.
+            AccessFs::ReadFile | AccessFs::ReadDir | AccessFs::Execute
+        }
         AccessMode::Write => {
             // Write access includes all operations needed for normal file manipulation:
             // - WriteFile: modify file contents
@@ -75,6 +79,12 @@ fn access_to_landlock(access: AccessMode, _abi: ABI) -> BitFlags<AccessFs> {
         }
         AccessMode::ReadWrite => {
             access_to_landlock(AccessMode::Read, _abi) | access_to_landlock(AccessMode::Write, _abi)
+        }
+        AccessMode::Interactive => {
+            // Interactive = ReadWrite + IoctlDev for TTY/PTY device operations.
+            // IoctlDev (Landlock ABI v5+) permits all ioctl commands on device nodes.
+            // On kernels < v5, restrict_self() returns PartiallyEnforced (safe degradation).
+            access_to_landlock(AccessMode::ReadWrite, _abi) | AccessFs::IoctlDev
         }
     }
 }
@@ -818,6 +828,46 @@ mod tests {
         assert!(rw.contains(AccessFs::Truncate));
         // Verify directory removal is still NOT included
         assert!(!rw.contains(AccessFs::RemoveDir));
+    }
+
+    #[test]
+    fn test_access_conversion_interactive() {
+        let abi = ABI::V5;
+
+        // Only Interactive includes IoctlDev
+        let interactive = access_to_landlock(AccessMode::Interactive, abi);
+        assert!(
+            interactive.contains(AccessFs::IoctlDev),
+            "Interactive should include IoctlDev for device ioctl (TTY, etc.)"
+        );
+        // Interactive inherits all ReadWrite permissions
+        assert!(interactive.contains(AccessFs::ReadFile));
+        assert!(interactive.contains(AccessFs::WriteFile));
+        assert!(interactive.contains(AccessFs::Execute));
+    }
+
+    #[test]
+    fn test_readwrite_no_ioctl_dev() {
+        let abi = ABI::V5;
+
+        // Read, Write, and ReadWrite must NOT include IoctlDev
+        let read = access_to_landlock(AccessMode::Read, abi);
+        assert!(
+            !read.contains(AccessFs::IoctlDev),
+            "Read must not include IoctlDev"
+        );
+
+        let write = access_to_landlock(AccessMode::Write, abi);
+        assert!(
+            !write.contains(AccessFs::IoctlDev),
+            "Write must not include IoctlDev"
+        );
+
+        let rw = access_to_landlock(AccessMode::ReadWrite, abi);
+        assert!(
+            !rw.contains(AccessFs::IoctlDev),
+            "ReadWrite must not include IoctlDev"
+        );
     }
 
     #[test]

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -62,7 +62,7 @@ const EXT_CLASS_READ_WRITE: &str = "com.apple.app-sandbox.read-write";
 pub fn extension_issue_file(path: &Path, access: AccessMode) -> Result<String> {
     let class = match access {
         AccessMode::Read => EXT_CLASS_READ,
-        AccessMode::Write | AccessMode::ReadWrite => EXT_CLASS_READ_WRITE,
+        AccessMode::Write | AccessMode::ReadWrite | AccessMode::Interactive => EXT_CLASS_READ_WRITE,
     };
 
     let class_c = CString::new(class)
@@ -366,7 +366,10 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
     // This prevents loading arbitrary shared libraries via DYLD_INSERT_LIBRARIES
     // from paths outside the sandbox's read set.
     for cap in caps.fs_capabilities() {
-        if matches!(cap.access, AccessMode::Read | AccessMode::ReadWrite) {
+        if matches!(
+            cap.access,
+            AccessMode::Read | AccessMode::ReadWrite | AccessMode::Interactive
+        ) {
             for filter in path_filters_for_cap(cap)? {
                 profile.push_str(&format!("(allow file-map-executable ({}))\n", filter));
             }
@@ -392,7 +395,7 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
     // (e.g. /tmp vs /private/tmp) so Seatbelt allows traversing symlinks.
     for cap in caps.fs_capabilities() {
         match cap.access {
-            AccessMode::Read | AccessMode::ReadWrite => {
+            AccessMode::Read | AccessMode::ReadWrite | AccessMode::Interactive => {
                 for filter in path_filters_for_cap(cap)? {
                     profile.push_str(&format!("(allow file-read* ({}))\n", filter));
                 }
@@ -431,7 +434,7 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
     // Emits rules for both original and resolved paths when they differ.
     for cap in caps.fs_capabilities() {
         match cap.access {
-            AccessMode::Write | AccessMode::ReadWrite => {
+            AccessMode::Write | AccessMode::ReadWrite | AccessMode::Interactive => {
                 for filter in path_filters_for_cap(cap)? {
                     profile.push_str(&format!("(allow file-write* ({}))\n", filter));
                 }

--- a/crates/nono/src/state.rs
+++ b/crates/nono/src/state.rs
@@ -62,6 +62,7 @@ impl SandboxState {
                 "read" => AccessMode::Read,
                 "write" => AccessMode::Write,
                 "read+write" => AccessMode::ReadWrite,
+                "interactive" => AccessMode::Interactive,
                 other => {
                     return Err(crate::error::NonoError::ConfigParse(format!(
                         "invalid access mode in sandbox state: {other}"

--- a/docs/cli/features/execution-modes.mdx
+++ b/docs/cli/features/execution-modes.mdx
@@ -9,14 +9,14 @@ nono provides three execution modes that trade off between attack surface, featu
 
 | Mode | Flag | Parent Sandboxed | Rollback | Expansion | Attack Surface |
 |------|------|-----------------|----------|-----------|----------------|
-| Direct | `--exec` | N/A (no parent) | No | No | Minimal |
+| Direct | `--interactive` / `-i` | N/A (no parent) | No | No | Minimal |
 | Monitor | (default) | Yes | No | No | Small |
 | Supervised | `--rollback` / `--supervised` | No | `--rollback` only | Linux only | Larger |
 
 ## Direct Mode
 
 ```bash
-nono run --exec --allow-cwd -- my-command
+nono run --interactive --allow-cwd -- my-command
 ```
 
 nono applies the sandbox and then `exec()`s directly into the target command. nono disappears from the process tree entirely - there is no parent process.
@@ -99,7 +99,7 @@ Do you need rollback snapshots?
         └── No
             │
             Do you need minimal overhead or TTY preservation?
-            ├── Yes → Direct (--exec)
+            ├── Yes → Direct (--interactive)
             └── No → Monitor (default)
 ```
 

--- a/docs/cli/features/network-proxy.mdx
+++ b/docs/cli/features/network-proxy.mdx
@@ -189,7 +189,7 @@ nono run -vv --network-profile claude-code --allow-cwd -- my-agent
 
 - **HTTP/1.1 only** - The CONNECT tunnel passes raw bytes (HTTP/2 works end-to-end), but the reverse proxy mode speaks HTTP/1.1 to upstream
 - **No per-port filtering on macOS** - Seatbelt cannot filter outbound by destination port (only ProxyOnly mode is supported, not arbitrary per-port rules)
-- **Proxy mode requires supervised execution** - The proxy runs in the unsandboxed parent process, so `--exec` mode is incompatible
+- **Proxy mode requires supervised execution** - The proxy runs in the unsandboxed parent process, so `--interactive` (direct exec) mode is incompatible
 
 ## Next Steps
 

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -176,7 +176,7 @@ The `interactive` field (default: `false`) indicates whether the application has
 }
 ```
 
-When `true`, nono uses direct exec mode (equivalent to `--exec` flag), which preserves the terminal for apps like Claude Code, vim, or htop.
+When `true`, nono uses interactive mode (equivalent to `--interactive` flag), which preserves the terminal for apps like Claude Code, vim, or htop. This also upgrades TTY device paths to Interactive access mode, adding IoctlDev on Linux Landlock V5+.
 
 ### Rollback Exclusions
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -449,12 +449,17 @@ Suppress the interactive post-exit review when using `--rollback`. Snapshots are
 nono run --rollback --no-rollback-prompt --allow-cwd -- my-agent
 ```
 
-#### `--exec`
+#### `--interactive` / `-i`
 
-Use direct execution mode. nono applies the sandbox and then `exec()`s directly into the target command. No parent process remains.
+Use interactive execution mode for TTY applications (e.g., Claude Code, vim, htop). nono applies the sandbox and then `exec()`s directly into the target command, preserving the terminal. Also upgrades TTY device paths (`/dev/tty`, `/dev/pts`) to Interactive access mode, which adds `IoctlDev` on Linux Landlock V5+.
+
+**WARNING**: Interactive mode weakens isolation for TTY devices. `IoctlDev` permits all ioctl commands on device nodes, including `TIOCSTI` (terminal input injection). Only use when the application genuinely needs terminal interaction.
+
+`--exec` is accepted as a hidden alias for backward compatibility.
 
 ```bash
-nono run --exec --allow-cwd -- my-command
+nono run --interactive --allow-cwd -- my-command
+nono run -i --allow-cwd -- my-command
 ```
 
 #### `--no-diagnostics`


### PR DESCRIPTION
## Summary

- Add `AccessMode::Interactive` variant (ReadWrite + IoctlDev on Landlock V5+)
- Remove `IoctlDev` from `AccessMode::Read` — restricts device ioctl to TTY paths only
- Rename `--exec` CLI flag to `--interactive` (`-i`), keeping `--exec` as hidden alias
- Add `#[non_exhaustive]` to `AccessMode` enum

Addresses review feedback from @lukehinds on the original approach (granting IoctlDev
to all Read paths was too broad).

Closes #192

## Problem

The original approach added `IoctlDev` to `AccessMode::Read`, which granted device
ioctl permissions to **every** read-accessible path. This was too broad — only TTY/PTY
devices (`/dev/tty`, `/dev/pts/*`) actually need ioctl for interactive apps.

## Solution

1. **New `AccessMode::Interactive`**: ReadWrite + IoctlDev (Linux only). Applied only
   to TTY device paths via `CapabilitySet::upgrade_tty_to_interactive()`.
2. **User intent protection**: Paths with `CapabilitySource::User` are never
   auto-upgraded — if a user explicitly set `/dev/tty` to `Read`, that's respected.
   Users who want interactive access on a specific path can set it via profile config.
3. **CLI unification**: `--exec` → `--interactive` (`-i`). The profile field
   `interactive: true` already existed, so terminology is now consistent.
4. **Activation**: `upgrade_tty_to_interactive()` is called only when `--interactive`
   flag is passed or profile sets `interactive: true`. The library never auto-upgrades
   on its own — the CLI owns this policy decision.

### TTY path scope

Only `/dev/tty` and `/dev/pts/*` are upgraded, per @lukehinds' guidance. `/dev/ptmx`
is excluded because it is the multiplexer (opens new PTYs) rather than an existing
terminal device — granting `IoctlDev` on it would be overly broad. `/dev/console` is
excluded as it is rarely present in container environments.

## Security Considerations

- **Tighter than before**: IoctlDev is no longer on all Read paths; only on TTY devices
  when `--interactive` is active
- **IoctlDev permits ALL ioctls**: including TIOCSTI (terminal input injection). The
  `--interactive` flag doc warns about weakened isolation
- **macOS**: `file-ioctl` is already granted to all allowed paths in the existing
  Seatbelt profile generation. `Interactive` does not change this behavior — it maps
  to ReadWrite for the read/write/map-exec classification only. This PR's IoctlDev
  isolation is Linux-specific.
- **Landlock < V5**: `restrict_self()` returns `PartiallyEnforced` (same pattern as
  `Truncate` on < V3). On older kernels, `--interactive` will not grant ioctl and
  interactive apps requiring terminal ioctl may fail. This is a fail-secure degradation.

### Why `#[non_exhaustive]` now?

Adding `Interactive` is already a breaking change (downstream exhaustive matches break).
Adding `#[non_exhaustive]` at the same time means future variants won't cause another
breaking bump — a single migration cost for downstream instead of repeated ones.

## Breaking Changes

- `AccessMode` is now `#[non_exhaustive]` — downstream exhaustive matches need `_ =>` arm
- New `AccessMode::Interactive` variant
- `--exec` flag renamed to `--interactive` (`--exec` remains as hidden alias)
- FFI: `NONO_ACCESS_MODE_INTERACTIVE = 3` added

Downstream bindings (nono-py, nono-ts) will need updates.

## Files Changed (21)

| Area | Files | Changes |
|------|-------|---------|
| Library | `capability.rs` | Interactive variant, `#[non_exhaustive]`, `upgrade_tty_to_interactive()`, dedup logic |
| Library | `sandbox/linux.rs` | Remove IoctlDev from Read, add Interactive arm |
| Library | `sandbox/macos.rs` | Interactive = ReadWrite in all match arms |
| Library | `query.rs`, `diagnostic.rs`, `state.rs` | Interactive support |
| CLI | `cli.rs` | `--interactive` / `-i` (alias `--exec`) |
| CLI | `main.rs` | TTY upgrade calls, remove `direct_exec` field |
| CLI | `output.rs`, `terminal_approval.rs`, `sandbox_state.rs`, `query_ext.rs`, `exec_strategy.rs`, `policy.rs`, `profile/mod.rs` | Interactive in all AccessMode matches |
| FFI | `types.rs`, `nono.h` | `NONO_ACCESS_MODE_INTERACTIVE = 3` |
| Docs | `flags.mdx`, `execution-modes.mdx`, `network-proxy.mdx`, `profiles-groups.mdx` | --exec → --interactive |

## Test Plan

- [x] `make ci` passes (clippy + fmt + all tests)
- [x] New tests: dedup (Interactive absorbs Read/Write/ReadWrite), TTY upgrade,
  user intent preservation, idempotency, Landlock conversion, display
- [x] Read no longer includes IoctlDev
- [x] ReadWrite does not include IoctlDev
- [x] Interactive = ReadWrite | IoctlDev
- [ ] Manual: `nono run --interactive --allow /dev/tty -- vim` on Landlock V5 kernel