### PR TITLE
fix: include character device files in policy group resolution

### DIFF
--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -413,7 +413,10 @@ fn add_fs_capability(
                 debug!("Could not add group directory {}: {}", path_str, e);
             }
         }
-    } else if path.is_file() {
+    } else {
+        // Accepts regular files, character devices (/dev/urandom, /dev/null, etc.),
+        // symlinks, and other non-directory paths — matching FsCapability::new_file()
+        // which rejects only directories.
         match FsCapability::new_file(&path, mode) {
             Ok(mut cap) => {
                 cap.source = source.clone();
@@ -423,11 +426,6 @@ fn add_fs_capability(
                 debug!("Could not add group file {}: {}", path_str, e);
             }
         }
-    } else {
-        debug!(
-            "Group path '{}' is neither file nor directory, skipping",
-            path_str
-        );
     }
 
     Ok(())
@@ -1312,6 +1310,68 @@ mod tests {
             result.is_ok(),
             "Unknown groups should not trigger required check"
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_resolve_character_device_files() {
+        // Character device files like /dev/urandom must be included in the
+        // capability set. Rust's Path::is_file() returns false for device
+        // files, so the resolver must not gate on is_file().
+        let policy_json = r#"{
+            "meta": { "version": 2, "schema_version": "2.0" },
+            "groups": {
+                "test_devices": {
+                    "description": "Device files",
+                    "platform": "linux",
+                    "allow": { "read": ["/dev/urandom", "/dev/null", "/dev/zero"] }
+                }
+            }
+        }"#;
+        let policy = load_policy(policy_json).expect("parse failed");
+        let mut caps = CapabilitySet::new();
+        resolve_groups(&policy, &["test_devices".to_string()], &mut caps).expect("resolve failed");
+
+        let resolved_paths: Vec<PathBuf> = caps
+            .fs_capabilities()
+            .iter()
+            .map(|c| c.resolved.clone())
+            .collect();
+
+        for device in &["/dev/urandom", "/dev/null", "/dev/zero"] {
+            assert!(
+                resolved_paths.iter().any(|p| p == Path::new(device)),
+                "{} must be included, got: {:?}",
+                device,
+                resolved_paths
+            );
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_embedded_policy_includes_device_files() {
+        // The system_read_linux group lists /dev/urandom, /dev/null, etc.
+        // Verify they survive policy resolution and end up in the capability set.
+        let policy = load_embedded_policy().expect("embedded policy");
+        let mut caps = CapabilitySet::new();
+        resolve_groups(&policy, &["system_read_linux".to_string()], &mut caps)
+            .expect("resolve failed");
+
+        let resolved_paths: Vec<PathBuf> = caps
+            .fs_capabilities()
+            .iter()
+            .map(|c| c.resolved.clone())
+            .collect();
+
+        for device in &["/dev/urandom", "/dev/null", "/dev/zero", "/dev/random"] {
+            assert!(
+                resolved_paths.iter().any(|p| p == Path::new(device)),
+                "{} must be included in system_read_linux capabilities, got: {:?}",
+                device,
+                resolved_paths
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`add_fs_capability()` in the CLI policy resolver gated non-directory paths on `path.is_file()`. Rust's `Path::is_file()` returns `false` for character devices, so device files listed in policy groups (`/dev/urandom`, `/dev/null`, `/dev/zero`, `/dev/random`, `/dev/full`, `/dev/tty`, `/dev/console`) were silently dropped from the capability set.

This is the CLI-side counterpart to #138, which fixed the same `is_file()` check in the library's `FsCapability::new_file()`. The library fix was necessary but insufficient — the CLI policy resolver dropped device paths before they ever reached the library.

## Reproduction

```
nono run --profile claude-code --allow-cwd -- claude -v
```

Bun (which Claude Code and opencode are built on) segfaults at `0xBBADBEEF`:

```
panic(main thread): Segmentation fault at address 0xBBADBEEF
oh no: Bun has crashed.
```

strace shows the cause — `/dev/urandom` is blocked by Landlock, and Bun crashes immediately after:

```
openat(AT_FDCWD, "/dev/urandom", O_RDONLY) = -1 EACCES (Permission denied)
--- SIGSEGV {si_signo=SIGSEGV, si_code=SEGV_MAPERR, si_addr=0xbbadbeef} ---
```

Bun uses `open("/dev/urandom")` rather than the `getrandom(2)` syscall, so Landlock enforcement on the device file path applies.

## Fix

Changed the `else if path.is_file()` branch to `else`, matching the library's `FsCapability::new_file()` which rejects only directories. After the fix, the verbose capability list shows 31 system/group paths (was 24 — the 7 missing were all character devices).

## Test plan

- [x] Added `test_resolve_character_device_files` — verifies device files in a policy group are resolved into capabilities
- [x] Added `test_embedded_policy_includes_device_files` — verifies the real `system_read_linux` group includes `/dev/urandom`, `/dev/null`, `/dev/zero`, `/dev/random`
- [x] Both tests fail without the fix, pass with it
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::unwrap_used` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test --workspace` passes (one pre-existing flaky failure in `test_check_sensitive_path` unrelated to this change)
- [x] Manual verification: `nono run --profile claude-code --allow-cwd -- claude -v` succeeds

Fixes #154 (Bun segfault component — the `/$bunfs` virtual path issue is separate)