### PR TITLE
fix: preserve supervised Linux open semantics

### DIFF
--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -24,11 +24,11 @@ use nono::{
     DiagnosticMode, NeverGrantChecker, NonoError, Result, Sandbox, SupervisorSocket,
 };
 use std::collections::HashSet;
-use std::ffi::CString;
+use std::ffi::{CString, OsStr};
 use std::os::fd::FromRawFd;
 use std::os::fd::{AsRawFd, OwnedFd};
 use std::os::unix::process::CommandExt;
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use tracing::{debug, info, warn};
 
@@ -63,6 +63,26 @@ const MAX_CRYPTO_THREADS: usize = 7;
 const MAX_DENIAL_RECORDS: usize = 1000;
 /// Hard cap on request IDs tracked for replay detection.
 const MAX_TRACKED_REQUEST_IDS: usize = 4096;
+
+/// Linux procfs context for resolving child-relative procfs paths in the supervisor.
+///
+/// `/proc/self/...` must refer to the sandboxed child process, not the unsandboxed
+/// supervisor. For seccomp interceptions we may also know the calling TID, which
+/// lets us resolve `/proc/thread-self/...` accurately.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProcfsAccessContext {
+    process_pid: u32,
+    thread_pid: Option<u32>,
+}
+
+impl ProcfsAccessContext {
+    fn new(process_pid: u32, thread_pid: Option<u32>) -> Self {
+        Self {
+            process_pid,
+            thread_pid,
+        }
+    }
+}
 
 /// Threading context for fork safety validation.
 ///
@@ -887,6 +907,7 @@ fn run_supervisor_loop(
                         if let Err(e) = handle_supervisor_message(
                             sock,
                             msg,
+                            child,
                             config,
                             &mut denials,
                             &mut seen_request_ids,
@@ -1004,6 +1025,7 @@ fn run_supervisor_loop(
                             if let Err(e) = handle_supervisor_message(
                                 sock,
                                 msg,
+                                child,
                                 config,
                                 &mut denials,
                                 &mut seen_request_ids,
@@ -1081,6 +1103,7 @@ fn run_supervisor_loop(
 fn handle_supervisor_message(
     sock: &mut SupervisorSocket,
     msg: SupervisorMessage,
+    child: Pid,
     config: &SupervisorConfig<'_>,
     denials: &mut Vec<DenialRecord>,
     seen_request_ids: &mut HashSet<String>,
@@ -1247,6 +1270,7 @@ fn handle_supervisor_message(
                     &request.access,
                     config.never_grant,
                     verified_digest.as_deref(),
+                    Some(ProcfsAccessContext::new(child.as_raw() as u32, None)),
                 ) {
                     Ok(file) => {
                         if let Err(e) = sock.send_fd(file.as_raw_fd()) {
@@ -1313,6 +1337,159 @@ fn unique_request_id() -> String {
     format!("{:x}-{:x}", nanos, seq)
 }
 
+/// Resolve `/proc/self` and `/proc/thread-self` against the sandboxed child.
+///
+/// Without this rewrite, canonicalizing `/proc/self/...` in the supervisor would
+/// resolve to the supervisor's procfs view instead of the child's.
+fn resolve_procfs_path_for_child(
+    path: &Path,
+    procfs_context: Option<ProcfsAccessContext>,
+) -> Result<PathBuf> {
+    let Some(procfs_context) = procfs_context else {
+        return Ok(path.to_path_buf());
+    };
+
+    let mut components = path.components();
+    if components.next() != Some(Component::RootDir)
+        || components.next() != Some(Component::Normal(OsStr::new("proc")))
+    {
+        return Ok(path.to_path_buf());
+    }
+
+    let Some(proc_component) = components.next() else {
+        return Ok(path.to_path_buf());
+    };
+
+    let mut rewritten = PathBuf::from("/proc");
+    match proc_component {
+        Component::Normal(part) if part == OsStr::new("self") => {
+            rewritten.push(procfs_context.process_pid.to_string());
+        }
+        Component::Normal(part) if part == OsStr::new("thread-self") => {
+            let thread_pid = procfs_context.thread_pid.ok_or_else(|| {
+                NonoError::SandboxInit(
+                    "Cannot resolve /proc/thread-self without a requesting thread ID".to_string(),
+                )
+            })?;
+            rewritten.push(procfs_context.process_pid.to_string());
+            rewritten.push("task");
+            rewritten.push(thread_pid.to_string());
+        }
+        _ => return Ok(path.to_path_buf()),
+    }
+
+    for component in components {
+        match component {
+            Component::Normal(part) => rewritten.push(part),
+            Component::CurDir => rewritten.push("."),
+            Component::ParentDir => rewritten.push(".."),
+            Component::RootDir | Component::Prefix(_) => {}
+        }
+    }
+
+    Ok(rewritten)
+}
+
+/// Enforce the supervisor's sensitive procfs deny rules.
+///
+/// Same-process procfs access is allowed after `/proc/self` rewriting. Foreign
+/// process reads stay blocked.
+fn validate_procfs_access(
+    canonical: &Path,
+    procfs_context: Option<ProcfsAccessContext>,
+) -> std::result::Result<(), OpenPathError> {
+    const SENSITIVE_PROC_FILES: &[&str] =
+        &["mem", "environ", "maps", "syscall", "stack", "cmdline"];
+
+    let Some(suffix) = canonical.to_str().and_then(|s| s.strip_prefix("/proc/")) else {
+        return Ok(());
+    };
+
+    let allowed_pid = procfs_context.map(|ctx| ctx.process_pid.to_string());
+    let components: Vec<&str> = suffix.split('/').collect();
+
+    if components.len() == 2
+        && components[0].chars().all(|c| c.is_ascii_digit())
+        && SENSITIVE_PROC_FILES.contains(&components[1])
+    {
+        if allowed_pid.as_deref() == Some(components[0]) {
+            return Ok(());
+        }
+        return Err(OpenPathError::policy_blocked(format!(
+            "Access to /proc/{}/{} is blocked by policy",
+            components[0], components[1],
+        )));
+    }
+
+    if components.len() == 4
+        && components[0].chars().all(|c| c.is_ascii_digit())
+        && components[1] == "task"
+        && components[2].chars().all(|c| c.is_ascii_digit())
+        && SENSITIVE_PROC_FILES.contains(&components[3])
+    {
+        if allowed_pid.as_deref() == Some(components[0]) {
+            return Ok(());
+        }
+        return Err(OpenPathError::policy_blocked(format!(
+            "Access to /proc/{}/task/{}/{} is blocked by policy",
+            components[0], components[2], components[3],
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[derive(Debug)]
+struct OpenPathError {
+    errno: i32,
+    message: String,
+    policy_blocked: bool,
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+impl OpenPathError {
+    fn policy_blocked(message: String) -> Self {
+        Self {
+            errno: libc::EPERM,
+            message,
+            policy_blocked: true,
+        }
+    }
+
+    fn io(message: String, source: &std::io::Error) -> Self {
+        Self {
+            errno: source.raw_os_error().unwrap_or(libc::EIO),
+            message,
+            policy_blocked: false,
+        }
+    }
+
+    fn internal(message: String) -> Self {
+        Self {
+            errno: libc::EIO,
+            message,
+            policy_blocked: false,
+        }
+    }
+
+    fn errno(&self) -> i32 {
+        self.errno
+    }
+
+    fn is_policy_blocked(&self) -> bool {
+        self.policy_blocked
+    }
+}
+
+impl std::fmt::Display for OpenPathError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for OpenPathError {}
+
 /// Open a filesystem path with the requested access mode.
 ///
 /// Used by the supervisor to open files on behalf of the sandboxed child
@@ -1329,84 +1506,51 @@ fn unique_request_id() -> String {
 /// supervisor only grants access to existing files. File creation should
 /// go through the initial capability set, not capability expansion.
 fn open_path_for_access(
-    path: &std::path::Path,
+    path: &Path,
     access: &nono::AccessMode,
     never_grant: &NeverGrantChecker,
     trust_digest: Option<&str>,
-) -> Result<std::fs::File> {
+    procfs_context: Option<ProcfsAccessContext>,
+) -> std::result::Result<std::fs::File, OpenPathError> {
+    let resolved_path = resolve_procfs_path_for_child(path, procfs_context)
+        .map_err(|e| OpenPathError::internal(e.to_string()))?;
+
     // Canonicalize to resolve symlinks before opening. This ensures
     // we check and open the real target, not a symlink alias.
-    let canonical = std::fs::canonicalize(path).map_err(|e| {
-        NonoError::SandboxInit(format!(
-            "Failed to canonicalize {} for access: {}",
-            path.display(),
-            e
-        ))
+    let canonical = std::fs::canonicalize(&resolved_path).map_err(|e| {
+        OpenPathError::io(
+            format!(
+                "Failed to canonicalize {} for access: {}",
+                path.display(),
+                e
+            ),
+            &e,
+        )
     })?;
 
     // Re-check never_grant on the resolved path. A symlink could point
     // from an innocuous path to a never_grant target.
     let check = never_grant.check(&canonical);
     if check.is_blocked() {
-        return Err(NonoError::SandboxInit(format!(
+        return Err(OpenPathError::policy_blocked(format!(
             "Path {} resolves to {} which is blocked by never_grant policy",
             path.display(),
             canonical.display(),
         )));
     }
 
-    // Block sensitive per-PID /proc paths that can't be enumerated in never_grant
-    // (they contain dynamic PIDs). These expose process memory/environment of
-    // arbitrary processes. Covers both /proc/<pid>/<file> and the equivalent
-    // /proc/<pid>/task/<tid>/<file> paths.
-    #[cfg(target_os = "linux")]
-    {
-        const SENSITIVE_PROC_FILES: &[&str] =
-            &["mem", "environ", "maps", "syscall", "stack", "cmdline"];
-        if let Some(suffix) = canonical.to_str().and_then(|s| s.strip_prefix("/proc/")) {
-            let components: Vec<&str> = suffix.split('/').collect();
-            // /proc/<pid>/<sensitive>
-            if components.len() == 2
-                && components[0].chars().all(|c| c.is_ascii_digit())
-                && SENSITIVE_PROC_FILES.contains(&components[1])
-            {
-                return Err(NonoError::SandboxInit(format!(
-                    "Access to /proc/{}/{} is blocked by policy",
-                    components[0], components[1],
-                )));
-            }
-            // /proc/<pid>/task/<tid>/<sensitive>
-            if components.len() == 4
-                && components[0].chars().all(|c| c.is_ascii_digit())
-                && components[1] == "task"
-                && components[2].chars().all(|c| c.is_ascii_digit())
-                && SENSITIVE_PROC_FILES.contains(&components[3])
-            {
-                return Err(NonoError::SandboxInit(format!(
-                    "Access to /proc/{}/task/{}/{} is blocked by policy",
-                    components[0], components[2], components[3],
-                )));
-            }
-            // /proc/self/<sensitive> and /proc/thread-self/<sensitive>
-            if components.len() == 2
-                && (components[0] == "self" || components[0] == "thread-self")
-                && SENSITIVE_PROC_FILES.contains(&components[1])
-            {
-                return Err(NonoError::SandboxInit(format!(
-                    "Access to /proc/{}/{} is blocked by policy",
-                    components[0], components[1],
-                )));
-            }
-        }
-    }
+    validate_procfs_access(&canonical, procfs_context)?;
 
     let file = open_canonical_path_no_symlinks(&canonical, access).map_err(|e| {
-        NonoError::SandboxInit(format!(
-            "Failed to open {} for {:?} access: {}",
-            canonical.display(),
-            access,
-            e
-        ))
+        OpenPathError::io(
+            format!(
+                "Failed to open {} for {:?} access: {}",
+                canonical.display(),
+                access,
+                e
+            ),
+            &e,
+        )
     })?;
 
     // TOCTOU re-verification: if this file was trust-verified, re-compute the
@@ -1421,11 +1565,14 @@ fn open_path_for_access(
         let mut buf = [0u8; 8192];
         loop {
             let n = (&file).read(&mut buf).map_err(|e| {
-                NonoError::SandboxInit(format!(
-                    "Failed to read {} for digest re-check: {}",
-                    canonical.display(),
-                    e,
-                ))
+                OpenPathError::io(
+                    format!(
+                        "Failed to read {} for digest re-check: {}",
+                        canonical.display(),
+                        e,
+                    ),
+                    &e,
+                )
             })?;
             if n == 0 {
                 break;
@@ -1443,7 +1590,7 @@ fn open_path_for_access(
             })
             .collect();
         if actual_digest != expected_digest {
-            return Err(NonoError::SandboxInit(format!(
+            return Err(OpenPathError::policy_blocked(format!(
                 "Instruction file {} was modified between trust verification and open \
                  (expected digest {}, got {}). Possible TOCTOU attack.",
                 path.display(),
@@ -1453,11 +1600,14 @@ fn open_path_for_access(
         }
         // Seek back to start so the child reads from the beginning
         (&file).seek(std::io::SeekFrom::Start(0)).map_err(|e| {
-            NonoError::SandboxInit(format!(
-                "Failed to seek {} after digest re-check: {}",
-                canonical.display(),
-                e,
-            ))
+            OpenPathError::io(
+                format!(
+                    "Failed to seek {} after digest re-check: {}",
+                    canonical.display(),
+                    e,
+                ),
+                &e,
+            )
         })?;
     }
 
@@ -1642,5 +1792,59 @@ mod tests {
             );
         }
         assert_eq!(denials.len(), MAX_DENIAL_RECORDS);
+    }
+
+    #[test]
+    fn test_resolve_procfs_self_for_child() {
+        let path = resolve_procfs_path_for_child(
+            Path::new("/proc/self/maps"),
+            Some(ProcfsAccessContext::new(4242, Some(4343))),
+        );
+        assert_eq!(path.ok(), Some(PathBuf::from("/proc/4242/maps")));
+    }
+
+    #[test]
+    fn test_resolve_procfs_thread_self_for_child() {
+        let path = resolve_procfs_path_for_child(
+            Path::new("/proc/thread-self/maps"),
+            Some(ProcfsAccessContext::new(4242, Some(4343))),
+        );
+        assert_eq!(path.ok(), Some(PathBuf::from("/proc/4242/task/4343/maps")));
+    }
+
+    #[test]
+    fn test_resolve_procfs_thread_self_requires_thread_context() {
+        let result = resolve_procfs_path_for_child(
+            Path::new("/proc/thread-self/maps"),
+            Some(ProcfsAccessContext::new(4242, None)),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_procfs_access_allows_child_sensitive_proc_path() {
+        let result = validate_procfs_access(
+            Path::new("/proc/4242/maps"),
+            Some(ProcfsAccessContext::new(4242, Some(4343))),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_procfs_access_blocks_foreign_sensitive_proc_path() {
+        let result = validate_procfs_access(
+            Path::new("/proc/1/maps"),
+            Some(ProcfsAccessContext::new(4242, Some(4343))),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_procfs_access_allows_child_task_sensitive_proc_path() {
+        let result = validate_procfs_access(
+            Path::new("/proc/4242/task/9999/maps"),
+            Some(ProcfsAccessContext::new(4242, Some(4343))),
+        );
+        assert!(result.is_ok());
     }
 }

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -99,9 +99,9 @@ pub(super) fn handle_seccomp_notification(
     mut trust_interceptor: Option<&mut TrustInterceptor>,
 ) -> Result<()> {
     use nono::sandbox::{
-        classify_access_from_flags, deny_notif, inject_fd, notif_id_valid, read_notif_path,
-        read_open_how, recv_notif, resolve_notif_path, validate_openat2_size, SYS_OPENAT,
-        SYS_OPENAT2,
+        classify_access_from_flags, continue_notif, deny_notif, inject_fd, notif_id_valid,
+        read_notif_path, read_open_how, recv_notif, resolve_notif_path, respond_notif_errno,
+        validate_openat2_size, SYS_OPENAT, SYS_OPENAT2,
     };
 
     // 1. Receive the notification
@@ -176,12 +176,22 @@ pub(super) fn handle_seccomp_notification(
         }
     };
 
-    let canonicalized = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+    let procfs_context = ProcfsAccessContext::new(child.as_raw() as u32, Some(notif.pid));
+    let resolved_path = match resolve_procfs_path_for_child(&path, Some(procfs_context)) {
+        Ok(resolved) => resolved,
+        Err(e) => {
+            debug!("Failed to resolve procfs path '{}': {}", path.display(), e);
+            let _ = deny_notif(notify_fd, notif.id);
+            return Ok(());
+        }
+    };
+    let canonicalized =
+        std::fs::canonicalize(&resolved_path).unwrap_or_else(|_| resolved_path.clone());
 
     // 4. Check never_grant BEFORE initial-set fast-path.
     let never_grant_check = config.never_grant.check(&canonicalized);
     if !never_grant_check.is_blocked() {
-        let never_grant_original = config.never_grant.check(&path);
+        let never_grant_original = config.never_grant.check(&resolved_path);
         if never_grant_original.is_blocked() {
             debug!(
                 "Seccomp: path {} (via {}) blocked by never_grant",
@@ -229,33 +239,84 @@ pub(super) fn handle_seccomp_notification(
     });
 
     if in_initial_set {
-        match open_path_for_access(&canonicalized, &access, config.never_grant, None) {
-            Ok(file) => {
-                if notif_id_valid(notify_fd, notif.id)? {
-                    if let Err(e) = inject_fd(notify_fd, notif.id, file.as_raw_fd()) {
-                        debug!(
-                            "inject_fd failed for initial-set path {}: {}",
-                            path.display(),
-                            e
+        if canonicalized.starts_with("/proc") {
+            match open_path_for_access(
+                &path,
+                &access,
+                config.never_grant,
+                None,
+                Some(procfs_context),
+            ) {
+                Ok(file) => {
+                    if notif_id_valid(notify_fd, notif.id)? {
+                        if let Err(e) = inject_fd(notify_fd, notif.id, file.as_raw_fd()) {
+                            debug!(
+                                "inject_fd failed for initial-set proc path {}: {}",
+                                path.display(),
+                                e
+                            );
+                            let _ = deny_notif(notify_fd, notif.id);
+                        }
+                    }
+                }
+                Err(e) => {
+                    debug!(
+                        "Failed to open initial-set proc path {}: {}",
+                        path.display(),
+                        e
+                    );
+                    if e.is_policy_blocked() {
+                        record_denial(
+                            denials,
+                            DenialRecord {
+                                path: canonicalized.clone(),
+                                access,
+                                reason: DenialReason::PolicyBlocked,
+                            },
                         );
                         let _ = deny_notif(notify_fd, notif.id);
+                    } else {
+                        let _ = respond_notif_errno(notify_fd, notif.id, e.errno());
                     }
                 }
             }
-            Err(e) => {
-                debug!("Failed to open initial-set path {}: {}", path.display(), e);
-                record_denial(
-                    denials,
-                    DenialRecord {
-                        path: canonicalized.clone(),
-                        access,
-                        reason: DenialReason::PolicyBlocked,
-                    },
+        } else if notif_id_valid(notify_fd, notif.id)? {
+            if let Err(e) = continue_notif(notify_fd, notif.id) {
+                debug!(
+                    "continue_notif failed for initial-set path {}: {}",
+                    path.display(),
+                    e
                 );
                 let _ = deny_notif(notify_fd, notif.id);
             }
         }
         return Ok(());
+    }
+
+    // Preserve native ENOENT/ENOTDIR behavior for nonexistent paths. Runtimes
+    // frequently probe optional locations (e.g. Bun's /$bunfs assets) and
+    // expect a normal "not found" result rather than a policy denial. This is
+    // safe because Landlock will still block any path that appears after the
+    // check but remains outside the initial allow-list.
+    match std::fs::symlink_metadata(&path) {
+        Ok(_) => {}
+        Err(e)
+            if e.kind() == std::io::ErrorKind::NotFound
+                || e.raw_os_error() == Some(libc::ENOTDIR) =>
+        {
+            if notif_id_valid(notify_fd, notif.id)? {
+                if let Err(send_err) = continue_notif(notify_fd, notif.id) {
+                    debug!(
+                        "continue_notif failed for missing path {}: {}",
+                        path.display(),
+                        send_err
+                    );
+                    let _ = deny_notif(notify_fd, notif.id);
+                }
+            }
+            return Ok(());
+        }
+        Err(_) => {}
     }
 
     // 6. Rate limit check
@@ -361,10 +422,11 @@ pub(super) fn handle_seccomp_notification(
     // Pass verified_digest to enable TOCTOU re-verification for instruction files
     if decision.is_granted() {
         match open_path_for_access(
-            &canonicalized,
+            &path,
             &access,
             config.never_grant,
             verified_digest.as_deref(),
+            Some(procfs_context),
         ) {
             Ok(file) => {
                 if let Err(e) = inject_fd(notify_fd, notif.id, file.as_raw_fd()) {
@@ -382,7 +444,11 @@ pub(super) fn handle_seccomp_notification(
                     canonicalized.display(),
                     e
                 );
-                let _ = deny_notif(notify_fd, notif.id);
+                if e.is_policy_blocked() {
+                    let _ = deny_notif(notify_fd, notif.id);
+                } else {
+                    let _ = respond_notif_errno(notify_fd, notif.id, e.errno());
+                }
             }
         }
     } else {

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -341,6 +341,7 @@ const SECCOMP_IOCTL_NOTIF_ADDFD: libc::c_ulong = 0x40182103;
 
 // Seccomp addfd flags
 const SECCOMP_ADDFD_FLAG_SEND: u32 = 1 << 1;
+const SECCOMP_USER_NOTIF_FLAG_CONTINUE: u32 = 1;
 
 // BPF constants
 const BPF_LD: u16 = 0x00;
@@ -832,19 +833,19 @@ pub fn inject_fd(
     Ok(())
 }
 
-/// Deny a seccomp notification with EPERM.
+/// Respond to a seccomp notification with a specific errno.
 ///
 /// Sends a response to the kernel that causes the child's syscall to
-/// return -1 with errno=EPERM.
+/// return -1 with the supplied errno.
 ///
 /// # Errors
 ///
 /// Returns an error if the ioctl fails.
-pub fn deny_notif(notify_fd: std::os::fd::RawFd, notif_id: u64) -> Result<()> {
+pub fn respond_notif_errno(notify_fd: std::os::fd::RawFd, notif_id: u64, errno: i32) -> Result<()> {
     let resp = SeccompNotifResp {
         id: notif_id,
         val: 0,
-        error: -libc::EPERM,
+        error: -errno,
         flags: 0,
     };
 
@@ -866,6 +867,48 @@ pub fn deny_notif(notify_fd: std::os::fd::RawFd, notif_id: u64) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Continue a seccomp notification, letting the child's original syscall run.
+///
+/// This preserves the original syscall semantics exactly. It is safe only when
+/// the syscall is already authorized by the sandbox's allow-list.
+pub fn continue_notif(notify_fd: std::os::fd::RawFd, notif_id: u64) -> Result<()> {
+    let resp = SeccompNotifResp {
+        id: notif_id,
+        val: 0,
+        error: 0,
+        flags: SECCOMP_USER_NOTIF_FLAG_CONTINUE,
+    };
+
+    let ret = unsafe {
+        libc::ioctl(
+            notify_fd,
+            SECCOMP_IOCTL_NOTIF_SEND,
+            &resp as *const SeccompNotifResp,
+        )
+    };
+
+    if ret < 0 {
+        return Err(NonoError::SandboxInit(format!(
+            "SECCOMP_IOCTL_NOTIF_SEND (continue) failed: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+
+    Ok(())
+}
+
+/// Deny a seccomp notification with EPERM.
+///
+/// Sends a response to the kernel that causes the child's syscall to
+/// return -1 with errno=EPERM.
+///
+/// # Errors
+///
+/// Returns an error if the ioctl fails.
+pub fn deny_notif(notify_fd: std::os::fd::RawFd, notif_id: u64) -> Result<()> {
+    respond_notif_errno(notify_fd, notif_id, libc::EPERM)
 }
 
 #[cfg(test)]

--- a/crates/nono/src/sandbox/mod.rs
+++ b/crates/nono/src/sandbox/mod.rs
@@ -21,9 +21,10 @@ pub use macos::{extension_consume, extension_issue_file, extension_release};
 // Re-export Linux seccomp-notify primitives for supervisor use
 #[cfg(target_os = "linux")]
 pub use linux::{
-    classify_access_from_flags, deny_notif, inject_fd, install_seccomp_notify, notif_id_valid,
-    read_notif_path, read_open_how, recv_notif, resolve_notif_path, validate_openat2_size, OpenHow,
-    SeccompData, SeccompNotif, SYS_OPENAT, SYS_OPENAT2,
+    classify_access_from_flags, continue_notif, deny_notif, inject_fd, install_seccomp_notify,
+    notif_id_valid, read_notif_path, read_open_how, recv_notif, resolve_notif_path,
+    respond_notif_errno, validate_openat2_size, OpenHow, SeccompData, SeccompNotif, SYS_OPENAT,
+    SYS_OPENAT2,
 };
 
 /// Information about sandbox support on this platform

--- a/docs/cli/internals/security-model.mdx
+++ b/docs/cli/internals/security-model.mdx
@@ -68,6 +68,13 @@ If the supervisor has a bug and fails to inject an fd, the child's syscall falls
 
 fd injection via `SECCOMP_IOCTL_NOTIF_ADDFD` eliminates this entirely. The supervisor opens the file itself — whatever path it read from the child's memory is what gets opened. The child's memory contents after that point are irrelevant.
 
+nono therefore avoids `CONTINUE` for any path that requires a supervisor authorization decision. The only Linux supervised-mode exceptions are tightly scoped compatibility cases where Landlock is already the enforcement floor:
+
+- **Initial allow-list hits outside procfs**: if the requested path is already inside the initial capability set, the supervisor can let the child's original syscall proceed because Landlock will independently enforce the same boundary.
+- **Missing-path probes (`ENOENT`/`ENOTDIR`)**: runtimes often probe optional files (`/$bunfs/...`, loader fallback paths, locale assets). Letting the original syscall continue preserves the kernel's native "not found" behavior instead of converting those probes into policy denials.
+
+For procfs paths, nono still resolves `/proc/self/...` in the child context and uses supervisor-opened fds so that procfs symlinks such as `/proc/<pid>/fd/*` cannot bypass target-path validation.
+
 ### Why not mount namespaces?
 
 A mount namespace with a minimal filesystem view would eliminate the information leak surface (the child could not `stat` paths outside the namespace). However:
@@ -110,7 +117,7 @@ The `SECCOMP_ADDFD_FLAG_SEND` flag is critical: it atomically injects the fd and
 
 - **Does not pass `O_CREAT`** — the supervisor cannot be tricked into creating files that do not exist
 - **Does not pass `O_TRUNC`** — the child cannot use the supervisor as a proxy to truncate files; it receives a plain writable fd and can seek/write within the file, but truncation is an explicit operation on an fd the user approved
-- **Does not use `SECCOMP_USER_NOTIF_FLAG_CONTINUE`** — the child never executes its own `openat`
+- **Does not use `SECCOMP_USER_NOTIF_FLAG_CONTINUE` for supervisor-approved paths** — authorization decisions still resolve to supervisor-opened fds, not the child's own `openat`
 
 ### Scope of an approved fd
 

--- a/scripts/test-linux-container.sh
+++ b/scripts/test-linux-container.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Run nono tests or ad hoc commands in a cached Linux Docker environment.
+
+set -euo pipefail
+
+IMAGE_NAME="${NONO_LINUX_IMAGE:-nono-linux-dev:bookworm}"
+DOCKERFILE="${NONO_LINUX_DOCKERFILE:-tools/docker/linux-dev.Dockerfile}"
+CACHE_PREFIX="${NONO_LINUX_CACHE_PREFIX:-nono-linux-bookworm}"
+REGISTRY_VOLUME="${NONO_LINUX_REGISTRY_VOLUME:-${CACHE_PREFIX}-cargo-registry}"
+GIT_VOLUME="${NONO_LINUX_GIT_VOLUME:-${CACHE_PREFIX}-cargo-git}"
+TARGET_VOLUME="${NONO_LINUX_TARGET_VOLUME:-${CACHE_PREFIX}-target}"
+REBUILD_IMAGE="${NONO_LINUX_REBUILD_IMAGE:-0}"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./scripts/test-linux-container.sh
+  ./scripts/test-linux-container.sh cargo test -p nono-cli
+  ./scripts/test-linux-container.sh bash -c 'cargo run -q -p nono-cli -- run --profile claude-code --dry-run -- echo ok'
+
+Behavior:
+  - Builds a reusable Linux dev image with required system packages
+  - Reuses Docker volumes for Cargo registry, Cargo git cache, and Linux target artifacts
+  - Defaults to `cargo test --workspace` when no command is provided
+
+Environment:
+  NONO_LINUX_REBUILD_IMAGE=1   Rebuild the Docker image before running
+  NONO_LINUX_IMAGE             Override image name (default: nono-linux-dev:bookworm)
+  NONO_LINUX_CACHE_PREFIX      Prefix for Docker cache volumes
+EOF
+}
+
+require_tool() {
+    local tool="$1"
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "error: required tool '$tool' not found" >&2
+        exit 1
+    fi
+}
+
+quote_args() {
+    printf '%q ' "$@"
+}
+
+build_image_if_needed() {
+    if [[ "$REBUILD_IMAGE" == "1" ]] || ! docker image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
+        docker build -t "$IMAGE_NAME" -f "$DOCKERFILE" .
+    fi
+}
+
+main() {
+    require_tool docker
+
+    if [[ ! -f "$DOCKERFILE" ]]; then
+        echo "error: dockerfile not found: $DOCKERFILE" >&2
+        exit 1
+    fi
+
+    if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+        usage
+        exit 0
+    fi
+
+    build_image_if_needed
+
+    if [[ "$#" -eq 0 ]]; then
+        set -- cargo test --workspace
+    fi
+
+    local command_string
+    command_string="$(quote_args "$@")"
+
+    docker run --rm \
+        -v "$(pwd)":/work \
+        -v "$REGISTRY_VOLUME":/usr/local/cargo/registry \
+        -v "$GIT_VOLUME":/usr/local/cargo/git \
+        -v "$TARGET_VOLUME":/cache/target \
+        -w /work \
+        -e CARGO_TARGET_DIR=/cache/target \
+        "$IMAGE_NAME" \
+        bash -c "set -euo pipefail; ${command_string}"
+}
+
+main "$@"

--- a/tests/integration/test_client_startup.sh
+++ b/tests/integration/test_client_startup.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Claude Code Startup Smoke Tests
+# Installs the real Claude Code CLI in an isolated HOME and verifies nono can
+# start it under both `run` and `wrap`.
+#
+# This suite exists specifically to guard against "runtime falls back to some
+# lower-level launcher/runtime" regressions like the OpenCode/Bun failure fixed
+# in PR #289. We use the published npm package instead of a mock binary so the
+# startup path exercises real Node/CLI behavior.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../lib/test_helpers.sh"
+
+echo ""
+echo -e "${BLUE}=== Claude Code Startup Smoke Tests ===${NC}"
+
+verify_nono_binary
+if ! require_working_sandbox "client startup suite"; then
+    print_summary
+    exit 0
+fi
+
+if ! skip_unless_linux "client startup smoke tests"; then
+    print_summary
+    exit 0
+fi
+
+ensure_node_toolchain() {
+    if command_exists node && command_exists npm; then
+        return 0
+    fi
+
+    if ! command_exists apt-get; then
+        skip_test "client startup smoke tests" "node/npm not installed and apt-get unavailable"
+        return 1
+    fi
+
+    local apt_cmd=(apt-get)
+    if [[ "$(id -u)" -ne 0 ]]; then
+        if command_exists sudo; then
+            apt_cmd=(sudo apt-get)
+        else
+            skip_test "client startup smoke tests" "node/npm not installed and sudo unavailable"
+            return 1
+        fi
+    fi
+
+    echo "Installing nodejs/npm for client startup smoke tests..."
+    "${apt_cmd[@]}" update >/dev/null 2>&1
+    "${apt_cmd[@]}" install -y nodejs npm >/dev/null 2>&1
+
+    if command_exists node && command_exists npm; then
+        return 0
+    fi
+
+    skip_test "client startup smoke tests" "failed to install node/npm"
+    return 1
+}
+
+if ! ensure_node_toolchain; then
+    print_summary
+    exit 0
+fi
+
+REAL_HOME="${HOME:-$(cd ~ && pwd)}"
+TMPDIR=$(mktemp -d "$REAL_HOME/nono-client-startup.XXXXXX")
+trap 'cleanup_test_dir "$TMPDIR"' EXIT
+
+CLIENT_HOME="$TMPDIR/home"
+CLAUDE_PREFIX="$CLIENT_HOME/.local/share/claude"
+CLIENT_PATH="$CLAUDE_PREFIX/bin:$PATH"
+CLAUDE_CODE_VERSION="2.1.71"
+
+mkdir -p \
+    "$CLIENT_HOME/.claude" \
+    "$CLAUDE_PREFIX"
+: > "$CLIENT_HOME/.claude.json"
+
+echo ""
+echo "Test home: $CLIENT_HOME"
+echo ""
+
+client_env() {
+    env \
+        HOME="$CLIENT_HOME" \
+        XDG_CONFIG_HOME="$CLIENT_HOME/.config" \
+        XDG_CACHE_HOME="$CLIENT_HOME/.cache" \
+        XDG_DATA_HOME="$CLIENT_HOME/.local/share" \
+        PATH="$CLIENT_PATH" \
+        NONO_NO_UPDATE_CHECK=1 \
+        "$@"
+}
+
+capture_last_nonempty_line() {
+    local output="$1"
+    printf '%s\n' "$output" | awk 'NF { line = $0 } END { print line }'
+}
+
+version_match_test() {
+    local name="$1"
+    local expected="$2"
+    shift 2
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    set +e
+    output=$("$@" </dev/null 2>&1)
+    actual=$?
+    set -e
+
+    if [[ "$actual" -ne 0 ]]; then
+        echo -e "  ${RED}FAIL${NC}: $name"
+        echo "       Expected exit code: 0, got: $actual"
+        local stripped
+        stripped=$(echo "$output" | sed 's/\x1b\[[0-9;]*m//g')
+        echo "       Output: ${stripped:0:2000}"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+
+    local last_line
+    last_line=$(capture_last_nonempty_line "$output")
+    if [[ "$last_line" == "$expected" ]]; then
+        echo -e "  ${GREEN}PASS${NC}: $name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    fi
+
+    echo -e "  ${RED}FAIL${NC}: $name"
+    echo "       Expected final line: $expected"
+    echo "       Actual final line:   $last_line"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    return 1
+}
+
+echo "--- Install Package ---"
+
+expect_success "install Claude Code npm package" \
+    npm install -g --silent --no-audit --no-fund --prefix "$CLAUDE_PREFIX" "@anthropic-ai/claude-code@$CLAUDE_CODE_VERSION"
+
+echo ""
+echo "--- Claude Code Startup ---"
+
+CLAUDE_VERSION=$(client_env claude --version)
+CLAUDE_VERSION=$(capture_last_nonempty_line "$CLAUDE_VERSION")
+
+version_match_test "plain claude reports pinned version" "$CLAUDE_VERSION" \
+    client_env claude --version
+
+version_match_test "nono run starts Claude Code successfully" "$CLAUDE_VERSION" \
+    client_env "$NONO_BIN" run --profile claude-code --allow-cwd --net-allow -- claude --version
+
+version_match_test "nono wrap starts Claude Code successfully" "$CLAUDE_VERSION" \
+    client_env "$NONO_BIN" wrap --profile claude-code --allow-cwd --net-allow -- claude --version
+
+print_summary

--- a/tests/integration/test_exec_strategy.sh
+++ b/tests/integration/test_exec_strategy.sh
@@ -44,6 +44,12 @@ run_test "default mode preserves exit code 1" 1 \
 run_test "default mode preserves exit code 42" 42 \
     "$NONO_BIN" run --allow "$TMPDIR" -- sh -c "exit 42"
 
+expect_output_contains "default mode preserves ENOENT for missing absolute paths" "No such file or directory" \
+    "$NONO_BIN" run --allow "$TMPDIR" -- cat /definitely-missing-nono-regression-path
+
+expect_output_not_contains "missing absolute path is not reported as supervisor denial" "Denied paths during this session" \
+    "$NONO_BIN" run --allow "$TMPDIR" -- cat /definitely-missing-nono-regression-path
+
 # =============================================================================
 # Direct Mode (nono wrap)
 # =============================================================================

--- a/tests/integration/test_network.sh
+++ b/tests/integration/test_network.sh
@@ -75,11 +75,17 @@ if command_exists curl; then
     expect_success "curl works by default" \
         "$NONO_BIN" run --allow "$TMPDIR" -- curl -s --max-time 10 https://example.com >/dev/null
 
-    expect_failure "claude-code profile blocks hosts outside developer allowlist" \
-        "$NONO_BIN" run --profile claude-code --allow-cwd -- curl -s --max-time 10 https://example.com >/dev/null
+    # Keep this assertion on a profile that still bundles a network_profile.
+    # claude-code used to carry a profile-level proxy allowlist, but the current
+    # built-in profile no longer sets network.network_profile in policy.json, so
+    # expecting it to block example.com is stale. python-dev still embeds the
+    # developer network profile, which makes it the right built-in fixture for
+    # validating "profile enables proxy filtering" plus the --net-allow override.
+    expect_failure "python-dev profile blocks hosts outside developer allowlist" \
+        "$NONO_BIN" run --profile python-dev --allow-cwd -- curl -s --max-time 10 https://example.com >/dev/null
 
-    expect_success "claude-code profile allows unrestricted network with --net-allow" \
-        "$NONO_BIN" run --profile claude-code --allow-cwd --net-allow -- curl -s --max-time 10 https://example.com >/dev/null
+    expect_success "python-dev profile allows unrestricted network with --net-allow" \
+        "$NONO_BIN" run --profile python-dev --allow-cwd --net-allow -- curl -s --max-time 10 https://example.com >/dev/null
 else
     skip_test "curl works by default" "curl not installed"
 fi

--- a/tests/integration/test_system_paths.sh
+++ b/tests/integration/test_system_paths.sh
@@ -115,6 +115,12 @@ if is_linux; then
     if [[ -d /proc ]]; then
         expect_success "can read /proc/self/status" \
             "$NONO_BIN" run --allow "$TMPDIR" -- cat /proc/self/status >/dev/null
+
+        expect_success "can read /proc/self/maps" \
+            "$NONO_BIN" run --allow "$TMPDIR" -- cat /proc/self/maps >/dev/null
+
+        expect_failure "cannot read foreign /proc/1/maps" \
+            "$NONO_BIN" run --allow "$TMPDIR" -- cat /proc/1/maps >/dev/null
     fi
 
     if [[ -d /sys ]]; then

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -72,6 +72,7 @@ SUITES=(
     "test_policy_queries.sh:Policy Queries"
     "test_shell.sh:Shell"
     "test_profiles.sh:Profiles"
+    "test_client_startup.sh:Client Startup"
     "test_env_sanitization.sh:Env Sanitization"
     "test_exec_strategy.sh:Exec Strategy"
     "test_trust_cli.sh:Trust CLI"

--- a/tools/docker/linux-dev.Dockerfile
+++ b/tools/docker/linux-dev.Dockerfile
@@ -1,0 +1,17 @@
+FROM rust:1-bookworm
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        libdbus-1-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CARGO_HOME=/usr/local/cargo
+ENV PATH=/usr/local/cargo/bin:${PATH}
+ENV CARGO_TERM_COLOR=always
+
+WORKDIR /work
+
+CMD ["bash"]


### PR DESCRIPTION
## Summary

Fix Linux supervised-mode compatibility for OpenCode/Bun.

The supervisor was changing the child process's normal `open()` behavior in a few ways that broke OpenCode under `nono run` while `nono wrap` still worked. This PR fixes that by:

- resolving `/proc/self/...` in the child's procfs context, not the supervisor's
- letting already-allowed syscalls continue natively instead of re-opening them in the supervisor
- preserving normal missing-file probe behavior for nonexistent paths like `/$bunfs/...` instead of turning them into supervisor denials

This fixes the regression where:

- `nono run --profile opencode --allow-cwd -- opencode --version` returned Bun `1.3.10`
- `nono wrap --profile opencode --allow-cwd -- opencode --version` returned OpenCode `1.2.21`

Fixes #287.

## Integration Test Notes

Two integration-test changes in this PR are intentional:

- The `Network` suite now uses `python-dev` instead of `claude-code` for the "profile blocks hosts outside developer allowlist" assertion. This is because the current built-in `claude-code` profile no longer embeds `network.network_profile` in `policy.json`, so expecting it to proxy-filter `example.com` is stale. `python-dev` still carries `network_profile: developer`, which makes it the correct built-in fixture for testing profile-driven proxy filtering and the `--net-allow` override.
- The new `test_client_startup.sh` smoke suite installs the real published Claude Code package in an isolated temp `HOME` and verifies that plain `claude`, `nono run`, and `nono wrap` all start the same client successfully. This is meant to catch the same class of startup/runtime regression that affected OpenCode.

## Testing

### Focused Rust tests

```text
$ bash scripts/test-linux-container.sh cargo test -p nono-cli exec_strategy --quiet
running 23 tests
.......................
test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 355 filtered out; finished in 0.00s
```

### Linux system path regression suite

```text
$ bash scripts/test-linux-container.sh env NONO_BIN=/cache/target/release/nono bash tests/integration/test_system_paths.sh
Tests run:     13
Passed:        13
Failed:        0
Skipped:       6
```

### Procfs regression checks

```text
$ bash scripts/test-linux-container.sh sh -c '/cache/target/release/nono run --allow /tmp -- cat /proc/self/maps >/dev/null; status=$?; echo self_maps_exit:$status'
self_maps_exit:0
```

```text
$ bash scripts/test-linux-container.sh sh -c '/cache/target/release/nono run --allow /tmp -- cat /proc/1/maps >/dev/null; status=$?; echo foreign_maps_exit:$status'
[nono]   /proc/1/maps (read) - permanently restricted by security policy
foreign_maps_exit:1
```

### Real OpenCode repro from the issue

Used the published package from the issue report: `opencode-ai@1.2.21`.

```text
$ bash scripts/test-linux-container.sh bash -lc 'set -euo pipefail; apt-get update >/tmp/apt.log; apt-get install -y nodejs npm >/tmp/npm-install.log; npm install -g opencode-ai@1.2.21 >/tmp/opencode-install.log; echo plain:$(opencode --version); echo run_start; /cache/target/release/nono run --profile opencode --allow-cwd -- opencode --version; echo wrap_start; /cache/target/release/nono wrap --profile opencode --allow-cwd -- opencode --version'
plain:1.2.21
run_start
...
1.2.21
wrap_start
...
1.2.21
```

### Real OpenCode help path under supervised mode

```text
$ bash scripts/test-linux-container.sh bash -lc 'set -euo pipefail; apt-get update >/tmp/apt.log; apt-get install -y nodejs npm >/tmp/npm-install.log; npm install -g opencode-ai@1.2.21 >/tmp/opencode-install.log; mkdir -p /root/.config/opencode /root/.cache/opencode /root/.local/share/opencode; /cache/target/release/nono run --profile opencode --allow-cwd -- opencode --help | head -n 20'
Commands:
  opencode completion
  opencode acp
  opencode mcp
  opencode [project]
  opencode attach <url>
  opencode run [message..]
```

### Claude Code startup regression test

Used the published package `@anthropic-ai/claude-code@2.1.71` in an isolated temp `HOME`.

```text
$ bash scripts/test-linux-container.sh env NONO_BIN=/cache/target/release/nono bash tests/integration/test_client_startup.sh
=== Claude Code Startup Smoke Tests ===
...
PASS: install Claude Code npm package
PASS: plain claude reports pinned version
PASS: nono run starts Claude Code successfully
PASS: nono wrap starts Claude Code successfully
```
