### PR TITLE
fix(cli): add ~/.opencode to opencode profile paths

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -708,6 +708,7 @@
       },
       "filesystem": {
         "allow": [
+          "$HOME/.opencode",
           "$HOME/.config/opencode",
           "$HOME/.cache/opencode",
           "$HOME/.local/share/opencode",

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -121,6 +121,10 @@ mod tests {
         assert!(profile
             .filesystem
             .allow
+            .contains(&"$HOME/.opencode".to_string()));
+        assert!(profile
+            .filesystem
+            .allow
             .contains(&"$HOME/.local/share/opentui".to_string()));
     }
 

--- a/docs/cli/clients/opencode.mdx
+++ b/docs/cli/clients/opencode.mdx
@@ -23,6 +23,7 @@ nono run --profile opencode -- opencode
 
 The built-in profile provides:
 - **Read+write access** to the current working directory
+- **Read+write access** to `~/.opencode` (binary and package data)
 - **Read+write access** to `~/.config/opencode` (configuration)
 - **Read+write access** to `~/.cache/opencode` (cache)
 - **Read+write access** to `~/.local/share/opencode` (data)


### PR DESCRIPTION
Fixes #420

## Summary
- Added `$HOME/.opencode` to the opencode profile's filesystem allow list
- Fixes `EACCES: permission denied, open '~/.opencode/package.json'` on startup

## Testing
- Clippy, fmt, and all tests pass