### PR TITLE
fix: allow OpenTUI data dir in opencode profile

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -552,7 +552,8 @@
         "allow": [
           "$HOME/.config/opencode",
           "$HOME/.cache/opencode",
-          "$HOME/.local/share/opencode"
+          "$HOME/.local/share/opencode",
+          "$HOME/.local/share/opentui"
         ]
       },
       "network": { "block": false, "network_profile": "developer" },

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -50,6 +50,10 @@ mod tests {
         assert_eq!(profile.meta.name, "opencode");
         assert_eq!(profile.workdir.access, WorkdirAccess::ReadWrite);
         assert!(profile.interactive);
+        assert!(profile
+            .filesystem
+            .allow
+            .contains(&"$HOME/.local/share/opentui".to_string()));
     }
 
     #[test]

--- a/docs/cli/clients/opencode.mdx
+++ b/docs/cli/clients/opencode.mdx
@@ -26,6 +26,7 @@ The built-in profile provides:
 - **Read+write access** to `~/.config/opencode` (configuration)
 - **Read+write access** to `~/.cache/opencode` (cache)
 - **Read+write access** to `~/.local/share/opencode` (data)
+- **Read+write access** to `~/.local/share/opentui` (OpenTUI parser/runtime data)
 - **Read+write access** to `/tmp` (temp files)
 - **Network access** enabled (required for AI provider API calls)
 
@@ -50,7 +51,8 @@ Create `~/.config/nono/profiles/opencode.json` for different permissions:
   "filesystem": {
     "read": [
       "$XDG_CONFIG_HOME/opencode",
-      "$XDG_DATA_HOME/opencode"
+      "$XDG_DATA_HOME/opencode",
+      "$XDG_DATA_HOME/opentui"
     ]
   },
   "network": {

--- a/tests/integration/test_profiles.sh
+++ b/tests/integration/test_profiles.sh
@@ -43,6 +43,9 @@ expect_failure "nonexistent profile exits non-zero" \
 expect_output_contains "claude-code profile lists .claude in dry-run" ".claude" \
     "$NONO_BIN" run --profile claude-code --dry-run -- echo "test"
 
+expect_output_contains "opencode profile lists OpenTUI data dir in dry-run" ".local/share/opentui" \
+    "$NONO_BIN" run --profile opencode --dry-run -- echo "test"
+
 expect_output_contains "dry-run output shows Capabilities section" "Capabilities:" \
     "$NONO_BIN" run --profile claude-code --dry-run -- echo "test"
 


### PR DESCRIPTION
## Summary
- allow the built-in `opencode` profile to access `~/.local/share/opentui`
- add a regression check for the new allow-list entry
- document the OpenTUI data directory in the opencode client docs

## Why
OpenCode's TUI uses OpenTUI runtime/parser data under `~/.local/share/opentui`. Under `nono run --profile opencode`, that path was denied, which causes the renderer to fall back and matches the broken markdown/code styling reported in #245.

## Testing
- `cargo test -p nono-cli test_get_builtin_opencode`
- `cargo fmt --check`
- `bash tests/integration/test_profiles.sh`
- `cargo run -q -p nono-cli -- run --profile opencode --dry-run -- echo test`

Fixes #245