### PR TITLE
feat: support multiple base profiles in extends field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +30,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ambient-id"
@@ -182,6 +202,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +230,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "bstr"
@@ -211,6 +252,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
@@ -514,6 +561,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "dbus"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +672,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +723,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +762,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,12 +785,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -722,6 +822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -729,6 +830,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
@@ -749,7 +856,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -843,7 +953,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -851,6 +961,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1224,6 +1339,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f29616f6e19415398eb186964fb7cbbeef572c79bede3622a8277667924bbe3"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "reqwest",
+ "rustls",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
 name = "keyring"
 version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,6 +1543,7 @@ dependencies = [
  "colored",
  "dirs",
  "dns-lookup",
+ "jsonschema",
  "keyring",
  "landlock",
  "nix",
@@ -1470,6 +1615,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,6 +1727,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
@@ -1766,6 +1987,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a618c14f8ba29d8193bb55e2bf13e4fb2b1115313ecb7ae94b43100c7ac7d5"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,7 +2058,9 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -2812,6 +3082,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2901,6 +3177,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2911,6 +3197,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ nono ships with built-in profiles for popular AI coding agents. Each profile def
 | **OpenClaw** | `openclaw` | [Guide](https://docs.nono.sh/cli/clients/openclaw) |
 | **Swival** | `swival` | [Guide](https://docs.nono.sh/cli/clients/swival) |
 
-Custom profiles can [extend built-in ones](https://docs.nono.sh/cli/features/profiles-groups) with `"extends": "claude-code"` to inherit all settings and add overrides. nono is agent-agnostic and works with any CLI command. See the [full documentation](https://docs.nono.sh) for usage details, configuration, and integration guides.
+Custom profiles can [extend built-in ones](https://docs.nono.sh/cli/features/profiles-groups) with `"extends": "claude-code"` (or multiple: `"extends": ["claude-code", "node-dev"]`) to inherit all settings and add overrides. nono is agent-agnostic and works with any CLI command. See the [full documentation](https://docs.nono.sh) for usage details, configuration, and integration guides.
 
 ## Projects using nono
 

--- a/crates/nono-cli/Cargo.toml
+++ b/crates/nono-cli/Cargo.toml
@@ -82,3 +82,4 @@ toml = "1.0"
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
+jsonschema = "0.45"

--- a/crates/nono-cli/README.md
+++ b/crates/nono-cli/README.md
@@ -104,6 +104,16 @@ User profiles can extend built-in or other user profiles with the `extends` fiel
 }
 ```
 
+You can also extend multiple profiles at once. Bases are merged left-to-right, then the child overrides:
+
+```json
+{
+  "extends": ["claude-code", "node-dev"],
+  "meta": { "name": "my-fullstack" },
+  "filesystem": { "allow": ["/opt/extra"] }
+}
+```
+
 Save to `~/.config/nono/profiles/my-claude.json`, then:
 
 ```bash
@@ -118,9 +128,11 @@ nono run --profile my-claude -- claude
 - **Scalars** (`meta`): child overrides
 - **Nullable scalars** (`network_profile`): absent inherits, `null` clears, string overrides
 
+When extending multiple bases, they are merged left-to-right using the same rules. The child then overrides the accumulated base.
+
 ### Chaining
 
-Profiles can form chains (up to 10 levels deep). Circular dependencies are detected and rejected.
+Profiles can form chains (up to 10 levels deep). Circular dependencies are detected and rejected. Shared transitive bases are deduplicated.
 
 ```
 my-dev.json → team-base.json → claude-code (built-in)

--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -11,8 +11,15 @@
       "description": "JSON Schema URI for editor validation and autocompletion."
     },
     "extends": {
-      "type": "string",
-      "description": "Name of a base profile to inherit from. All fields from the base profile are used as defaults, with this profile's values taking precedence."
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        }
+      ],
+      "description": "Name of a base profile (or array of base profiles) to inherit from. All fields from the base profile are used as defaults, with this profile's values taking precedence. When an array is given, bases are merged left-to-right before the child is applied. Shared transitive bases are deduplicated: each profile is resolved at most once."
     },
     "meta": {
       "$ref": "#/$defs/ProfileMeta",

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -132,7 +132,7 @@ impl ProfileDef {
         policy.exclude_groups =
             profile::dedup_append(&self.exclude_groups, &self.policy.exclude_groups);
         profile::Profile {
-            extends: self.extends.clone(),
+            extends: self.extends.as_ref().map(|s| vec![s.clone()]),
             meta: self.meta.clone(),
             security: profile::SecurityConfig {
                 groups: self.security.groups.clone(),

--- a/crates/nono-cli/src/policy_cmd.rs
+++ b/crates/nono-cli/src/policy_cmd.rs
@@ -401,7 +401,7 @@ fn print_profile_line(name: &str, result: &Result<Profile>, t: &theme::Theme) {
         Ok(p) => {
             let desc = p.meta.description.as_deref().unwrap_or("").to_string();
             let extends = profile::load_profile_extends(name)
-                .map(|e| format!("extends {}", e))
+                .map(|v| format!("extends {}", v.join(", ")))
                 .unwrap_or_default();
             println!(
                 "    {:<16} {:<42} {}",
@@ -454,7 +454,7 @@ fn cmd_show(args: PolicyShowArgs) -> Result<()> {
         println!(
             "  {}      {}",
             theme::fg("Extends:", t.subtext),
-            theme::fg(extends, t.text)
+            theme::fg(&extends.join(", "), t.text)
         );
     }
 
@@ -675,12 +675,12 @@ fn print_fs_paths(label: &str, paths: &[String], t: &theme::Theme, raw: bool) {
 fn profile_to_json(
     name: &str,
     profile: &Profile,
-    raw_extends: &Option<String>,
+    raw_extends: &Option<Vec<String>>,
 ) -> serde_json::Value {
     let mut val = serde_json::json!({
         "name": name,
         "description": profile.meta.description.as_deref().unwrap_or(""),
-        "extends": raw_extends.as_deref().unwrap_or(""),
+        "extends": raw_extends.as_ref().map(|v| serde_json::json!(v)).unwrap_or(serde_json::Value::Null),
     });
 
     // Security

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -801,12 +801,48 @@ pub struct OpenUrlConfig {
     pub allow_localhost: bool,
 }
 
+/// Deserialize the `extends` field from either a single string or an array of strings.
+///
+/// Accepts:
+/// - `"extends": "base"` → `Some(vec!["base"])`
+/// - `"extends": ["a", "b"]` → `Some(vec!["a", "b"])`
+/// - absent / null → `None`
+fn deserialize_extends<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum ExtendsValue {
+        Single(String),
+        Multiple(Vec<String>),
+    }
+
+    let value: Option<ExtendsValue> = Option::deserialize(deserializer)?;
+    Ok(match value {
+        Some(ExtendsValue::Single(s)) => Some(vec![s]),
+        Some(ExtendsValue::Multiple(v)) => {
+            if v.is_empty() {
+                None
+            } else {
+                Some(v)
+            }
+        }
+        None => None,
+    })
+}
+
 /// A complete profile definition
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Profile {
-    /// Optional base profile to inherit from (by name)
-    #[serde(default)]
-    pub extends: Option<String>,
+    /// Optional base profile(s) to inherit from (by name).
+    /// Accepts either a single string `"extends": "base"` or an array
+    /// `"extends": ["base-a", "base-b"]`. Multiple bases are merged
+    /// left-to-right before the child overrides.
+    #[serde(default, deserialize_with = "deserialize_extends")]
+    pub extends: Option<Vec<String>>,
     #[serde(default)]
     pub meta: ProfileMeta,
     #[serde(default)]
@@ -855,11 +891,11 @@ pub fn is_user_override(name: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Load a profile's raw (unresolved) extends target name.
+/// Load a profile's raw (unresolved) extends target names.
 ///
-/// Returns `Some(base_name)` if the profile declares `extends`, `None` otherwise.
+/// Returns `Some(base_names)` if the profile declares `extends`, `None` otherwise.
 /// This reads the raw profile definition before inheritance resolution clears the field.
-pub fn load_profile_extends(name_or_path: &str) -> Option<String> {
+pub fn load_profile_extends(name_or_path: &str) -> Option<Vec<String>> {
     // Direct file path
     if name_or_path.contains('/') || name_or_path.ends_with(".json") {
         return parse_profile_file(Path::new(name_or_path))
@@ -883,7 +919,7 @@ pub fn load_profile_extends(name_or_path: &str) -> Option<String> {
     // Built-in profile
     if let Ok(policy) = crate::policy::load_embedded_policy() {
         if let Some(def) = policy.profiles.get(name_or_path) {
-            return def.extends.clone();
+            return def.extends.as_ref().map(|s| vec![s.clone()]);
         }
     }
 
@@ -1038,12 +1074,19 @@ const MAX_INHERITANCE_DEPTH: usize = 10;
 
 /// Resolve the `extends` chain for a profile.
 ///
-/// If the profile declares `extends`, the base profile is loaded, its own
-/// `extends` resolved recursively, and the two are merged. The `visited` vec
+/// If the profile declares `extends` (one or more base names), each base is
+/// loaded and resolved recursively, then they are fold-merged left-to-right.
+/// The accumulated base is finally merged with the child. The `visited` vec
 /// tracks profile names already in the chain to detect circular dependencies.
+///
+/// Shared transitive bases are handled naturally: `visited` tracks only the
+/// current ancestor chain (push before recurse, pop after). When two siblings
+/// share a transitive base, it is resolved once per sibling; because
+/// `merge_profiles` is idempotent, the result is correct. Only true cycles
+/// (a profile extending one of its own ancestors) are rejected.
 fn resolve_extends(child: Profile, visited: &mut Vec<String>, depth: usize) -> Result<Profile> {
-    let base_name = match child.extends {
-        Some(ref name) => name.clone(),
+    let base_names = match child.extends {
+        Some(ref names) => names.clone(),
         None => return Ok(child),
     };
 
@@ -1055,20 +1098,35 @@ fn resolve_extends(child: Profile, visited: &mut Vec<String>, depth: usize) -> R
         )));
     }
 
-    if visited.contains(&base_name) {
-        return Err(NonoError::ProfileInheritance(format!(
-            "circular dependency detected: {} -> {}",
-            visited.join(" -> "),
-            base_name
-        )));
+    // Resolve each base and fold-merge them left-to-right
+    let mut accumulated_base: Option<Profile> = None;
+    for base_name in &base_names {
+        if visited.contains(base_name) {
+            return Err(NonoError::ProfileInheritance(format!(
+                "circular dependency detected: {} -> {}",
+                visited.join(" -> "),
+                base_name
+            )));
+        }
+
+        visited.push(base_name.clone());
+
+        let base = load_base_profile_raw(base_name)?;
+        let resolved_base = resolve_extends(base, visited, depth + 1)?;
+        // Pop to restore the stack to the pre-base state. On the error path
+        // above (? propagation), visited is abandoned so the missing pop is harmless.
+        visited.pop();
+
+        accumulated_base = Some(match accumulated_base {
+            Some(acc) => merge_profiles(acc, resolved_base),
+            None => resolved_base,
+        });
     }
 
-    visited.push(base_name.clone());
-
-    let base = load_base_profile_raw(&base_name)?;
-    let resolved_base = resolve_extends(base, visited, depth + 1)?;
-
-    Ok(merge_profiles(resolved_base, child))
+    match accumulated_base {
+        Some(base) => Ok(merge_profiles(base, child)),
+        None => Ok(child),
+    }
 }
 
 /// Load a base profile by name WITHOUT applying implicit default-group merging.
@@ -2266,7 +2324,7 @@ mod tests {
 
     fn child_profile() -> Profile {
         Profile {
-            extends: Some("base".to_string()),
+            extends: Some(vec!["base".to_string()]),
             meta: ProfileMeta {
                 name: "child".to_string(),
                 version: "2.0".to_string(),
@@ -2698,7 +2756,7 @@ mod tests {
     #[test]
     fn test_extends_missing_base_error() {
         let profile = Profile {
-            extends: Some("nonexistent-profile-xyz".to_string()),
+            extends: Some(vec!["nonexistent-profile-xyz".to_string()]),
             ..Default::default()
         };
 
@@ -2716,7 +2774,7 @@ mod tests {
     fn test_extends_circular_dependency_error() {
         // Simulate: visited already has "b", and we try to extend "b" again
         let profile = Profile {
-            extends: Some("b".to_string()),
+            extends: Some(vec!["b".to_string()]),
             ..Default::default()
         };
 
@@ -2734,7 +2792,7 @@ mod tests {
     #[test]
     fn test_extends_self_reference_error() {
         let profile = Profile {
-            extends: Some("self-ref".to_string()),
+            extends: Some(vec!["self-ref".to_string()]),
             ..Default::default()
         };
 
@@ -2752,7 +2810,7 @@ mod tests {
     #[test]
     fn test_extends_depth_limit_error() {
         let profile = Profile {
-            extends: Some("deep".to_string()),
+            extends: Some(vec!["deep".to_string()]),
             ..Default::default()
         };
 
@@ -2773,7 +2831,7 @@ mod tests {
     fn test_extends_empty_child_inherits_all() {
         let base = base_profile();
         let empty_child = Profile {
-            extends: Some("base".to_string()),
+            extends: Some(vec!["base".to_string()]),
             ..Default::default()
         };
 
@@ -2870,7 +2928,7 @@ mod tests {
 
     #[test]
     fn test_merge_profiles_extends_consumed() {
-        let child = child_profile(); // has extends = Some("base")
+        let child = child_profile(); // has extends = Some(vec!["base"])
         let merged = merge_profiles(base_profile(), child);
         assert!(
             merged.extends.is_none(),
@@ -2969,16 +3027,230 @@ mod tests {
 
     #[test]
     fn test_extends_field_deserialization() {
+        // Single string form
         let json_str = r#"{
             "extends": "claude-code",
             "meta": { "name": "ext-test" }
         }"#;
-        let profile: Profile = serde_json::from_str(json_str).expect("parse");
-        assert_eq!(profile.extends, Some("claude-code".to_string()));
+        let profile: Profile = serde_json::from_str(json_str).expect("parse single");
+        assert_eq!(profile.extends, Some(vec!["claude-code".to_string()]));
 
+        // Array form
+        let json_str = r#"{
+            "extends": ["claude-code", "opencode"],
+            "meta": { "name": "ext-multi" }
+        }"#;
+        let profile: Profile = serde_json::from_str(json_str).expect("parse array");
+        assert_eq!(
+            profile.extends,
+            Some(vec!["claude-code".to_string(), "opencode".to_string()])
+        );
+
+        // Absent field
         let json_str = r#"{ "meta": { "name": "no-ext" } }"#;
-        let profile: Profile = serde_json::from_str(json_str).expect("parse");
+        let profile: Profile = serde_json::from_str(json_str).expect("parse absent");
         assert!(profile.extends.is_none());
+
+        // Empty array
+        let json_str = r#"{ "extends": [], "meta": { "name": "empty-ext" } }"#;
+        let profile: Profile = serde_json::from_str(json_str).expect("parse empty array");
+        assert!(
+            profile.extends.is_none(),
+            "empty array should normalize to None"
+        );
+    }
+
+    #[test]
+    fn test_extends_empty_string_in_array_rejected() {
+        // An empty string passes deserialization but is caught by load_base_profile_raw
+        let profile = Profile {
+            extends: Some(vec!["".to_string()]),
+            ..Default::default()
+        };
+
+        let result = resolve_extends(profile, &mut Vec::new(), 0);
+        assert!(result.is_err());
+        let err = result.expect_err("empty string base should error");
+        assert!(
+            err.to_string().contains("invalid base profile name"),
+            "Error should mention invalid name: {}",
+            err
+        );
+    }
+
+    // --- Multiple extends tests ---
+
+    #[test]
+    fn test_extends_multiple_bases() {
+        // Child extends ["a", "b"] — gets merged groups/filesystem from both
+        let base_a = Profile {
+            extends: None,
+            meta: ProfileMeta {
+                name: "a".to_string(),
+                ..Default::default()
+            },
+            security: SecurityConfig {
+                groups: vec!["group_a".to_string()],
+                ..Default::default()
+            },
+            filesystem: FilesystemConfig {
+                allow: vec!["/a/path".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let base_b = Profile {
+            extends: None,
+            meta: ProfileMeta {
+                name: "b".to_string(),
+                ..Default::default()
+            },
+            security: SecurityConfig {
+                groups: vec!["group_b".to_string()],
+                ..Default::default()
+            },
+            filesystem: FilesystemConfig {
+                allow: vec!["/b/path".to_string()],
+                read: vec!["/b/read".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let child = Profile {
+            extends: Some(vec!["a".to_string(), "b".to_string()]),
+            meta: ProfileMeta {
+                name: "child".to_string(),
+                ..Default::default()
+            },
+            filesystem: FilesystemConfig {
+                allow: vec!["/child/path".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Simulate what resolve_extends does: merge a + b, then merge with child
+        let merged_bases = merge_profiles(base_a, base_b);
+        let merged = merge_profiles(merged_bases, child);
+
+        assert_eq!(merged.meta.name, "child");
+        assert!(merged.filesystem.allow.contains(&"/a/path".to_string()));
+        assert!(merged.filesystem.allow.contains(&"/b/path".to_string()));
+        assert!(merged.filesystem.allow.contains(&"/child/path".to_string()));
+        assert!(merged.filesystem.read.contains(&"/b/read".to_string()));
+        assert!(merged.security.groups.contains(&"group_a".to_string()));
+        assert!(merged.security.groups.contains(&"group_b".to_string()));
+        assert!(merged.extends.is_none());
+    }
+
+    #[test]
+    fn test_extends_multiple_ordering() {
+        // Later bases override earlier for scalar fields (network_profile, workdir)
+        let base_a = Profile {
+            extends: None,
+            network: NetworkConfig {
+                network_profile: InheritableValue::Set("net-a".to_string()),
+                ..Default::default()
+            },
+            workdir: WorkdirConfig {
+                access: WorkdirAccess::Read,
+            },
+            interactive: false,
+            ..Default::default()
+        };
+
+        let base_b = Profile {
+            extends: None,
+            network: NetworkConfig {
+                network_profile: InheritableValue::Set("net-b".to_string()),
+                ..Default::default()
+            },
+            workdir: WorkdirConfig {
+                access: WorkdirAccess::ReadWrite,
+            },
+            interactive: true,
+            ..Default::default()
+        };
+
+        // Merge a then b: b should win for scalars
+        let merged = merge_profiles(base_a, base_b);
+        assert_eq!(
+            merged.network.network_profile,
+            InheritableValue::Set("net-b".to_string()),
+            "later base should override network_profile"
+        );
+        assert_eq!(
+            merged.workdir.access,
+            WorkdirAccess::ReadWrite,
+            "later base should override workdir"
+        );
+        assert!(merged.interactive, "interactive should be OR'd");
+    }
+
+    #[test]
+    fn test_extends_duplicate_base_deduplicates() {
+        // extends: ["claude-code", "claude-code"] — duplicate is silently skipped
+        let profile = Profile {
+            extends: Some(vec!["claude-code".to_string(), "claude-code".to_string()]),
+            ..Default::default()
+        };
+
+        let result = resolve_extends(profile, &mut Vec::new(), 0);
+        assert!(
+            result.is_ok(),
+            "duplicate base should be deduplicated, not error: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_extends_multiple_builtin_default() {
+        // Test extending a single built-in profile (default) via array syntax
+        let dir = tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("multi-ext.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "extends": ["default"],
+                "meta": { "name": "multi-ext-test" },
+                "filesystem": { "allow": ["/tmp/multi-ext"] }
+            }"#,
+        )
+        .expect("write profile");
+
+        let profile = load_from_file(&profile_path).expect("load extended profile");
+        assert_eq!(profile.meta.name, "multi-ext-test");
+        assert!(profile
+            .filesystem
+            .allow
+            .contains(&"/tmp/multi-ext".to_string()));
+        assert!(profile.extends.is_none());
+    }
+
+    #[test]
+    fn test_extends_multiple_shared_transitive_base_deduplicates() {
+        // Two built-in profiles that both extend "default" — shared base is deduplicated
+        let dir = tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("shared-base.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "extends": ["claude-code", "opencode"],
+                "meta": { "name": "shared-base-test" }
+            }"#,
+        )
+        .expect("write profile");
+
+        let result = load_from_file(&profile_path);
+        assert!(
+            result.is_ok(),
+            "shared transitive base should be deduplicated, not error: {:?}",
+            result
+        );
+        let profile = result.expect("shared base profile");
+        assert_eq!(profile.meta.name, "shared-base-test");
     }
 
     #[test]
@@ -3180,5 +3452,171 @@ mod tests {
             profile.security.ipc_mode,
             Some(ProfileIpcMode::SharedMemoryOnly)
         );
+    }
+
+    // --- JSON Schema validation tests ---
+
+    /// Helper: validate a JSON string against the embedded profile schema.
+    fn validate_against_schema(json_str: &str) -> std::result::Result<(), String> {
+        let schema_str = crate::config::embedded::embedded_profile_schema();
+        let schema: serde_json::Value =
+            serde_json::from_str(schema_str).expect("schema is valid JSON");
+        let instance: serde_json::Value =
+            serde_json::from_str(json_str).expect("instance is valid JSON");
+        let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+        let errors: Vec<_> = validator.iter_errors(&instance).collect();
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors
+                .iter()
+                .map(|e| format!("{} at {}", e, e.instance_path()))
+                .collect::<Vec<_>>()
+                .join("; "))
+        }
+    }
+
+    #[test]
+    fn test_schema_validates_extends_as_string() {
+        let json = r#"{
+            "extends": "default",
+            "meta": { "name": "str-extends" },
+            "filesystem": { "allow": ["/tmp/test"] }
+        }"#;
+        validate_against_schema(json)
+            .expect("extends as a single string should pass schema validation");
+    }
+
+    #[test]
+    fn test_schema_validates_extends_as_array() {
+        let json = r#"{
+            "extends": ["default", "claude-code"],
+            "meta": { "name": "arr-extends" },
+            "filesystem": { "allow": ["/tmp/test"] }
+        }"#;
+        validate_against_schema(json)
+            .expect("extends as an array of strings should pass schema validation");
+    }
+
+    #[test]
+    fn test_schema_validates_extends_single_element_array() {
+        let json = r#"{
+            "extends": ["default"],
+            "meta": { "name": "single-arr" }
+        }"#;
+        validate_against_schema(json)
+            .expect("extends as single-element array should pass schema validation");
+    }
+
+    #[test]
+    fn test_schema_rejects_extends_empty_array() {
+        let json = r#"{
+            "extends": [],
+            "meta": { "name": "empty-arr" }
+        }"#;
+        let result = validate_against_schema(json);
+        assert!(
+            result.is_err(),
+            "empty extends array should fail schema validation"
+        );
+    }
+
+    #[test]
+    fn test_schema_rejects_extends_numeric() {
+        let json = r#"{
+            "extends": 42,
+            "meta": { "name": "bad-extends" }
+        }"#;
+        let result = validate_against_schema(json);
+        assert!(
+            result.is_err(),
+            "numeric extends should fail schema validation"
+        );
+    }
+
+    #[test]
+    fn test_schema_rejects_extends_array_of_non_strings() {
+        let json = r#"{
+            "extends": [1, 2],
+            "meta": { "name": "bad-arr" }
+        }"#;
+        let result = validate_against_schema(json);
+        assert!(
+            result.is_err(),
+            "array of ints should fail schema validation"
+        );
+    }
+
+    #[test]
+    fn test_schema_validates_absent_extends() {
+        let json = r#"{
+            "meta": { "name": "no-extends" },
+            "filesystem": { "allow": ["/tmp"] }
+        }"#;
+        validate_against_schema(json).expect("absent extends should pass schema validation");
+    }
+
+    #[test]
+    fn test_schema_validates_full_profile() {
+        let json = r#"{
+            "extends": ["default"],
+            "meta": {
+                "name": "full-test",
+                "version": "1.0.0",
+                "description": "A test profile",
+                "author": "test"
+            },
+            "security": {
+                "groups": ["git_config", "node_runtime"],
+                "signal_mode": "isolated",
+                "capability_elevation": false
+            },
+            "filesystem": {
+                "allow": ["/tmp/project"],
+                "read": ["/etc"],
+                "allow_file": ["/tmp/config.json"]
+            },
+            "policy": {
+                "exclude_groups": ["dangerous_commands"],
+                "add_allow_read": ["/opt/data"],
+                "override_deny": ["/etc/hosts"]
+            },
+            "network": {
+                "block": false,
+                "network_profile": "anthropic",
+                "proxy_allow": ["extra.example.com"],
+                "allow_port": [8080]
+            },
+            "workdir": { "access": "readwrite" },
+            "undo": {
+                "exclude_patterns": ["node_modules"],
+                "exclude_globs": ["*.tmp"]
+            }
+        }"#;
+        validate_against_schema(json)
+            .expect("full profile with array extends should pass schema validation");
+    }
+
+    #[test]
+    fn test_schema_validates_builtin_profiles_in_policy_json() {
+        // Validate that all built-in profiles in policy.json conform to the schema
+        let policy_str = include_str!("../../data/policy.json");
+        let policy: serde_json::Value =
+            serde_json::from_str(policy_str).expect("policy.json is valid JSON");
+        let profiles = policy["profiles"]
+            .as_object()
+            .expect("profiles is an object");
+
+        for (name, profile_value) in profiles {
+            let result = validate_against_schema(
+                &serde_json::to_string(profile_value).expect("re-serialize"),
+            );
+            assert!(
+                result.is_ok(),
+                "built-in profile '{}' should conform to schema: {}",
+                name,
+                result.expect_err("already checked is_ok")
+            );
+        }
     }
 }

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -363,7 +363,7 @@ mod tests {
         let json = serde_json::to_string(&skeleton).expect("serialize");
         let profile: Profile = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(profile.meta.name, "full-test");
-        assert_eq!(profile.extends, Some("default".to_string()));
+        assert_eq!(profile.extends, Some(vec!["default".to_string()]));
         assert_eq!(
             profile.meta.description,
             Some("A full test profile".to_string())


### PR DESCRIPTION
Accept both `"extends": "single"` and `"extends": ["a", "b"]` via serde untagged enum deserialization. Multiple bases are resolved recursively and fold-merged left-to-right before the child overrides.

Diamond inheritance is intentionally rejected — the visited set is shared across sibling bases to prevent confusing permission accumulation.

Closes #391