### PR TITLE
fix(network): add claude.ai to llm_apis allow list

### DIFF
--- a/crates/nono-cli/data/network-policy.json
+++ b/crates/nono-cli/data/network-policy.json
@@ -9,6 +9,7 @@
       "hosts": [
         "api.openai.com",
         "api.anthropic.com",
+        "claude.ai",
         "generativelanguage.googleapis.com",
         "aiplatform.googleapis.com",
         "api.groq.com",


### PR DESCRIPTION
This pull request adds `claude.ai` to the `llm_apis` network group in `network-policy.json`

When using the `--network-profile claude-code` switch, we see errors from Claude when it tries to send a preflight request to claude.ai for security reasons (see this related issue: https://github.com/anthropics/claude-code/issues/6188#issuecomment-3207937328)

Before
<img width="2406" height="321" alt="image" src="https://github.com/user-attachments/assets/1c1ee8fb-81da-449e-9cba-ba1e90db8291" />

After: Works as expected.


## Test plan
- [ ] Verify the JSON is valid: `jq . crates/nono-cli/data/network-policy.json`
- [ ] Build and run tests: `make ci`
- [ ] Test with `nono run --network-profile claude-code -- curl -I https://claude.ai`
