### PR TITLE
feat: restyle --help output with grouped sections and bold headings

### DIFF
--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -57,7 +57,13 @@ pub struct Cli {
     pub silent: bool,
 
     /// Color theme for output (mocha, latte, frappe, macchiato, tokyo-night, minimal)
-    #[arg(long, global = true, env = "NONO_THEME", value_name = "THEME", help_heading = "OPTIONS")]
+    #[arg(
+        long,
+        global = true,
+        env = "NONO_THEME",
+        value_name = "THEME",
+        help_heading = "OPTIONS"
+    )]
     pub theme: Option<String>,
 
     #[command(subcommand)]
@@ -521,7 +527,12 @@ pub struct SandboxArgs {
     pub network_profile: Option<String>,
 
     /// Allow additional hosts through the proxy (repeatable)
-    #[arg(long = "allow-proxy", alias = "proxy-allow", value_name = "HOST", help_heading = "NETWORK")]
+    #[arg(
+        long = "allow-proxy",
+        alias = "proxy-allow",
+        value_name = "HOST",
+        help_heading = "NETWORK"
+    )]
     pub allow_proxy: Vec<String>,
 
     /// Allow binding on a TCP port. macOS: enables blanket inbound (no per-port filtering)

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -793,6 +793,14 @@ nono run --config ./nono.toml -- command
   Configuration file support is planned for a future release.
 </Note>
 
+#### `--help`, `-h`
+
+Print help information for the command.
+
+```bash
+nono run --help
+```
+
 ## `nono why` Options
 
 The `why` command checks why a path or network operation would be allowed or denied. It's designed for both human debugging and programmatic use by AI agents.


### PR DESCRIPTION
## Summary

Closes #339

- Restyle all `--help` output to match a consistent format: bold uppercase section headings, compact examples with inline `#` comments
- Group `SandboxArgs` flags into **FILESYSTEM**, **NETWORK**, **CREDENTIALS**, **COMMANDS**, and **OPTIONS** sections via `help_heading`
- Add **ROLLBACK** group for `nono run` rollback flags, **QUERY/CONTEXT** groups for `nono why`
- Use `Styles::plain().header(Style::new().bold())` so only section headings are bold, not individual flag names
- Shorten flag descriptions to one-liners while preserving security-relevant caveats (macOS blanket inbound on `--allow-bind`, `never_grant` on `--override-deny`, etc.)
- Remove dead `display_order` attributes (no effect with hardcoded root template)
- Add drift-detection tests: `test_root_help_lists_all_commands` and `test_subcommand_help_structure`

## Test plan

- [ ] `make ci` passes (clippy, fmt, all tests)
- [ ] `nono --help` shows grouped command sections
- [ ] `nono shell --help` / `nono run --help` show FILESYSTEM/NETWORK/CREDENTIALS/COMMANDS/OPTIONS groupings
- [ ] `nono run --help` shows ROLLBACK group
- [ ] `nono why --help` shows QUERY/OPTIONS/CONTEXT groups
- [ ] `nono rollback --help` / `nono audit --help` / `nono trust --help` show COMMANDS + OPTIONS without duplication
- [ ] Bold only on section headings, not flag names
- [ ] New tests catch drift (rename a flag → test fails on example reference)