### PR TITLE
fix: Add pnpm support to policy.json

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -363,7 +363,9 @@
           "~/.npm",
           "~/.node",
           "~/.local/share/fnm",
-          "/usr/local/lib/node_modules"
+          "/usr/local/lib/node_modules",
+          "~/Library/pnpm",
+          "~/.local/share/pnpm"
         ]
       }
     },


### PR DESCRIPTION
Adding pnpm paths for MacOS and Linux to policy.json. 