### PR TITLE
feat: make claude-code profile platform-aware

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -386,13 +386,41 @@
         ]
       }
     },
-    "vscode": {
-      "description": "Visual Studio Code configuration and extension directories",
+    "claude_code_macos": {
+      "description": "Claude Code macOS-specific state and credential paths",
+      "platform": "macos",
+      "allow": {
+        "read": [
+          "$HOME/Library/Keychains/login.keychain-db"
+        ]
+      }
+    },
+    "claude_code_linux": {
+      "description": "Claude Code Linux-specific state paths",
+      "platform": "linux",
+      "allow": {
+        "read": [
+          "$HOME/.local/share/claude"
+        ]
+      }
+    },
+    "vscode_macos": {
+      "description": "Visual Studio Code configuration and extension directories for macOS",
       "platform": "macos",
       "allow": {
         "write": [
           "$HOME/.vscode",
           "$HOME/Library/Application Support/Code"
+        ]
+      }
+    },
+    "vscode_linux": {
+      "description": "Visual Studio Code configuration and extension directories for Linux",
+      "platform": "linux",
+      "allow": {
+        "write": [
+          "$HOME/.vscode",
+          "$HOME/.config/Code"
         ]
       }
     },
@@ -484,15 +512,24 @@
         "author": "nono-project"
       },
       "security": {
-        "groups": ["user_caches_macos", "node_runtime", "rust_runtime", "python_runtime", "vscode", "unlink_protection"],
+        "groups": [
+          "claude_code_macos",
+          "claude_code_linux",
+          "user_caches_macos",
+          "node_runtime",
+          "rust_runtime",
+          "python_runtime",
+          "vscode_macos",
+          "vscode_linux",
+          "unlink_protection"
+        ],
         "signal_mode": "isolated"
       },
       "trust_groups": [],
       "filesystem": {
         "allow": ["$HOME/.claude"],
-        "read": ["$HOME/.local/share/claude"],
         "allow_file": ["$HOME/.claude.json", "$HOME/.claude.json.lock"],
-        "read_file": ["$HOME/Library/Keychains/login.keychain-db", "$HOME/.gitconfig", "$HOME/.gitignore_global", "$HOME/.config/git/ignore"]
+        "read_file": ["$HOME/.gitconfig", "$HOME/.gitignore_global", "$HOME/.config/git/ignore"]
       },
       "network": { "block": false },
       "workdir": { "access": "readwrite" },

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -1092,6 +1092,122 @@ mod tests {
     }
 
     #[test]
+    fn test_embedded_claude_code_profile_uses_platform_groups_for_os_paths() {
+        let policy = load_embedded_policy().expect("embedded policy");
+        let profile = policy
+            .profiles
+            .get("claude-code")
+            .expect("claude-code profile missing");
+
+        assert!(profile
+            .security
+            .groups
+            .contains(&"claude_code_macos".to_string()));
+        assert!(profile
+            .security
+            .groups
+            .contains(&"claude_code_linux".to_string()));
+        assert!(profile
+            .security
+            .groups
+            .contains(&"vscode_macos".to_string()));
+        assert!(profile
+            .security
+            .groups
+            .contains(&"vscode_linux".to_string()));
+        assert!(!profile
+            .filesystem
+            .read
+            .contains(&"$HOME/.local/share/claude".to_string()));
+        assert!(!profile
+            .filesystem
+            .read_file
+            .contains(&"$HOME/Library/Keychains/login.keychain-db".to_string()));
+    }
+
+    #[test]
+    fn test_embedded_claude_code_platform_groups_have_expected_paths() {
+        let policy = load_embedded_policy().expect("embedded policy");
+
+        let claude_code_macos = policy
+            .groups
+            .get("claude_code_macos")
+            .expect("claude_code_macos group missing");
+        assert_eq!(claude_code_macos.platform.as_deref(), Some("macos"));
+        assert!(claude_code_macos
+            .allow
+            .as_ref()
+            .expect("claude_code_macos allow missing")
+            .read
+            .contains(&"$HOME/Library/Keychains/login.keychain-db".to_string()));
+
+        let claude_code_linux = policy
+            .groups
+            .get("claude_code_linux")
+            .expect("claude_code_linux group missing");
+        assert_eq!(claude_code_linux.platform.as_deref(), Some("linux"));
+        assert!(claude_code_linux
+            .allow
+            .as_ref()
+            .expect("claude_code_linux allow missing")
+            .read
+            .contains(&"$HOME/.local/share/claude".to_string()));
+
+        let vscode_macos = policy
+            .groups
+            .get("vscode_macos")
+            .expect("vscode_macos group missing");
+        assert_eq!(vscode_macos.platform.as_deref(), Some("macos"));
+        let vscode_macos_paths = &vscode_macos
+            .allow
+            .as_ref()
+            .expect("vscode_macos allow missing")
+            .write;
+        assert!(vscode_macos_paths.contains(&"$HOME/.vscode".to_string()));
+        assert!(vscode_macos_paths.contains(&"$HOME/Library/Application Support/Code".to_string()));
+
+        let vscode_linux = policy
+            .groups
+            .get("vscode_linux")
+            .expect("vscode_linux group missing");
+        assert_eq!(vscode_linux.platform.as_deref(), Some("linux"));
+        let vscode_linux_paths = &vscode_linux
+            .allow
+            .as_ref()
+            .expect("vscode_linux allow missing")
+            .write;
+        assert!(vscode_linux_paths.contains(&"$HOME/.vscode".to_string()));
+        assert!(vscode_linux_paths.contains(&"$HOME/.config/Code".to_string()));
+    }
+
+    #[test]
+    fn test_embedded_claude_code_platform_groups_filter_by_os() {
+        let policy = load_embedded_policy().expect("embedded policy");
+        let mut caps = CapabilitySet::new();
+        let resolved = resolve_groups(
+            &policy,
+            &[
+                "claude_code_macos".to_string(),
+                "claude_code_linux".to_string(),
+                "vscode_macos".to_string(),
+                "vscode_linux".to_string(),
+            ],
+            &mut caps,
+        )
+        .expect("resolve failed");
+
+        assert_eq!(resolved.names.len(), 2);
+
+        if cfg!(target_os = "macos") {
+            assert!(resolved.names.contains(&"claude_code_macos".to_string()));
+            assert!(resolved.names.contains(&"vscode_macos".to_string()));
+        } else {
+            assert!(resolved.names.contains(&"claude_code_linux".to_string()));
+            assert!(resolved.names.contains(&"vscode_linux".to_string()));
+        }
+    }
+
+    #[test]
     fn test_resolve_read_group() {
         let policy = load_policy(sample_policy_json()).expect("parse failed");
         let mut caps = CapabilitySet::new();

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -34,6 +34,35 @@ mod tests {
     }
 
     #[test]
+    fn test_get_builtin_claude_code_uses_platform_groups_for_os_paths() {
+        let profile = get_builtin("claude-code").expect("Profile not found");
+        assert!(profile
+            .security
+            .groups
+            .contains(&"claude_code_macos".to_string()));
+        assert!(profile
+            .security
+            .groups
+            .contains(&"claude_code_linux".to_string()));
+        assert!(profile
+            .security
+            .groups
+            .contains(&"vscode_macos".to_string()));
+        assert!(profile
+            .security
+            .groups
+            .contains(&"vscode_linux".to_string()));
+        assert!(!profile
+            .filesystem
+            .read
+            .contains(&"$HOME/.local/share/claude".to_string()));
+        assert!(!profile
+            .filesystem
+            .read_file
+            .contains(&"$HOME/Library/Keychains/login.keychain-db".to_string()));
+    }
+
+    #[test]
     fn test_get_builtin_openclaw() {
         let profile = get_builtin("openclaw").expect("Profile not found");
         assert_eq!(profile.meta.name, "openclaw");

--- a/docs/cli/clients/claude-code.mdx
+++ b/docs/cli/clients/claude-code.mdx
@@ -30,8 +30,10 @@ The built-in profile provides:
 - **Read+write access** to `~/.claude` (agent state, debug logs, project config)
 - **Read+write access** to `~/.claude.json` (settings file)
 - **Read+write access** to `~/.vscode` (VS Code extensions directory)
-- **Read+write access** to `~/Library/Application Support/Code` (VS Code app data, macOS)
-- **Read access** to `~/.local/share/claude` (Claude Code binary installation path)
+- **Read+write access** to the OS-specific VS Code app data directory:
+  `~/Library/Application Support/Code` on macOS, `~/.config/Code` on Linux
+- **Read access** to the OS-specific Claude Code state path:
+  `~/Library/Keychains/login.keychain-db` on macOS, `~/.local/share/claude` on Linux
 - **Network access** enabled (required for Anthropic API)
 - **Interactive mode** enabled (preserves TTY for Claude's terminal UI)
 - **Automatic hook installation** for sandbox-aware error handling
@@ -184,7 +186,7 @@ You only need `--read` (not `--allow`) for these directories. This permits PATH 
 
 ### VS Code Extension
 
-Claude Code installs a VS Code extension on startup. The built-in profile already grants write access to both `~/.vscode` and `~/Library/Application Support/Code` (macOS). No additional flags are needed for VS Code extension installation.
+Claude Code installs a VS Code extension on startup. The built-in profile already grants write access to `~/.vscode` plus the OS-specific VS Code data directory: `~/Library/Application Support/Code` on macOS or `~/.config/Code` on Linux. No additional flags are needed for VS Code extension installation.
 
 ### Git Configuration
 

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -395,9 +395,9 @@ These are a hard safety net below all other policy.
 nono run --profile claude-code -- claude
 ```
 
-**Groups:** `user_caches_macos`, `node_runtime`, `rust_runtime`, `python_runtime`, `vscode`, `unlink_protection` (plus all base_groups)
+**Groups:** `claude_code_macos`, `claude_code_linux`, `user_caches_macos`, `node_runtime`, `rust_runtime`, `python_runtime`, `vscode_macos`, `vscode_linux`, `unlink_protection` (plus all base_groups)
 
-**Filesystem:** `~/.claude` (read+write), `~/.claude.json` (read+write)
+**Filesystem:** `~/.claude` (read+write), `~/.claude.json` (read+write), plus platform-specific Claude Code and VS Code paths from the matching `_macos` or `_linux` groups
 
 **Network:** Allowed
 


### PR DESCRIPTION
## Summary
- keep a single `claude-code` built-in profile and use platform-scoped policy groups for OS-specific paths
- move macOS-only and Linux-only Claude Code path grants out of the profile filesystem block into `claude_code_macos` / `claude_code_linux`
- split VS Code access into `vscode_macos` / `vscode_linux` so the profile resolves the right app-data directory on each OS
- add embedded policy tests, built-in profile coverage, and docs updates for the new behavior

## Why
The built-in `claude-code` profile already used platform-aware policy groups, but its raw `filesystem` entries were not platform-aware. That meant one stable profile name still tried to apply Linux-only paths on macOS and macOS-only paths on Linux. This keeps the existing profile model and uses the `platform` selector already built into `policy.json` instead of adding OS-specific profile names or widening the profile schema.

## Testing
`cargo test -p nono-cli --quiet`
```text
running 376 tests
....................................................................................... 87/376
....................................................................................... 174/376
....................................................................................... 261/376
....................................................................................... 348/376
............................
test result: ok. 376 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s

running 7 tests
.......
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.43s
```

`NONO_LINUX_DOCKERFILE=/Users/josephgimenez/workspace/security/nono-issue-281/tools/docker/linux-dev.Dockerfile /Users/josephgimenez/workspace/security/nono-issue-281/scripts/test-linux-container.sh cargo test -p nono-cli claude_code -- --nocapture`
```text
   Compiling nono-cli v0.14.0 (/work/crates/nono-cli)
   Compiling nono v0.14.0 (/work/crates/nono)
   Compiling nono-proxy v0.14.0 (/work/crates/nono-proxy)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 8.37s
     Running unittests src/main.rs (/cache/target/debug/deps/nono-dff2435b167b1e7e)

running 6 tests
test network_policy::tests::test_claude_code_profile_includes_github_credential ... ok
test policy::tests::test_embedded_claude_code_profile_uses_platform_groups_for_os_paths ... ok
test profile::builtin::tests::test_get_builtin_claude_code_uses_platform_groups_for_os_paths ... ok
test policy::tests::test_embedded_claude_code_platform_groups_have_expected_paths ... ok
test profile::builtin::tests::test_get_builtin_claude_code ... ok
test policy::tests::test_embedded_claude_code_platform_groups_filter_by_os ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 412 filtered out; finished in 0.00s

     Running tests/env_vars.rs (/cache/target/debug/deps/env_vars-d96d4a6b2871ec74)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.00s
```

`NONO_LINUX_DOCKERFILE=/Users/josephgimenez/workspace/security/nono-issue-281/tools/docker/linux-dev.Dockerfile /Users/josephgimenez/workspace/security/nono-issue-281/scripts/test-linux-container.sh cargo test -p nono-cli test_from_profile_with_groups -- --nocapture`
```text
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
     Running unittests src/main.rs (/cache/target/debug/deps/nono-dff2435b167b1e7e)

running 1 test
test capability_ext::tests::test_from_profile_with_groups ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 417 filtered out; finished in 0.00s

     Running tests/env_vars.rs (/cache/target/debug/deps/env_vars-d96d4a6b2871ec74)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.00s
```
