### PR TITLE
fix: add uv paths to python_runtime group

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -382,7 +382,6 @@
         "read": [
           "~/.pyenv",
           "~/.local/lib",
-          "~/.local/bin",
           "~/.local/share/uv",
           "~/.conda"
         ]

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -338,7 +338,7 @@ nono ships with 22 built-in groups:
 **Runtime groups** (language toolchain paths):
 - `node_runtime` - nvm, fnm, npm, volta
 - `rust_runtime` - rustup, cargo
-- `python_runtime` - pyenv, conda, pip
+- `python_runtime` - pyenv, conda, pip, uv
 - `user_tools` - Local bins, .desktop files, man pages, shell completions
 
 **Protection groups**:


### PR DESCRIPTION
uv-installed tools and virtual python interpreters couldn't execute due to missing ~/.local/bin and ~/.local/share/uv in the group.