### PR TITLE
fix: add pnpm paths to policy.json

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -363,7 +363,9 @@
           "~/.npm",
           "~/.node",
           "~/.local/share/fnm",
-          "/usr/local/lib/node_modules"
+          "/usr/local/lib/node_modules",
+          "~/Library/pnpm",
+          "~/.local/share/pnpm"
         ]
       }
     },


### PR DESCRIPTION
Adding pnpm paths to policy.json. This allows pnpm support for MacOS and Linux.