### PR TITLE
Add 1Password credential injection documentation

### DIFF
--- a/docs/cli/features/credential-injection.mdx
+++ b/docs/cli/features/credential-injection.mdx
@@ -1,6 +1,6 @@
 ---
 title: Credential Injection
-description: Keep API keys out of the sandbox with transparent credential injection
+description: Keep API keys out of the sandbox with transparent credential injection from the system keystore or 1Password
 ---
 
 Credential injection keeps API keys out of the sandboxed process entirely. The agent sees a local HTTP URL and the proxy handles authentication transparently.
@@ -71,6 +71,142 @@ echo -n "your-gemini-key" | secret-tool store --label="nono: gemini_api_key" \
 ```
 
 **Important:** Use `username` (not `account`) as the attribute name. The `target default` attribute is required for the keyring crate to find the entry.
+
+## 1Password Integration
+
+nono supports [1Password](https://1password.com/) `op://` URIs as a credential source anywhere you would use a keyring account name. This works with both `--env-credential` (CLI) and profile-based credentials (`env_credentials`, `custom_credentials`). The 1Password CLI (`op`) must be installed and authenticated.
+
+### Finding Your Secret Path
+
+`op://` URIs have the format `op://<vault>/<item>/<field>`. Use the `op` CLI to discover each segment:
+
+```bash
+# 1. List your vaults
+op vault list
+
+# 2. List items in a vault
+op item list --vault Development
+
+# 3. See all fields on an item
+op item get "OpenAI API Key" --vault Development
+
+# 4. The resulting URI
+op://Development/OpenAI API Key/credential
+```
+
+The field name depends on the item type — "Password" items have a `password` field, "API Credential" items typically have `credential`, and custom items use whatever field labels you set. Run `op item get` to see all available fields for a given item.
+
+### CLI: Direct Environment Variable Injection
+
+Pass an `op://` URI to `--env-credential` with an explicit `=VAR_NAME` suffix:
+
+```bash
+# Single 1Password secret
+nono run --allow . --env-credential 'op://Development/OpenAI/credential=OPENAI_API_KEY' -- my-agent
+
+# Multiple secrets (mixed keyring + 1Password)
+nono run --allow . --env-credential 'openai_api_key,op://Development/Anthropic/api-key=ANTHROPIC_API_KEY' -- my-agent
+```
+
+The `=VAR_NAME` suffix is **required** for `op://` URIs. Unlike keyring account names (which are auto-uppercased), a URI like `op://Development/OpenAI/credential` has no meaningful uppercase form. Bare URIs are rejected:
+
+```
+$ nono run --allow . --env-credential 'op://vault/item/field' -- agent
+nono: 1Password credential requires an explicit variable name.
+      Use format: op://vault/item/field=MY_VAR
+```
+
+### Profile: Environment Credential Injection
+
+In a profile's `env_credentials` section, use an `op://` URI as the key instead of a keyring account name:
+
+```json
+{
+  "meta": { "name": "my-agent" },
+  "env_credentials": {
+    "op://Development/OpenAI/credential": "OPENAI_API_KEY"
+  }
+}
+```
+
+```bash
+nono run --profile my-agent -- my-agent
+# Child process sees: OPENAI_API_KEY=sk-actual-secret-value
+```
+
+### Profile: Proxy Credential Injection
+
+For network API keys, proxy injection is recommended — the child process never sees the real secret. Use an `op://` URI in `credential_key`:
+
+```json
+{
+  "meta": { "name": "my-agent-secure" },
+  "network": {
+    "custom_credentials": {
+      "openai": {
+        "upstream": "https://api.openai.com/v1",
+        "credential_key": "op://Development/OpenAI API Key/credential",
+        "env_var": "OPENAI_API_KEY",
+        "inject_header": "Authorization",
+        "credential_format": "Bearer {}"
+      },
+      "anthropic": {
+        "upstream": "https://api.anthropic.com",
+        "credential_key": "op://Development/Anthropic/api-key",
+        "env_var": "ANTHROPIC_API_KEY",
+        "inject_header": "x-api-key",
+        "credential_format": "{}"
+      }
+    },
+    "proxy_credentials": ["openai", "anthropic"]
+  }
+}
+```
+
+```bash
+nono run --profile my-agent-secure -- my-agent
+# Child process sees: OPENAI_API_KEY=nono_sess_a1b2c3... (phantom token)
+# Proxy transparently swaps to real Bearer sk-... when forwarding to api.openai.com
+```
+
+### Mixed Mode: Environment + Proxy Credentials
+
+You can combine both injection modes in a single profile. Use `env_credentials` for non-network secrets (database passwords, tokens) and `custom_credentials` with proxy injection for API keys:
+
+```json
+{
+  "meta": { "name": "mixed-example" },
+  "env_credentials": {
+    "op://Infrastructure/Database/password": "DATABASE_PASSWORD"
+  },
+  "network": {
+    "custom_credentials": {
+      "openai": {
+        "upstream": "https://api.openai.com/v1",
+        "credential_key": "op://Development/OpenAI/credential",
+        "env_var": "OPENAI_API_KEY",
+        "inject_header": "Authorization",
+        "credential_format": "Bearer {}"
+      }
+    },
+    "proxy_credentials": ["openai"]
+  }
+}
+```
+
+### Backward Compatibility
+
+Existing keyring-based workflows are completely unchanged. Keyring account names continue to work identically:
+
+```bash
+# Keyring credentials (unchanged)
+nono run --allow . --env-credential openai_api_key -- my-agent
+# Child process sees: OPENAI_API_KEY=<value from system keyring>
+```
+
+`op://` URIs are recognized by their prefix and routed to 1Password; all other values are treated as keyring account names.
+
+---
 
 ## Environment Variables
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -349,11 +349,14 @@ nono run --allow-cwd --block-command my-dangerous-tool -- my-script.sh
 
 #### `--env-credential`
 
-Load credentials from the system keystore (macOS Keychain / Linux Secret Service) and inject them as environment variables. The sandboxed process can read these credentials directly.
+Load credentials from the system keystore (macOS Keychain / Linux Secret Service) or 1Password and inject them as environment variables. The sandboxed process can read these credentials directly.
 
 ```bash
 # Load specific credentials by account name
 nono run --allow-cwd --env-credential openai_api_key,anthropic_api_key -- my-agent
+
+# Load from 1Password (op:// URI with =VAR_NAME suffix)
+nono run --allow-cwd --env-credential 'op://Development/OpenAI/credential=OPENAI_API_KEY' -- my-agent
 
 # Use with profile (loads credentials defined in profile's [env_credentials] section)
 nono run --profile claude-code --env-credential -- claude


### PR DESCRIPTION
## Summary

- Add a new **1Password Integration** section to `credential-injection.mdx` covering `op://` URI support for CLI (`--env-credential`), profile `env_credentials`, profile `custom_credentials` (proxy injection), mixed mode, and backward compatibility
- Update `flags.mdx` to mention `op://` URI support in the `--env-credential` section

## Test plan

- [ ] Review rendered markdown on Mintlify for correct formatting
- [ ] Verify all code examples match the implemented `op://` URI behavior
- [ ] Confirm the error message for bare `op://` URIs matches the CLI output

🤖 Generated with [Claude Code](https://claude.com/claude-code)