### PR TITLE
fix: pre-create claude-code config lock file on Linux

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -487,7 +487,7 @@
       "filesystem": {
         "allow": ["$HOME/.claude"],
         "read": ["$HOME/.local/share/claude"],
-        "allow_file": ["$HOME/.claude.json"],
+        "allow_file": ["$HOME/.claude.json", "$HOME/.claude.json.lock"],
         "read_file": ["$HOME/Library/Keychains/login.keychain-db", "$HOME/.gitconfig", "$HOME/.gitignore_global", "$HOME/.config/git/ignore"]
       },
       "network": { "block": false },

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -1219,6 +1219,22 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
         .map(|p| p.network.custom_credentials.clone())
         .unwrap_or_default();
 
+    // On Linux, pre-create the Claude Code config lock file before building
+    // capabilities. Claude Code's saveConfigWithLock creates ~/.claude.json.lock
+    // next to ~/.claude.json. Landlock cannot grant permission to create new
+    // files in ~/ without opening the entire directory, so we pre-create the
+    // lock file and grant access to it via the profile's allow_file list.
+    #[cfg(target_os = "linux")]
+    if args.profile.as_deref() == Some("claude-code") {
+        let home = config::validated_home()?;
+        let lock_path = std::path::Path::new(&home).join(".claude.json.lock");
+        if !lock_path.exists() {
+            if let Err(e) = std::fs::File::create(&lock_path) {
+                warn!("Failed to pre-create {}: {}", lock_path.display(), e);
+            }
+        }
+    }
+
     // Build capabilities from profile or arguments.
     // Unlink overrides are deferred so they can cover the CWD path added below.
     let (mut caps, needs_unlink_overrides) = if let Some(ref prof) = loaded_profile {


### PR DESCRIPTION
## Summary

- Add `$HOME/.claude.json.lock` to the claude-code profile's `allow_file` list
- On Linux, pre-create the lock file before sandbox application when using the claude-code profile

## Problem

Claude Code's `saveConfigWithLock` creates `~/.claude.json.lock` next to `~/.claude.json`. On Linux, Landlock cannot grant permission to create new files in `~/` without opening the entire home directory for writes (`LANDLOCK_ACCESS_FS_MAKE_REG`). This causes Claude Code to crash with `EACCES` after a few minutes when it first tries to persist config changes.

## How it works

1. The lock file is pre-created before capabilities are built, so Landlock can attach a `PathBeneath` rule to it
2. Lock acquisition (`lockSync`): succeeds because the file exists and is writable
3. Atomic write (temp file): fails with `EACCES`, but `safeWriteFileAtomically` falls back to direct `writeFileSync` which succeeds
4. Lock release (`unlinkSync`): fails with `EACCES`, but this is non-fatal — `lockSync` handles stale locks

The pre-creation is guarded with `#[cfg(target_os = "linux")]` since macOS Seatbelt does not have this limitation.

Closes #220

## Test plan

- [x] `cargo clippy` and `cargo test` pass
- [x] `nono run --profile claude-code --allow-cwd -- claude` starts successfully on Linux
- [x] Claude Code session survives config save (use interactively for several minutes)