### PR TITLE
fix: show platform-correct path in user-level policy warning

### DIFF
--- a/crates/nono-cli/src/trust_cmd.rs
+++ b/crates/nono-cli/src/trust_cmd.rs
@@ -964,10 +964,12 @@ fn load_trust_policy(explicit_path: Option<&Path>) -> Result<trust::TrustPolicy>
             "Project policies are not authoritative without a user-level policy to anchor trust."
                 .yellow()
         );
+        let policy_path = user_trust_policy_path()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "~/.config/nono/trust-policy.json".to_string());
         eprintln!(
             "  {}",
-            "Create a signed policy at ~/.config/nono/trust-policy.json to enforce verification."
-                .yellow()
+            format!("Create a signed policy at {policy_path} to enforce verification.").yellow()
         );
         return Ok(project_policy);
     }

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -68,9 +68,13 @@ pub fn load_scan_policy(root: &Path, trust_override: bool) -> Result<TrustPolicy
                 "Project policies are not authoritative without a user-level policy to anchor trust."
                     .yellow()
             );
+            let policy_path = user_path
+                .as_deref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| "~/.config/nono/trust-policy.json".to_string());
             eprintln!(
                 "  {}",
-                "Create a signed policy at ~/.config/nono/trust-policy.json to enforce verification."
+                format!("Create a signed policy at {policy_path} to enforce verification.")
                     .yellow()
             );
             Ok(p)


### PR DESCRIPTION
The warning message directing users to create a user-level trust policy hardcoded ~/.config/nono/trust-policy.json, which is only correct on Linux. On macOS, dirs::config_dir() returns ~/Library/Application Support, so nono looks for the policy at a different path.

Users following the warning on macOS would create the file in the wrong location, leaving the warning in place and the trust chain unanchored.

Fix both trust_scan.rs and trust_cmd.rs to derive the suggested path from the same dirs::config_dir() call used to locate the policy.