### PR TITLE
fix: allow CLI flags to upgrade access mode of profile-covered paths

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -306,37 +306,34 @@ impl CapabilitySetExt for CapabilitySet {
     }
 }
 
-/// Apply CLI argument overrides on top of existing capabilities
+/// Apply CLI argument overrides on top of existing capabilities.
+///
+/// CLI directory args are always added, even if the path is already covered by
+/// a profile or group capability. The subsequent `deduplicate()` call resolves
+/// conflicts using source priority (User wins over Group/System) and merges
+/// complementary access modes (Read + Write = ReadWrite).
 fn add_cli_overrides(caps: &mut CapabilitySet, args: &SandboxArgs) -> Result<()> {
     let protected_roots = ProtectedRoots::from_defaults()?;
 
     // Additional directories from CLI
     for path in &args.allow {
         validate_requested_dir(path, "CLI", &protected_roots)?;
-        if !caps.path_covered(path) {
-            if let Some(cap) =
-                try_new_dir(path, AccessMode::ReadWrite, "Skipping non-existent path")?
-            {
-                caps.add_fs(cap);
-            }
+        if let Some(cap) = try_new_dir(path, AccessMode::ReadWrite, "Skipping non-existent path")? {
+            caps.add_fs(cap);
         }
     }
 
     for path in &args.read {
         validate_requested_dir(path, "CLI", &protected_roots)?;
-        if !caps.path_covered(path) {
-            if let Some(cap) = try_new_dir(path, AccessMode::Read, "Skipping non-existent path")? {
-                caps.add_fs(cap);
-            }
+        if let Some(cap) = try_new_dir(path, AccessMode::Read, "Skipping non-existent path")? {
+            caps.add_fs(cap);
         }
     }
 
     for path in &args.write {
         validate_requested_dir(path, "CLI", &protected_roots)?;
-        if !caps.path_covered(path) {
-            if let Some(cap) = try_new_dir(path, AccessMode::Write, "Skipping non-existent path")? {
-                caps.add_fs(cap);
-            }
+        if let Some(cap) = try_new_dir(path, AccessMode::Write, "Skipping non-existent path")? {
+            caps.add_fs(cap);
         }
     }
 
@@ -647,5 +644,139 @@ mod tests {
         // Dangerous commands should be blocked (cross-platform)
         assert!(caps.blocked_commands().contains(&"rm".to_string()));
         assert!(caps.blocked_commands().contains(&"dd".to_string()));
+    }
+
+    #[test]
+    fn test_cli_allow_upgrades_profile_read_path() {
+        // Regression test: a profile sets a path as read-only, and --allow on
+        // the CLI should upgrade it to ReadWrite. Previously, path_covered()
+        // in add_cli_overrides() silently dropped the CLI entry because it
+        // only checked path containment, not access mode.
+        let dir = tempdir().expect("tmpdir");
+        let target = dir.path().join("readonly_dir");
+        std::fs::create_dir(&target).expect("create target dir");
+
+        let profile_path = dir.path().join("test-profile.json");
+        std::fs::write(
+            &profile_path,
+            format!(
+                r#"{{
+                    "meta": {{ "name": "test-upgrade" }},
+                    "filesystem": {{ "read": ["{}"] }}
+                }}"#,
+                target.display()
+            ),
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+
+        let workdir = tempdir().expect("workdir");
+        let args = SandboxArgs {
+            allow: vec![target.clone()],
+            read: vec![],
+            write: vec![],
+            allow_file: vec![],
+            read_file: vec![],
+            write_file: vec![],
+            net_block: false,
+            network_profile: None,
+            proxy_allow: vec![],
+            proxy_credential: vec![],
+            external_proxy: None,
+            allow_command: vec![],
+            block_command: vec![],
+            env_credential: None,
+            profile: None,
+            allow_cwd: false,
+            workdir: None,
+            config: None,
+            verbose: 0,
+            dry_run: false,
+            allow_bind: vec![],
+            proxy_port: None,
+        };
+
+        let (caps, _) =
+            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+
+        let canonical = target.canonicalize().expect("canonicalize target");
+        let cap = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| c.resolved == canonical)
+            .expect("target path should be in capabilities");
+
+        assert_eq!(
+            cap.access,
+            AccessMode::ReadWrite,
+            "CLI --allow should upgrade profile read-only path to ReadWrite, got {:?}",
+            cap.access,
+        );
+    }
+
+    #[test]
+    fn test_cli_write_merges_with_profile_read_path() {
+        // Same regression but with --write instead of --allow.
+        // Profile read + CLI write should merge to ReadWrite.
+        let dir = tempdir().expect("tmpdir");
+        let target = dir.path().join("readonly_dir");
+        std::fs::create_dir(&target).expect("create target dir");
+
+        let profile_path = dir.path().join("test-profile.json");
+        std::fs::write(
+            &profile_path,
+            format!(
+                r#"{{
+                    "meta": {{ "name": "test-merge" }},
+                    "filesystem": {{ "read": ["{}"] }}
+                }}"#,
+                target.display()
+            ),
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+
+        let workdir = tempdir().expect("workdir");
+        let args = SandboxArgs {
+            allow: vec![],
+            read: vec![],
+            write: vec![target.clone()],
+            allow_file: vec![],
+            read_file: vec![],
+            write_file: vec![],
+            net_block: false,
+            network_profile: None,
+            proxy_allow: vec![],
+            proxy_credential: vec![],
+            external_proxy: None,
+            allow_command: vec![],
+            block_command: vec![],
+            env_credential: None,
+            profile: None,
+            allow_cwd: false,
+            workdir: None,
+            config: None,
+            verbose: 0,
+            dry_run: false,
+            allow_bind: vec![],
+            proxy_port: None,
+        };
+
+        let (caps, _) =
+            CapabilitySet::from_profile(&profile, workdir.path(), &args).expect("build caps");
+
+        let canonical = target.canonicalize().expect("canonicalize target");
+        let cap = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| c.resolved == canonical)
+            .expect("target path should be in capabilities");
+
+        assert_eq!(
+            cap.access,
+            AccessMode::ReadWrite,
+            "CLI --write + profile read should merge to ReadWrite, got {:?}",
+            cap.access,
+        );
     }
 }

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -1118,6 +1118,69 @@ mod tests {
         assert_eq!(surviving.resolved, real_path);
     }
 
+    #[test]
+    fn test_deduplicate_user_upgrades_group_read_to_readwrite() {
+        // Group sets ~/.npm as Read, user passes --allow ~/.npm (ReadWrite).
+        // User intent must win: surviving entry should be ReadWrite with User source.
+        let path = PathBuf::from("/some/path");
+
+        let mut caps = CapabilitySet::new();
+        // Group entry first (e.g., from node_runtime security group)
+        caps.add_fs(FsCapability {
+            original: path.clone(),
+            resolved: path.clone(),
+            access: AccessMode::Read,
+            is_file: false,
+            source: CapabilitySource::Group("node_runtime".to_string()),
+        });
+        // User entry second (e.g., from --allow CLI flag)
+        caps.add_fs(FsCapability {
+            original: path.clone(),
+            resolved: path.clone(),
+            access: AccessMode::ReadWrite,
+            is_file: false,
+            source: CapabilitySource::User,
+        });
+
+        caps.deduplicate();
+        assert_eq!(caps.fs_capabilities().len(), 1);
+        let surviving = &caps.fs_capabilities()[0];
+        assert_eq!(surviving.access, AccessMode::ReadWrite);
+        assert!(matches!(surviving.source, CapabilitySource::User));
+    }
+
+    #[test]
+    fn test_deduplicate_user_write_merges_with_group_read() {
+        // Group sets a path as Read, user passes --write for same path.
+        // Should merge to ReadWrite since User wins and Read+Write=ReadWrite.
+        let path = PathBuf::from("/some/path");
+
+        let mut caps = CapabilitySet::new();
+        // Group entry first (e.g., from profile security group)
+        caps.add_fs(FsCapability {
+            original: path.clone(),
+            resolved: path.clone(),
+            access: AccessMode::Read,
+            is_file: false,
+            source: CapabilitySource::Group("node_runtime".to_string()),
+        });
+        // User entry second (e.g., from --write CLI flag)
+        caps.add_fs(FsCapability {
+            original: path.clone(),
+            resolved: path.clone(),
+            access: AccessMode::Write,
+            is_file: false,
+            source: CapabilitySource::User,
+        });
+
+        caps.deduplicate();
+        assert_eq!(caps.fs_capabilities().len(), 1);
+        let surviving = &caps.fs_capabilities()[0];
+        // User wins, and Read+Write should merge to ReadWrite
+        assert_eq!(surviving.access, AccessMode::ReadWrite);
+        assert!(matches!(surviving.source, CapabilitySource::User));
+    }
+
     #[cfg(unix)]
     #[test]
     fn test_fs_capability_symlink_resolution() {


### PR DESCRIPTION
## Summary

`add_cli_overrides()` used `path_covered()` to skip CLI directory args (`--allow`, `--read`, `--write`) when the path was already covered by a profile or group capability. Since `path_covered()` only checks path containment and ignores access mode, CLI flags like `--allow ~/.npm` were silently dropped when a profile group (e.g., `node_runtime`) already had `~/.npm` as read-only. The subsequent `deduplicate()` call — which correctly handles User > Group priority and access merging — never got a chance to resolve the conflict.

**Fix:** Remove `path_covered()` guards from directory args in `add_cli_overrides()`. CLI entries are now always added, and `deduplicate()` resolves conflicts with its existing priority rules. This is consistent with how file-level args (`--allow-file`, `--read-file`, `--write-file`) already work — they never had `path_covered()` guards.

## How I found this

I run Claude Code inside nono with `--profile claude-code` and systematically tested common package managers (npm, pnpm, yarn, composer, go, cargo). npm failed with EACCES writing to `~/.npm` despite passing `--allow ~/.npm`. After ruling out file ownership issues, I traced it to `add_cli_overrides()` where `path_covered()` silently discards the CLI entry because `node_runtime` already covers `~/.npm` as read-only. The same issue affects `~/.cargo` and `~/.rustup` (from `rust_runtime`) and any other group-covered path.

## Reproduction

```sh
# node_runtime group sets ~/.npm as read-only in claude-code profile.
# --allow should upgrade to readwrite, but is silently dropped.
nono run --profile claude-code --allow ~/.npm --allow-cwd -- npm install lodash
# Result: EACCES writing to ~/.npm cache
```

## Test plan

- `test_cli_allow_upgrades_profile_read_path` — profile sets path as read, CLI `--allow` upgrades to ReadWrite
- `test_cli_write_merges_with_profile_read_path` — profile read + CLI `--write` merges to ReadWrite
- Both tests **fail without the fix** and **pass with it** (verified by temporarily reverting)
- Additional dedup-level tests for User vs Group source priority
- `cargo test --workspace` passes
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::unwrap_used` clean
- `cargo fmt --all -- --check` clean