### PR TITLE
Add platform.claude.com to llm_apis allowlist

### DIFF
--- a/crates/nono-cli/data/network-policy.json
+++ b/crates/nono-cli/data/network-policy.json
@@ -10,6 +10,7 @@
         "api.openai.com",
         "api.anthropic.com",
         "claude.ai",
+        "platform.claude.com",
         "generativelanguage.googleapis.com",
         "aiplatform.googleapis.com",
         "api.groq.com",


### PR DESCRIPTION
## Summary

Claude Code uses `platform.claude.com` for all OAuth token operations:
- Token exchange: `POST platform.claude.com/v1/oauth/token`
- Authorization: `platform.claude.com/oauth/authorize`
- Manual callback: `platform.claude.com/oauth/code/callback`

Without this host in the allowlist, the CONNECT tunnel is denied (403), causing:
1. `/login` fails with "OAuth error: Request failed with status code 403"
2. Automatic token refresh fails, requiring frequent re-authentication

The allowlist already includes `api.anthropic.com` and `claude.ai` but was missing `platform.claude.com`.

## Test plan
- Verify `nono run --profile claude-code -- claude` can complete `/login` without `--proxy-allow platform.claude.com`
- Verify token refresh works automatically after access token expires (~9h)