### PR TITLE
fix(profile): allow clearing inherited network_profile

### DIFF
--- a/crates/nono-cli/README.md
+++ b/crates/nono-cli/README.md
@@ -87,7 +87,8 @@ nono run --profile my-claude -- claude
 - **Lists** (filesystem paths, security groups, rollback patterns): appended and deduplicated
 - **HashMaps** (credentials, hooks): merged, child wins on same key
 - **Booleans** (`network.block`, `interactive`): OR — either activates
-- **Scalars** (`meta`, `network_profile`): child overrides
+- **Scalars** (`meta`): child overrides
+- **Nullable scalars** (`network_profile`): absent inherits, `null` clears, string overrides
 
 ### Chaining
 

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -1346,9 +1346,11 @@ fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<PreparedSandbox> 
         .as_ref()
         .map(|p| p.rollback.exclude_globs.clone())
         .unwrap_or_default();
-    let profile_network_profile = loaded_profile
-        .as_ref()
-        .and_then(|p| p.network.network_profile.clone());
+    let profile_network_profile = loaded_profile.as_ref().and_then(|p| {
+        p.network
+            .resolved_network_profile()
+            .map(|value| value.to_string())
+    });
     let profile_proxy_allow = loaded_profile
         .as_ref()
         .map(|p| p.network.proxy_allow.clone())

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -7,7 +7,7 @@
 mod builtin;
 
 use nono::{NonoError, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -424,6 +424,51 @@ fn validate_env_credential_keys(profile: &Profile) -> Result<()> {
     Ok(())
 }
 
+/// Three-state value used for inheritable profile fields.
+///
+/// - `Inherit`: field was absent in the child profile, so keep the base value
+/// - `Clear`: field was explicitly set to `null`, so remove the base value
+/// - `Set(T)`: field was provided with a concrete override value
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum InheritableValue<T> {
+    #[default]
+    Inherit,
+    Clear,
+    Set(T),
+}
+
+impl<T> InheritableValue<T> {
+    fn merge(self, base: Self) -> Self {
+        match self {
+            Self::Inherit => base,
+            Self::Clear => Self::Clear,
+            Self::Set(value) => Self::Set(value),
+        }
+    }
+
+    pub fn as_ref(&self) -> Option<&T> {
+        match self {
+            Self::Set(value) => Some(value),
+            Self::Inherit | Self::Clear => None,
+        }
+    }
+}
+
+impl<'de, T> Deserialize<'de> for InheritableValue<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match Option::<T>::deserialize(deserializer)? {
+            Some(value) => Ok(Self::Set(value)),
+            None => Ok(Self::Clear),
+        }
+    }
+}
+
 /// Network configuration in a profile
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct NetworkConfig {
@@ -432,8 +477,11 @@ pub struct NetworkConfig {
     pub block: bool,
     /// Network proxy profile name (from network-policy.json).
     /// When set, outbound traffic is filtered through the proxy.
+    ///
+    /// `null` explicitly clears an inherited profile value, while an absent
+    /// field inherits the base profile's value.
     #[serde(default)]
-    pub network_profile: Option<String>,
+    pub network_profile: InheritableValue<String>,
     /// Additional hosts to allow through the proxy (on top of profile hosts)
     #[serde(default)]
     pub proxy_allow: Vec<String>,
@@ -448,9 +496,13 @@ pub struct NetworkConfig {
 }
 
 impl NetworkConfig {
+    pub fn resolved_network_profile(&self) -> Option<&str> {
+        self.network_profile.as_ref().map(String::as_str)
+    }
+
     /// Whether any profile setting requires proxy mode activation.
     pub fn has_proxy_flags(&self) -> bool {
-        self.network_profile.is_some()
+        self.resolved_network_profile().is_some()
             || !self.proxy_allow.is_empty()
             || !self.proxy_credentials.is_empty()
     }
@@ -814,7 +866,7 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
             network_profile: child
                 .network
                 .network_profile
-                .or(base.network.network_profile),
+                .merge(base.network.network_profile),
             proxy_allow: dedup_append(&base.network.proxy_allow, &child.network.proxy_allow),
             proxy_credentials: dedup_append(
                 &base.network.proxy_credentials,
@@ -1798,7 +1850,7 @@ mod tests {
             },
             network: NetworkConfig {
                 block: false,
-                network_profile: Some("base-net".to_string()),
+                network_profile: InheritableValue::Set("base-net".to_string()),
                 proxy_allow: vec!["base.example.com".to_string()],
                 proxy_credentials: vec!["base_cred".to_string()],
                 custom_credentials: HashMap::new(),
@@ -1848,7 +1900,7 @@ mod tests {
             },
             network: NetworkConfig {
                 block: false,
-                network_profile: None,
+                network_profile: InheritableValue::Inherit,
                 proxy_allow: vec!["child.example.com".to_string()],
                 proxy_credentials: vec![],
                 custom_credentials: HashMap::new(),
@@ -1966,21 +2018,28 @@ mod tests {
 
     #[test]
     fn test_merge_profiles_network_profile_override() {
-        let base = base_profile(); // has network_profile = Some("base-net")
-        let child = child_profile(); // has network_profile = None
+        let base = base_profile(); // has network_profile = Set("base-net")
+        let child = child_profile(); // has network_profile = Inherit
 
-        // Child None -> inherit base
+        // Child Inherit -> inherit base
         let merged = merge_profiles(base.clone(), child);
-        assert_eq!(merged.network.network_profile, Some("base-net".to_string()));
+        assert_eq!(merged.network.resolved_network_profile(), Some("base-net"));
 
         // Child has explicit value -> override
         let mut overriding_child = child_profile();
-        overriding_child.network.network_profile = Some("child-net".to_string());
+        overriding_child.network.network_profile = InheritableValue::Set("child-net".to_string());
         let merged = merge_profiles(base, overriding_child);
-        assert_eq!(
-            merged.network.network_profile,
-            Some("child-net".to_string())
-        );
+        assert_eq!(merged.network.resolved_network_profile(), Some("child-net"));
+    }
+
+    #[test]
+    fn test_merge_profiles_network_profile_null_clears_base() {
+        let base = base_profile();
+        let mut child = child_profile();
+        child.network.network_profile = InheritableValue::Clear;
+
+        let merged = merge_profiles(base, child);
+        assert_eq!(merged.network.resolved_network_profile(), None);
     }
 
     #[test]
@@ -2342,7 +2401,10 @@ mod tests {
         // Should inherit base workdir
         assert_eq!(merged.workdir.access, base.workdir.access);
         // Should inherit base network settings
-        assert_eq!(merged.network.network_profile, base.network.network_profile);
+        assert_eq!(
+            merged.network.resolved_network_profile(),
+            base.network.resolved_network_profile()
+        );
         assert_eq!(merged.network.proxy_allow, base.network.proxy_allow);
         // Should inherit rollback config
         assert_eq!(
@@ -2442,5 +2504,60 @@ mod tests {
         let json_str = r#"{ "meta": { "name": "no-ext" } }"#;
         let profile: Profile = serde_json::from_str(json_str).expect("parse");
         assert!(profile.extends.is_none());
+    }
+
+    #[test]
+    fn test_network_profile_deserialization_distinguishes_absent_null_and_value() {
+        let absent: Profile = serde_json::from_str(r#"{ "meta": { "name": "absent" } }"#)
+            .expect("parse absent profile");
+        assert_eq!(absent.network.network_profile, InheritableValue::Inherit);
+
+        let cleared: Profile = serde_json::from_str(
+            r#"{
+                "meta": { "name": "cleared" },
+                "network": { "network_profile": null }
+            }"#,
+        )
+        .expect("parse cleared profile");
+        assert_eq!(cleared.network.network_profile, InheritableValue::Clear);
+
+        let set: Profile = serde_json::from_str(
+            r#"{
+                "meta": { "name": "set" },
+                "network": { "network_profile": "developer" }
+            }"#,
+        )
+        .expect("parse profile with network profile");
+        assert_eq!(
+            set.network.network_profile,
+            InheritableValue::Set("developer".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extends_can_clear_inherited_network_profile_with_null() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("claude-code-netopen.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "claude-code-netopen" },
+                "extends": "claude-code",
+                "network": { "network_profile": null }
+            }"#,
+        )
+        .expect("write profile");
+
+        let profile = load_profile_from_path(&profile_path).expect("load profile");
+        assert_eq!(profile.network.resolved_network_profile(), None);
+        assert!(!profile.network.has_proxy_flags());
+        assert!(
+            profile
+                .filesystem
+                .allow
+                .iter()
+                .any(|path| path == "$HOME/.claude"),
+            "expected filesystem grants from claude-code to still be inherited",
+        );
     }
 }

--- a/docs/cli/clients/claude-code.mdx
+++ b/docs/cli/clients/claude-code.mdx
@@ -62,6 +62,22 @@ If you need different permissions, create a custom profile at `~/.config/nono/pr
 }
 ```
 
+If you want to inherit the built-in Claude Code profile but remove its network filtering, create a separate extending profile and explicitly clear the inherited network profile:
+
+```json
+{
+  "meta": { "name": "claude-code-netopen" },
+  "extends": "claude-code",
+  "network": { "network_profile": null }
+}
+```
+
+Then run:
+
+```bash
+nono run --profile claude-code-netopen -- claude
+```
+
 **Usage:**
 ```bash
 nono run --profile claude-code --env-credential -- claude

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -129,7 +129,7 @@ The `network` section controls network access and credential injection:
 | Field | Description |
 |-------|-------------|
 | `block` | Block all network access (default: `false`) |
-| `network_profile` | Network profile name for host filtering (e.g., `minimal`, `claude-code`, `enterprise`) |
+| `network_profile` | Network profile name for host filtering (e.g., `minimal`, `claude-code`, `enterprise`). Set to `null` in a child profile to clear an inherited value. |
 | `proxy_allow` | Additional hosts to allow through the proxy |
 | `proxy_credentials` | Credential services to enable via reverse proxy (e.g., `openai`, `anthropic`) |
 | `custom_credentials` | Custom credential service definitions for APIs not in the built-in list |
@@ -254,6 +254,16 @@ nono run --profile claude-code --net-block -- claude
 
 # Add extra directory access
 nono run --profile claude-code --allow ~/other-project -- claude
+```
+
+To keep a base profile but clear an inherited network profile, set `network.network_profile` to `null` in the child:
+
+```json
+{
+  "meta": { "name": "claude-code-netopen" },
+  "extends": "claude-code",
+  "network": { "network_profile": null }
+}
 ```
 
 You can also create a user profile with the same name to override a built-in profile entirely.


### PR DESCRIPTION
## Summary

Follow-up for #249.

This fixes the `extends` bug called out in [the issue discussion](https://github.com/always-further/nono/issues/249#issuecomment-4007755076): a child profile can now explicitly clear an inherited `network_profile` by setting `"network_profile": null`.

The change adds three-state merge semantics for `network.network_profile`:

- absent field: inherit the base profile's value
- `null`: explicitly clear the inherited value
- string: override with a new network profile

It also updates the runtime consumer to read the resolved value and documents the new inheritance behavior.

## Example

```json
{
  "meta": { "name": "claude-code-netopen" },
  "extends": "claude-code",
  "network": { "network_profile": null }
}
```

```bash
nono run --profile claude-code-netopen -- claude
```

That keeps the built-in `claude-code` filesystem, command, hook, and workdir policy, but disables its inherited proxy filtering.

## Testing

Automated:

- `cargo test -p nono-cli`

### Manual Testing

I performed the following manual steps locally.

#### Setup

```bash
tmpdir=$(mktemp -d)
profile="$tmpdir/claude-code-netopen.json"
cat > "$profile" <<'JSON'
{
  "meta": { "name": "claude-code-netopen" },
  "extends": "claude-code",
  "network": { "network_profile": null }
}
JSON
```

#### 1. Baseline: built-in `claude-code` still enables proxy filtering

```bash
cargo run -q -p nono-cli -- run --profile claude-code --dry-run -- echo hi | sed -n '1,16p'
```

Output excerpt:

```text
Capabilities:
  Filesystem:
    /Users/josephgimenez/.claude [read+write] (dir)
    /Users/josephgimenez/.local/share/claude [read] (dir)
    /Users/josephgimenez/.claude.json [read+write] (file)
    /Users/josephgimenez/Library/Keychains/login.keychain-db [read] (file)
    /Users/josephgimenez/.gitconfig [read] (file)
    /Users/josephgimenez/.config/git/ignore [read] (file)
    + 40 system/group paths (use -v to show)
  Network:
    outbound: proxy (localhost:0)
```

#### 2. Extending profile with `network_profile: null` inherits the filesystem policy but clears proxy mode

```bash
cargo run -q -p nono-cli -- run --profile "$profile" --dry-run -- echo hi | sed -n '1,16p'
```

Output excerpt:

```text
Capabilities:
  Filesystem:
    /Users/josephgimenez/.claude [read+write] (dir)
    /Users/josephgimenez/.local/share/claude [read] (dir)
    /Users/josephgimenez/.claude.json [read+write] (file)
    /Users/josephgimenez/Library/Keychains/login.keychain-db [read] (file)
    /Users/josephgimenez/.gitconfig [read] (file)
    /Users/josephgimenez/.config/git/ignore [read] (file)
    + 40 system/group paths (use -v to show)
  Network:
    outbound: allowed
```

#### Cleanup

```bash
rm -rf "$tmpdir"
```
