### PR TITLE
docs: update Homebrew install references

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ nono audit show 20260216-193311-20751 --json
 
 ## Quick Start
 
-### Homebrew (macOS and Linux)
+### Homebrew (macOS/Linux)
 
 ```bash
 brew install nono

--- a/crates/nono-cli/README.md
+++ b/crates/nono-cli/README.md
@@ -4,7 +4,7 @@ CLI for capability-based sandboxing using Landlock (Linux) and Seatbelt (macOS).
 
 ## Installation
 
-### Homebrew (macOS and Linux)
+### Homebrew (macOS/Linux)
 
 ```bash
 brew install nono

--- a/docs/cli/getting_started/installation.mdx
+++ b/docs/cli/getting_started/installation.mdx
@@ -3,7 +3,7 @@ title: Installation
 description: How to install nono on your system
 ---
 
-## Homebrew (macOS and Linux)
+## Homebrew (macOS/Linux)
 
 ```bash
 brew install nono


### PR DESCRIPTION
## Summary
- update Homebrew install docs to mention macOS/Linux
- remove outdated Homebrew note

## Testing
- not run (docs only)