### PR TITLE
docs: fix installation command for nono-cli package

### DIFF
--- a/docs/cli/getting_started/installation.mdx
+++ b/docs/cli/getting_started/installation.mdx
@@ -17,8 +17,8 @@ Download the `.deb` package from [GitHub Releases](https://github.com/always-fur
 
 ```bash
 VERSION=$(curl -sI https://github.com/always-further/nono/releases/latest | grep -i location | grep -oP 'v\K[0-9.]+')
-wget https://github.com/always-further/nono/releases/download/v${VERSION}/nono-cli_${VERSION}-1_amd64.deb
-sudo dpkg -i nono-cli_${VERSION}-1_amd64.deb
+wget https://github.com/always-further/nono/releases/download/v${VERSION}/nono-cli_${VERSION}_amd64.deb
+sudo dpkg -i nono-cli_${VERSION}_amd64.deb
 ```
 
 Other distributions are in the process of being packaged. In the meantime, you can use the prebuilt binaries or build from source.


### PR DESCRIPTION
By following the instruction guide I noticed that I need to make these changes.