### PR TITLE
fix: update security vulnerability disclosure link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ We encourage using AI tools to contribute to nono. However, you must understand 
 
 ## Security
 
-If you discover a security vulnerability, please **do not open a public issue**. Instead, follow the responsible disclosure process outlined in our [Security Policy](https://github.com/always-further/nono/blob/main/SECURITY.md).
+If you discover a security vulnerability, please **do not open a public issue**. Instead, follow the responsible disclosure process outlined in our [Security Policy](https://github.com/always-further/nono/security).
 
 ## License
 


### PR DESCRIPTION
Noticed that the link was broken and assumed it was meant to point here now