### PR TITLE
chore: add DCO sign-off requirement to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,7 @@ make fmt             # Auto-format
 - **Environment variables in tests**: Tests that modify `HOME`, `TMPDIR`, `XDG_CONFIG_HOME`, or other env vars must save and restore the original value. Rust runs unit tests in parallel within the same process, so an unrestored env var causes flaky failures in unrelated tests (e.g. `config::check_sensitive_path` fails when another test temporarily sets `HOME` to a fake path). Always use save/restore pattern and keep the modified window as short as possible.
 - **Attributes**: Apply `#[must_use]` to functions returning critical Results.
 - **Lazy use of dead code**: Avoid `#[allow(dead_code)]`. If code is unused, either remove it or write tests that use it.
+- **Commits**: All commits must include a DCO sign-off line (`Signed-off-by: Name <email>`).
 
 ## Key Design Decisions
 


### PR DESCRIPTION
I noticed I am not the only one to always forget about it, this should make it smoother in the future.