### PR TITLE
fix: add tilde expansion to profile paths and opencode binary access

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -368,6 +368,15 @@
         ]
       }
     },
+    "opencode_linux": {
+      "description": "OpenCode binary directory (Landlock requires directory read to execute binaries)",
+      "platform": "linux",
+      "allow": {
+        "read": [
+          "~/.opencode/bin"
+        ]
+      }
+    },
     "python_runtime": {
       "description": "Python runtime paths",
       "allow": {
@@ -618,7 +627,7 @@
         "author": "nono-project"
       },
       "security": {
-        "groups": ["user_caches_macos", "user_caches_linux", "node_runtime", "unlink_protection"],
+        "groups": ["user_caches_macos", "user_caches_linux", "node_runtime", "opencode_linux", "unlink_protection"],
         "signal_mode": "isolated"
       },
       "trust_groups": [],

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1057,6 +1057,15 @@ pub fn expand_vars(path: &str, workdir: &Path) -> Result<PathBuf> {
 
     let home = config::validated_home()?;
 
+    // Expand ~/... to $HOME/... before other substitutions
+    let path = if let Some(rest) = path.strip_prefix("~/") {
+        format!("{}/{}", home, rest)
+    } else if path == "~" {
+        home.clone()
+    } else {
+        path.to_string()
+    };
+
     let expanded = path.replace("$WORKDIR", &workdir.to_string_lossy());
 
     // Expand $TMPDIR and $UID


### PR DESCRIPTION
`expand_vars()` only handled `$HOME` but not `~/` prefix, causing user profile paths like `~/.opencode/bin` to fail resolution. 

Add Linux-only group for opencode binary directory since Landlock requires directory read access to execute binaries within it.