### PR TITLE
feat: add a profile for swival

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ nono run --profile claude-code -- claude
 nono run --profile codex -- codex
 nono run --profile opencode -- opencode
 nono run --profile openclaw -- openclaw
+nono run --profile swival -- swival
 
 nono run --allow-cwd -- python3 my_agent.py
 nono run --allow-cwd -- npx @anthropic/agent-framework
@@ -80,7 +81,7 @@ DENIED
   Details: Path matches sensitive pattern 'Block access to cryptographic keys, tokens, and cloud credentials'. Access blocked by security policy.
 ```
 
-Built-in profiles for [Claude Code](https://docs.nono.sh/cli/clients/claude-code), [Codex](https://docs.nono.sh/cli/clients/codex), [OpenCode](https://docs.nono.sh/cli/clients/opencode), and [OpenClaw](https://docs.nono.sh/cli/clients/openclaw) — or define your own with custom permissions.
+Built-in profiles for [Claude Code](https://docs.nono.sh/cli/clients/claude-code), [Codex](https://docs.nono.sh/cli/clients/codex), [OpenCode](https://docs.nono.sh/cli/clients/opencode), [OpenClaw](https://docs.nono.sh/cli/clients/openclaw), and [Swival](https://docs.nono.sh/cli/clients/swival) — or define your own with custom permissions.
 
 ## Library
 
@@ -281,6 +282,7 @@ nono ships with built-in profiles for popular AI coding agents. Each profile def
 | **Codex** | `codex` | [Guide](https://docs.nono.sh/cli/clients/codex) |
 | **OpenCode** | `opencode` | [Guide](https://docs.nono.sh/cli/clients/opencode) |
 | **OpenClaw** | `openclaw` | [Guide](https://docs.nono.sh/cli/clients/openclaw) |
+| **Swival** | `swival` | [Guide](https://docs.nono.sh/cli/clients/swival) |
 
 Custom profiles can [extend built-in ones](https://docs.nono.sh/cli/features/profiles-groups) with `"extends": "claude-code"` to inherit all settings and add overrides. nono is agent-agnostic and works with any CLI command. See the [full documentation](https://docs.nono.sh) for usage details, configuration, and integration guides.
 

--- a/crates/nono-cli/README.md
+++ b/crates/nono-cli/README.md
@@ -67,6 +67,7 @@ nono run --allow-cwd --dry-run -- command
 | Codex | `nono run --profile codex -- codex` |
 | OpenCode | `nono run --profile opencode -- opencode` |
 | OpenClaw | `nono run --profile openclaw -- openclaw gateway` |
+| Swival | `nono run --profile swival -- swival` |
 
 ## Profile Inheritance
 

--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -739,6 +739,40 @@
       "network": { "block": false, "network_profile": "developer" },
       "workdir": { "access": "readwrite" },
       "interactive": false
+    },
+    "swival": {
+      "meta": {
+        "name": "swival",
+        "version": "1.0.0",
+        "description": "Swival CLI coding agent",
+        "author": "nono-project"
+      },
+      "security": {
+        "groups": [
+          "python_runtime",
+          "node_runtime",
+          "user_caches_macos",
+          "user_caches_linux",
+          "unlink_protection"
+        ],
+        "signal_mode": "isolated",
+        "capability_elevation": false
+      },
+      "trust_groups": [],
+      "filesystem": {
+        "allow": [
+          "$HOME/.config/swival",
+          "$HOME/.local/share/swival"
+        ],
+        "read_file": ["$HOME/.gitconfig", "$HOME/.gitignore_global", "$HOME/.config/git/ignore"]
+      },
+      "network": { "block": false },
+      "workdir": { "access": "readwrite" },
+      "undo": {
+        "exclude_patterns": ["node_modules", "__pycache__", ".swival"],
+        "exclude_globs": ["*.pyc"]
+      },
+      "interactive": true
     }
   }
 }

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -115,6 +115,27 @@ mod tests {
     }
 
     #[test]
+    fn test_get_builtin_swival() {
+        let profile = get_builtin("swival").expect("Profile not found");
+        assert_eq!(profile.meta.name, "swival");
+        assert_eq!(profile.workdir.access, WorkdirAccess::ReadWrite);
+        assert!(profile.interactive);
+        assert!(!profile.network.block);
+        assert!(profile
+            .filesystem
+            .allow
+            .contains(&"$HOME/.config/swival".to_string()));
+        assert!(profile
+            .security
+            .groups
+            .contains(&"python_runtime".to_string()));
+        assert!(profile
+            .security
+            .groups
+            .contains(&"unlink_protection".to_string()));
+    }
+
+    #[test]
     fn test_get_builtin_nonexistent() {
         assert!(get_builtin("nonexistent").is_none());
     }
@@ -126,6 +147,7 @@ mod tests {
         assert!(profiles.contains(&"codex".to_string()));
         assert!(profiles.contains(&"openclaw".to_string()));
         assert!(profiles.contains(&"opencode".to_string()));
+        assert!(profiles.contains(&"swival".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
Hi!

And congrats for Nono, this is a very useful tool!

This PR adds a sandbox profile for the [Swival](https://swival.dev) CLI coding agent with Python runtime, network access, and workdir read/write.

Thank you!