### PR TITLE
fix(setup): detect Landlock via syscall probe instead of LSM file

### DIFF
--- a/crates/nono-cli/src/setup.rs
+++ b/crates/nono-cli/src/setup.rs
@@ -185,6 +185,8 @@ impl SetupRunner {
                 e
             )))?;
 
+        println!("  * Landlock enabled (syscall probe)");
+
         println!("  * {}", detected);
         println!("  * Available features:");
 


### PR DESCRIPTION
`nono setup` fails on WSL2 because it checks `/sys/kernel/security/lsm` before testing actual Landlock capability. This file doesn't exist in WSL2, so setup reports Landlock as unavailable even though the syscalls work (ABI V3).

This reorders the check: `detect_abi()` syscall probe first (authoritative), removing the LSM file check. The syscall probe error (with the same troubleshooting guidance) is used if the probe fails. This matches the [kernel docs' recommendation](https://docs.kernel.org/userspace-api/landlock.html#:~:text=Developers%20can%20also%20easily%20check%20for%20Landlock%20support%20with%20a%20related%20system%20call.) to detect via syscall.

**Verification:**
- clippy (including `unwrap_used`): clean
- fmt: clean
- `cargo test -p nono-cli`: 537 unit + 33 integration pass
- `nono setup --check-only` on WSL2: succeeds, detects V3
  ```
  nono v0.20.0
  [1/4] Checking installation...
    * nono binary found at /usr/bin/nono
    * Version: 0.20.0
    * Platform: Linux (Landlock sandbox)
  
  [2/4] Testing sandbox support...
    * Kernel version: 6.6.87.2-microsoft-standard-WSL2
    * Landlock enabled (syscall probe)
    * Landlock V3
    * Available features:
        - Basic filesystem access control
        - File rename across directories (Refer)
        - File truncation (Truncate)
    * Filesystem ruleset creation verified
    * TCP network filtering: not supported by this ABI
  ```


Fixes: #416 