### PR TITLE
feat(proxy): oauth2 client-credentials token exchange with cache

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -381,9 +381,9 @@
     },
     "CustomCredentialDef": {
       "type": "object",
-      "description": "Custom credential route definition for the reverse proxy. Defines how to route requests and inject credentials for a service.",
+      "description": "Custom credential route definition for the reverse proxy. Defines how to route requests and inject credentials for a service. Must have either credential_key or auth (mutually exclusive).",
       "additionalProperties": false,
-      "required": ["upstream", "credential_key"],
+      "required": ["upstream"],
       "properties": {
         "upstream": {
           "type": "string",
@@ -391,7 +391,11 @@
         },
         "credential_key": {
           "type": "string",
-          "description": "Keystore account name for the credential (e.g., \"telegram_bot_token\"), or a 1Password op:// URI, or an apple-password:// URI."
+          "description": "Keystore account name for the credential (e.g., \"telegram_bot_token\"), or a 1Password op:// URI, or an apple-password:// URI. Mutually exclusive with auth."
+        },
+        "auth": {
+          "$ref": "#/$defs/OAuth2Config",
+          "description": "OAuth2 client_credentials configuration. When present, the proxy handles token exchange automatically. Mutually exclusive with credential_key."
         },
         "inject_mode": {
           "$ref": "#/$defs/InjectMode",
@@ -542,6 +546,34 @@
             { "type": "null" }
           ],
           "description": "Override query parameter name for proxy-side query_param mode. Falls back to parent query_param_name when omitted."
+        }
+      }
+    },
+    "OAuth2Config": {
+      "type": "object",
+      "description": "OAuth2 client_credentials configuration for automatic token exchange. The proxy exchanges client_id + client_secret for an access_token, caches it, and refreshes automatically before expiry.",
+      "additionalProperties": false,
+      "required": ["token_url", "client_id", "client_secret"],
+      "properties": {
+        "token_url": {
+          "type": "string",
+          "description": "Token endpoint URL (e.g., \"https://auth.example.com/oauth/token\"). Must use HTTPS, or HTTP only for loopback addresses."
+        },
+        "client_id": {
+          "type": "string",
+          "description": "Client ID — plain value or credential reference (env://, file://, op://)."
+        },
+        "client_secret": {
+          "type": "string",
+          "description": "Client secret — credential reference (env://, file://, op://)."
+        },
+        "scope": {
+          "type": "string",
+          "description": "OAuth2 scopes (space-separated). Empty or omitted means no scope parameter is sent.",
+          "default": ""
+        }
+      }
+    },
         }
       }
     },

--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -574,9 +574,6 @@
         }
       }
     },
-        }
-      }
-    },
     "SecretsConfig": {
       "type": "object",
       "description": "Maps keystore account names (or op://, apple-password://, env:// URIs) to environment variable names. Secrets are loaded from the system keystore under the service name \"nono\".",

--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -223,16 +223,7 @@ pub fn resolve_credentials(
                 })?;
             }
 
-            // Pass through OAuth2 config if present
-            let oauth2 = cred
-                .auth
-                .as_ref()
-                .map(|auth| nono_proxy::config::OAuth2Config {
-                    token_url: auth.token_url.clone(),
-                    client_id: auth.client_id.clone(),
-                    client_secret: auth.client_secret.clone(),
-                    scope: auth.scope.clone(),
-                });
+            let oauth2 = cred.auth.clone();
 
             routes.push(RouteConfig {
                 prefix: name.clone(),
@@ -964,6 +955,7 @@ mod tests {
                 path_replacement: None,
                 query_param_name: None,
                 env_var: None,
+                endpoint_rules: vec![],
             },
         );
 
@@ -1007,6 +999,7 @@ mod tests {
                 path_replacement: None,
                 query_param_name: None,
                 env_var: None,
+                endpoint_rules: vec![],
             },
         );
 

--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -222,10 +222,22 @@ pub fn resolve_credentials(
                     ))
                 })?;
             }
+
+            // Pass through OAuth2 config if present
+            let oauth2 = cred
+                .auth
+                .as_ref()
+                .map(|auth| nono_proxy::config::OAuth2Config {
+                    token_url: auth.token_url.clone(),
+                    client_id: auth.client_id.clone(),
+                    client_secret: auth.client_secret.clone(),
+                    scope: auth.scope.clone(),
+                });
+
             routes.push(RouteConfig {
                 prefix: name.clone(),
                 upstream: cred.upstream.clone(),
-                credential_key: Some(cred.credential_key.clone()),
+                credential_key: cred.credential_key.clone(),
                 inject_mode: cred.inject_mode.clone(),
                 inject_header: cred.inject_header.clone(),
                 credential_format: cred.credential_format.clone(),
@@ -256,7 +268,7 @@ pub fn resolve_credentials(
                         crate::policy::expand_path(p).map(|pb| pb.to_string_lossy().into_owned())
                     })
                     .transpose()?,
-                oauth2: None,
+                oauth2,
             });
         } else if let Some(cred) = policy.credentials.get(name) {
             // Validate env_var against dangerous variable blocklist
@@ -465,7 +477,8 @@ mod tests {
             "telegram".to_string(),
             CustomCredentialDef {
                 upstream: "https://api.telegram.org".to_string(),
-                credential_key: "telegram_bot_token".to_string(),
+                credential_key: Some("telegram_bot_token".to_string()),
+                auth: None,
                 inject_mode: InjectMode::Header,
                 inject_header: "Authorization".to_string(),
                 credential_format: "Bearer {}".to_string(),
@@ -504,7 +517,8 @@ mod tests {
             "openai".to_string(),
             CustomCredentialDef {
                 upstream: "https://my-proxy.example.com/openai".to_string(),
-                credential_key: "my_openai_key".to_string(),
+                credential_key: Some("my_openai_key".to_string()),
+                auth: None,
                 inject_mode: InjectMode::Header,
                 inject_header: "X-Custom-Auth".to_string(),
                 credential_format: "Token {}".to_string(),
@@ -539,7 +553,8 @@ mod tests {
             "telegram".to_string(),
             CustomCredentialDef {
                 upstream: "https://api.telegram.org".to_string(),
-                credential_key: "telegram_bot_token".to_string(),
+                credential_key: Some("telegram_bot_token".to_string()),
+                auth: None,
                 inject_mode: InjectMode::Header,
                 inject_header: "Authorization".to_string(),
                 credential_format: "Bearer {}".to_string(),
@@ -584,7 +599,8 @@ mod tests {
             "local".to_string(),
             CustomCredentialDef {
                 upstream: "http://localhost:8080/api".to_string(),
-                credential_key: "local_api_key".to_string(),
+                credential_key: Some("local_api_key".to_string()),
+                auth: None,
                 inject_mode: InjectMode::Header,
                 inject_header: "Authorization".to_string(),
                 credential_format: "Bearer {}".to_string(),
@@ -665,7 +681,8 @@ mod tests {
             "local".to_string(),
             CustomCredentialDef {
                 upstream: "http://127.1.2.3:8080/api".to_string(),
-                credential_key: "local_api_key".to_string(),
+                credential_key: Some("local_api_key".to_string()),
+                auth: None,
                 inject_mode: InjectMode::Header,
                 inject_header: "Authorization".to_string(),
                 credential_format: "Bearer {}".to_string(),
@@ -697,7 +714,8 @@ mod tests {
             "local".to_string(),
             CustomCredentialDef {
                 upstream: "http://0.0.0.0:3000/api".to_string(),
-                credential_key: "local_api_key".to_string(),
+                credential_key: Some("local_api_key".to_string()),
+                auth: None,
                 inject_mode: InjectMode::Header,
                 inject_header: "Authorization".to_string(),
                 credential_format: "Bearer {}".to_string(),
@@ -729,7 +747,8 @@ mod tests {
             "test".to_string(),
             CustomCredentialDef {
                 upstream: "https://api.example.com".to_string(),
-                credential_key: "api_key".to_string(),
+                credential_key: Some("api_key".to_string()),
+                auth: None,
                 inject_mode: InjectMode::Header,
                 inject_header: "X-Custom-Auth".to_string(),
                 credential_format: "Token {}".to_string(),
@@ -766,7 +785,8 @@ mod tests {
             "openai".to_string(),
             CustomCredentialDef {
                 upstream: "https://api.openai.com/v1".to_string(),
-                credential_key: "op://Development/OpenAI/credential".to_string(),
+                credential_key: Some("op://Development/OpenAI/credential".to_string()),
+                auth: None,
                 inject_mode: InjectMode::Header,
                 inject_header: "Authorization".to_string(),
                 credential_format: "Bearer {}".to_string(),
@@ -877,7 +897,8 @@ mod tests {
             "evil".to_string(),
             CustomCredentialDef {
                 upstream: "https://api.example.com".to_string(),
-                credential_key: "safe_key".to_string(),
+                credential_key: Some("safe_key".to_string()),
+                auth: None,
                 inject_mode: InjectMode::Header,
                 inject_header: "Authorization".to_string(),
                 credential_format: "Bearer {}".to_string(),
@@ -914,5 +935,87 @@ mod tests {
             "developer profile should include github credential, got: {:?}",
             resolved.profile_credentials
         );
+    }
+
+    #[test]
+    fn test_resolve_credentials_with_oauth2_auth() {
+        use crate::profile::CustomCredentialDef;
+        use nono_proxy::config::OAuth2Config;
+
+        let json = embedded_network_policy_json();
+        let policy = load_network_policy(json).unwrap();
+
+        let mut custom = HashMap::new();
+        custom.insert(
+            "my_api".to_string(),
+            CustomCredentialDef {
+                upstream: "https://api.example.com".to_string(),
+                credential_key: None,
+                auth: Some(OAuth2Config {
+                    token_url: "https://auth.example.com/oauth/token".to_string(),
+                    client_id: "my-client".to_string(),
+                    client_secret: "env://CLIENT_SECRET".to_string(),
+                    scope: "api.read".to_string(),
+                }),
+                inject_mode: InjectMode::Header,
+                inject_header: "Authorization".to_string(),
+                credential_format: "Bearer {}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                env_var: None,
+            },
+        );
+
+        let routes = resolve_credentials(&policy, &["my_api".to_string()], &custom).unwrap();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].prefix, "my_api");
+        assert_eq!(routes[0].upstream, "https://api.example.com");
+        assert!(
+            routes[0].credential_key.is_none(),
+            "OAuth2 route should not have credential_key"
+        );
+        assert!(
+            routes[0].oauth2.is_some(),
+            "OAuth2 route should have oauth2 config"
+        );
+        let oauth2 = routes[0].oauth2.as_ref().unwrap();
+        assert_eq!(oauth2.token_url, "https://auth.example.com/oauth/token");
+        assert_eq!(oauth2.client_id, "my-client");
+        assert_eq!(oauth2.client_secret, "env://CLIENT_SECRET");
+        assert_eq!(oauth2.scope, "api.read");
+    }
+
+    #[test]
+    fn test_resolve_credentials_without_oauth2_has_none() {
+        use crate::profile::CustomCredentialDef;
+
+        let json = embedded_network_policy_json();
+        let policy = load_network_policy(json).unwrap();
+
+        let mut custom = HashMap::new();
+        custom.insert(
+            "standard".to_string(),
+            CustomCredentialDef {
+                upstream: "https://api.example.com".to_string(),
+                credential_key: Some("my_key".to_string()),
+                auth: None,
+                inject_mode: InjectMode::Header,
+                inject_header: "Authorization".to_string(),
+                credential_format: "Bearer {}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                env_var: None,
+            },
+        );
+
+        let routes = resolve_credentials(&policy, &["standard".to_string()], &custom).unwrap();
+        assert_eq!(routes.len(), 1);
+        assert!(
+            routes[0].oauth2.is_none(),
+            "Non-OAuth2 route should not have oauth2 config"
+        );
+        assert_eq!(routes[0].credential_key, Some("my_key".to_string()));
     }
 }

--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -256,6 +256,7 @@ pub fn resolve_credentials(
                         crate::policy::expand_path(p).map(|pb| pb.to_string_lossy().into_owned())
                     })
                     .transpose()?,
+                oauth2: None,
             });
         } else if let Some(cred) = policy.credentials.get(name) {
             // Validate env_var against dangerous variable blocklist
@@ -286,6 +287,7 @@ pub fn resolve_credentials(
                 tls_ca: None, // Built-in credentials don't support custom CAs
                 tls_client_cert: None,
                 tls_client_key: None,
+                oauth2: None,
             });
         }
         // We already validated existence above, so this else branch won't be hit

--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -954,8 +954,12 @@ mod tests {
                 path_pattern: None,
                 path_replacement: None,
                 query_param_name: None,
+                proxy: None,
                 env_var: None,
                 endpoint_rules: vec![],
+                tls_ca: None,
+                tls_client_cert: None,
+                tls_client_key: None,
             },
         );
 
@@ -998,8 +1002,12 @@ mod tests {
                 path_pattern: None,
                 path_replacement: None,
                 query_param_name: None,
+                proxy: None,
                 env_var: None,
                 endpoint_rules: vec![],
+                tls_ca: None,
+                tls_client_cert: None,
+                tls_client_key: None,
             },
         );
 

--- a/crates/nono-cli/src/policy_cmd.rs
+++ b/crates/nono-cli/src/policy_cmd.rs
@@ -1313,15 +1313,17 @@ fn cmd_diff(args: PolicyDiffArgs) -> Result<()> {
                 );
             }
             if old.credential_key != new.credential_key {
+                let old_key = old.credential_key.as_deref().unwrap_or("<none>");
+                let new_key = new.credential_key.as_deref().unwrap_or("<none>");
                 println!(
                     "      {} credential_key: {}",
                     theme::fg("-", t.red),
-                    theme::fg(&old.credential_key, t.red)
+                    theme::fg(old_key, t.red)
                 );
                 println!(
                     "      {} credential_key: {}",
                     theme::fg("+", t.green),
-                    theme::fg(&new.credential_key, t.green)
+                    theme::fg(new_key, t.green)
                 );
             }
             if old.inject_mode != new.inject_mode {
@@ -2176,6 +2178,17 @@ fn resolve_to_manifest(
             })
             .collect::<Result<Vec<_>>>()?;
 
+        let source = if let Some(source) = cred.credential_key.as_ref() {
+            source.parse().map_err(|e| {
+                NonoError::ConfigParse(format!("invalid credential source: {e}"))
+            })?
+        } else {
+            return Err(NonoError::ConfigParse(format!(
+                "custom credential '{}' uses auth, which cannot be exported to a capability manifest",
+                name
+            )));
+        };
+
         credentials.push(manifest::Credential {
             name: name
                 .parse()
@@ -2184,10 +2197,7 @@ fn resolve_to_manifest(
                 .upstream
                 .parse()
                 .map_err(|e| NonoError::ConfigParse(format!("invalid credential upstream: {e}")))?,
-            source: cred
-                .credential_key
-                .parse()
-                .map_err(|e| NonoError::ConfigParse(format!("invalid credential source: {e}")))?,
+            source,
             inject: Some(manifest::CredentialInject {
                 mode: inject_mode,
                 header: cred.inject_header.clone(),

--- a/crates/nono-cli/src/policy_cmd.rs
+++ b/crates/nono-cli/src/policy_cmd.rs
@@ -2152,6 +2152,8 @@ fn resolve_to_manifest(
         };
 
     // Credentials (custom_credentials from profile → manifest credentials)
+    // OAuth2 credentials (auth field) are not yet representable in the manifest
+    // schema, so only static-key credentials are exported.
     let mut credentials = Vec::new();
     for (name, cred) in &prof.network.custom_credentials {
         let inject_mode = match cred.inject_mode {
@@ -2178,17 +2180,6 @@ fn resolve_to_manifest(
             })
             .collect::<Result<Vec<_>>>()?;
 
-        let source = if let Some(source) = cred.credential_key.as_ref() {
-            source.parse().map_err(|e| {
-                NonoError::ConfigParse(format!("invalid credential source: {e}"))
-            })?
-        } else {
-            return Err(NonoError::ConfigParse(format!(
-                "custom credential '{}' uses auth, which cannot be exported to a capability manifest",
-                name
-            )));
-        };
-
         credentials.push(manifest::Credential {
             name: name
                 .parse()
@@ -2197,7 +2188,12 @@ fn resolve_to_manifest(
                 .upstream
                 .parse()
                 .map_err(|e| NonoError::ConfigParse(format!("invalid credential upstream: {e}")))?,
-            source,
+            source: match cred.credential_key.as_ref() {
+                Some(key) => key.parse().map_err(|e| {
+                    NonoError::ConfigParse(format!("invalid credential source: {e}"))
+                })?,
+                None => continue,
+            },
             inject: Some(manifest::CredentialInject {
                 mode: inject_mode,
                 header: cred.inject_header.clone(),

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -3148,6 +3148,7 @@ mod tests {
             path_replacement: None,
             query_param_name: None,
             env_var: None,
+            endpoint_rules: vec![],
         }
     }
 

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -12,8 +12,8 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-// Re-export InjectMode from nono-proxy for use in profiles
-pub use nono_proxy::config::InjectMode;
+// Re-export InjectMode and OAuth2Config from nono-proxy for use in profiles
+pub use nono_proxy::config::{InjectMode, OAuth2Config};
 
 /// Profile metadata
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -102,8 +102,15 @@ pub struct PolicyPatchConfig {
 pub struct CustomCredentialDef {
     /// Upstream URL to proxy requests to (e.g., "https://api.telegram.org")
     pub upstream: String,
-    /// Keystore account name for the credential (e.g., "telegram_bot_token")
-    pub credential_key: String,
+    /// Keystore account name for the credential (e.g., "telegram_bot_token").
+    /// Mutually exclusive with `auth` — use one or the other.
+    #[serde(default)]
+    pub credential_key: Option<String>,
+    /// Optional OAuth2 client_credentials configuration.
+    /// When present, the proxy handles token exchange automatically.
+    /// Mutually exclusive with `credential_key` — use one or the other.
+    #[serde(default)]
+    pub auth: Option<OAuth2Config>,
     /// Injection mode (default: "header")
     #[serde(default)]
     pub inject_mode: InjectMode,
@@ -280,23 +287,45 @@ fn validate_credential_key(context_name: &str, key: &str) -> Result<()> {
 ///   - `query_param`: query_param_name required, valid query param name
 ///   - `basic_auth`: no additional required fields
 fn validate_custom_credential(name: &str, cred: &CustomCredentialDef) -> Result<()> {
-    // Validate credential_key - required for all modes
-    validate_credential_key(name, &cred.credential_key)?;
-
-    // When credential_key is a URI manager reference, env_var is required because the URI
-    // cannot be meaningfully uppercased into an env var name (e.g.,
-    // "op://vault/item/field" -> "OP://VAULT/ITEM/FIELD" is nonsensical).
-    if (nono::keystore::is_op_uri(&cred.credential_key)
-        || nono::keystore::is_apple_password_uri(&cred.credential_key)
-        || nono::keystore::is_file_uri(&cred.credential_key))
-        && cred.env_var.is_none()
-    {
+    // Mutual exclusion: credential_key and auth cannot both be set
+    if cred.credential_key.is_some() && cred.auth.is_some() {
         return Err(NonoError::ProfileParse(format!(
-            "env_var is required for custom credential '{}' when credential_key is a URI \
-             manager reference (op://, apple-password://, or file://); \
-             set it to the SDK API key env var name (e.g., \"OPENAI_API_KEY\")",
+            "custom credential '{}' has both 'credential_key' and 'auth' set; \
+             these are mutually exclusive — use one or the other",
             name
         )));
+    }
+
+    // At least one of credential_key or auth must be set
+    if cred.credential_key.is_none() && cred.auth.is_none() {
+        return Err(NonoError::ProfileParse(format!(
+            "custom credential '{}' must have either 'credential_key' or 'auth' set",
+            name
+        )));
+    }
+
+    // Validate OAuth2 auth if present
+    if let Some(ref auth) = cred.auth {
+        validate_oauth2_auth(name, auth)?;
+    }
+
+    // Validate credential_key if present
+    if let Some(ref key) = cred.credential_key {
+        validate_credential_key(name, key)?;
+
+        // When credential_key is a URI manager reference, env_var is required because the URI
+        // cannot be meaningfully uppercased into an env var name (e.g.,
+        // "op://vault/item/field" -> "OP://VAULT/ITEM/FIELD" is nonsensical).
+        if (nono::keystore::is_op_uri(key) || nono::keystore::is_apple_password_uri(key))
+            && cred.env_var.is_none()
+        {
+            return Err(NonoError::ProfileParse(format!(
+                "env_var is required for custom credential '{}' when credential_key is a URI \
+                 manager reference (op:// or apple-password://); \
+                 set it to the SDK API key env var name (e.g., \"OPENAI_API_KEY\")",
+                name
+            )));
+        }
     }
 
     // Validate env_var format if specified
@@ -319,20 +348,23 @@ fn validate_custom_credential(name: &str, cred: &CustomCredentialDef) -> Result<
     // Validate upstream URL (HTTPS required, HTTP only for loopback)
     validate_upstream_url(&cred.upstream, name)?;
 
-    // Mode-specific validation
-    match cred.inject_mode {
-        InjectMode::Header => {
-            validate_header_mode(name, cred)?;
-        }
-        InjectMode::UrlPath => {
-            validate_url_path_mode(name, cred)?;
-        }
-        InjectMode::QueryParam => {
-            validate_query_param_mode(name, cred)?;
-        }
-        InjectMode::BasicAuth => {
-            // No additional required fields for basic_auth mode
-            // Credential value is expected to be "username:password" format
+    // Mode-specific validation (only applies to credential_key-based routes,
+    // not OAuth2 routes which always inject as Bearer header)
+    if cred.credential_key.is_some() {
+        match cred.inject_mode {
+            InjectMode::Header => {
+                validate_header_mode(name, cred)?;
+            }
+            InjectMode::UrlPath => {
+                validate_url_path_mode(name, cred)?;
+            }
+            InjectMode::QueryParam => {
+                validate_query_param_mode(name, cred)?;
+            }
+            InjectMode::BasicAuth => {
+                // No additional required fields for basic_auth mode
+                // Credential value is expected to be "username:password" format
+            }
         }
     }
 
@@ -454,6 +486,36 @@ fn validate_proxy_override(name: &str, cred: &CustomCredentialDef) -> Result<()>
                 )));
             }
         }
+    }
+
+    Ok(())
+}
+
+/// Validate OAuth2 client_credentials auth configuration.
+///
+/// Checks:
+/// - `token_url` must be HTTPS (or HTTP for loopback addresses)
+/// - `client_id` must not be empty
+/// - `client_secret` must not be empty and must be a credential reference
+///   (env://, file://, op://, apple-password://) or plain value
+fn validate_oauth2_auth(name: &str, auth: &OAuth2Config) -> Result<()> {
+    // Validate token_url — same rules as upstream URL (HTTPS or loopback HTTP)
+    validate_upstream_url(&auth.token_url, &format!("{}/auth.token_url", name))?;
+
+    // client_id must not be empty
+    if auth.client_id.is_empty() {
+        return Err(NonoError::ProfileParse(format!(
+            "auth.client_id for custom credential '{}' cannot be empty",
+            name
+        )));
+    }
+
+    // client_secret must not be empty
+    if auth.client_secret.is_empty() {
+        return Err(NonoError::ProfileParse(format!(
+            "auth.client_secret for custom credential '{}' cannot be empty",
+            name
+        )));
     }
 
     Ok(())
@@ -2567,7 +2629,8 @@ mod tests {
     fn header_cred_builder() -> CustomCredentialDef {
         CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
-            credential_key: "api_key".to_string(),
+            credential_key: Some("api_key".to_string()),
+            auth: None,
             inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
@@ -2593,7 +2656,7 @@ mod tests {
     fn test_validate_custom_credential_http_loopback_allowed() {
         let mut cred = header_cred_builder();
         cred.upstream = "http://127.0.0.1:8080/api".to_string();
-        cred.credential_key = "local_key".to_string();
+        cred.credential_key = Some("local_key".to_string());
         assert!(validate_custom_credential("local", &cred).is_ok());
     }
 
@@ -2627,7 +2690,7 @@ mod tests {
     #[test]
     fn test_validate_custom_credential_invalid_key_rejected() {
         let mut cred = header_cred_builder();
-        cred.credential_key = "api-key".to_string(); // hyphens not allowed
+        cred.credential_key = Some("api-key".to_string()); // hyphens not allowed
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("hyphen in key should be rejected");
         assert!(err.to_string().contains("alphanumeric"));
@@ -2702,7 +2765,7 @@ mod tests {
     fn test_validate_custom_credential_http_localhost_allowed() {
         let mut cred = header_cred_builder();
         cred.upstream = "http://localhost:3000/api".to_string();
-        cred.credential_key = "local_key".to_string();
+        cred.credential_key = Some("local_key".to_string());
         assert!(validate_custom_credential("local", &cred).is_ok());
     }
 
@@ -2710,7 +2773,7 @@ mod tests {
     fn test_validate_custom_credential_http_ipv6_loopback_allowed() {
         let mut cred = header_cred_builder();
         cred.upstream = "http://[::1]:8080/api".to_string();
-        cred.credential_key = "local_key".to_string();
+        cred.credential_key = Some("local_key".to_string());
         assert!(validate_custom_credential("local", &cred).is_ok());
     }
 
@@ -2718,7 +2781,7 @@ mod tests {
     fn test_validate_custom_credential_http_0_0_0_0_allowed() {
         let mut cred = header_cred_builder();
         cred.upstream = "http://0.0.0.0:3000/api".to_string();
-        cred.credential_key = "local_key".to_string();
+        cred.credential_key = Some("local_key".to_string());
         assert!(validate_custom_credential("local", &cred).is_ok());
     }
 
@@ -2730,7 +2793,8 @@ mod tests {
     fn test_validate_url_path_mode_valid() {
         let cred = CustomCredentialDef {
             upstream: "https://api.telegram.org".to_string(),
-            credential_key: "telegram_token".to_string(),
+            credential_key: Some("telegram_token".to_string()),
+            auth: None,
             inject_mode: InjectMode::UrlPath,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
@@ -2751,7 +2815,8 @@ mod tests {
     fn test_validate_url_path_mode_missing_pattern() {
         let cred = CustomCredentialDef {
             upstream: "https://api.telegram.org".to_string(),
-            credential_key: "telegram_token".to_string(),
+            credential_key: Some("telegram_token".to_string()),
+            auth: None,
             inject_mode: InjectMode::UrlPath,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
@@ -2774,7 +2839,8 @@ mod tests {
     fn test_validate_url_path_mode_pattern_without_placeholder() {
         let cred = CustomCredentialDef {
             upstream: "https://api.telegram.org".to_string(),
-            credential_key: "telegram_token".to_string(),
+            credential_key: Some("telegram_token".to_string()),
+            auth: None,
             inject_mode: InjectMode::UrlPath,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
@@ -2797,7 +2863,8 @@ mod tests {
     fn test_validate_url_path_mode_with_replacement() {
         let cred = CustomCredentialDef {
             upstream: "https://api.telegram.org".to_string(),
-            credential_key: "telegram_token".to_string(),
+            credential_key: Some("telegram_token".to_string()),
+            auth: None,
             inject_mode: InjectMode::UrlPath,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
@@ -2818,7 +2885,8 @@ mod tests {
     fn test_validate_url_path_mode_replacement_without_placeholder() {
         let cred = CustomCredentialDef {
             upstream: "https://api.telegram.org".to_string(),
-            credential_key: "telegram_token".to_string(),
+            credential_key: Some("telegram_token".to_string()),
+            auth: None,
             inject_mode: InjectMode::UrlPath,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
@@ -2841,7 +2909,8 @@ mod tests {
     fn test_validate_query_param_mode_valid() {
         let cred = CustomCredentialDef {
             upstream: "https://maps.googleapis.com".to_string(),
-            credential_key: "google_maps_key".to_string(),
+            credential_key: Some("google_maps_key".to_string()),
+            auth: None,
             inject_mode: InjectMode::QueryParam,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
@@ -2862,7 +2931,8 @@ mod tests {
     fn test_validate_query_param_mode_missing_param_name() {
         let cred = CustomCredentialDef {
             upstream: "https://maps.googleapis.com".to_string(),
-            credential_key: "google_maps_key".to_string(),
+            credential_key: Some("google_maps_key".to_string()),
+            auth: None,
             inject_mode: InjectMode::QueryParam,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
@@ -2885,7 +2955,8 @@ mod tests {
     fn test_validate_query_param_mode_empty_param_name() {
         let cred = CustomCredentialDef {
             upstream: "https://maps.googleapis.com".to_string(),
-            credential_key: "google_maps_key".to_string(),
+            credential_key: Some("google_maps_key".to_string()),
+            auth: None,
             inject_mode: InjectMode::QueryParam,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
@@ -2908,7 +2979,8 @@ mod tests {
     fn test_validate_basic_auth_mode_valid() {
         let cred = CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
-            credential_key: "example_basic_auth".to_string(),
+            credential_key: Some("example_basic_auth".to_string()),
+            auth: None,
             inject_mode: InjectMode::BasicAuth,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
@@ -2987,7 +3059,7 @@ mod tests {
         // When credential_key is a URI manager ref, env_var must be set because
         // uppercasing the URI produces a nonsensical env var name.
         let mut cred = header_cred_builder();
-        cred.credential_key = "op://Development/OpenAI/credential".to_string();
+        cred.credential_key = Some("op://Development/OpenAI/credential".to_string());
         cred.env_var = None;
         let result = validate_custom_credential("openai", &cred);
         let err = result.expect_err("op:// URI without env_var should be rejected");
@@ -2997,7 +3069,7 @@ mod tests {
     #[test]
     fn test_validate_env_var_with_op_uri_and_env_var_ok() {
         let mut cred = header_cred_builder();
-        cred.credential_key = "op://Development/OpenAI/credential".to_string();
+        cred.credential_key = Some("op://Development/OpenAI/credential".to_string());
         cred.env_var = Some("OPENAI_API_KEY".to_string());
         assert!(validate_custom_credential("openai", &cred).is_ok());
     }
@@ -3005,7 +3077,7 @@ mod tests {
     #[test]
     fn test_validate_env_var_with_apple_password_uri_requires_env_var() {
         let mut cred = header_cred_builder();
-        cred.credential_key = "apple-password://github.com/alice@example.com".to_string();
+        cred.credential_key = Some("apple-password://github.com/alice@example.com".to_string());
         cred.env_var = None;
         let result = validate_custom_credential("github", &cred);
         let err = result.expect_err("apple-password URI without env_var should be rejected");
@@ -3015,7 +3087,7 @@ mod tests {
     #[test]
     fn test_validate_env_var_with_apple_password_uri_and_env_var_ok() {
         let mut cred = header_cred_builder();
-        cred.credential_key = "apple-password://github.com/alice@example.com".to_string();
+        cred.credential_key = Some("apple-password://github.com/alice@example.com".to_string());
         cred.env_var = Some("GITHUB_PASSWORD".to_string());
         assert!(validate_custom_credential("github", &cred).is_ok());
     }
@@ -3053,6 +3125,182 @@ mod tests {
         let mut cred = header_cred_builder();
         cred.env_var = Some("MY_CUSTOM_VAR".to_string());
         assert!(validate_custom_credential("test", &cred).is_ok());
+    }
+
+    // ============================================================================
+    // OAuth2 auth validation tests
+    // ============================================================================
+
+    fn oauth2_cred_builder() -> CustomCredentialDef {
+        CustomCredentialDef {
+            upstream: "https://api.example.com".to_string(),
+            credential_key: None,
+            auth: Some(OAuth2Config {
+                token_url: "https://auth.example.com/oauth/token".to_string(),
+                client_id: "my-client".to_string(),
+                client_secret: "env://CLIENT_SECRET".to_string(),
+                scope: "read write".to_string(),
+            }),
+            inject_mode: InjectMode::Header,
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
+            env_var: None,
+        }
+    }
+
+    #[test]
+    fn test_validate_oauth2_auth_valid() {
+        let cred = oauth2_cred_builder();
+        assert!(validate_custom_credential("test", &cred).is_ok());
+    }
+
+    #[test]
+    fn test_validate_oauth2_auth_and_credential_key_mutually_exclusive() {
+        let mut cred = oauth2_cred_builder();
+        cred.credential_key = Some("some_key".to_string());
+        let result = validate_custom_credential("test", &cred);
+        let err = result.expect_err("both auth and credential_key should be rejected");
+        assert!(err.to_string().contains("mutually exclusive"));
+    }
+
+    #[test]
+    fn test_validate_oauth2_neither_auth_nor_credential_key_rejected() {
+        let mut cred = oauth2_cred_builder();
+        cred.credential_key = None;
+        cred.auth = None;
+        let result = validate_custom_credential("test", &cred);
+        let err = result.expect_err("neither auth nor credential_key should be rejected");
+        assert!(err.to_string().contains("must have either"));
+    }
+
+    #[test]
+    fn test_validate_oauth2_token_url_http_remote_rejected() {
+        let mut cred = oauth2_cred_builder();
+        cred.auth = Some(OAuth2Config {
+            token_url: "http://auth.remote.com/oauth/token".to_string(),
+            client_id: "my-client".to_string(),
+            client_secret: "env://SECRET".to_string(),
+            scope: String::new(),
+        });
+        let result = validate_custom_credential("test", &cred);
+        let err = result.expect_err("HTTP to remote token_url should be rejected");
+        assert!(err.to_string().contains("HTTPS"));
+    }
+
+    #[test]
+    fn test_validate_oauth2_token_url_http_localhost_allowed() {
+        let mut cred = oauth2_cred_builder();
+        cred.auth = Some(OAuth2Config {
+            token_url: "http://localhost:8080/oauth/token".to_string(),
+            client_id: "my-client".to_string(),
+            client_secret: "env://SECRET".to_string(),
+            scope: String::new(),
+        });
+        assert!(validate_custom_credential("test", &cred).is_ok());
+    }
+
+    #[test]
+    fn test_validate_oauth2_empty_client_id_rejected() {
+        let mut cred = oauth2_cred_builder();
+        cred.auth = Some(OAuth2Config {
+            token_url: "https://auth.example.com/oauth/token".to_string(),
+            client_id: "".to_string(),
+            client_secret: "env://SECRET".to_string(),
+            scope: String::new(),
+        });
+        let result = validate_custom_credential("test", &cred);
+        let err = result.expect_err("empty client_id should be rejected");
+        assert!(err.to_string().contains("client_id"));
+        assert!(err.to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn test_validate_oauth2_empty_client_secret_rejected() {
+        let mut cred = oauth2_cred_builder();
+        cred.auth = Some(OAuth2Config {
+            token_url: "https://auth.example.com/oauth/token".to_string(),
+            client_id: "my-client".to_string(),
+            client_secret: "".to_string(),
+            scope: String::new(),
+        });
+        let result = validate_custom_credential("test", &cred);
+        let err = result.expect_err("empty client_secret should be rejected");
+        assert!(err.to_string().contains("client_secret"));
+        assert!(err.to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn test_validate_oauth2_scope_optional() {
+        let mut cred = oauth2_cred_builder();
+        cred.auth = Some(OAuth2Config {
+            token_url: "https://auth.example.com/oauth/token".to_string(),
+            client_id: "my-client".to_string(),
+            client_secret: "env://SECRET".to_string(),
+            scope: String::new(),
+        });
+        assert!(validate_custom_credential("test", &cred).is_ok());
+    }
+
+    #[test]
+    fn test_parse_profile_with_oauth2_auth() {
+        let json = r#"{
+            "meta": { "name": "oauth2-test" },
+            "network": {
+                "custom_credentials": {
+                    "my_api": {
+                        "upstream": "https://api.example.com",
+                        "auth": {
+                            "token_url": "https://auth.example.com/oauth/token",
+                            "client_id": "my-client",
+                            "client_secret": "env://CLIENT_SECRET",
+                            "scope": "api.read"
+                        }
+                    }
+                }
+            }
+        }"#;
+        let dir = tempdir().expect("tmpdir");
+        let path = dir.path().join("oauth2-test.json");
+        std::fs::write(&path, json).expect("write profile");
+        let profile = load_profile_from_path(&path).expect("parse profile");
+        let cred = &profile.network.custom_credentials["my_api"];
+        assert!(cred.credential_key.is_none());
+        assert!(cred.auth.is_some());
+        let auth = cred.auth.as_ref().unwrap();
+        assert_eq!(auth.token_url, "https://auth.example.com/oauth/token");
+        assert_eq!(auth.client_id, "my-client");
+        assert_eq!(auth.client_secret, "env://CLIENT_SECRET");
+        assert_eq!(auth.scope, "api.read");
+    }
+
+    #[test]
+    fn test_parse_profile_with_oauth2_auth_and_credential_key_rejected() {
+        let json = r#"{
+            "meta": { "name": "invalid-test" },
+            "network": {
+                "custom_credentials": {
+                    "my_api": {
+                        "upstream": "https://api.example.com",
+                        "credential_key": "some_key",
+                        "auth": {
+                            "token_url": "https://auth.example.com/oauth/token",
+                            "client_id": "my-client",
+                            "client_secret": "env://CLIENT_SECRET"
+                        }
+                    }
+                }
+            }
+        }"#;
+        let dir = tempdir().expect("tmpdir");
+        let path = dir.path().join("invalid-test.json");
+        std::fs::write(&path, json).expect("write profile");
+        let result = load_profile_from_path(&path);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("mutually exclusive"));
     }
 
     #[test]
@@ -3293,7 +3541,8 @@ mod tests {
             "svc_a".to_string(),
             CustomCredentialDef {
                 upstream: "https://a.example.com".to_string(),
-                credential_key: "key_a".to_string(),
+                credential_key: Some("key_a".to_string()),
+                auth: None,
                 inject_mode: InjectMode::Header,
                 inject_header: "Authorization".to_string(),
                 credential_format: "Bearer {}".to_string(),
@@ -3314,7 +3563,8 @@ mod tests {
             "svc_b".to_string(),
             CustomCredentialDef {
                 upstream: "https://b.example.com".to_string(),
-                credential_key: "key_b".to_string(),
+                credential_key: Some("key_b".to_string()),
+                auth: None,
                 inject_mode: InjectMode::Header,
                 inject_header: "Authorization".to_string(),
                 credential_format: "Token {}".to_string(),
@@ -3453,7 +3703,8 @@ mod tests {
             "svc_shared".to_string(),
             CustomCredentialDef {
                 upstream: "https://base.example.com".to_string(),
-                credential_key: "key_base".to_string(),
+                credential_key: Some("key_base".to_string()),
+                auth: None,
                 inject_mode: InjectMode::Header,
                 inject_header: "Authorization".to_string(),
                 credential_format: "Bearer {}".to_string(),
@@ -3474,7 +3725,8 @@ mod tests {
             "svc_shared".to_string(),
             CustomCredentialDef {
                 upstream: "https://child.example.com".to_string(),
-                credential_key: "key_child".to_string(),
+                credential_key: Some("key_child".to_string()),
+                auth: None,
                 inject_mode: InjectMode::Header,
                 inject_header: "Authorization".to_string(),
                 credential_format: "Token {}".to_string(),
@@ -3496,7 +3748,7 @@ mod tests {
             cred.upstream, "https://child.example.com",
             "child should win on same-key collision"
         );
-        assert_eq!(cred.credential_key, "key_child");
+        assert_eq!(cred.credential_key, Some("key_child".to_string()));
     }
 
     // --- Loading pipeline tests ---

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -3149,8 +3149,12 @@ mod tests {
             path_pattern: None,
             path_replacement: None,
             query_param_name: None,
+            proxy: None,
             env_var: None,
             endpoint_rules: vec![],
+            tls_ca: None,
+            tls_client_cert: None,
+            tls_client_key: None,
         }
     }
 

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -316,12 +316,14 @@ fn validate_custom_credential(name: &str, cred: &CustomCredentialDef) -> Result<
         // When credential_key is a URI manager reference, env_var is required because the URI
         // cannot be meaningfully uppercased into an env var name (e.g.,
         // "op://vault/item/field" -> "OP://VAULT/ITEM/FIELD" is nonsensical).
-        if (nono::keystore::is_op_uri(key) || nono::keystore::is_apple_password_uri(key))
+        if (nono::keystore::is_op_uri(key)
+            || nono::keystore::is_apple_password_uri(key)
+            || nono::keystore::is_file_uri(key))
             && cred.env_var.is_none()
         {
             return Err(NonoError::ProfileParse(format!(
                 "env_var is required for custom credential '{}' when credential_key is a URI \
-                 manager reference (op:// or apple-password://); \
+                 manager reference (op://, apple-password://, or file://); \
                  set it to the SDK API key env var name (e.g., \"OPENAI_API_KEY\")",
                 name
             )));
@@ -4935,7 +4937,8 @@ mod tests {
     fn test_validate_custom_credential_file_uri_accepted() {
         let cred = CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
-            credential_key: "file:///run/secrets/api-token".to_string(),
+            credential_key: Some("file:///run/secrets/api-token".to_string()),
+            auth: None,
             inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
@@ -4959,7 +4962,8 @@ mod tests {
     fn test_validate_custom_credential_file_uri_requires_env_var() {
         let cred = CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
-            credential_key: "file:///run/secrets/api-token".to_string(),
+            credential_key: Some("file:///run/secrets/api-token".to_string()),
+            auth: None,
             inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
@@ -4986,7 +4990,8 @@ mod tests {
     fn test_validate_custom_credential_file_uri_invalid_rejected() {
         let cred = CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
-            credential_key: "file://relative/path".to_string(),
+            credential_key: Some("file://relative/path".to_string()),
+            auth: None,
             inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
@@ -5013,7 +5018,8 @@ mod tests {
     fn test_validate_custom_credential_file_uri_traversal_rejected() {
         let cred = CustomCredentialDef {
             upstream: "https://api.example.com".to_string(),
-            credential_key: "file:///run/secrets/../../../etc/shadow".to_string(),
+            credential_key: Some("file:///run/secrets/../../../etc/shadow".to_string()),
+            auth: None,
             inject_mode: InjectMode::Header,
             inject_header: "Authorization".to_string(),
             credential_format: "Bearer {}".to_string(),
@@ -5096,7 +5102,10 @@ mod tests {
             .custom_credentials
             .get("my_service")
             .expect("my_service credential should exist");
-        assert_eq!(cred.credential_key, "file:///run/secrets/api-token");
+        assert_eq!(
+            cred.credential_key,
+            Some("file:///run/secrets/api-token".to_string())
+        );
         assert_eq!(cred.env_var, Some("MY_API_KEY".to_string()));
     }
 }

--- a/crates/nono-proxy/src/config.rs
+++ b/crates/nono-proxy/src/config.rs
@@ -167,6 +167,13 @@ pub struct RouteConfig {
     /// to the certificate in `tls_client_cert`.
     #[serde(default)]
     pub tls_client_key: Option<String>,
+
+    /// Optional OAuth2 client_credentials configuration.
+    /// When present, the proxy handles token exchange automatically instead
+    /// of using a static credential from the keystore.
+    /// Mutually exclusive with `credential_key` — use one or the other.
+    #[serde(default)]
+    pub oauth2: Option<OAuth2Config>,
 }
 
 /// Optional proxy-side overrides for credential injection shape.
@@ -352,6 +359,28 @@ pub struct ExternalProxyAuth {
 
 fn default_auth_scheme() -> String {
     "basic".to_string()
+}
+
+/// OAuth2 client_credentials configuration for automatic token exchange.
+///
+/// When configured on a route, the proxy handles the token lifecycle:
+/// 1. Exchanges client_id + client_secret for an access_token at startup
+/// 2. Caches the token with TTL from the `expires_in` response
+/// 3. Refreshes automatically before expiry (30s buffer)
+/// 4. Injects the access_token as `Authorization: Bearer <token>`
+///
+/// The agent never sees client_id or client_secret — only a phantom token.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OAuth2Config {
+    /// Token endpoint URL (e.g., "https://auth.example.com/oauth/token")
+    pub token_url: String,
+    /// Client ID — plain value or credential reference (env://, file://, op://)
+    pub client_id: String,
+    /// Client secret — credential reference (env://, file://, op://)
+    pub client_secret: String,
+    /// OAuth2 scopes (space-separated). Empty = no scope parameter sent.
+    #[serde(default)]
+    pub scope: String,
 }
 
 #[cfg(test)]
@@ -682,5 +711,66 @@ mod tests {
         let deserialized: EndpointRule = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.method, "GET");
         assert_eq!(deserialized.path, "/api/*/data");
+    }
+
+    // ========================================================================
+    // OAuth2Config tests
+    // ========================================================================
+
+    #[test]
+    fn test_oauth2_config_deserialization() {
+        let json = r#"{
+            "token_url": "https://auth.example.com/oauth/token",
+            "client_id": "my-client",
+            "client_secret": "env://CLIENT_SECRET",
+            "scope": "read write"
+        }"#;
+        let config: OAuth2Config = serde_json::from_str(json).unwrap();
+        assert_eq!(config.token_url, "https://auth.example.com/oauth/token");
+        assert_eq!(config.client_id, "my-client");
+        assert_eq!(config.client_secret, "env://CLIENT_SECRET");
+        assert_eq!(config.scope, "read write");
+    }
+
+    #[test]
+    fn test_oauth2_config_default_scope() {
+        let json = r#"{
+            "token_url": "https://auth.example.com/oauth/token",
+            "client_id": "my-client",
+            "client_secret": "env://SECRET"
+        }"#;
+        let config: OAuth2Config = serde_json::from_str(json).unwrap();
+        assert_eq!(config.scope, "");
+    }
+
+    #[test]
+    fn test_route_config_with_oauth2() {
+        let json = r#"{
+            "prefix": "/my-api",
+            "upstream": "https://api.example.com",
+            "oauth2": {
+                "token_url": "https://auth.example.com/oauth/token",
+                "client_id": "agent-1",
+                "client_secret": "env://CLIENT_SECRET",
+                "scope": "api.read"
+            }
+        }"#;
+        let route: RouteConfig = serde_json::from_str(json).unwrap();
+        assert!(route.oauth2.is_some());
+        assert!(route.credential_key.is_none());
+        let oauth2 = route.oauth2.unwrap();
+        assert_eq!(oauth2.token_url, "https://auth.example.com/oauth/token");
+    }
+
+    #[test]
+    fn test_route_config_without_oauth2() {
+        let json = r#"{
+            "prefix": "/openai",
+            "upstream": "https://api.openai.com",
+            "credential_key": "openai"
+        }"#;
+        let route: RouteConfig = serde_json::from_str(json).unwrap();
+        assert!(route.oauth2.is_none());
+        assert!(route.credential_key.is_some());
     }
 }

--- a/crates/nono-proxy/src/credential.rs
+++ b/crates/nono-proxy/src/credential.rs
@@ -446,7 +446,10 @@ mod tests {
             oauth2_routes,
         };
 
-        assert!(!store.is_empty(), "store with OAuth2 routes should not be empty");
+        assert!(
+            !store.is_empty(),
+            "store with OAuth2 routes should not be empty"
+        );
         assert_eq!(store.len(), 1);
         assert!(store.get_oauth2("my-api").is_some());
         assert!(store.get("my-api").is_none());
@@ -491,6 +494,7 @@ mod tests {
             path_replacement: None,
             query_param_name: None,
             env_var: Some("MY_API_KEY".to_string()),
+            endpoint_rules: vec![],
             oauth2: Some(OAuth2Config {
                 // Non-routable address: exchange will fail at TCP connect
                 token_url: "https://127.0.0.1:1/oauth/token".to_string(),
@@ -512,11 +516,17 @@ mod tests {
         std::env::remove_var("TEST_OAUTH2_CLIENT_SECRET");
 
         // load() should succeed (route skipped, not hard error)
-        assert!(store.is_ok(), "load should not fail on unreachable OAuth2 endpoint");
+        assert!(
+            store.is_ok(),
+            "load should not fail on unreachable OAuth2 endpoint"
+        );
         let store = store.unwrap();
 
         // The route should have been skipped (token exchange failed)
-        assert!(store.is_empty(), "unreachable OAuth2 endpoint should result in skipped route");
+        assert!(
+            store.is_empty(),
+            "unreachable OAuth2 endpoint should result in skipped route"
+        );
         assert!(store.get_oauth2("my-api").is_none());
     }
 

--- a/crates/nono-proxy/src/credential.rs
+++ b/crates/nono-proxy/src/credential.rs
@@ -11,8 +11,10 @@
 
 use crate::config::{InjectMode, RouteConfig};
 use crate::error::{ProxyError, Result};
+use crate::oauth2::{OAuth2ExchangeConfig, TokenCache};
 use base64::Engine;
 use std::collections::HashMap;
+use tokio_rustls::TlsConnector;
 use tracing::{debug, warn};
 use zeroize::Zeroizing;
 
@@ -72,32 +74,48 @@ impl std::fmt::Debug for LoadedCredential {
     }
 }
 
+/// An OAuth2 route entry: token cache + upstream URL.
+#[derive(Debug)]
+pub struct OAuth2Route {
+    /// Token cache for automatic refresh
+    pub cache: TokenCache,
+    /// Upstream URL (e.g., "https://api.example.com")
+    pub upstream: String,
+}
+
 /// Credential store for all configured routes.
 #[derive(Debug)]
 pub struct CredentialStore {
     /// Map from route prefix to loaded credential
     credentials: HashMap<String, LoadedCredential>,
+    /// Map from route prefix to OAuth2 route (token cache + upstream)
+    oauth2_routes: HashMap<String, OAuth2Route>,
 }
 
 impl CredentialStore {
     /// Load credentials for all configured routes from the system keystore.
     ///
-    /// Routes without a `credential_key` are skipped (no credential injection).
-    /// Routes whose credential is not found (e.g. unset env var) are skipped
-    /// with a warning — this allows profiles to declare optional credentials
-    /// without failing when they are unavailable.
+    /// Routes without a `credential_key` or `oauth2` block are skipped (no
+    /// credential injection). Routes whose credential is not found (e.g.
+    /// unset env var) are skipped with a warning — this allows profiles to
+    /// declare optional credentials without failing when they are unavailable.
+    ///
+    /// OAuth2 routes perform an initial token exchange at startup. If the
+    /// exchange fails, the route is skipped (graceful degradation).
+    ///
+    /// The `tls_connector` is required for OAuth2 token exchange HTTPS calls.
     ///
     /// Returns an error only for hard failures (keystore access errors,
     /// config parse errors, non-UTF-8 values).
-    pub fn load(routes: &[RouteConfig]) -> Result<Self> {
+    pub fn load(routes: &[RouteConfig], tls_connector: &TlsConnector) -> Result<Self> {
         let mut credentials = HashMap::new();
+        let mut oauth2_routes = HashMap::new();
 
         for route in routes {
             // Normalize prefix: strip leading/trailing slashes so it matches
             // the bare service name returned by parse_service_prefix() in
             // the reverse proxy path (e.g., "/anthropic" -> "anthropic").
             let normalized_prefix = route.prefix.trim_matches('/').to_string();
-
             if let Some(ref key) = route.credential_key {
                 debug!(
                     "Loading credential for route prefix: {} (mode: {:?})",
@@ -181,10 +199,76 @@ impl CredentialStore {
                             .or_else(|| route.query_param_name.clone()),
                     },
                 );
+                continue;
+            }
+
+            // OAuth2 client_credentials path
+            if let Some(ref oauth2) = route.oauth2 {
+                debug!(
+                    "Loading OAuth2 credential for route prefix: {}",
+                    route.prefix
+                );
+
+                let client_id =
+                    match nono::keystore::load_secret_by_ref(KEYRING_SERVICE, &oauth2.client_id) {
+                        Ok(s) => s,
+                        Err(nono::NonoError::SecretNotFound(msg)) => {
+                            debug!(
+                                "OAuth2 client_id not available for route '{}': {}",
+                                route.prefix, msg
+                            );
+                            continue;
+                        }
+                        Err(e) => return Err(ProxyError::Credential(e.to_string())),
+                    };
+
+                let client_secret = match nono::keystore::load_secret_by_ref(
+                    KEYRING_SERVICE,
+                    &oauth2.client_secret,
+                ) {
+                    Ok(s) => s,
+                    Err(nono::NonoError::SecretNotFound(msg)) => {
+                        debug!(
+                            "OAuth2 client_secret not available for route '{}': {}",
+                            route.prefix, msg
+                        );
+                        continue;
+                    }
+                    Err(e) => return Err(ProxyError::Credential(e.to_string())),
+                };
+
+                let config = OAuth2ExchangeConfig {
+                    token_url: oauth2.token_url.clone(),
+                    client_id,
+                    client_secret,
+                    scope: oauth2.scope.clone(),
+                };
+
+                match TokenCache::new(config, tls_connector.clone()) {
+                    Ok(cache) => {
+                        oauth2_routes.insert(
+                            route.prefix.clone(),
+                            OAuth2Route {
+                                cache,
+                                upstream: route.upstream.clone(),
+                            },
+                        );
+                    }
+                    Err(e) => {
+                        debug!(
+                            "OAuth2 token exchange failed for route '{}': {}, skipping",
+                            route.prefix, e
+                        );
+                        continue;
+                    }
+                }
             }
         }
 
-        Ok(Self { credentials })
+        Ok(Self {
+            credentials,
+            oauth2_routes,
+        })
     }
 
     /// Create an empty credential store (no credential injection).
@@ -192,31 +276,43 @@ impl CredentialStore {
     pub fn empty() -> Self {
         Self {
             credentials: HashMap::new(),
+            oauth2_routes: HashMap::new(),
         }
     }
 
-    /// Get a credential for a route prefix, if configured.
+    /// Get a static credential for a route prefix, if configured.
     #[must_use]
     pub fn get(&self, prefix: &str) -> Option<&LoadedCredential> {
         self.credentials.get(prefix)
     }
 
-    /// Check if any credentials are loaded.
+    /// Get an OAuth2 route (token cache + upstream) for a route prefix, if configured.
+    #[must_use]
+    pub fn get_oauth2(&self, prefix: &str) -> Option<&OAuth2Route> {
+        self.oauth2_routes.get(prefix)
+    }
+
+    /// Check if any credentials (static or OAuth2) are loaded.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.credentials.is_empty()
+        self.credentials.is_empty() && self.oauth2_routes.is_empty()
     }
 
-    /// Number of loaded credentials.
+    /// Number of loaded credentials (static + OAuth2).
     #[must_use]
     pub fn len(&self) -> usize {
-        self.credentials.len()
+        self.credentials.len() + self.oauth2_routes.len()
     }
 
-    /// Returns the set of route prefixes that have loaded credentials.
+    /// Returns the set of route prefixes that have loaded credentials
+    /// (both static keystore and OAuth2 routes).
     #[must_use]
     pub fn loaded_prefixes(&self) -> std::collections::HashSet<String> {
-        self.credentials.keys().cloned().collect()
+        self.credentials
+            .keys()
+            .chain(self.oauth2_routes.keys())
+            .cloned()
+            .collect()
     }
 }
 
@@ -228,6 +324,21 @@ const KEYRING_SERVICE: &str = nono::keystore::DEFAULT_SERVICE;
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
+    /// Build a TLS connector for tests (never used for real connections).
+    fn test_tls_connector() -> TlsConnector {
+        let mut root_store = rustls::RootCertStore::empty();
+        root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+        let tls_config = rustls::ClientConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+        TlsConnector::from(Arc::new(tls_config))
+    }
 
     #[test]
     fn test_empty_credential_store() {
@@ -235,6 +346,8 @@ mod tests {
         assert!(store.is_empty());
         assert_eq!(store.len(), 0);
         assert!(store.get("openai").is_none());
+        assert!(store.get("/openai").is_none());
+        assert!(store.get_oauth2("/openai").is_none());
     }
 
     #[test]
@@ -279,6 +392,7 @@ mod tests {
 
     #[test]
     fn test_load_no_credential_routes() {
+        let tls = test_tls_connector();
         let routes = vec![RouteConfig {
             prefix: "/test".to_string(),
             upstream: "https://example.com".to_string(),
@@ -297,9 +411,126 @@ mod tests {
             tls_client_key: None,
             oauth2: None,
         }];
-        let store = CredentialStore::load(&routes);
+        let store = CredentialStore::load(&routes, &tls);
         assert!(store.is_ok());
         let store = store.unwrap_or_else(|_| CredentialStore::empty());
         assert!(store.is_empty());
+    }
+
+    #[test]
+    fn test_get_oauth2_returns_none_for_non_oauth2_routes() {
+        let store = CredentialStore::empty();
+        assert!(store.get_oauth2("openai").is_none());
+        assert!(store.get_oauth2("my-api").is_none());
+    }
+
+    #[test]
+    fn test_is_empty_false_with_only_oauth2_routes() {
+        // Simulate a store with only OAuth2 routes by constructing directly.
+        // We can't call load() with a real OAuth2 config (no token server),
+        // so we build the struct manually to test the is_empty/len logic.
+        use std::time::Duration;
+
+        let cache = make_test_token_cache("test-token", Duration::from_secs(3600));
+        let mut oauth2_routes = HashMap::new();
+        oauth2_routes.insert(
+            "my-api".to_string(),
+            OAuth2Route {
+                cache,
+                upstream: "https://api.example.com".to_string(),
+            },
+        );
+
+        let store = CredentialStore {
+            credentials: HashMap::new(),
+            oauth2_routes,
+        };
+
+        assert!(!store.is_empty(), "store with OAuth2 routes should not be empty");
+        assert_eq!(store.len(), 1);
+        assert!(store.get_oauth2("my-api").is_some());
+        assert!(store.get("my-api").is_none());
+    }
+
+    #[test]
+    fn test_loaded_prefixes_includes_oauth2() {
+        use std::time::Duration;
+
+        let cache = make_test_token_cache("test-token", Duration::from_secs(3600));
+        let mut oauth2_routes = HashMap::new();
+        oauth2_routes.insert(
+            "my-api".to_string(),
+            OAuth2Route {
+                cache,
+                upstream: "https://api.example.com".to_string(),
+            },
+        );
+
+        let store = CredentialStore {
+            credentials: HashMap::new(),
+            oauth2_routes,
+        };
+
+        let prefixes = store.loaded_prefixes();
+        assert!(prefixes.contains("my-api"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_load_oauth2_unreachable_endpoint_skips_route() {
+        use crate::config::OAuth2Config;
+
+        let tls = test_tls_connector();
+        let routes = vec![RouteConfig {
+            prefix: "my-api".to_string(),
+            upstream: "https://api.example.com".to_string(),
+            credential_key: None,
+            inject_mode: InjectMode::Header,
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
+            env_var: Some("MY_API_KEY".to_string()),
+            oauth2: Some(OAuth2Config {
+                // Non-routable address: exchange will fail at TCP connect
+                token_url: "https://127.0.0.1:1/oauth/token".to_string(),
+                // Use env:// refs that point at test env vars
+                client_id: "env://TEST_OAUTH2_CLIENT_ID".to_string(),
+                client_secret: "env://TEST_OAUTH2_CLIENT_SECRET".to_string(),
+                scope: String::new(),
+            }),
+        }];
+
+        // Set env vars so credential loading succeeds (exchange will fail)
+        std::env::set_var("TEST_OAUTH2_CLIENT_ID", "test-client");
+        std::env::set_var("TEST_OAUTH2_CLIENT_SECRET", "test-secret");
+
+        let store = CredentialStore::load(&routes, &tls);
+
+        // Clean up env vars
+        std::env::remove_var("TEST_OAUTH2_CLIENT_ID");
+        std::env::remove_var("TEST_OAUTH2_CLIENT_SECRET");
+
+        // load() should succeed (route skipped, not hard error)
+        assert!(store.is_ok(), "load should not fail on unreachable OAuth2 endpoint");
+        let store = store.unwrap();
+
+        // The route should have been skipped (token exchange failed)
+        assert!(store.is_empty(), "unreachable OAuth2 endpoint should result in skipped route");
+        assert!(store.get_oauth2("my-api").is_none());
+    }
+
+    /// Build a test `TokenCache` with a pre-populated token.
+    fn make_test_token_cache(token: &str, ttl: std::time::Duration) -> TokenCache {
+        use crate::oauth2::OAuth2ExchangeConfig;
+
+        let config = OAuth2ExchangeConfig {
+            token_url: "https://127.0.0.1:1/oauth/token".to_string(),
+            client_id: Zeroizing::new("test-client".to_string()),
+            client_secret: Zeroizing::new("test-secret".to_string()),
+            scope: String::new(),
+        };
+
+        TokenCache::new_from_parts(config, test_tls_connector(), token, ttl)
     }
 }

--- a/crates/nono-proxy/src/credential.rs
+++ b/crates/nono-proxy/src/credential.rs
@@ -295,6 +295,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            oauth2: None,
         }];
         let store = CredentialStore::load(&routes);
         assert!(store.is_ok());

--- a/crates/nono-proxy/src/credential.rs
+++ b/crates/nono-proxy/src/credential.rs
@@ -324,7 +324,41 @@ const KEYRING_SERVICE: &str = nono::keystore::DEFAULT_SERVICE;
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        original: Vec<(&'static str, Option<String>)>,
+    }
+
+    #[allow(clippy::disallowed_methods)]
+    impl EnvVarGuard {
+        fn set_all(vars: &[(&'static str, &str)]) -> Self {
+            let original = vars
+                .iter()
+                .map(|(key, _)| (*key, std::env::var(key).ok()))
+                .collect::<Vec<_>>();
+
+            for (key, value) in vars {
+                std::env::set_var(key, value);
+            }
+
+            Self { original }
+        }
+    }
+
+    #[allow(clippy::disallowed_methods)]
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            for (key, value) in self.original.iter().rev() {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
 
     /// Build a TLS connector for tests (never used for real connections).
     fn test_tls_connector() -> TlsConnector {
@@ -482,6 +516,11 @@ mod tests {
     async fn test_load_oauth2_unreachable_endpoint_skips_route() {
         use crate::config::OAuth2Config;
 
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _env = EnvVarGuard::set_all(&[
+            ("TEST_OAUTH2_CLIENT_ID", "test-client"),
+            ("TEST_OAUTH2_CLIENT_SECRET", "test-secret"),
+        ]);
         let tls = test_tls_connector();
         let routes = vec![RouteConfig {
             prefix: "my-api".to_string(),
@@ -493,8 +532,12 @@ mod tests {
             path_pattern: None,
             path_replacement: None,
             query_param_name: None,
+            proxy: None,
             env_var: Some("MY_API_KEY".to_string()),
             endpoint_rules: vec![],
+            tls_ca: None,
+            tls_client_cert: None,
+            tls_client_key: None,
             oauth2: Some(OAuth2Config {
                 // Non-routable address: exchange will fail at TCP connect
                 token_url: "https://127.0.0.1:1/oauth/token".to_string(),
@@ -505,15 +548,7 @@ mod tests {
             }),
         }];
 
-        // Set env vars so credential loading succeeds (exchange will fail)
-        std::env::set_var("TEST_OAUTH2_CLIENT_ID", "test-client");
-        std::env::set_var("TEST_OAUTH2_CLIENT_SECRET", "test-secret");
-
         let store = CredentialStore::load(&routes, &tls);
-
-        // Clean up env vars
-        std::env::remove_var("TEST_OAUTH2_CLIENT_ID");
-        std::env::remove_var("TEST_OAUTH2_CLIENT_SECRET");
 
         // load() should succeed (route skipped, not hard error)
         assert!(

--- a/crates/nono-proxy/src/error.rs
+++ b/crates/nono-proxy/src/error.rs
@@ -36,6 +36,9 @@ pub enum ProxyError {
     #[error("HTTP parse error: {0}")]
     HttpParse(String),
 
+    #[error("OAuth2 token exchange error: {0}")]
+    OAuth2Exchange(String),
+
     #[error("Proxy shutdown")]
     Shutdown,
 

--- a/crates/nono-proxy/src/lib.rs
+++ b/crates/nono-proxy/src/lib.rs
@@ -24,6 +24,7 @@ pub mod credential;
 pub mod error;
 pub mod external;
 pub mod filter;
+pub mod oauth2;
 pub mod reverse;
 pub mod route;
 pub mod server;

--- a/crates/nono-proxy/src/oauth2.rs
+++ b/crates/nono-proxy/src/oauth2.rs
@@ -186,10 +186,7 @@ impl TokenCache {
                 guard.access_token.clone()
             }
             Err(e) => {
-                warn!(
-                    "OAuth2 token refresh failed, returning stale token: {}",
-                    e
-                );
+                warn!("OAuth2 token refresh failed, returning stale token: {}", e);
                 guard.access_token.clone()
             }
         }
@@ -244,11 +241,7 @@ async fn exchange_token(
     };
 
     // ── Build form body ──────────────────────────────────────────────────
-    let body = build_token_request_body(
-        &config.client_id,
-        &config.client_secret,
-        &config.scope,
-    );
+    let body = build_token_request_body(&config.client_id, &config.client_secret, &config.scope);
 
     // ── Build HTTP/1.1 request ───────────────────────────────────────────
     let request = Zeroizing::new(format!(
@@ -270,9 +263,25 @@ async fn exchange_token(
     let addr = format!("{}:{}", host, port);
 
     let response_bytes = tokio::time::timeout(EXCHANGE_TIMEOUT, async {
-        let tcp = TcpStream::connect(&addr).await.map_err(|e| {
-            ProxyError::OAuth2Exchange(format!("TCP connect to {}: {}", addr, e))
-        })?;
+        let tcp = TcpStream::connect(&addr)
+            .await
+            .map_err(|e| ProxyError::OAuth2Exchange(format!("TCP connect to {}: {}", addr, e)))?;
+
+        async fn send_and_read<S: tokio::io::AsyncWrite + tokio::io::AsyncRead + Unpin>(
+            stream: &mut S,
+            request: &[u8],
+            host: &str,
+        ) -> Result<Vec<u8>> {
+            stream
+                .write_all(request)
+                .await
+                .map_err(|e| ProxyError::OAuth2Exchange(format!("write to {}: {}", host, e)))?;
+            stream
+                .flush()
+                .await
+                .map_err(|e| ProxyError::OAuth2Exchange(format!("flush to {}: {}", host, e)))?;
+            read_http_response(stream).await
+        }
 
         if is_https {
             let server_name =
@@ -280,37 +289,18 @@ async fn exchange_token(
                     ProxyError::OAuth2Exchange(format!("invalid TLS server name: {}", host))
                 })?;
 
-            let mut tls = tls_connector
-                .connect(server_name, tcp)
-                .await
-                .map_err(|e| {
-                    ProxyError::OAuth2Exchange(format!("TLS handshake with {}: {}", host, e))
-                })?;
-
-            tls.write_all(request.as_bytes()).await.map_err(|e| {
-                ProxyError::OAuth2Exchange(format!("write to {}: {}", host, e))
-            })?;
-            tls.flush().await.map_err(|e| {
-                ProxyError::OAuth2Exchange(format!("flush to {}: {}", host, e))
+            let mut tls = tls_connector.connect(server_name, tcp).await.map_err(|e| {
+                ProxyError::OAuth2Exchange(format!("TLS handshake with {}: {}", host, e))
             })?;
 
-            read_http_response(&mut tls).await
+            send_and_read(&mut tls, request.as_bytes(), &host).await
         } else {
             let mut tcp = tcp;
-            tcp.write_all(request.as_bytes()).await.map_err(|e| {
-                ProxyError::OAuth2Exchange(format!("write to {}: {}", host, e))
-            })?;
-            tcp.flush().await.map_err(|e| {
-                ProxyError::OAuth2Exchange(format!("flush to {}: {}", host, e))
-            })?;
-
-            read_http_response(&mut tcp).await
+            send_and_read(&mut tcp, request.as_bytes(), &host).await
         }
     })
     .await
-    .map_err(|_| {
-        ProxyError::OAuth2Exchange(format!("token exchange with {} timed out", addr))
-    })??;
+    .map_err(|_| ProxyError::OAuth2Exchange(format!("token exchange with {} timed out", addr)))??;
 
     // ── Parse HTTP response ──────────────────────────────────────────────
     let response_str = String::from_utf8(response_bytes).map_err(|_| {
@@ -323,7 +313,9 @@ async fn exchange_token(
         .map(|i| i + 4)
         .or_else(|| response_str.find("\n\n").map(|i| i + 2))
         .ok_or_else(|| {
-            ProxyError::OAuth2Exchange("malformed HTTP response: no header/body separator".to_string())
+            ProxyError::OAuth2Exchange(
+                "malformed HTTP response: no header/body separator".to_string(),
+            )
         })?;
 
     // Check status code
@@ -342,15 +334,14 @@ async fn exchange_token(
 }
 
 /// Read a full HTTP response from a stream up to [`MAX_TOKEN_RESPONSE`] bytes.
-async fn read_http_response<S: tokio::io::AsyncRead + Unpin>(
-    stream: &mut S,
-) -> Result<Vec<u8>> {
+async fn read_http_response<S: tokio::io::AsyncRead + Unpin>(stream: &mut S) -> Result<Vec<u8>> {
     let mut buf = Vec::with_capacity(4096);
     let mut tmp = [0u8; 4096];
     loop {
-        let n = stream.read(&mut tmp).await.map_err(|e| {
-            ProxyError::OAuth2Exchange(format!("read response: {}", e))
-        })?;
+        let n = stream
+            .read(&mut tmp)
+            .await
+            .map_err(|e| ProxyError::OAuth2Exchange(format!("read response: {}", e)))?;
         if n == 0 {
             break;
         }
@@ -369,10 +360,7 @@ async fn read_http_response<S: tokio::io::AsyncRead + Unpin>(
 fn parse_status_code(line: &str) -> u16 {
     // "HTTP/1.1 200 OK" -> "200"
     let mut parts = line.split_whitespace();
-    parts
-        .nth(1)
-        .and_then(|code| code.parse().ok())
-        .unwrap_or(0)
+    parts.nth(1).and_then(|code| code.parse().ok()).unwrap_or(0)
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -412,9 +400,7 @@ fn parse_token_response(json: &str) -> Result<(Zeroizing<String>, Duration)> {
         .get("access_token")
         .and_then(|v| v.as_str())
         .ok_or_else(|| {
-            ProxyError::OAuth2Exchange(
-                "token response missing 'access_token' field".to_string(),
-            )
+            ProxyError::OAuth2Exchange("token response missing 'access_token' field".to_string())
         })?;
 
     let expires_in_secs = value
@@ -441,7 +427,8 @@ mod tests {
 
     #[test]
     fn test_parse_token_response_success() {
-        let json = r#"{"access_token":"eyJhbGciOiJSUzI1NiJ9","token_type":"Bearer","expires_in":3600}"#;
+        let json =
+            r#"{"access_token":"eyJhbGciOiJSUzI1NiJ9","token_type":"Bearer","expires_in":3600}"#;
         let (token, expires) = parse_token_response(json).unwrap();
         assert_eq!(token.as_str(), "eyJhbGciOiJSUzI1NiJ9");
         assert_eq!(expires, Duration::from_secs(3600));

--- a/crates/nono-proxy/src/oauth2.rs
+++ b/crates/nono-proxy/src/oauth2.rs
@@ -106,8 +106,12 @@ impl TokenCache {
     /// (DNS, TCP, TLS, non-200, malformed JSON). The calling code skips the
     /// route so the proxy can still start for other routes.
     pub fn new(config: OAuth2ExchangeConfig, tls_connector: TlsConnector) -> Result<Self> {
-        let (access_token, expires_in) =
-            tokio::runtime::Handle::current().block_on(exchange_token(&config, &tls_connector))?;
+        // Use block_in_place to avoid panicking when called from within an
+        // async context (e.g., server::start() which is async). This moves
+        // the blocking work off the async worker thread.
+        let (access_token, expires_in) = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(exchange_token(&config, &tls_connector))
+        })?;
 
         let expires_at = Instant::now() + expires_in;
         debug!(
@@ -123,6 +127,27 @@ impl TokenCache {
             config,
             tls_connector,
         })
+    }
+
+    /// Create a `TokenCache` with a pre-populated token (for testing).
+    ///
+    /// Skips the initial token exchange. Used by tests that need a cache
+    /// without a real OAuth2 server.
+    #[cfg(test)]
+    pub(crate) fn new_from_parts(
+        config: OAuth2ExchangeConfig,
+        tls_connector: TlsConnector,
+        token: &str,
+        ttl: Duration,
+    ) -> Self {
+        Self {
+            token: Arc::new(RwLock::new(CachedToken {
+                access_token: Zeroizing::new(token.to_string()),
+                expires_at: Instant::now() + ttl,
+            })),
+            config,
+            tls_connector,
+        }
     }
 
     /// Return a valid access token, refreshing if needed.
@@ -540,13 +565,6 @@ mod tests {
         .with_no_client_auth();
         let tls_connector = TlsConnector::from(Arc::new(tls_config));
 
-        TokenCache {
-            token: Arc::new(RwLock::new(CachedToken {
-                access_token: Zeroizing::new(token.to_string()),
-                expires_at: Instant::now() + ttl,
-            })),
-            config,
-            tls_connector,
-        }
+        TokenCache::new_from_parts(config, tls_connector, token, ttl)
     }
 }

--- a/crates/nono-proxy/src/oauth2.rs
+++ b/crates/nono-proxy/src/oauth2.rs
@@ -1,0 +1,552 @@
+//! OAuth2 `client_credentials` token exchange and caching.
+//!
+//! Provides [`TokenCache`] — a thread-safe cache that holds an OAuth2 access
+//! token and refreshes it on demand before expiry. Designed for the reverse
+//! proxy credential injection flow where the agent never sees the real
+//! client_id/client_secret.
+//!
+//! ## Design
+//!
+//! - **No background tasks**: Token validity is checked on each use via
+//!   [`TokenCache::get_or_refresh()`]. If the cached token is about to expire
+//!   (within 30 seconds), a synchronous refresh is attempted.
+//! - **Graceful degradation**: If a refresh attempt fails but a stale token
+//!   exists, the stale token is returned with a warning log. This avoids
+//!   transient auth-server outages from cascading into request failures.
+//! - **TLS via rustls**: Uses the same `webpki-roots` + `tokio-rustls` stack
+//!   as the rest of the proxy. No additional HTTP client dependencies.
+
+use crate::error::{ProxyError, Result};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::sync::RwLock;
+use tokio_rustls::TlsConnector;
+use tracing::{debug, warn};
+use zeroize::Zeroizing;
+
+/// Buffer subtracted from `expires_in` to refresh before the token actually
+/// expires. Avoids edge cases where a token expires between check and use.
+const EXPIRY_BUFFER_SECS: u64 = 30;
+
+/// Default TTL when the token endpoint omits `expires_in`.
+const DEFAULT_EXPIRES_IN_SECS: u64 = 3600;
+
+/// Timeout for the TCP connect + TLS handshake + HTTP exchange.
+const EXCHANGE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Maximum response body size from the token endpoint (64 KiB).
+const MAX_TOKEN_RESPONSE: usize = 64 * 1024;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Public types
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Resolved OAuth2 credentials ready for token exchange.
+///
+/// All secret fields use [`Zeroizing`] so they are zeroed on drop.
+pub struct OAuth2ExchangeConfig {
+    pub token_url: String,
+    pub client_id: Zeroizing<String>,
+    pub client_secret: Zeroizing<String>,
+    pub scope: String,
+}
+
+/// Custom Debug that redacts secrets.
+impl std::fmt::Debug for OAuth2ExchangeConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OAuth2ExchangeConfig")
+            .field("token_url", &self.token_url)
+            .field("client_id", &"[REDACTED]")
+            .field("client_secret", &"[REDACTED]")
+            .field("scope", &self.scope)
+            .finish()
+    }
+}
+
+/// Thread-safe OAuth2 access-token cache with on-demand refresh.
+pub struct TokenCache {
+    token: Arc<RwLock<CachedToken>>,
+    config: OAuth2ExchangeConfig,
+    tls_connector: TlsConnector,
+}
+
+impl std::fmt::Debug for TokenCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenCache")
+            .field("config", &self.config)
+            .finish()
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Internal types
+// ────────────────────────────────────────────────────────────────────────────
+
+struct CachedToken {
+    access_token: Zeroizing<String>,
+    expires_at: Instant,
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// TokenCache implementation
+// ────────────────────────────────────────────────────────────────────────────
+
+impl TokenCache {
+    /// Create a new cache and perform the **initial** token exchange.
+    ///
+    /// Called during [`CredentialStore::load()`](crate::credential::CredentialStore::load)
+    /// which is synchronous. We bridge into async via
+    /// [`tokio::runtime::Handle::current().block_on()`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProxyError::OAuth2Exchange`] if the initial exchange fails
+    /// (DNS, TCP, TLS, non-200, malformed JSON). The calling code skips the
+    /// route so the proxy can still start for other routes.
+    pub fn new(config: OAuth2ExchangeConfig, tls_connector: TlsConnector) -> Result<Self> {
+        let (access_token, expires_in) =
+            tokio::runtime::Handle::current().block_on(exchange_token(&config, &tls_connector))?;
+
+        let expires_at = Instant::now() + expires_in;
+        debug!(
+            "OAuth2 initial token acquired, expires in {}s",
+            expires_in.as_secs()
+        );
+
+        Ok(Self {
+            token: Arc::new(RwLock::new(CachedToken {
+                access_token,
+                expires_at,
+            })),
+            config,
+            tls_connector,
+        })
+    }
+
+    /// Return a valid access token, refreshing if needed.
+    ///
+    /// If the cached token is still valid (expires > 30 s from now), returns
+    /// the cached value without any network call.
+    ///
+    /// If expired, attempts one exchange. On failure, returns the **stale**
+    /// token with a warning — better to try a possibly-expired token than to
+    /// fail the request outright.
+    pub async fn get_or_refresh(&self) -> Zeroizing<String> {
+        // Fast path — token still valid.
+        {
+            let guard = self.token.read().await;
+            if Instant::now() + Duration::from_secs(EXPIRY_BUFFER_SECS) < guard.expires_at {
+                return guard.access_token.clone();
+            }
+        }
+
+        // Slow path — need to refresh.
+        let mut guard = self.token.write().await;
+
+        // Double-check after acquiring write lock (another task may have refreshed).
+        if Instant::now() + Duration::from_secs(EXPIRY_BUFFER_SECS) < guard.expires_at {
+            return guard.access_token.clone();
+        }
+
+        match exchange_token(&self.config, &self.tls_connector).await {
+            Ok((new_token, expires_in)) => {
+                debug!(
+                    "OAuth2 token refreshed, expires in {}s",
+                    expires_in.as_secs()
+                );
+                guard.access_token = new_token;
+                guard.expires_at = Instant::now() + expires_in;
+                guard.access_token.clone()
+            }
+            Err(e) => {
+                warn!(
+                    "OAuth2 token refresh failed, returning stale token: {}",
+                    e
+                );
+                guard.access_token.clone()
+            }
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Token exchange (HTTP POST)
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Perform a single `client_credentials` token exchange against the token
+/// endpoint described in `config`.
+///
+/// Returns `(access_token, expires_in_duration)`.
+async fn exchange_token(
+    config: &OAuth2ExchangeConfig,
+    tls_connector: &TlsConnector,
+) -> Result<(Zeroizing<String>, Duration)> {
+    let parsed = url::Url::parse(&config.token_url).map_err(|e| {
+        ProxyError::OAuth2Exchange(format!("invalid token_url '{}': {}", config.token_url, e))
+    })?;
+
+    let scheme = parsed.scheme();
+    let is_https = match scheme {
+        "https" => true,
+        "http" => false,
+        other => {
+            return Err(ProxyError::OAuth2Exchange(format!(
+                "unsupported scheme '{}' in token_url",
+                other
+            )));
+        }
+    };
+
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| {
+            ProxyError::OAuth2Exchange(format!("missing host in token_url '{}'", config.token_url))
+        })?
+        .to_string();
+
+    let default_port: u16 = if is_https { 443 } else { 80 };
+    let port = parsed.port().unwrap_or(default_port);
+    let path = if parsed.path().is_empty() {
+        "/"
+    } else {
+        parsed.path()
+    };
+    let path_with_query = match parsed.query() {
+        Some(q) => format!("{}?{}", path, q),
+        None => path.to_string(),
+    };
+
+    // ── Build form body ──────────────────────────────────────────────────
+    let body = build_token_request_body(
+        &config.client_id,
+        &config.client_secret,
+        &config.scope,
+    );
+
+    // ── Build HTTP/1.1 request ───────────────────────────────────────────
+    let request = Zeroizing::new(format!(
+        "POST {} HTTP/1.1\r\n\
+         Host: {}\r\n\
+         Content-Type: application/x-www-form-urlencoded\r\n\
+         Content-Length: {}\r\n\
+         Accept: application/json\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {}",
+        path_with_query,
+        host,
+        body.len(),
+        body.as_str()
+    ));
+
+    // ── TCP + optional TLS ───────────────────────────────────────────────
+    let addr = format!("{}:{}", host, port);
+
+    let response_bytes = tokio::time::timeout(EXCHANGE_TIMEOUT, async {
+        let tcp = TcpStream::connect(&addr).await.map_err(|e| {
+            ProxyError::OAuth2Exchange(format!("TCP connect to {}: {}", addr, e))
+        })?;
+
+        if is_https {
+            let server_name =
+                rustls::pki_types::ServerName::try_from(host.clone()).map_err(|_| {
+                    ProxyError::OAuth2Exchange(format!("invalid TLS server name: {}", host))
+                })?;
+
+            let mut tls = tls_connector
+                .connect(server_name, tcp)
+                .await
+                .map_err(|e| {
+                    ProxyError::OAuth2Exchange(format!("TLS handshake with {}: {}", host, e))
+                })?;
+
+            tls.write_all(request.as_bytes()).await.map_err(|e| {
+                ProxyError::OAuth2Exchange(format!("write to {}: {}", host, e))
+            })?;
+            tls.flush().await.map_err(|e| {
+                ProxyError::OAuth2Exchange(format!("flush to {}: {}", host, e))
+            })?;
+
+            read_http_response(&mut tls).await
+        } else {
+            let mut tcp = tcp;
+            tcp.write_all(request.as_bytes()).await.map_err(|e| {
+                ProxyError::OAuth2Exchange(format!("write to {}: {}", host, e))
+            })?;
+            tcp.flush().await.map_err(|e| {
+                ProxyError::OAuth2Exchange(format!("flush to {}: {}", host, e))
+            })?;
+
+            read_http_response(&mut tcp).await
+        }
+    })
+    .await
+    .map_err(|_| {
+        ProxyError::OAuth2Exchange(format!("token exchange with {} timed out", addr))
+    })??;
+
+    // ── Parse HTTP response ──────────────────────────────────────────────
+    let response_str = String::from_utf8(response_bytes).map_err(|_| {
+        ProxyError::OAuth2Exchange("token endpoint returned non-UTF-8 response".to_string())
+    })?;
+
+    // Split headers from body
+    let body_start = response_str
+        .find("\r\n\r\n")
+        .map(|i| i + 4)
+        .or_else(|| response_str.find("\n\n").map(|i| i + 2))
+        .ok_or_else(|| {
+            ProxyError::OAuth2Exchange("malformed HTTP response: no header/body separator".to_string())
+        })?;
+
+    // Check status code
+    let status_line = response_str.lines().next().unwrap_or("");
+    let status_code = parse_status_code(status_line);
+    if !(200..300).contains(&status_code) {
+        let body_preview: String = response_str[body_start..].chars().take(200).collect();
+        return Err(ProxyError::OAuth2Exchange(format!(
+            "token endpoint returned HTTP {}: {}",
+            status_code, body_preview
+        )));
+    }
+
+    let json_body = &response_str[body_start..];
+    parse_token_response(json_body)
+}
+
+/// Read a full HTTP response from a stream up to [`MAX_TOKEN_RESPONSE`] bytes.
+async fn read_http_response<S: tokio::io::AsyncRead + Unpin>(
+    stream: &mut S,
+) -> Result<Vec<u8>> {
+    let mut buf = Vec::with_capacity(4096);
+    let mut tmp = [0u8; 4096];
+    loop {
+        let n = stream.read(&mut tmp).await.map_err(|e| {
+            ProxyError::OAuth2Exchange(format!("read response: {}", e))
+        })?;
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        if buf.len() > MAX_TOKEN_RESPONSE {
+            return Err(ProxyError::OAuth2Exchange(format!(
+                "token response exceeds {} bytes",
+                MAX_TOKEN_RESPONSE
+            )));
+        }
+    }
+    Ok(buf)
+}
+
+/// Parse the HTTP status code from the status line.
+fn parse_status_code(line: &str) -> u16 {
+    // "HTTP/1.1 200 OK" -> "200"
+    let mut parts = line.split_whitespace();
+    parts
+        .nth(1)
+        .and_then(|code| code.parse().ok())
+        .unwrap_or(0)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Request / response helpers (pub(crate) for testing)
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Build the `application/x-www-form-urlencoded` body for the token request.
+///
+/// The `scope` parameter is omitted when empty.
+fn build_token_request_body(
+    client_id: &str,
+    client_secret: &str,
+    scope: &str,
+) -> Zeroizing<String> {
+    let mut body = Zeroizing::new(format!(
+        "grant_type=client_credentials&client_id={}&client_secret={}",
+        urlencoding::encode(client_id),
+        urlencoding::encode(client_secret),
+    ));
+    if !scope.is_empty() {
+        body.push_str(&format!("&scope={}", urlencoding::encode(scope)));
+    }
+    body
+}
+
+/// Parse a standard OAuth2 token response JSON.
+///
+/// Expects `{"access_token": "...", "expires_in": 3600, ...}`.
+/// - `access_token` is required.
+/// - `expires_in` defaults to [`DEFAULT_EXPIRES_IN_SECS`] if missing.
+fn parse_token_response(json: &str) -> Result<(Zeroizing<String>, Duration)> {
+    let value: serde_json::Value = serde_json::from_str(json).map_err(|e| {
+        ProxyError::OAuth2Exchange(format!("invalid JSON from token endpoint: {}", e))
+    })?;
+
+    let access_token = value
+        .get("access_token")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            ProxyError::OAuth2Exchange(
+                "token response missing 'access_token' field".to_string(),
+            )
+        })?;
+
+    let expires_in_secs = value
+        .get("expires_in")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(DEFAULT_EXPIRES_IN_SECS);
+
+    Ok((
+        Zeroizing::new(access_token.to_string()),
+        Duration::from_secs(expires_in_secs),
+    ))
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    // ── parse_token_response ─────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_token_response_success() {
+        let json = r#"{"access_token":"eyJhbGciOiJSUzI1NiJ9","token_type":"Bearer","expires_in":3600}"#;
+        let (token, expires) = parse_token_response(json).unwrap();
+        assert_eq!(token.as_str(), "eyJhbGciOiJSUzI1NiJ9");
+        assert_eq!(expires, Duration::from_secs(3600));
+    }
+
+    #[test]
+    fn test_parse_token_response_missing_expires_defaults() {
+        let json = r#"{"access_token":"tok_abc","token_type":"Bearer"}"#;
+        let (token, expires) = parse_token_response(json).unwrap();
+        assert_eq!(token.as_str(), "tok_abc");
+        assert_eq!(expires, Duration::from_secs(DEFAULT_EXPIRES_IN_SECS));
+    }
+
+    #[test]
+    fn test_parse_token_response_missing_access_token_errors() {
+        let json = r#"{"token_type":"Bearer","expires_in":3600}"#;
+        let err = parse_token_response(json).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("access_token"),
+            "error should mention access_token: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_parse_token_response_non_json_errors() {
+        let err = parse_token_response("this is not json").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid JSON"),
+            "error should mention invalid JSON: {}",
+            msg
+        );
+    }
+
+    // ── build_token_request_body ─────────────────────────────────────────
+
+    #[test]
+    fn test_build_token_request_body() {
+        let body = build_token_request_body("my-client", "s3cret!", "read write");
+        assert!(body.contains("grant_type=client_credentials"));
+        assert!(body.contains("client_id=my-client"));
+        assert!(body.contains("client_secret=s3cret%21"));
+        assert!(body.contains("scope=read%20write"));
+    }
+
+    #[test]
+    fn test_build_token_request_body_no_scope() {
+        let body = build_token_request_body("cid", "csec", "");
+        assert!(body.contains("grant_type=client_credentials"));
+        assert!(body.contains("client_id=cid"));
+        assert!(body.contains("client_secret=csec"));
+        assert!(!body.contains("scope="), "empty scope should be omitted");
+    }
+
+    // ── parse_status_code ────────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_status_code_200() {
+        assert_eq!(parse_status_code("HTTP/1.1 200 OK"), 200);
+    }
+
+    #[test]
+    fn test_parse_status_code_401() {
+        assert_eq!(parse_status_code("HTTP/1.1 401 Unauthorized"), 401);
+    }
+
+    #[test]
+    fn test_parse_status_code_garbage() {
+        assert_eq!(parse_status_code("not http"), 0);
+    }
+
+    // ── TokenCache expiry logic ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_token_cache_returns_valid_token() {
+        // Construct a cache with a token that expires far in the future.
+        let cache = make_test_cache("valid_token", Duration::from_secs(3600));
+        let token = cache.get_or_refresh().await;
+        assert_eq!(token.as_str(), "valid_token");
+    }
+
+    #[tokio::test]
+    async fn test_token_cache_detects_expiry() {
+        // Token that "expired" 10 seconds ago. Because exchange_token will
+        // fail (no real server), the stale token is returned.
+        let cache = make_test_cache("stale_token", Duration::from_secs(0));
+        // Manually set expires_at to the past.
+        {
+            let mut guard = cache.token.write().await;
+            guard.expires_at = Instant::now() - Duration::from_secs(10);
+        }
+        let token = cache.get_or_refresh().await;
+        // Should still get the stale token (graceful degradation).
+        assert_eq!(token.as_str(), "stale_token");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    /// Build a `TokenCache` with a pre-populated token for unit tests.
+    /// The `exchange_token` config points to a non-routable address so any
+    /// actual exchange attempt will fail (which is fine — we test cache logic).
+    fn make_test_cache(token: &str, ttl: Duration) -> TokenCache {
+        let config = OAuth2ExchangeConfig {
+            token_url: "https://127.0.0.1:1/oauth/token".to_string(),
+            client_id: Zeroizing::new("test-client".to_string()),
+            client_secret: Zeroizing::new("test-secret".to_string()),
+            scope: String::new(),
+        };
+
+        // Build a minimal TLS connector (never actually used in these tests).
+        let mut root_store = rustls::RootCertStore::empty();
+        root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+        let tls_config = rustls::ClientConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+        let tls_connector = TlsConnector::from(Arc::new(tls_config));
+
+        TokenCache {
+            token: Arc::new(RwLock::new(CachedToken {
+                access_token: Zeroizing::new(token.to_string()),
+                expires_at: Instant::now() + ttl,
+            })),
+            config,
+            tls_connector,
+        }
+    }
+}

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -81,18 +81,17 @@ pub async fn handle_reverse_proxy(
 
     // Extract service prefix from path (e.g., "/openai/v1/chat" -> ("openai", "/v1/chat"))
     let (service, upstream_path) = parse_service_prefix(&path)?;
-
-    // Look up route for service (required — provides upstream URL and L7 filtering)
     let route = ctx
         .route_store
         .get(&service)
         .ok_or_else(|| ProxyError::UnknownService {
             prefix: service.clone(),
         })?;
+    let static_cred = ctx.credential_store.get(&service);
+    let oauth2_route = ctx.credential_store.get_oauth2(&service);
 
-    // L7 endpoint filtering: check method+path against rules before any
-    // credential operations. Denied endpoints get 403 immediately.
-    // This check runs regardless of whether a credential is configured.
+    // L7 endpoint filtering runs for all reverse-proxy routes, whether or not
+    // they inject a credential.
     if !route.endpoint_rules.is_allowed(&method, &upstream_path) {
         let reason = format!(
             "endpoint denied: {} {} on service '{}'",
@@ -110,15 +109,28 @@ pub async fn handle_reverse_proxy(
         return Ok(());
     }
 
-    // Look up credential for service (optional — not all routes inject credentials)
-    let cred = ctx.credential_store.get(&service);
+    if let Some(oauth2_route) = oauth2_route {
+        return handle_oauth2_credential(
+            oauth2_route,
+            route,
+            &service,
+            &upstream_path,
+            &method,
+            &version,
+            stream,
+            remaining_header,
+            buffered_body,
+            ctx,
+        )
+        .await;
+    }
+
+    let cred = static_cred;
 
     // Authenticate the request. Every reverse proxy request must prove
     // possession of the session token, regardless of whether a credential
     // is configured — this is the localhost auth boundary.
     if let Some(cred) = cred {
-        // Credential route: validate phantom token from the service's auth
-        // header (mode-dependent: header, url_path, query_param, basic_auth).
         if let Err(e) = validate_phantom_token_for_mode(
             &cred.proxy_inject_mode,
             remaining_header,
@@ -138,30 +150,18 @@ pub async fn handle_reverse_proxy(
             send_error(stream, 401, "Unauthorized").await?;
             return Ok(());
         }
-    } else {
-        // No-credential route (L7 filtering only): validate session token
-        // via Proxy-Authorization header. This is the same auth path that
-        // CONNECT tunnels use — the token arrives via HTTPS_PROXY userinfo.
-        if let Err(e) = token::validate_proxy_auth(remaining_header, ctx.session_token) {
-            audit::log_denied(
-                ctx.audit_log,
-                audit::ProxyMode::Reverse,
-                &service,
-                0,
-                &e.to_string(),
-            );
-            send_error(stream, 407, "Proxy Authentication Required").await?;
-            return Ok(());
-        }
+    } else if let Err(e) = token::validate_proxy_auth(remaining_header, ctx.session_token) {
+        audit::log_denied(
+            ctx.audit_log,
+            audit::ProxyMode::Reverse,
+            &service,
+            0,
+            &e.to_string(),
+        );
+        send_error(stream, 407, "Proxy Authentication Required").await?;
+        return Ok(());
     }
 
-    // Transform the path based on injection mode (url_path and query_param modes).
-    // When no credential is configured, the path is forwarded unchanged.
-    //
-    // When the proxy-side injection mode differs from the upstream mode,
-    // strip proxy-side artifacts (path segment or query param containing the
-    // phantom token) before applying the upstream transform. Without this,
-    // the phantom token would leak to the upstream in the URL.
     let transformed_path = if let Some(cred) = cred {
         let cleaned_path = strip_proxy_artifacts(
             &upstream_path,
@@ -182,8 +182,6 @@ pub async fn handle_reverse_proxy(
         upstream_path.clone()
     };
 
-    // Parse upstream URL with potentially transformed path.
-    // Upstream URL comes from the route, not the credential.
     let upstream_url = format!(
         "{}{}",
         route.upstream.trim_end_matches('/'),
@@ -192,8 +190,6 @@ pub async fn handle_reverse_proxy(
     debug!("Forwarding to upstream: {} {}", method, upstream_url);
 
     let (upstream_host, upstream_port, upstream_path_full) = parse_upstream_url(&upstream_url)?;
-
-    // DNS resolve + host check via the filter
     let check = ctx.filter.check_host(&upstream_host, upstream_port).await?;
     if !check.result.is_allowed() {
         let reason = check.result.reason();
@@ -209,50 +205,20 @@ pub async fn handle_reverse_proxy(
         return Ok(());
     }
 
-    // Collect remaining request headers (excluding Host, Content-Length,
-    // and Proxy-Authorization which is proxy-hop-only).
-    // When a credential is present, also strip the credential's auth header
-    // (it contains the phantom token, not a real credential).
-    // When no credential is present, pass all other headers through —
-    // the caller may have a real Authorization header for the upstream.
     let strip_header = cred.map(|c| c.proxy_header_name.as_str()).unwrap_or("");
     let filtered_headers = filter_headers(remaining_header, strip_header);
     let content_length = extract_content_length(remaining_header);
+    let body = read_request_body(stream, content_length, buffered_body).await?;
 
-    // Read request body if present, with size limit.
-    // `buffered_body` may contain bytes the BufReader read ahead beyond
-    // headers; we prepend those to avoid data loss.
-    let body = if let Some(len) = content_length {
-        if len > MAX_REQUEST_BODY {
-            send_error(stream, 413, "Payload Too Large").await?;
-            return Ok(());
-        }
-        let mut buf = Vec::with_capacity(len);
-        let pre = buffered_body.len().min(len);
-        buf.extend_from_slice(&buffered_body[..pre]);
-        let remaining = len - pre;
-        if remaining > 0 {
-            let mut rest = vec![0u8; remaining];
-            stream.read_exact(&mut rest).await?;
-            buf.extend_from_slice(&rest);
-        }
-        buf
-    } else {
-        Vec::new()
-    };
-
-    // Connect to upstream over TLS using pre-resolved addresses.
-    // Use the per-route TLS connector (with custom CA) if configured,
-    // otherwise fall back to the shared default connector.
     let connector = route.tls_connector.as_ref().unwrap_or(ctx.tls_connector);
-    let upstream_result = connect_upstream_tls(
+    let mut tls_stream = match connect_upstream_tls(
         &upstream_host,
         upstream_port,
         &check.resolved_addrs,
         connector,
     )
-    .await;
-    let mut tls_stream = match upstream_result {
+    .await
+    {
         Ok(s) => s,
         Err(e) => {
             warn!("Upstream connection failed: {}", e);
@@ -268,34 +234,28 @@ pub async fn handle_reverse_proxy(
         }
     };
 
-    // Build the upstream request into a Zeroizing buffer since it may contain
-    // credential values. This ensures credentials are zeroed from heap memory
-    // when the buffer is dropped.
     let mut request = Zeroizing::new(format!(
         "{} {} {}\r\nHost: {}\r\n",
         method, upstream_path_full, version, upstream_host
     ));
 
-    // Inject credential based on mode (only if credential is configured)
     if let Some(cred) = cred {
         inject_credential_for_mode(cred, &mut request);
     }
 
-    // Forward filtered headers. The credential's auth header was already
-    // stripped by filter_headers() when a credential is present, so no
-    // additional skipping is needed here.
+    let auth_header_lower = cred.map(|c| c.header_name.to_lowercase());
     for (name, value) in &filtered_headers {
+        if let (Some(cred), Some(header_lower)) = (cred, auth_header_lower.as_ref()) {
+            if matches!(cred.inject_mode, InjectMode::Header | InjectMode::BasicAuth)
+                && name.to_lowercase() == *header_lower
+            {
+                continue;
+            }
+        }
         request.push_str(&format!("{}: {}\r\n", name, value));
     }
 
-    // Force Connection: close so the upstream closes after responding.
-    // nono opens a fresh TCP+TLS connection per request and never reuses
-    // them, so keep-alive only wastes resources and — critically — causes
-    // the read-until-EOF response loop below to block indefinitely when
-    // the server holds the connection open.
     request.push_str("Connection: close\r\n");
-
-    // Content-Length for body
     if !body.is_empty() {
         request.push_str(&format!("Content-Length: {}\r\n", body.len()));
     }
@@ -307,8 +267,173 @@ pub async fn handle_reverse_proxy(
     }
     tls_stream.flush().await?;
 
-    // Stream the response back to the client without buffering.
-    // This handles SSE (text/event-stream), chunked transfer, and regular responses.
+    let status_code = stream_response(&mut tls_stream, stream).await?;
+    audit::log_reverse_proxy(ctx.audit_log, &service, &method, &upstream_path, status_code);
+    Ok(())
+}
+
+/// Handle a reverse proxy request using an OAuth2 token cache.
+///
+/// Retrieves a (possibly refreshed) access token from the cache and injects
+/// it as `Authorization: Bearer <token>`. The agent authenticates with the
+/// session token via the `Authorization: Bearer <phantom>` header, which is
+/// validated and then replaced with the real OAuth2 access token.
+#[allow(clippy::too_many_arguments)]
+async fn handle_oauth2_credential(
+    oauth2_route: &crate::credential::OAuth2Route,
+    route: &crate::route::LoadedRoute,
+    service: &str,
+    upstream_path: &str,
+    method: &str,
+    version: &str,
+    stream: &mut TcpStream,
+    remaining_header: &[u8],
+    buffered_body: &[u8],
+    ctx: &ReverseProxyCtx<'_>,
+) -> Result<()> {
+    // Get (possibly refreshed) OAuth2 access token
+    let access_token = oauth2_route.cache.get_or_refresh().await;
+
+    // Validate session token from Authorization header (phantom token pattern).
+    // OAuth2 routes still require the agent to authenticate with the session
+    // token — this prevents unauthorized access to the token-exchanged credential.
+    if let Err(e) = validate_phantom_token(remaining_header, "Authorization", ctx.session_token) {
+        audit::log_denied(
+            ctx.audit_log,
+            audit::ProxyMode::Reverse,
+            service,
+            0,
+            &e.to_string(),
+        );
+        send_error(stream, 401, "Unauthorized").await?;
+        return Ok(());
+    }
+
+    let upstream_url = format!(
+        "{}{}",
+        oauth2_route.upstream.trim_end_matches('/'),
+        upstream_path
+    );
+    debug!("OAuth2 forwarding to upstream: {} {}", method, upstream_url);
+
+    let (upstream_host, upstream_port, upstream_path_full) = parse_upstream_url(&upstream_url)?;
+
+    // DNS resolve + host check via the filter
+    let check = ctx.filter.check_host(&upstream_host, upstream_port).await?;
+    if !check.result.is_allowed() {
+        let reason = check.result.reason();
+        warn!("Upstream host denied by filter: {}", reason);
+        send_error(stream, 403, "Forbidden").await?;
+        audit::log_denied(
+            ctx.audit_log,
+            audit::ProxyMode::Reverse,
+            service,
+            0,
+            &reason,
+        );
+        return Ok(());
+    }
+
+    // Collect remaining request headers, stripping the client-supplied
+    // Authorization header that carries the phantom token.
+    let filtered_headers = filter_headers(remaining_header, "Authorization");
+    let content_length = extract_content_length(remaining_header);
+
+    // Read request body
+    let body = read_request_body(stream, content_length, buffered_body).await?;
+
+    // Connect to upstream over TLS, honoring any per-route custom CA / mTLS.
+    let connector = route.tls_connector.as_ref().unwrap_or(ctx.tls_connector);
+    let mut tls_stream = match connect_upstream_tls(
+        &upstream_host,
+        upstream_port,
+        &check.resolved_addrs,
+        connector,
+    )
+    .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("Upstream connection failed: {}", e);
+            send_error(stream, 502, "Bad Gateway").await?;
+            audit::log_denied(
+                ctx.audit_log,
+                audit::ProxyMode::Reverse,
+                service,
+                0,
+                &e.to_string(),
+            );
+            return Ok(());
+        }
+    };
+
+    // Build upstream request with Bearer token injection
+    let mut request = Zeroizing::new(format!(
+        "{} {} {}\r\nHost: {}\r\n",
+        method, upstream_path_full, version, upstream_host
+    ));
+
+    // Inject OAuth2 access token as Authorization: Bearer
+    request.push_str(&format!("Authorization: Bearer {}\r\n", access_token.as_str()));
+
+    // Forward filtered headers (auth headers already stripped by filter_headers)
+    for (name, value) in &filtered_headers {
+        request.push_str(&format!("{}: {}\r\n", name, value));
+    }
+
+    if !body.is_empty() {
+        request.push_str(&format!("Content-Length: {}\r\n", body.len()));
+    }
+    request.push_str("\r\n");
+
+    tls_stream.write_all(request.as_bytes()).await?;
+    if !body.is_empty() {
+        tls_stream.write_all(&body).await?;
+    }
+    tls_stream.flush().await?;
+
+    // Stream the response back
+    let status_code = stream_response(&mut tls_stream, stream).await?;
+
+    audit::log_reverse_proxy(ctx.audit_log, service, method, upstream_path, status_code);
+    Ok(())
+}
+
+/// Read request body from the client stream with size limit.
+///
+/// `buffered_body` contains bytes the BufReader read ahead beyond headers.
+async fn read_request_body(
+    stream: &mut TcpStream,
+    content_length: Option<usize>,
+    buffered_body: &[u8],
+) -> Result<Vec<u8>> {
+    if let Some(len) = content_length {
+        if len > MAX_REQUEST_BODY {
+            send_error(stream, 413, "Payload Too Large").await?;
+            return Ok(Vec::new());
+        }
+        let mut buf = Vec::with_capacity(len);
+        let pre = buffered_body.len().min(len);
+        buf.extend_from_slice(&buffered_body[..pre]);
+        let remaining = len - pre;
+        if remaining > 0 {
+            let mut rest = vec![0u8; remaining];
+            stream.read_exact(&mut rest).await?;
+            buf.extend_from_slice(&rest);
+        }
+        Ok(buf)
+    } else {
+        Ok(Vec::new())
+    }
+}
+
+/// Stream the upstream TLS response back to the client.
+///
+/// Returns the HTTP status code parsed from the first chunk.
+async fn stream_response(
+    tls_stream: &mut tokio_rustls::client::TlsStream<TcpStream>,
+    stream: &mut TcpStream,
+) -> Result<u16> {
     let mut response_buf = [0u8; 8192];
     let mut status_code: u16 = 502;
     let mut first_chunk = true;
@@ -323,9 +448,6 @@ pub async fn handle_reverse_proxy(
             }
         };
 
-        // Parse status from first chunk. The HTTP status line format is:
-        // "HTTP/1.1 200 OK\r\n..." — we need the 3-digit code after the
-        // first space. We scan up to 32 bytes (enough for any valid status line).
         if first_chunk {
             status_code = parse_response_status(&response_buf[..n]);
             first_chunk = false;
@@ -335,14 +457,7 @@ pub async fn handle_reverse_proxy(
         stream.flush().await?;
     }
 
-    audit::log_reverse_proxy(
-        ctx.audit_log,
-        &service,
-        &method,
-        &upstream_path,
-        status_code,
-    );
-    Ok(())
+    Ok(status_code)
 }
 
 /// Parse an HTTP request line into (method, path, version).

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -208,7 +208,10 @@ pub async fn handle_reverse_proxy(
     let strip_header = cred.map(|c| c.proxy_header_name.as_str()).unwrap_or("");
     let filtered_headers = filter_headers(remaining_header, strip_header);
     let content_length = extract_content_length(remaining_header);
-    let body = read_request_body(stream, content_length, buffered_body).await?;
+    let body = match read_request_body(stream, content_length, buffered_body).await? {
+        Some(body) => body,
+        None => return Ok(()),
+    };
 
     let connector = route.tls_connector.as_ref().unwrap_or(ctx.tls_connector);
     let mut tls_stream = match connect_upstream_tls(
@@ -340,7 +343,10 @@ async fn handle_oauth2_credential(
     let content_length = extract_content_length(remaining_header);
 
     // Read request body
-    let body = read_request_body(stream, content_length, buffered_body).await?;
+    let body = match read_request_body(stream, content_length, buffered_body).await? {
+        Some(body) => body,
+        None => return Ok(()),
+    };
 
     // Connect to upstream over TLS, honoring any per-route custom CA / mTLS.
     let connector = route.tls_connector.as_ref().unwrap_or(ctx.tls_connector);
@@ -406,11 +412,11 @@ async fn read_request_body(
     stream: &mut TcpStream,
     content_length: Option<usize>,
     buffered_body: &[u8],
-) -> Result<Vec<u8>> {
+) -> Result<Option<Vec<u8>>> {
     if let Some(len) = content_length {
         if len > MAX_REQUEST_BODY {
             send_error(stream, 413, "Payload Too Large").await?;
-            return Ok(Vec::new());
+            return Ok(None);
         }
         let mut buf = Vec::with_capacity(len);
         let pre = buffered_body.len().min(len);
@@ -421,9 +427,9 @@ async fn read_request_body(
             stream.read_exact(&mut rest).await?;
             buf.extend_from_slice(&rest);
         }
-        Ok(buf)
+        Ok(Some(buf))
     } else {
-        Ok(Vec::new())
+        Ok(Some(Vec::new()))
     }
 }
 

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -271,7 +271,13 @@ pub async fn handle_reverse_proxy(
     tls_stream.flush().await?;
 
     let status_code = stream_response(&mut tls_stream, stream).await?;
-    audit::log_reverse_proxy(ctx.audit_log, &service, &method, &upstream_path, status_code);
+    audit::log_reverse_proxy(
+        ctx.audit_log,
+        &service,
+        &method,
+        &upstream_path,
+        status_code,
+    );
     Ok(())
 }
 
@@ -380,7 +386,10 @@ async fn handle_oauth2_credential(
     ));
 
     // Inject OAuth2 access token as Authorization: Bearer
-    request.push_str(&format!("Authorization: Bearer {}\r\n", access_token.as_str()));
+    request.push_str(&format!(
+        "Authorization: Bearer {}\r\n",
+        access_token.as_str()
+    ));
 
     // Forward filtered headers (auth headers already stripped by filter_headers)
     for (name, value) in &filtered_headers {

--- a/crates/nono-proxy/src/route.rs
+++ b/crates/nono-proxy/src/route.rs
@@ -399,6 +399,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            oauth2: None,
         }];
 
         let store = RouteStore::load(&routes).unwrap();
@@ -433,6 +434,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            oauth2: None,
         }];
 
         let store = RouteStore::load(&routes).unwrap();
@@ -458,6 +460,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            oauth2: None,
         }];
 
         let store = RouteStore::load(&routes).unwrap();
@@ -484,6 +487,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                oauth2: None,
             },
             RouteConfig {
                 prefix: "anthropic".to_string(),
@@ -501,6 +505,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                oauth2: None,
             },
         ];
 
@@ -819,6 +824,7 @@ h56ZLEEqHfVWFhJWIKRSabtxYPV/VJyMv+lo3L0QwSKsouHs3dtF1zVQ
             tls_ca: None,
             tls_client_cert: Some(cert_path.to_str().unwrap().to_string()),
             tls_client_key: Some(key_path.to_str().unwrap().to_string()),
+            oauth2: None,
         }];
 
         let store = RouteStore::load(&routes).expect("should load mTLS route");

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -219,25 +219,11 @@ pub async fn start(config: ProxyConfig) -> Result<ProxyHandle> {
     } else {
         RouteStore::load(&config.routes)?
     };
-
-    // Load credentials for reverse proxy routes (only routes with credential_key)
-    let credential_store = if config.routes.is_empty() {
-        CredentialStore::empty()
-    } else {
-        CredentialStore::load(&config.routes)?
-    };
-    let loaded_routes = credential_store.loaded_prefixes();
-
-    // Build filter
-    let filter = if config.allowed_hosts.is_empty() {
-        ProxyFilter::allow_all()
-    } else {
-        ProxyFilter::new(&config.allowed_hosts)
-    };
-
     // Build shared TLS connector (root cert store is expensive to construct).
     // Use the ring provider explicitly to avoid ambiguity when multiple
     // crypto providers are in the dependency tree.
+    // Must be created before CredentialStore::load() because OAuth2 token
+    // exchange needs TLS.
     let mut root_store = rustls::RootCertStore::empty();
     root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     let tls_config = rustls::ClientConfig::builder_with_provider(Arc::new(
@@ -248,6 +234,21 @@ pub async fn start(config: ProxyConfig) -> Result<ProxyHandle> {
     .with_root_certificates(root_store)
     .with_no_client_auth();
     let tls_connector = tokio_rustls::TlsConnector::from(Arc::new(tls_config));
+
+    // Load credentials for reverse proxy routes (static keystore + OAuth2)
+    let credential_store = if config.routes.is_empty() {
+        CredentialStore::empty()
+    } else {
+        CredentialStore::load(&config.routes, &tls_connector)?
+    };
+    let loaded_routes = credential_store.loaded_prefixes();
+
+    // Build filter
+    let filter = if config.allowed_hosts.is_empty() {
+        ProxyFilter::allow_all()
+    } else {
+        ProxyFilter::new(&config.allowed_hosts)
+    };
 
     // Build bypass matcher from external proxy config (once, not per-request)
     let bypass_matcher = config

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -610,6 +610,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                oauth2: None,
             }],
             ..Default::default()
         };
@@ -654,6 +655,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                oauth2: None,
             }],
             ..Default::default()
         };
@@ -707,6 +709,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                oauth2: None,
             }],
             ..Default::default()
         };
@@ -766,6 +769,7 @@ mod tests {
                     tls_ca: None,
                     tls_client_cert: None,
                     tls_client_key: None,
+                    oauth2: None,
                 },
                 crate::config::RouteConfig {
                     prefix: "github".to_string(),
@@ -783,6 +787,7 @@ mod tests {
                     tls_ca: None,
                     tls_client_cert: None,
                     tls_client_key: None,
+                    oauth2: None,
                 },
             ],
             ..Default::default()

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -850,6 +850,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                oauth2: None,
             }],
             ..Default::default()
         };
@@ -883,6 +884,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                oauth2: None,
             }],
             ..Default::default()
         };
@@ -933,6 +935,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                oauth2: None,
             }],
             ..Default::default()
         };
@@ -970,6 +973,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                oauth2: None,
             }],
             ..Default::default()
         };


### PR DESCRIPTION
Addresses discussion point 3 in #424

## Summary

Adds OAuth2 `client_credentials` token exchange to the credential proxy. The agent never sees client secrets or access tokens — it makes plain HTTP requests and the proxy handles authentication transparently.

Profile config (mutually exclusive with `credential_key`):
```json
{
  "custom_credentials": {
    "mcp": {
      "upstream": "https://mcp.example.com",
      "auth": {
        "token_url": "https://keycloak.example.com/realms/app/protocol/openid-connect/token",
        "client_id": "file:///vault/secrets/mcp-client-id",
        "client_secret": "file:///vault/secrets/mcp-client-secret",
        "scope": "openid"
      },
      "inject_header": "Authorization"
    }
  }
}
```

- Token exchange at startup, auto-refresh when within 30s of expiry
- `client_id` and `client_secret` support `file://` and `env://` URI schemes
- Token cache with TTL — no redundant exchanges
- Composes with `file://` credential source (PR #515)

## Production context

Running for a week in a Kubernetes cluster with Landlock V4 enforcement. Used for Keycloak OIDC authentication to internal MCP services. Agents authenticate transparently without seeing any credentials.

## Security considerations

- Client secrets are read at startup before the sandbox activates
- Access tokens are held in proxy memory only, never exposed to the child process
- Token refresh happens inside the proxy — the agent has no visibility into the OAuth2 flow
- Mutual exclusion with `credential_key` prevents ambiguous credential config

## Test plan

- [x] OAuth2 config deserializes from profile JSON
- [x] `client_id` / `client_secret` support `file://` and `env://`
- [x] Mutual exclusion with `credential_key` validated
- [x] Token cache respects TTL
- [x] All existing tests pass