### PR TITLE
feat(proxy): add L7 method+path endpoint filtering for reverse proxy routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,6 +1578,7 @@ version = "0.25.0"
 dependencies = [
  "base64",
  "getrandom 0.4.1",
+ "globset",
  "http-body-util",
  "hyper",
  "hyper-rustls",

--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -399,6 +399,30 @@
             { "type": "null" }
           ],
           "description": "Explicit environment variable name for the phantom token (e.g., \"OPENAI_API_KEY\"). Required when credential_key is a URI manager reference (op:// or apple-password://)."
+        },
+        "endpoint_rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/EndpointRule"
+          },
+          "description": "L7 endpoint rules for method+path filtering. When non-empty, only requests matching at least one rule are allowed (default-deny). When empty or absent, all endpoints are permitted.",
+          "default": []
+        }
+      }
+    },
+    "EndpointRule": {
+      "type": "object",
+      "description": "HTTP method+path access rule for restricting which API endpoints an agent can access through a credential route.",
+      "additionalProperties": false,
+      "required": ["method", "path"],
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "HTTP method to match (e.g., \"GET\", \"POST\") or \"*\" for any method."
+        },
+        "path": {
+          "type": "string",
+          "description": "URL path glob pattern. Uses standard glob syntax: \"*\" matches one path segment, \"**\" matches zero or more segments."
         }
       }
     },

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -604,6 +604,17 @@ pub struct SandboxArgs {
     )]
     pub proxy_credential: Vec<String>,
 
+    /// Restrict a credential service to specific HTTP method+path patterns (repeatable).
+    /// Format: "SERVICE:METHOD:/path/pattern" (e.g., "github:GET:/repos/*/issues")
+    /// Use "*" for any method: "github:*:/repos/*/issues"
+    /// Patterns: "*" matches one path segment, "**" matches zero or more.
+    #[arg(
+        long = "allow-endpoint",
+        value_name = "SERVICE:METHOD:PATH",
+        help_heading = "CREDENTIALS"
+    )]
+    pub allow_endpoint: Vec<String>,
+
     /// Load credentials as env vars. For network API keys, prefer --credential
     #[arg(
         long,
@@ -825,6 +836,7 @@ impl From<WrapSandboxArgs> for SandboxArgs {
             external_proxy_bypass: Vec::new(),
             proxy_port: None,
             proxy_credential: Vec::new(),
+            allow_endpoint: Vec::new(),
             env_credential: args.env_credential,
             env_credential_map: args.env_credential_map,
             allow_command: args.allow_command,
@@ -2164,6 +2176,34 @@ mod tests {
                 assert!(args.block_net);
             }
             _ => panic!("Expected Why command"),
+        }
+    }
+
+    #[test]
+    fn test_allow_endpoint_flag_parses() {
+        let cli = Cli::parse_from([
+            "nono",
+            "run",
+            "--allow",
+            ".",
+            "--credential",
+            "github",
+            "--allow-endpoint",
+            "github:GET:/repos/*/issues",
+            "--allow-endpoint",
+            "github:POST:/repos/*/issues/*/comments",
+            "echo",
+        ]);
+        match cli.command {
+            Commands::Run(args) => {
+                assert_eq!(args.sandbox.allow_endpoint.len(), 2);
+                assert_eq!(args.sandbox.allow_endpoint[0], "github:GET:/repos/*/issues");
+                assert_eq!(
+                    args.sandbox.allow_endpoint[1],
+                    "github:POST:/repos/*/issues/*/comments"
+                );
+            }
+            _ => panic!("Expected Run command"),
         }
     }
 

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -898,6 +898,7 @@ fn run_sandbox(run_args: RunArgs, silent: bool) -> Result<()> {
             upstream_proxy: effective_upstream_proxy,
             upstream_bypass: effective_bypass,
             allow_bind_ports: effective_listen_ports,
+            allow_endpoint: args.allow_endpoint.clone(),
             proxy_port: args.proxy_port,
             open_url_origins: prepared.open_url_origins,
             open_url_allow_localhost: prepared.open_url_allow_localhost,
@@ -1097,6 +1098,8 @@ struct ExecutionFlags {
     upstream_bypass: Vec<String>,
     /// Ports the sandboxed process is allowed to bind (from --allow-bind)
     allow_bind_ports: Vec<u16>,
+    /// Endpoint rules from --allow-endpoint (parsed into per-service rules)
+    allow_endpoint: Vec<String>,
     /// Fixed port for the credential proxy (from --proxy-port)
     proxy_port: Option<u16>,
     /// Allowed URL origins for supervisor-delegated browser opens
@@ -1144,6 +1147,7 @@ impl ExecutionFlags {
             upstream_proxy: None,
             upstream_bypass: Vec::new(),
             allow_bind_ports: Vec::new(),
+            allow_endpoint: Vec::new(),
             proxy_port: None,
             open_url_origins: Vec::new(),
             open_url_allow_localhost: false,
@@ -1291,6 +1295,25 @@ fn build_proxy_config_from_flags(
     let expanded_allow_domain =
         network_policy::expand_proxy_allow(&net_policy, &flags.allow_domain);
 
+    // Apply --allow-endpoint rules to matching routes
+    for entry in &flags.allow_endpoint {
+        let (service, rule) = parse_allow_endpoint(entry)?;
+        let mut found = false;
+        for route in &mut resolved.routes {
+            if route.prefix == service {
+                route.endpoint_rules.push(rule.clone());
+                found = true;
+            }
+        }
+        if !found {
+            return Err(NonoError::ConfigParse(format!(
+                "--allow-endpoint references unknown service '{}'. \
+                 Add it with --credential {} first.",
+                service, service
+            )));
+        }
+    }
+
     // Build the proxy config with expanded extra hosts
     let mut proxy_config = network_policy::build_proxy_config(&resolved, &expanded_allow_domain);
 
@@ -1309,6 +1332,44 @@ fn build_proxy_config_from_flags(
     }
 
     Ok(proxy_config)
+}
+
+/// Parse an `--allow-endpoint` value in "SERVICE:METHOD:/path/pattern" format.
+fn parse_allow_endpoint(entry: &str) -> Result<(String, nono_proxy::config::EndpointRule)> {
+    // Split on first two colons: "github:GET:/repos/*/issues"
+    // -> ("github", "GET", "/repos/*/issues")
+    let first_colon = entry.find(':').ok_or_else(|| {
+        NonoError::ConfigParse(format!(
+            "invalid --allow-endpoint format '{}': expected SERVICE:METHOD:/path",
+            entry
+        ))
+    })?;
+    let service = &entry[..first_colon];
+    let rest = &entry[first_colon + 1..];
+
+    let second_colon = rest.find(':').ok_or_else(|| {
+        NonoError::ConfigParse(format!(
+            "invalid --allow-endpoint format '{}': expected SERVICE:METHOD:/path",
+            entry
+        ))
+    })?;
+    let method = &rest[..second_colon];
+    let path = &rest[second_colon + 1..];
+
+    if service.is_empty() || method.is_empty() || path.is_empty() {
+        return Err(NonoError::ConfigParse(format!(
+            "invalid --allow-endpoint format '{}': service, method, and path must be non-empty",
+            entry
+        )));
+    }
+
+    Ok((
+        service.to_string(),
+        nono_proxy::config::EndpointRule {
+            method: method.to_string(),
+            path: path.to_string(),
+        },
+    ))
 }
 
 fn cleanup_capability_state_file(cap_file_path: &std::path::Path) {

--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -5,7 +5,7 @@
 
 use crate::profile::CustomCredentialDef;
 use nono::{NonoError, Result};
-use nono_proxy::config::{InjectMode, ProxyConfig, RouteConfig};
+use nono_proxy::config::{EndpointRule, InjectMode, ProxyConfig, RouteConfig};
 use serde::Deserialize;
 use std::collections::HashMap;
 use tracing::debug;
@@ -77,6 +77,11 @@ pub struct CredentialDef {
     /// from `credential_key.to_uppercase()`.
     #[serde(default)]
     pub env_var: Option<String>,
+
+    /// Optional L7 endpoint rules for method+path filtering.
+    /// When non-empty, only matching method+path combinations are allowed.
+    #[serde(default)]
+    pub endpoint_rules: Vec<EndpointRule>,
 }
 
 fn default_inject_header() -> String {
@@ -228,6 +233,7 @@ pub fn resolve_credentials(
                 path_replacement: cred.path_replacement.clone(),
                 query_param_name: cred.query_param_name.clone(),
                 env_var: cred.env_var.clone(),
+                endpoint_rules: cred.endpoint_rules.clone(),
             });
         } else if let Some(cred) = policy.credentials.get(name) {
             // Validate env_var against dangerous variable blocklist
@@ -253,6 +259,7 @@ pub fn resolve_credentials(
                 path_replacement: None,
                 query_param_name: None,
                 env_var: cred.env_var.clone(),
+                endpoint_rules: cred.endpoint_rules.clone(),
             });
         }
         // We already validated existence above, so this else branch won't be hit
@@ -431,6 +438,7 @@ mod tests {
                 path_replacement: None,
                 query_param_name: None,
                 env_var: None,
+                endpoint_rules: vec![],
             },
         );
 
@@ -465,6 +473,7 @@ mod tests {
                 path_replacement: None,
                 query_param_name: None,
                 env_var: None,
+                endpoint_rules: vec![],
             },
         );
 
@@ -495,6 +504,7 @@ mod tests {
                 path_replacement: None,
                 query_param_name: None,
                 env_var: None,
+                endpoint_rules: vec![],
             },
         );
 
@@ -535,6 +545,7 @@ mod tests {
                 path_replacement: None,
                 query_param_name: None,
                 env_var: None,
+                endpoint_rules: vec![],
             },
         );
 
@@ -611,6 +622,7 @@ mod tests {
                 path_replacement: None,
                 query_param_name: None,
                 env_var: None,
+                endpoint_rules: vec![],
             },
         );
 
@@ -638,6 +650,7 @@ mod tests {
                 path_replacement: None,
                 query_param_name: None,
                 env_var: None,
+                endpoint_rules: vec![],
             },
         );
 
@@ -665,6 +678,7 @@ mod tests {
                 path_replacement: None,
                 query_param_name: None,
                 env_var: None,
+                endpoint_rules: vec![],
             },
         );
 
@@ -697,6 +711,7 @@ mod tests {
                 path_replacement: None,
                 query_param_name: None,
                 env_var: Some("OPENAI_API_KEY".to_string()),
+                endpoint_rules: vec![],
             },
         );
 
@@ -803,6 +818,7 @@ mod tests {
                 path_replacement: None,
                 query_param_name: None,
                 env_var: Some("LD_PRELOAD".to_string()),
+                endpoint_rules: vec![],
             },
         );
 

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -142,6 +142,11 @@ pub struct CustomCredentialDef {
     /// `apple-password://`).
     #[serde(default)]
     pub env_var: Option<String>,
+
+    /// Optional L7 endpoint rules for method+path filtering.
+    /// When non-empty, only matching method+path combinations are allowed.
+    #[serde(default)]
+    pub endpoint_rules: Vec<nono_proxy::config::EndpointRule>,
 }
 
 fn default_inject_header() -> String {
@@ -1879,6 +1884,7 @@ mod tests {
             path_replacement: None,
             query_param_name: None,
             env_var: None,
+            endpoint_rules: vec![],
         }
     }
 
@@ -2037,6 +2043,7 @@ mod tests {
             path_replacement: None,
             query_param_name: None,
             env_var: None,
+            endpoint_rules: vec![],
         };
         assert!(validate_custom_credential("telegram", &cred).is_ok());
     }
@@ -2053,6 +2060,7 @@ mod tests {
             path_replacement: None,
             query_param_name: None,
             env_var: None,
+            endpoint_rules: vec![],
         };
         let result = validate_custom_credential("telegram", &cred);
         let err = result.expect_err("missing path_pattern should be rejected");
@@ -2071,6 +2079,7 @@ mod tests {
             path_replacement: None,
             query_param_name: None,
             env_var: None,
+            endpoint_rules: vec![],
         };
         let result = validate_custom_credential("telegram", &cred);
         let err = result.expect_err("pattern without {} should be rejected");
@@ -2089,6 +2098,7 @@ mod tests {
             path_replacement: Some("/v2/bot{}/".to_string()),
             query_param_name: None,
             env_var: None,
+            endpoint_rules: vec![],
         };
         assert!(validate_custom_credential("telegram", &cred).is_ok());
     }
@@ -2105,6 +2115,7 @@ mod tests {
             path_replacement: Some("/v2/bot/fixed/".to_string()), // No {} placeholder
             query_param_name: None,
             env_var: None,
+            endpoint_rules: vec![],
         };
         let result = validate_custom_credential("telegram", &cred);
         let err = result.expect_err("replacement without {} should be rejected");
@@ -2123,6 +2134,7 @@ mod tests {
             path_replacement: None,
             query_param_name: Some("key".to_string()),
             env_var: None,
+            endpoint_rules: vec![],
         };
         assert!(validate_custom_credential("google_maps", &cred).is_ok());
     }
@@ -2139,6 +2151,7 @@ mod tests {
             path_replacement: None,
             query_param_name: None, // Missing required field
             env_var: None,
+            endpoint_rules: vec![],
         };
         let result = validate_custom_credential("google_maps", &cred);
         let err = result.expect_err("missing query_param_name should be rejected");
@@ -2157,6 +2170,7 @@ mod tests {
             path_replacement: None,
             query_param_name: Some("".to_string()), // Empty
             env_var: None,
+            endpoint_rules: vec![],
         };
         let result = validate_custom_credential("google_maps", &cred);
         let err = result.expect_err("empty query_param_name should be rejected");
@@ -2175,6 +2189,7 @@ mod tests {
             path_replacement: None,
             query_param_name: None,
             env_var: None,
+            endpoint_rules: vec![],
         };
         // BasicAuth mode doesn't require additional fields
         // Credential value is expected to be "username:password" format
@@ -2494,6 +2509,7 @@ mod tests {
                 path_replacement: None,
                 query_param_name: None,
                 env_var: None,
+                endpoint_rules: vec![],
             },
         );
 
@@ -2510,6 +2526,7 @@ mod tests {
                 path_replacement: None,
                 query_param_name: None,
                 env_var: None,
+                endpoint_rules: vec![],
             },
         );
 
@@ -2644,6 +2661,7 @@ mod tests {
                 path_replacement: None,
                 query_param_name: None,
                 env_var: None,
+                endpoint_rules: vec![],
             },
         );
 
@@ -2660,6 +2678,7 @@ mod tests {
                 path_replacement: None,
                 query_param_name: None,
                 env_var: None,
+                endpoint_rules: vec![],
             },
         );
 

--- a/crates/nono-proxy/Cargo.toml
+++ b/crates/nono-proxy/Cargo.toml
@@ -29,6 +29,7 @@ base64 = "0.22"
 subtle = "2"
 url = "2"
 urlencoding = "2"
+globset.workspace = true
 
 # TLS for upstream connections (reverse proxy mode)
 hyper-rustls = { version = "0.27", features = ["http1", "ring", "webpki-tokio"] }

--- a/crates/nono-proxy/src/config.rs
+++ b/crates/nono-proxy/src/config.rs
@@ -3,6 +3,7 @@
 //! Defines the configuration for the proxy server, including allowed hosts,
 //! credential routes, and external proxy settings.
 
+use globset::Glob;
 use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 
@@ -124,6 +125,118 @@ pub struct RouteConfig {
     /// otherwise produce a nonsensical env var name.
     #[serde(default)]
     pub env_var: Option<String>,
+
+    /// Optional L7 endpoint rules for method+path filtering.
+    ///
+    /// When non-empty, only requests matching at least one rule are allowed
+    /// (default-deny). When empty, all method+path combinations are permitted
+    /// (backward compatible).
+    #[serde(default)]
+    pub endpoint_rules: Vec<EndpointRule>,
+}
+
+/// An HTTP method+path access rule for reverse proxy endpoint filtering.
+///
+/// Used to restrict which API endpoints an agent can access through a
+/// credential route. Patterns use `/` separated segments with wildcards:
+/// - `*` matches exactly one path segment
+/// - `**` matches zero or more path segments
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EndpointRule {
+    /// HTTP method to match ("GET", "POST", etc.) or "*" for any method.
+    pub method: String,
+    /// URL path pattern with glob segments.
+    /// Example: "/api/v4/projects/*/merge_requests/**"
+    pub path: String,
+}
+
+/// Pre-compiled endpoint rules for the request hot path.
+///
+/// Built once at proxy startup from `EndpointRule` definitions. Holds
+/// compiled `globset::GlobMatcher`s so the hot path does a regex match,
+/// not a glob compile.
+pub struct CompiledEndpointRules {
+    rules: Vec<CompiledRule>,
+}
+
+struct CompiledRule {
+    method: String,
+    matcher: globset::GlobMatcher,
+}
+
+impl CompiledEndpointRules {
+    /// Compile endpoint rules into matchers. Invalid glob patterns are
+    /// rejected at startup with an error, not silently ignored at runtime.
+    pub fn compile(rules: &[EndpointRule]) -> Result<Self, String> {
+        let mut compiled = Vec::with_capacity(rules.len());
+        for rule in rules {
+            let glob = Glob::new(&rule.path)
+                .map_err(|e| format!("invalid endpoint path pattern '{}': {}", rule.path, e))?;
+            compiled.push(CompiledRule {
+                method: rule.method.clone(),
+                matcher: glob.compile_matcher(),
+            });
+        }
+        Ok(Self { rules: compiled })
+    }
+
+    /// Check if the given method+path is allowed.
+    /// Returns `true` if no rules were compiled (allow-all, backward compatible).
+    #[must_use]
+    pub fn is_allowed(&self, method: &str, path: &str) -> bool {
+        if self.rules.is_empty() {
+            return true;
+        }
+        let normalized = normalize_path(path);
+        self.rules.iter().any(|r| {
+            (r.method == "*" || r.method.eq_ignore_ascii_case(method))
+                && r.matcher.is_match(&normalized)
+        })
+    }
+}
+
+impl std::fmt::Debug for CompiledEndpointRules {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompiledEndpointRules")
+            .field("count", &self.rules.len())
+            .finish()
+    }
+}
+
+/// Check if any endpoint rule permits the given method+path.
+/// Returns `true` if rules is empty (allow-all, backward compatible).
+///
+/// Test convenience only — compiles globs on each call. Production code
+/// should use `CompiledEndpointRules::is_allowed()` instead.
+#[cfg(test)]
+fn endpoint_allowed(rules: &[EndpointRule], method: &str, path: &str) -> bool {
+    if rules.is_empty() {
+        return true;
+    }
+    let normalized = normalize_path(path);
+    rules.iter().any(|r| {
+        (r.method == "*" || r.method.eq_ignore_ascii_case(method))
+            && Glob::new(&r.path)
+                .ok()
+                .map(|g| g.compile_matcher())
+                .is_some_and(|m| m.is_match(&normalized))
+    })
+}
+
+/// Normalize a URL path for matching: strip query string, collapse double
+/// slashes, strip trailing slash (but preserve root "/").
+fn normalize_path(path: &str) -> String {
+    // Strip query string
+    let path = path.split('?').next().unwrap_or(path);
+
+    // Collapse double slashes by splitting on '/' and filtering empties,
+    // then rejoin. This also strips trailing slash.
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    if segments.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{}", segments.join("/"))
+    }
 }
 
 fn default_inject_header() -> String {
@@ -215,5 +328,217 @@ mod tests {
         let json = r#"{"address": "proxy:3128", "auth": null}"#;
         let ext: ExternalProxyConfig = serde_json::from_str(json).unwrap();
         assert!(ext.bypass_hosts.is_empty());
+    }
+
+    // ========================================================================
+    // EndpointRule + path matching tests
+    // ========================================================================
+
+    #[test]
+    fn test_endpoint_allowed_empty_rules_allows_all() {
+        assert!(endpoint_allowed(&[], "GET", "/anything"));
+        assert!(endpoint_allowed(&[], "DELETE", "/admin/nuke"));
+    }
+
+    /// Helper: check a single rule against method+path via endpoint_allowed.
+    fn check(rule: &EndpointRule, method: &str, path: &str) -> bool {
+        endpoint_allowed(std::slice::from_ref(rule), method, path)
+    }
+
+    #[test]
+    fn test_endpoint_rule_exact_path() {
+        let rule = EndpointRule {
+            method: "GET".to_string(),
+            path: "/v1/chat/completions".to_string(),
+        };
+        assert!(check(&rule, "GET", "/v1/chat/completions"));
+        assert!(!check(&rule, "GET", "/v1/chat"));
+        assert!(!check(&rule, "GET", "/v1/chat/completions/extra"));
+    }
+
+    #[test]
+    fn test_endpoint_rule_method_case_insensitive() {
+        let rule = EndpointRule {
+            method: "get".to_string(),
+            path: "/api".to_string(),
+        };
+        assert!(check(&rule, "GET", "/api"));
+        assert!(check(&rule, "Get", "/api"));
+    }
+
+    #[test]
+    fn test_endpoint_rule_method_wildcard() {
+        let rule = EndpointRule {
+            method: "*".to_string(),
+            path: "/api/resource".to_string(),
+        };
+        assert!(check(&rule, "GET", "/api/resource"));
+        assert!(check(&rule, "DELETE", "/api/resource"));
+        assert!(check(&rule, "POST", "/api/resource"));
+    }
+
+    #[test]
+    fn test_endpoint_rule_method_mismatch() {
+        let rule = EndpointRule {
+            method: "GET".to_string(),
+            path: "/api/resource".to_string(),
+        };
+        assert!(!check(&rule, "POST", "/api/resource"));
+        assert!(!check(&rule, "DELETE", "/api/resource"));
+    }
+
+    #[test]
+    fn test_endpoint_rule_single_wildcard() {
+        let rule = EndpointRule {
+            method: "GET".to_string(),
+            path: "/api/v4/projects/*/merge_requests".to_string(),
+        };
+        assert!(check(&rule, "GET", "/api/v4/projects/123/merge_requests"));
+        assert!(check(
+            &rule,
+            "GET",
+            "/api/v4/projects/my-proj/merge_requests"
+        ));
+        assert!(!check(&rule, "GET", "/api/v4/projects/merge_requests"));
+    }
+
+    #[test]
+    fn test_endpoint_rule_double_wildcard() {
+        let rule = EndpointRule {
+            method: "GET".to_string(),
+            path: "/api/v4/projects/**".to_string(),
+        };
+        assert!(check(&rule, "GET", "/api/v4/projects/123"));
+        assert!(check(&rule, "GET", "/api/v4/projects/123/merge_requests"));
+        assert!(check(&rule, "GET", "/api/v4/projects/a/b/c/d"));
+        assert!(!check(&rule, "GET", "/api/v4/other"));
+    }
+
+    #[test]
+    fn test_endpoint_rule_double_wildcard_middle() {
+        let rule = EndpointRule {
+            method: "*".to_string(),
+            path: "/api/**/notes".to_string(),
+        };
+        assert!(check(&rule, "GET", "/api/notes"));
+        assert!(check(&rule, "POST", "/api/projects/123/notes"));
+        assert!(check(&rule, "GET", "/api/a/b/c/notes"));
+        assert!(!check(&rule, "GET", "/api/a/b/c/comments"));
+    }
+
+    #[test]
+    fn test_endpoint_rule_strips_query_string() {
+        let rule = EndpointRule {
+            method: "GET".to_string(),
+            path: "/api/data".to_string(),
+        };
+        assert!(check(&rule, "GET", "/api/data?page=1&limit=10"));
+    }
+
+    #[test]
+    fn test_endpoint_rule_trailing_slash_normalized() {
+        let rule = EndpointRule {
+            method: "GET".to_string(),
+            path: "/api/data".to_string(),
+        };
+        assert!(check(&rule, "GET", "/api/data/"));
+        assert!(check(&rule, "GET", "/api/data"));
+    }
+
+    #[test]
+    fn test_endpoint_rule_double_slash_normalized() {
+        let rule = EndpointRule {
+            method: "GET".to_string(),
+            path: "/api/data".to_string(),
+        };
+        assert!(check(&rule, "GET", "/api//data"));
+    }
+
+    #[test]
+    fn test_endpoint_rule_root_path() {
+        let rule = EndpointRule {
+            method: "GET".to_string(),
+            path: "/".to_string(),
+        };
+        assert!(check(&rule, "GET", "/"));
+        assert!(!check(&rule, "GET", "/anything"));
+    }
+
+    #[test]
+    fn test_compiled_endpoint_rules_hot_path() {
+        let rules = vec![
+            EndpointRule {
+                method: "GET".to_string(),
+                path: "/repos/*/issues".to_string(),
+            },
+            EndpointRule {
+                method: "POST".to_string(),
+                path: "/repos/*/issues/*/comments".to_string(),
+            },
+        ];
+        let compiled = CompiledEndpointRules::compile(&rules).unwrap();
+        assert!(compiled.is_allowed("GET", "/repos/myrepo/issues"));
+        assert!(compiled.is_allowed("POST", "/repos/myrepo/issues/42/comments"));
+        assert!(!compiled.is_allowed("DELETE", "/repos/myrepo"));
+        assert!(!compiled.is_allowed("GET", "/repos/myrepo/pulls"));
+    }
+
+    #[test]
+    fn test_compiled_endpoint_rules_empty_allows_all() {
+        let compiled = CompiledEndpointRules::compile(&[]).unwrap();
+        assert!(compiled.is_allowed("DELETE", "/admin/nuke"));
+    }
+
+    #[test]
+    fn test_compiled_endpoint_rules_invalid_pattern_rejected() {
+        let rules = vec![EndpointRule {
+            method: "GET".to_string(),
+            path: "/api/[invalid".to_string(),
+        }];
+        assert!(CompiledEndpointRules::compile(&rules).is_err());
+    }
+
+    #[test]
+    fn test_endpoint_allowed_multiple_rules() {
+        let rules = vec![
+            EndpointRule {
+                method: "GET".to_string(),
+                path: "/repos/*/issues".to_string(),
+            },
+            EndpointRule {
+                method: "POST".to_string(),
+                path: "/repos/*/issues/*/comments".to_string(),
+            },
+        ];
+        assert!(endpoint_allowed(&rules, "GET", "/repos/myrepo/issues"));
+        assert!(endpoint_allowed(
+            &rules,
+            "POST",
+            "/repos/myrepo/issues/42/comments"
+        ));
+        assert!(!endpoint_allowed(&rules, "DELETE", "/repos/myrepo"));
+        assert!(!endpoint_allowed(&rules, "GET", "/repos/myrepo/pulls"));
+    }
+
+    #[test]
+    fn test_endpoint_rule_serde_default() {
+        let json = r#"{
+            "prefix": "/test",
+            "upstream": "https://example.com"
+        }"#;
+        let route: RouteConfig = serde_json::from_str(json).unwrap();
+        assert!(route.endpoint_rules.is_empty());
+    }
+
+    #[test]
+    fn test_endpoint_rule_serde_roundtrip() {
+        let rule = EndpointRule {
+            method: "GET".to_string(),
+            path: "/api/*/data".to_string(),
+        };
+        let json = serde_json::to_string(&rule).unwrap();
+        let deserialized: EndpointRule = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.method, "GET");
+        assert_eq!(deserialized.path, "/api/*/data");
     }
 }

--- a/crates/nono-proxy/src/credential.rs
+++ b/crates/nono-proxy/src/credential.rs
@@ -5,7 +5,7 @@
 //! requests via headers, URL paths, query parameters, or Basic Auth.
 //! The sandboxed agent never sees the real credentials.
 
-use crate::config::{InjectMode, RouteConfig};
+use crate::config::{CompiledEndpointRules, InjectMode, RouteConfig};
 use crate::error::{ProxyError, Result};
 use base64::Engine;
 use std::collections::HashMap;
@@ -36,6 +36,11 @@ pub struct LoadedCredential {
     // --- Query param mode ---
     /// Query parameter name
     pub query_param_name: Option<String>,
+
+    // --- L7 endpoint filtering ---
+    /// Pre-compiled endpoint rules for method+path filtering.
+    /// Compiled once at load time to avoid per-request glob compilation.
+    pub endpoint_rules: CompiledEndpointRules,
 }
 
 /// Custom Debug impl that redacts secret values to prevent accidental leakage
@@ -51,6 +56,7 @@ impl std::fmt::Debug for LoadedCredential {
             .field("path_pattern", &self.path_pattern)
             .field("path_replacement", &self.path_replacement)
             .field("query_param_name", &self.query_param_name)
+            .field("endpoint_rules", &self.endpoint_rules)
             .finish()
     }
 }
@@ -120,6 +126,10 @@ impl CredentialStore {
                         path_pattern: route.path_pattern.clone(),
                         path_replacement: route.path_replacement.clone(),
                         query_param_name: route.query_param_name.clone(),
+                        endpoint_rules: CompiledEndpointRules::compile(&route.endpoint_rules)
+                            .map_err(|e| {
+                                ProxyError::Credential(format!("route '{}': {}", route.prefix, e))
+                            })?,
                     },
                 );
             }
@@ -166,6 +176,7 @@ impl CredentialStore {
 const KEYRING_SERVICE: &str = nono::keystore::DEFAULT_SERVICE;
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -191,6 +202,7 @@ mod tests {
             path_pattern: None,
             path_replacement: None,
             query_param_name: None,
+            endpoint_rules: CompiledEndpointRules::compile(&[]).unwrap(),
         };
 
         let debug_output = format!("{:?}", cred);
@@ -228,6 +240,7 @@ mod tests {
             path_replacement: None,
             query_param_name: None,
             env_var: None,
+            endpoint_rules: vec![],
         }];
         let store = CredentialStore::load(&routes);
         assert!(store.is_ok());

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -87,6 +87,25 @@ pub async fn handle_reverse_proxy(
             prefix: service.clone(),
         })?;
 
+    // L7 endpoint filtering: check method+path against rules before any
+    // credential operations. Denied endpoints get 403 immediately.
+    if !cred.endpoint_rules.is_allowed(&method, &upstream_path) {
+        let reason = format!(
+            "endpoint denied: {} {} on service '{}'",
+            method, upstream_path, service
+        );
+        warn!("{}", reason);
+        audit::log_denied(
+            ctx.audit_log,
+            audit::ProxyMode::Reverse,
+            &service,
+            0,
+            &reason,
+        );
+        send_error(stream, 403, "Forbidden").await?;
+        return Ok(());
+    }
+
     // Validate phantom token based on injection mode.
     // For header/basic_auth modes: validate from Authorization/x-api-key header
     // For url_path mode: validate from URL path pattern

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -464,6 +464,7 @@ mod tests {
                 path_replacement: None,
                 query_param_name: None,
                 env_var: None,
+                endpoint_rules: vec![],
             }],
             ..Default::default()
         };
@@ -502,6 +503,7 @@ mod tests {
                 path_replacement: None,
                 query_param_name: None,
                 env_var: None, // No explicit env_var — should fall back to uppercase
+                endpoint_rules: vec![],
             }],
             ..Default::default()
         };
@@ -549,6 +551,7 @@ mod tests {
                 path_replacement: None,
                 query_param_name: None,
                 env_var: Some("OPENAI_API_KEY".to_string()),
+                endpoint_rules: vec![],
             }],
             ..Default::default()
         };
@@ -602,6 +605,7 @@ mod tests {
                     path_replacement: None,
                     query_param_name: None,
                     env_var: None,
+                    endpoint_rules: vec![],
                 },
                 crate::config::RouteConfig {
                     prefix: "github".to_string(),
@@ -614,6 +618,7 @@ mod tests {
                     path_replacement: None,
                     query_param_name: None,
                     env_var: Some("GITHUB_TOKEN".to_string()),
+                    endpoint_rules: vec![],
                 },
             ],
             ..Default::default()

--- a/docs/cli/features/credential-injection.mdx
+++ b/docs/cli/features/credential-injection.mdx
@@ -506,6 +506,61 @@ Reverse proxy requests are authenticated using an `X-Nono-Token` header containi
 
 This prevents other localhost processes from accessing the credential injection routes.
 
+## Endpoint Filtering
+
+By default, a credential route allows the agent to access any endpoint on the upstream API. Endpoint filtering restricts which HTTP method+path combinations are allowed, enforcing least-privilege at the API level.
+
+### CLI Usage
+
+Use `--allow-endpoint` to restrict a credential service to specific patterns:
+
+```bash
+# Allow only chat completions through OpenAI
+nono run --allow-cwd --credential openai \
+  --allow-endpoint 'openai:POST:/v1/chat/completions' \
+  -- my-agent
+
+# Allow GitHub issue reads and comment writes, block everything else
+nono run --allow-cwd --credential github \
+  --allow-endpoint 'github:GET:/repos/*/issues/**' \
+  --allow-endpoint 'github:POST:/repos/*/issues/*/comments' \
+  -- my-agent
+```
+
+When any endpoint rules are configured for a service, requests that don't match receive `403 Forbidden` and are logged in the audit trail.
+
+### Profile Configuration
+
+Endpoint rules can also be defined in custom credentials within profiles:
+
+```json
+{
+  "network": {
+    "custom_credentials": {
+      "gitlab": {
+        "upstream": "https://gitlab.example.com",
+        "credential_key": "gitlab_token",
+        "endpoint_rules": [
+          { "method": "GET", "path": "/api/v4/projects/*/merge_requests/**" },
+          { "method": "POST", "path": "/api/v4/projects/*/merge_requests/*/notes" }
+        ]
+      }
+    }
+  }
+}
+```
+
+### Pattern Syntax
+
+Path patterns use standard glob syntax (same as `.gitignore` and nono profile `include` patterns):
+
+| Pattern | Matches |
+|---------|---------|
+| `/v1/chat/completions` | Exact path only |
+| `/repos/*/issues` | One segment wildcard (e.g., `/repos/myrepo/issues`) |
+| `/api/**` | Zero or more segments (e.g., `/api/v1/data/export`) |
+| `*` | Any method (when used as the method field) |
+
 ## Security Properties
 
 - **Credentials never enter the sandbox** - The agent process has no access to API keys, even through environment variables or memory

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -328,6 +328,31 @@ Custom credentials can be defined in profiles for APIs not covered by the built-
 
 See [Credential Injection](/cli/features/credential-injection) for complete documentation including custom credential definitions.
 
+#### `--allow-endpoint`
+
+Restrict a credential service to specific HTTP method+path patterns. When set, only requests matching at least one rule are proxied; all others receive 403 Forbidden. Can be specified multiple times.
+
+Format: `SERVICE:METHOD:PATH`
+
+- **SERVICE**: credential service name (e.g., `openai`, `github`)
+- **METHOD**: HTTP method (`GET`, `POST`, etc.) or `*` for any method
+- **PATH**: URL path glob pattern (`*` matches one segment, `**` matches zero or more)
+
+```bash
+# Allow only chat completions through OpenAI
+nono run --allow-cwd --credential openai \
+  --allow-endpoint 'openai:POST:/v1/chat/completions' \
+  -- my-agent
+
+# Allow GitHub issue reads and comment writes, block everything else
+nono run --allow-cwd --credential github \
+  --allow-endpoint 'github:GET:/repos/*/issues/**' \
+  --allow-endpoint 'github:POST:/repos/*/issues/*/comments' \
+  -- my-agent
+```
+
+Endpoint rules can also be defined in profiles via `endpoint_rules` on custom credentials. See [Credential Injection](/cli/features/credential-injection#endpoint-filtering) for details.
+
 #### `--upstream-proxy`
 
 Chain outbound connections through an upstream (enterprise) proxy. Cloud metadata endpoints are still denied.


### PR DESCRIPTION
Closes #465

## Summary

- Add `--allow-endpoint SERVICE:METHOD:/path/pattern` CLI flag to restrict which API endpoints an agent can reach through credential routes
- Endpoint rules use globset patterns (`*` one segment, `**` zero or more), compiled once at startup
- Denied requests get 403 before any credential operations
- Configurable via CLI flags, profile JSON, or network policy

## Example

```bash
nono run --credential github \
  --allow-endpoint 'github:GET:/repos/*/issues/**' \
  --allow-endpoint 'github:POST:/repos/*/issues/*/comments' \
  -- my-agent
```

## Test plan

 18 new unit tests (pattern matching, compiled hot path, invalid patterns, CLI parsing)
 All 1,125 existing tests pass
 clippy + fmt clean

First PR here, great project!
The kernel-enforced sandbox approach with the clean library/CLI separation is really well done.
Happy to iterate on feedback!