### PR TITLE
feat: add execute and execute-file flags

### DIFF
--- a/bindings/c/include/nono.h
+++ b/bindings/c/include/nono.h
@@ -24,6 +24,12 @@
 
 #define NONO_ACCESS_MODE_READ_WRITE 2
 
+#define NONO_ACCESS_MODE_EXECUTE 3
+
+#define NONO_ACCESS_MODE_READ_EXECUTE 4
+
+#define NONO_ACCESS_MODE_READ_WRITE_EXECUTE 5
+
 /**
  * Sentinel value returned on error (NULL pointer, out-of-bounds index).
  */

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -14,6 +14,9 @@ use std::os::raw::c_char;
 pub const NONO_ACCESS_MODE_READ: u32 = 0;
 pub const NONO_ACCESS_MODE_WRITE: u32 = 1;
 pub const NONO_ACCESS_MODE_READ_WRITE: u32 = 2;
+pub const NONO_ACCESS_MODE_EXECUTE: u32 = 3;
+pub const NONO_ACCESS_MODE_READ_EXECUTE: u32 = 4;
+pub const NONO_ACCESS_MODE_READ_WRITE_EXECUTE: u32 = 5;
 /// Sentinel value returned on error (NULL pointer, out-of-bounds index).
 pub const NONO_ACCESS_MODE_INVALID: u32 = u32::MAX;
 
@@ -25,6 +28,9 @@ pub fn validate_access_mode(raw: u32) -> Option<nono::AccessMode> {
         NONO_ACCESS_MODE_READ => Some(nono::AccessMode::Read),
         NONO_ACCESS_MODE_WRITE => Some(nono::AccessMode::Write),
         NONO_ACCESS_MODE_READ_WRITE => Some(nono::AccessMode::ReadWrite),
+        NONO_ACCESS_MODE_EXECUTE => Some(nono::AccessMode::Execute),
+        NONO_ACCESS_MODE_READ_EXECUTE => Some(nono::AccessMode::ReadExecute),
+        NONO_ACCESS_MODE_READ_WRITE_EXECUTE => Some(nono::AccessMode::ReadWriteExecute),
         _ => None,
     }
 }
@@ -36,6 +42,9 @@ pub fn access_mode_to_raw(mode: nono::AccessMode) -> u32 {
         nono::AccessMode::Read => NONO_ACCESS_MODE_READ,
         nono::AccessMode::Write => NONO_ACCESS_MODE_WRITE,
         nono::AccessMode::ReadWrite => NONO_ACCESS_MODE_READ_WRITE,
+        nono::AccessMode::Execute => NONO_ACCESS_MODE_EXECUTE,
+        nono::AccessMode::ReadExecute => NONO_ACCESS_MODE_READ_EXECUTE,
+        nono::AccessMode::ReadWriteExecute => NONO_ACCESS_MODE_READ_WRITE_EXECUTE,
     }
 }
 

--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -244,6 +244,21 @@
           "type": "array",
           "items": { "type": "string" },
           "description": "Single files with write-only access."
+        },
+        "execute": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Directories or files with execute-only access (no read or write)."
+        },
+        "readexecute": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Directories or files with read+execute access."
+        },
+        "readwriteexecute": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Directories or files with read+write+execute access."
         }
       }
     },
@@ -271,6 +286,21 @@
           "type": "array",
           "items": { "type": "string" },
           "description": "Additional read-write directories to allow."
+        },
+        "add_allow_execute": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional execute-only paths to allow."
+        },
+        "add_allow_readexecute": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional read+execute paths to allow."
+        },
+        "add_allow_readwriteexecute": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional read+write+execute paths to allow."
         },
         "add_deny_access": {
           "type": "array",

--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -175,6 +175,21 @@
           "/Volumes",
           "/run",
           "/nix"
+        ],
+        "execute": [
+          "/bin",
+          "/sbin",
+          "/usr/bin",
+          "/usr/sbin",
+          "/usr/local/bin",
+          "/usr/lib",
+          "/usr/local/lib",
+          "/System/Library",
+          "/Library",
+          "/Library/Frameworks",
+          "/private/var/db/dyld",
+          "/var/db/dyld",
+          "/opt/homebrew"
         ]
       },
       "symlink_pairs": {
@@ -247,7 +262,26 @@
           "/proc/stat",
           "/proc/loadavg",
           "/proc/version",
-          "/proc/filesystems"
+          "/proc/filesystems",
+          "/home/linuxbrew/.linuxbrew"
+        ],
+        "execute": [
+          "/bin",
+          "/sbin",
+          "/usr/bin",
+          "/usr/sbin",
+          "/usr/local/bin",
+          "/lib",
+          "/lib64",
+          "/lib/x86_64-linux-gnu",
+          "/lib/aarch64-linux-gnu",
+          "/usr/lib",
+          "/usr/lib64",
+          "/usr/lib/x86_64-linux-gnu",
+          "/usr/lib/aarch64-linux-gnu",
+          "/usr/local/lib",
+          "/usr/local/lib64",
+          "/home/linuxbrew/.linuxbrew"
         ]
       }
     },
@@ -352,13 +386,16 @@
           "~/.local/share/man",
           "~/.local/share/bash-completion",
           "~/.local/share/zsh"
+        ],
+        "execute": [
+          "~/.local/bin"
         ]
       }
     },
     "node_runtime": {
       "description": "Node.js runtime and package manager paths",
       "allow": {
-        "read": [
+        "readwriteexecute": [
           "~/.nvm",
           "~/.fnm",
           "~/.npm",
@@ -376,6 +413,9 @@
       "allow": {
         "read": [
           "~/.opencode/bin"
+        ],
+        "execute": [
+          "~/.opencode/bin"
         ]
       }
     },
@@ -383,6 +423,12 @@
       "description": "Python runtime paths (pyenv, conda, uv)",
       "allow": {
         "read": [
+          "~/.pyenv",
+          "~/.local/lib",
+          "~/.local/share/uv",
+          "~/.conda"
+        ],
+        "execute": [
           "~/.pyenv",
           "~/.local/lib",
           "~/.local/share/uv",
@@ -396,6 +442,10 @@
         "read": [
           "~/.cargo",
           "~/.rustup"
+        ],
+        "execute": [
+          "~/.cargo",
+          "~/.rustup"
         ]
       }
     },
@@ -403,6 +453,10 @@
       "description": "Go toolchain paths",
       "allow": {
         "read": [
+          "~/go",
+          "/usr/local/go"
+        ],
+        "execute": [
           "~/go",
           "/usr/local/go"
         ]
@@ -413,6 +467,11 @@
       "platform": "macos",
       "allow": {
         "read": [
+          "/opt/homebrew",
+          "/usr/local/Cellar",
+          "/usr/local/opt"
+        ],
+        "execute": [
           "/opt/homebrew",
           "/usr/local/Cellar",
           "/usr/local/opt"
@@ -489,6 +548,13 @@
         "read": [
           "~/.nix-profile",
           "~/.nix-defexpr",
+          "/run/current-system/sw",
+          "/etc/profiles/per-user",
+          "/nix/var/nix/profiles",
+          "/nix/store"
+        ],
+        "execute": [
+          "~/.nix-profile",
           "/run/current-system/sw",
           "/etc/profiles/per-user",
           "/nix/var/nix/profiles",
@@ -620,8 +686,12 @@
         "signal_mode": "isolated"
       },
       "filesystem": {},
-      "network": { "block": false },
-      "workdir": { "access": "none" },
+      "network": {
+        "block": false
+      },
+      "workdir": {
+        "access": "none"
+      },
       "interactive": false
     },
     "linux-host-compat": {
@@ -641,8 +711,12 @@
         "signal_mode": "isolated"
       },
       "filesystem": {},
-      "network": { "block": false },
-      "workdir": { "access": "none" },
+      "network": {
+        "block": false
+      },
+      "workdir": {
+        "access": "none"
+      },
       "interactive": false
     },
     "openclaw": {
@@ -654,7 +728,9 @@
         "author": "nono-project"
       },
       "security": {
-        "groups": ["node_runtime"],
+        "groups": [
+          "node_runtime"
+        ],
         "signal_mode": "isolated"
       },
       "filesystem": {
@@ -664,10 +740,17 @@
           "$TMPDIR/openclaw-$UID"
         ]
       },
-      "network": { "block": false },
-      "workdir": { "access": "read" },
+      "network": {
+        "block": false
+      },
+      "workdir": {
+        "access": "read"
+      },
       "undo": {
-        "exclude_patterns": ["node_modules", ".next"]
+        "exclude_patterns": [
+          "node_modules",
+          ".next"
+        ]
       },
       "interactive": false
     },
@@ -680,11 +763,19 @@
         "author": "nono-project"
       },
       "security": {
-        "groups": ["user_caches_macos", "user_caches_linux", "node_runtime", "opencode_linux", "linux_sysfs_read", "git_config", "unlink_protection"],
+        "groups": [
+          "user_caches_macos",
+          "user_caches_linux",
+          "node_runtime",
+          "opencode_linux",
+          "linux_sysfs_read",
+          "git_config",
+          "unlink_protection"
+        ],
         "signal_mode": "isolated"
       },
       "filesystem": {
-        "allow": [
+        "readwriteexecute": [
           "$HOME/.opencode",
           "$HOME/.config/opencode",
           "$HOME/.cache/opencode",
@@ -694,10 +785,17 @@
           "$TMPDIR"
         ]
       },
-      "network": { "block": false },
-      "workdir": { "access": "readwrite" },
+      "network": {
+        "block": false
+      },
+      "workdir": {
+        "access": "readwrite"
+      },
       "undo": {
-        "exclude_patterns": ["node_modules", ".next"]
+        "exclude_patterns": [
+          "node_modules",
+          ".next"
+        ]
       },
       "interactive": true
     },
@@ -710,13 +808,20 @@
         "author": "nono-project"
       },
       "security": {
-        "groups": ["python_runtime"],
+        "groups": [
+          "python_runtime"
+        ],
         "signal_mode": "isolated",
         "ipc_mode": "full"
       },
       "filesystem": {},
-      "network": { "block": false, "network_profile": "developer" },
-      "workdir": { "access": "readwrite" },
+      "network": {
+        "block": false,
+        "network_profile": "developer"
+      },
+      "workdir": {
+        "access": "readwrite"
+      },
       "interactive": false
     },
     "node-dev": {
@@ -728,12 +833,19 @@
         "author": "nono-project"
       },
       "security": {
-        "groups": ["node_runtime"],
+        "groups": [
+          "node_runtime"
+        ],
         "signal_mode": "isolated"
       },
       "filesystem": {},
-      "network": { "block": false, "network_profile": "developer" },
-      "workdir": { "access": "readwrite" },
+      "network": {
+        "block": false,
+        "network_profile": "developer"
+      },
+      "workdir": {
+        "access": "readwrite"
+      },
       "interactive": false
     },
     "go-dev": {
@@ -745,12 +857,19 @@
         "author": "nono-project"
       },
       "security": {
-        "groups": ["go_runtime"],
+        "groups": [
+          "go_runtime"
+        ],
         "signal_mode": "isolated"
       },
       "filesystem": {},
-      "network": { "block": false, "network_profile": "developer" },
-      "workdir": { "access": "readwrite" },
+      "network": {
+        "block": false,
+        "network_profile": "developer"
+      },
+      "workdir": {
+        "access": "readwrite"
+      },
       "interactive": false
     },
     "rust-dev": {
@@ -762,12 +881,19 @@
         "author": "nono-project"
       },
       "security": {
-        "groups": ["rust_runtime"],
+        "groups": [
+          "rust_runtime"
+        ],
         "signal_mode": "isolated"
       },
       "filesystem": {},
-      "network": { "block": false, "network_profile": "developer" },
-      "workdir": { "access": "readwrite" },
+      "network": {
+        "block": false,
+        "network_profile": "developer"
+      },
+      "workdir": {
+        "access": "readwrite"
+      },
       "interactive": false
     },
     "swival": {
@@ -797,11 +923,21 @@
           "$HOME/.local/share/swival"
         ]
       },
-      "network": { "block": false },
-      "workdir": { "access": "readwrite" },
+      "network": {
+        "block": false
+      },
+      "workdir": {
+        "access": "readwrite"
+      },
       "undo": {
-        "exclude_patterns": ["node_modules", "__pycache__", ".swival"],
-        "exclude_globs": ["*.pyc"]
+        "exclude_patterns": [
+          "node_modules",
+          "__pycache__",
+          ".swival"
+        ],
+        "exclude_globs": [
+          "*.pyc"
+        ]
       },
       "interactive": true
     }

--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -395,14 +395,21 @@
     "node_runtime": {
       "description": "Node.js runtime and package manager paths",
       "allow": {
-        "readwriteexecute": [
+        "read": [
+          "~/.node",
+          "~/.node-gyp"
+        ],
+        "readexecute": [
           "~/.nvm",
           "~/.fnm",
-          "~/.npm",
-          "~/.node",
           "~/.local/share/fnm",
-          "/usr/local/lib/node_modules",
-          "~/Library/pnpm",
+          "/usr/local/lib/node_modules"
+        ],
+        "readwrite": [
+          "~/.npm",
+          "~/Library/pnpm"
+        ],
+        "readwriteexecute": [
           "~/.local/share/pnpm"
         ]
       }

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -845,6 +845,7 @@ impl CapabilitySetExt for CapabilitySet {
             &protected_roots,
             &mut caps,
             "Profile policy path",
+            allow_parent_of_protected,
         )?;
         apply_profile_dir_allows(
             &profile.policy.add_allow_readexecute,
@@ -853,6 +854,7 @@ impl CapabilitySetExt for CapabilitySet {
             &protected_roots,
             &mut caps,
             "Profile policy path",
+            allow_parent_of_protected,
         )?;
         apply_profile_dir_allows(
             &profile.policy.add_allow_readwriteexecute,
@@ -861,6 +863,7 @@ impl CapabilitySetExt for CapabilitySet {
             &protected_roots,
             &mut caps,
             "Profile policy path",
+            allow_parent_of_protected,
         )?;
 
         for path_template in &profile.policy.add_deny_access {

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -468,86 +468,13 @@ pub trait CapabilitySetExt {
 impl CapabilitySetExt for CapabilitySet {
     fn from_args(args: &SandboxArgs) -> Result<(CapabilitySet, bool)> {
         let mut caps = CapabilitySet::new();
-        let protected_roots = ProtectedRoots::from_defaults()?;
 
         // Resolve base policy groups (system paths, deny rules, dangerous commands)
         let loaded_policy = policy::load_embedded_policy()?;
         let default_groups = default_profile_groups()?;
         let mut resolved = policy::resolve_groups(&loaded_policy, &default_groups, &mut caps)?;
 
-        // Directory permissions (canonicalize handles existence check atomically)
-        for path in &args.allow {
-            validate_requested_dir(path, "CLI", &protected_roots, false)?;
-            if let Some(cap) =
-                try_new_dir(path, AccessMode::ReadWrite, "Skipping non-existent path")?
-            {
-                caps.add_fs(cap);
-            }
-        }
-
-        for path in &args.read {
-            validate_requested_dir(path, "CLI", &protected_roots, false)?;
-            if let Some(cap) = try_new_dir(path, AccessMode::Read, "Skipping non-existent path")? {
-                caps.add_fs(cap);
-            }
-        }
-
-        for path in &args.write {
-            validate_requested_dir(path, "CLI", &protected_roots, false)?;
-            if let Some(cap) = try_new_dir(path, AccessMode::Write, "Skipping non-existent path")? {
-                caps.add_fs(cap);
-            }
-        }
-
-        // Single file permissions
-        for path in &args.allow_file {
-            validate_requested_file(path, "CLI", &protected_roots, false)?;
-            if let Some(cap) =
-                try_new_file(path, AccessMode::ReadWrite, "Skipping non-existent file")?
-            {
-                caps.add_fs(cap);
-            }
-        }
-
-        for path in &args.read_file {
-            validate_requested_file(path, "CLI", &protected_roots, false)?;
-            if let Some(cap) = try_new_file(path, AccessMode::Read, "Skipping non-existent file")? {
-                caps.add_fs(cap);
-            }
-        }
-
-        for path in &args.write_file {
-            validate_requested_file(path, "CLI", &protected_roots, false)?;
-            if let Some(cap) = try_new_file(path, AccessMode::Write, "Skipping non-existent file")?
-            {
-                caps.add_fs(cap);
-            }
-        }
-
-        // AF_UNIX socket capabilities (issue #685 / #696). See
-        // add_cli_unix_socket_caps for the full flag handling + implied
-        // fs-grant sugar.
-        add_cli_unix_socket_caps(&mut caps, args, &protected_roots, false)?;
-
-        // Execute permissions (directory and single file). Standardized to
-        // ReadExecute since execve(2) requires reading the binary header.
-        for path in &args.execute {
-            validate_requested_dir(path, "CLI", &protected_roots, false)?;
-            if let Some(cap) =
-                try_new_dir(path, AccessMode::ReadExecute, "Skipping non-existent path")?
-            {
-                caps.add_fs(cap);
-            }
-        }
-
-        for path in &args.execute_file {
-            validate_requested_file(path, "CLI", &protected_roots, false)?;
-            if let Some(cap) =
-                try_new_file(path, AccessMode::ReadExecute, "Skipping non-existent file")?
-            {
-                caps.add_fs(cap);
-            }
-        }
+        apply_cli_fs_grants(&mut caps, args, false)?;
 
         apply_cli_network_mode(&mut caps, args);
 
@@ -1103,9 +1030,48 @@ fn add_cli_overrides(
     args: &SandboxArgs,
     allow_parent_of_protected: bool,
 ) -> Result<()> {
+    apply_cli_fs_grants(caps, args, allow_parent_of_protected)?;
+
+    apply_cli_network_mode(caps, args);
+
+    for port in &args.allow_port {
+        caps.add_localhost_port(*port);
+    }
+
+    #[cfg(target_os = "macos")]
+    if !args.allow_connect_port.is_empty() {
+        return Err(NonoError::UnsupportedPlatform(
+            "--allow-connect-port is not supported on macOS: Seatbelt cannot filter by TCP port. \
+             Use --allow-domain for host-level filtering, or ProxyOnly mode."
+                .to_string(),
+        ));
+    }
+    #[cfg(not(target_os = "macos"))]
+    for port in &args.allow_connect_port {
+        caps.add_tcp_connect_port(*port);
+    }
+
+    for cmd in &args.allow_command {
+        caps.add_allowed_command(cmd.clone());
+    }
+
+    for cmd in &args.block_command {
+        caps.add_blocked_command(cmd);
+    }
+
+    Ok(())
+}
+
+/// Helper to apply all filesystem-related grants from CLI arguments.
+/// Standardizes execution flags to use ReadExecute access mode.
+fn apply_cli_fs_grants(
+    caps: &mut CapabilitySet,
+    args: &SandboxArgs,
+    allow_parent_of_protected: bool,
+) -> Result<()> {
     let protected_roots = ProtectedRoots::from_defaults()?;
 
-    // Additional directories from CLI
+    // Directories
     for path in &args.allow {
         validate_requested_dir(path, "CLI", &protected_roots, allow_parent_of_protected)?;
         if let Some(cap) = try_new_dir(path, AccessMode::ReadWrite, "Skipping non-existent path")? {
@@ -1127,7 +1093,7 @@ fn add_cli_overrides(
         }
     }
 
-    // Additional files from CLI
+    // Single files
     for path in &args.allow_file {
         validate_requested_file(path, "CLI", &protected_roots, allow_parent_of_protected)?;
         if let Some(cap) = try_new_file(path, AccessMode::ReadWrite, "Skipping non-existent file")?
@@ -1153,8 +1119,8 @@ fn add_cli_overrides(
     // AF_UNIX socket capabilities from CLI overrides.
     add_cli_unix_socket_caps(caps, args, &protected_roots, allow_parent_of_protected)?;
 
-    // Execute permissions (directory and single file). Standardized to
-    // ReadExecute since execve(2) requires reading the binary header.
+    // Execute permissions (standardized to ReadExecute since execve(2) requires
+    // reading the binary header).
     for path in &args.execute {
         validate_requested_dir(path, "CLI", &protected_roots, allow_parent_of_protected)?;
         if let Some(cap) = try_new_dir(path, AccessMode::ReadExecute, "Skipping non-existent path")?
@@ -1170,37 +1136,6 @@ fn add_cli_overrides(
         {
             caps.add_fs(cap);
         }
-    }
-
-    // CLI network flags override profile network settings.
-    apply_cli_network_mode(caps, args);
-
-    // Localhost IPC ports from CLI
-    for port in &args.allow_port {
-        caps.add_localhost_port(*port);
-    }
-
-    // Outbound TCP connect port allowlist from CLI (Linux Landlock V4+ only)
-    #[cfg(target_os = "macos")]
-    if !args.allow_connect_port.is_empty() {
-        return Err(NonoError::UnsupportedPlatform(
-            "--allow-connect-port is not supported on macOS: Seatbelt cannot filter by TCP port. \
-             Use --allow-domain for host-level filtering, or ProxyOnly mode."
-                .to_string(),
-        ));
-    }
-    #[cfg(not(target_os = "macos"))]
-    for port in &args.allow_connect_port {
-        caps.add_tcp_connect_port(*port);
-    }
-
-    // Command allow/block from CLI
-    for cmd in &args.allow_command {
-        caps.add_allowed_command(cmd.clone());
-    }
-
-    for cmd in &args.block_command {
-        caps.add_blocked_command(cmd);
     }
 
     Ok(())

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -529,6 +529,26 @@ impl CapabilitySetExt for CapabilitySet {
         // fs-grant sugar.
         add_cli_unix_socket_caps(&mut caps, args, &protected_roots, false)?;
 
+        // Execute permissions (directory and single file). Standardized to
+        // ReadExecute since execve(2) requires reading the binary header.
+        for path in &args.execute {
+            validate_requested_dir(path, "CLI", &protected_roots, false)?;
+            if let Some(cap) =
+                try_new_dir(path, AccessMode::ReadExecute, "Skipping non-existent path")?
+            {
+                caps.add_fs(cap);
+            }
+        }
+
+        for path in &args.execute_file {
+            validate_requested_file(path, "CLI", &protected_roots, false)?;
+            if let Some(cap) =
+                try_new_file(path, AccessMode::ReadExecute, "Skipping non-existent file")?
+            {
+                caps.add_fs(cap);
+            }
+        }
+
         apply_cli_network_mode(&mut caps, args);
 
         // Localhost IPC ports
@@ -823,6 +843,46 @@ impl CapabilitySetExt for CapabilitySet {
             }
         }
 
+        // execute, readexecute, readwriteexecute (directories or files)
+        for path_template in &fs.execute {
+            let path = expand_vars(path_template, workdir)?;
+            let label = format!("Profile path '{}' does not exist, skipping", path_template);
+            if let Some(mut cap) = if path.is_dir() {
+                try_new_dir(&path, AccessMode::Execute, &label)?
+            } else {
+                try_new_file(&path, AccessMode::Execute, &label)?
+            } {
+                cap.source = CapabilitySource::Profile;
+                caps.add_fs(cap);
+            }
+        }
+
+        for path_template in &fs.readexecute {
+            let path = expand_vars(path_template, workdir)?;
+            let label = format!("Profile path '{}' does not exist, skipping", path_template);
+            if let Some(mut cap) = if path.is_dir() {
+                try_new_dir(&path, AccessMode::ReadExecute, &label)?
+            } else {
+                try_new_file(&path, AccessMode::ReadExecute, &label)?
+            } {
+                cap.source = CapabilitySource::Profile;
+                caps.add_fs(cap);
+            }
+        }
+
+        for path_template in &fs.readwriteexecute {
+            let path = expand_vars(path_template, workdir)?;
+            let label = format!("Profile path '{}' does not exist, skipping", path_template);
+            if let Some(mut cap) = if path.is_dir() {
+                try_new_dir(&path, AccessMode::ReadWriteExecute, &label)?
+            } else {
+                try_new_file(&path, AccessMode::ReadWriteExecute, &label)?
+            } {
+                cap.source = CapabilitySource::Profile;
+                caps.add_fs(cap);
+            }
+        }
+
         // Policy patch additions
         apply_profile_dir_allows(
             &profile.policy.add_allow_readwrite,
@@ -850,6 +910,30 @@ impl CapabilitySetExt for CapabilitySet {
             &mut caps,
             "Profile policy path",
             allow_parent_of_protected,
+        )?;
+        apply_profile_dir_allows(
+            &profile.policy.add_allow_execute,
+            AccessMode::Execute,
+            workdir,
+            &protected_roots,
+            &mut caps,
+            "Profile policy path",
+        )?;
+        apply_profile_dir_allows(
+            &profile.policy.add_allow_readexecute,
+            AccessMode::ReadExecute,
+            workdir,
+            &protected_roots,
+            &mut caps,
+            "Profile policy path",
+        )?;
+        apply_profile_dir_allows(
+            &profile.policy.add_allow_readwriteexecute,
+            AccessMode::ReadWriteExecute,
+            workdir,
+            &protected_roots,
+            &mut caps,
+            "Profile policy path",
         )?;
 
         for path_template in &profile.policy.add_deny_access {
@@ -1068,6 +1152,25 @@ fn add_cli_overrides(
 
     // AF_UNIX socket capabilities from CLI overrides.
     add_cli_unix_socket_caps(caps, args, &protected_roots, allow_parent_of_protected)?;
+
+    // Execute permissions (directory and single file). Standardized to
+    // ReadExecute since execve(2) requires reading the binary header.
+    for path in &args.execute {
+        validate_requested_dir(path, "CLI", &protected_roots, allow_parent_of_protected)?;
+        if let Some(cap) = try_new_dir(path, AccessMode::ReadExecute, "Skipping non-existent path")?
+        {
+            caps.add_fs(cap);
+        }
+    }
+
+    for path in &args.execute_file {
+        validate_requested_file(path, "CLI", &protected_roots, allow_parent_of_protected)?;
+        if let Some(cap) =
+            try_new_file(path, AccessMode::ReadExecute, "Skipping non-existent file")?
+        {
+            caps.add_fs(cap);
+        }
+    }
 
     // CLI network flags override profile network settings.
     apply_cli_network_mode(caps, args);

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -204,11 +204,11 @@ pub enum Commands {
 {all-args}
 {after-help}")]
     #[command(after_help = "\x1b[1mEXAMPLES\x1b[0m
-  nono why --path ~/.ssh --op read             # Check if ~/.ssh is readable
-  nono why --path ./src --op write --allow .   # Check with capability context
-  nono why --json --path ~/.aws --op read      # JSON output for agents
+  nono why ~/.ssh --op read                    # Check if ~/.ssh is readable
+  nono why ./src --op write --allow .          # Check with capability context
+  nono why ~/.aws --op read --json             # JSON output for agents
   nono why --host api.openai.com --port 443    # Query network access
-  nono why --self --path /tmp --op write       # Inside sandbox, query own capabilities
+  nono why /tmp --op write --self              # Inside sandbox, query own capabilities
 ")]
     Why(Box<WhyArgs>),
 
@@ -894,6 +894,14 @@ pub struct SandboxArgs {
     #[arg(long, value_name = "DIR", help_heading = "FILESYSTEM")]
     pub allow_unix_socket_dir_bind: Vec<PathBuf>,
 
+    /// Allow execute-only access to a directory (recursive)
+    #[arg(long, value_name = "DIR", help_heading = "FILESYSTEM")]
+    pub execute: Vec<PathBuf>,
+
+    /// Allow execute-only access to a single file
+    #[arg(long, value_name = "FILE", help_heading = "FILESYSTEM")]
+    pub execute_file: Vec<PathBuf>,
+
     /// Override a deny rule for a path. Pair with --allow/--read/--write grant
     #[arg(long, value_name = "PATH", help_heading = "FILESYSTEM")]
     pub override_deny: Vec<PathBuf>,
@@ -1177,6 +1185,14 @@ pub struct WrapSandboxArgs {
     #[arg(long, value_name = "DIR", help_heading = "FILESYSTEM")]
     pub allow_unix_socket_dir_bind: Vec<PathBuf>,
 
+    /// Allow execute-only access to a directory (recursive)
+    #[arg(long, value_name = "DIR", help_heading = "FILESYSTEM")]
+    pub execute: Vec<PathBuf>,
+
+    /// Allow execute-only access to a single file
+    #[arg(long, value_name = "FILE", help_heading = "FILESYSTEM")]
+    pub execute_file: Vec<PathBuf>,
+
     /// Override a deny rule for a path. Pair with --allow/--read/--write grant
     #[arg(long, value_name = "PATH", help_heading = "FILESYSTEM")]
     pub override_deny: Vec<PathBuf>,
@@ -1309,6 +1325,8 @@ impl From<WrapSandboxArgs> for SandboxArgs {
             allow: args.allow,
             read: args.read,
             write: args.write,
+            execute: args.execute,
+            execute_file: args.execute_file,
             allow_file: args.allow_file,
             read_file: args.read_file,
             write_file: args.write_file,
@@ -1521,7 +1539,7 @@ pub struct SetupArgs {
 #[command(disable_help_flag = true)]
 pub struct WhyArgs {
     /// Path to check
-    #[arg(long, help_heading = "QUERY")]
+    #[arg(help_heading = "QUERY")]
     pub path: Option<PathBuf>,
 
     /// Operation to check: read, write, or readwrite
@@ -1564,6 +1582,14 @@ pub struct WhyArgs {
     /// Single files to allow read-only access (for query context)
     #[arg(long, value_name = "FILE", help_heading = "CONTEXT")]
     pub read_file: Vec<PathBuf>,
+
+    /// Specific file or directory to allow execution (for query context)
+    #[arg(long, value_name = "PATH", help_heading = "CONTEXT")]
+    pub execute: Vec<PathBuf>,
+
+    /// Specific file to allow execution (for query context)
+    #[arg(long, value_name = "FILE", help_heading = "CONTEXT")]
+    pub execute_file: Vec<PathBuf>,
 
     /// Single files to allow write-only access (for query context)
     #[arg(long, value_name = "FILE", help_heading = "CONTEXT")]
@@ -1632,6 +1658,8 @@ pub enum WhyOp {
     /// Read and write access
     #[value(name = "readwrite")]
     ReadWrite,
+    /// Execute access
+    Execute,
 }
 
 #[derive(Parser, Debug)]

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1660,6 +1660,10 @@ pub enum WhyOp {
     ReadWrite,
     /// Execute access
     Execute,
+    /// Read and execute access
+    ReadExecute,
+    /// Read, write, and execute access
+    ReadWriteExecute,
 }
 
 #[derive(Parser, Debug)]

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -3119,6 +3119,9 @@ fn open_canonical_path_no_symlinks(
         nono::AccessMode::Read => libc::O_RDONLY,
         nono::AccessMode::Write => libc::O_WRONLY,
         nono::AccessMode::ReadWrite => libc::O_RDWR,
+        nono::AccessMode::Execute => libc::O_RDONLY,
+        nono::AccessMode::ReadExecute => libc::O_RDONLY,
+        nono::AccessMode::ReadWriteExecute => libc::O_RDWR,
     } | libc::O_NOFOLLOW
         | libc::O_CLOEXEC;
 

--- a/crates/nono-cli/src/learn.rs
+++ b/crates/nono-cli/src/learn.rs
@@ -1562,10 +1562,10 @@ fn process_accesses(
 
     for (path, entry) in learned_entries {
         match (entry.access, entry.is_file) {
-            (AccessMode::Read, true) => {
+            (AccessMode::Read | AccessMode::Execute | AccessMode::ReadExecute, true) => {
                 result.read_files.insert(path);
             }
-            (AccessMode::Read, false) => {
+            (AccessMode::Read | AccessMode::Execute | AccessMode::ReadExecute, false) => {
                 result.read_paths.insert(path);
             }
             (AccessMode::Write, true) => {
@@ -1574,10 +1574,10 @@ fn process_accesses(
             (AccessMode::Write, false) => {
                 result.write_paths.insert(path);
             }
-            (AccessMode::ReadWrite, true) => {
+            (AccessMode::ReadWrite | AccessMode::ReadWriteExecute, true) => {
                 result.readwrite_files.insert(path);
             }
-            (AccessMode::ReadWrite, false) => {
+            (AccessMode::ReadWrite | AccessMode::ReadWriteExecute, false) => {
                 result.readwrite_paths.insert(path);
             }
         }

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -376,7 +376,7 @@ mod tests {
 
     #[test]
     fn test_pre_exec_update_check_enabled_for_non_exec_commands() {
-        let why = Cli::parse_from(["nono", "why", "--path", "/tmp", "--op", "read"]);
+        let why = Cli::parse_from(["nono", "why", "/tmp", "--op", "read"]);
         assert!(allows_pre_exec_update_check(&why.command));
 
         let ps = Cli::parse_from(["nono", "ps"]);

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -225,6 +225,9 @@ fn format_access_badge(access: &AccessMode) -> String {
         AccessMode::Read => theme::badge("  r  ", t.green, BADGE_FG_DARK),
         AccessMode::Write => theme::badge("  w  ", t.yellow, BADGE_FG_DARK),
         AccessMode::ReadWrite => theme::badge(" r+w ", t.brand, BADGE_FG_DARK),
+        AccessMode::Execute => theme::badge("  e  ", t.brand, BADGE_FG_DARK),
+        AccessMode::ReadExecute => theme::badge(" r+e ", t.brand, BADGE_FG_DARK),
+        AccessMode::ReadWriteExecute => theme::badge("r+w+e", t.brand, BADGE_FG_DARK),
     }
 }
 
@@ -244,6 +247,9 @@ fn format_access_inline(access: &AccessMode) -> colored::ColoredString {
         AccessMode::Read => theme::fg("read", t.green),
         AccessMode::Write => theme::fg("write", t.yellow),
         AccessMode::ReadWrite => theme::fg("read+write", t.brand),
+        AccessMode::Execute => theme::fg("execute", t.brand),
+        AccessMode::ReadExecute => theme::fg("read+execute", t.brand),
+        AccessMode::ReadWriteExecute => theme::fg("read+write+execute", t.brand),
     }
 }
 

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -69,6 +69,15 @@ pub struct AllowOps {
     /// Paths granted read+write access
     #[serde(default)]
     pub readwrite: Vec<String>,
+    /// Paths granted execute access
+    #[serde(default)]
+    pub execute: Vec<String>,
+    /// Paths granted read+execute access
+    #[serde(default)]
+    pub readexecute: Vec<String>,
+    /// Paths granted read+write+execute access
+    #[serde(default)]
+    pub readwriteexecute: Vec<String>,
 }
 
 /// Deny operations nested under `deny`
@@ -407,6 +416,15 @@ fn resolve_single_group(
         }
         for path_str in &allow.readwrite {
             add_fs_capability(group_name, path_str, AccessMode::ReadWrite, &source, caps)?;
+        }
+        for path_str in &allow.execute {
+            add_fs_capability(path_str, AccessMode::Execute, &source, caps)?;
+        }
+        for path_str in &allow.readexecute {
+            add_fs_capability(path_str, AccessMode::ReadExecute, &source, caps)?;
+        }
+        for path_str in &allow.readwriteexecute {
+            add_fs_capability(path_str, AccessMode::ReadWriteExecute, &source, caps)?;
         }
     }
 
@@ -943,6 +961,7 @@ pub fn apply_deny_overrides(
         // Seatbelt allow rules for only the first grant's access mode.
         let mut grant_has_read = false;
         let mut grant_has_write = false;
+        let mut grant_has_execute = false;
         for cap in caps.fs_capabilities() {
             if !cap.source.is_user_intent() {
                 continue;
@@ -960,10 +979,20 @@ pub fn apply_deny_overrides(
                         grant_has_read = true;
                         grant_has_write = true;
                     }
+                    AccessMode::Execute => grant_has_execute = true,
+                    AccessMode::ReadExecute => {
+                        grant_has_read = true;
+                        grant_has_execute = true;
+                    }
+                    AccessMode::ReadWriteExecute => {
+                        grant_has_read = true;
+                        grant_has_write = true;
+                        grant_has_execute = true;
+                    }
                 }
             }
         }
-        if !grant_has_read && !grant_has_write {
+        if !grant_has_read && !grant_has_write && !grant_has_execute {
             return Err(NonoError::SandboxInit(format!(
                 "override_deny '{}' has no matching grant. \
                  Add a filesystem allow (--allow, --read, --write, or profile filesystem/policy) \

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -834,7 +834,7 @@ pub fn apply_macos_keychain_db_exception(caps: &mut CapabilitySet) {
         // `deny_keychains_macos` group emits `(deny file-read-data (subpath ...))`).
         // Emitting the specific op with a literal path ensures the override wins.
         match access {
-            AccessMode::Read => {
+            AccessMode::Read | AccessMode::ReadExecute => {
                 allow_rules.push(format!("(allow file-read-data ({}))", filter));
                 allow_rules.push(format!("(allow file-read* ({}))", filter));
             }
@@ -842,12 +842,13 @@ pub fn apply_macos_keychain_db_exception(caps: &mut CapabilitySet) {
                 allow_rules.push(format!("(allow file-write-data ({}))", filter));
                 allow_rules.push(format!("(allow file-write* ({}))", filter));
             }
-            AccessMode::ReadWrite => {
+            AccessMode::ReadWrite | AccessMode::ReadWriteExecute => {
                 allow_rules.push(format!("(allow file-read-data ({}))", filter));
                 allow_rules.push(format!("(allow file-read* ({}))", filter));
                 allow_rules.push(format!("(allow file-write-data ({}))", filter));
                 allow_rules.push(format!("(allow file-write* ({}))", filter));
             }
+            AccessMode::Execute => {}
         }
     }
 
@@ -886,7 +887,7 @@ pub fn apply_macos_keychain_db_exception(caps: &mut CapabilitySet) {
         // the specific-op denies from deny_keychains_macos.
         for filter in filters {
             match access {
-                AccessMode::Read => {
+                AccessMode::Read | AccessMode::ReadExecute => {
                     allow_rules.push(format!("(allow file-read-data ({}))", filter));
                     allow_rules.push(format!("(allow file-read* ({}))", filter));
                 }
@@ -894,12 +895,13 @@ pub fn apply_macos_keychain_db_exception(caps: &mut CapabilitySet) {
                     allow_rules.push(format!("(allow file-write-data ({}))", filter));
                     allow_rules.push(format!("(allow file-write* ({}))", filter));
                 }
-                AccessMode::ReadWrite => {
+                AccessMode::ReadWrite | AccessMode::ReadWriteExecute => {
                     allow_rules.push(format!("(allow file-read-data ({}))", filter));
                     allow_rules.push(format!("(allow file-read* ({}))", filter));
                     allow_rules.push(format!("(allow file-write-data ({}))", filter));
                     allow_rules.push(format!("(allow file-write* ({}))", filter));
                 }
+                AccessMode::Execute => {}
             }
         }
     }

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -418,13 +418,19 @@ fn resolve_single_group(
             add_fs_capability(group_name, path_str, AccessMode::ReadWrite, &source, caps)?;
         }
         for path_str in &allow.execute {
-            add_fs_capability(path_str, AccessMode::Execute, &source, caps)?;
+            add_fs_capability(group_name, path_str, AccessMode::Execute, &source, caps)?;
         }
         for path_str in &allow.readexecute {
-            add_fs_capability(path_str, AccessMode::ReadExecute, &source, caps)?;
+            add_fs_capability(group_name, path_str, AccessMode::ReadExecute, &source, caps)?;
         }
         for path_str in &allow.readwriteexecute {
-            add_fs_capability(path_str, AccessMode::ReadWriteExecute, &source, caps)?;
+            add_fs_capability(
+                group_name,
+                path_str,
+                AccessMode::ReadWriteExecute,
+                &source,
+                caps,
+            )?;
         }
     }
 

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -57,11 +57,11 @@ mod tests {
         assert!(profile.interactive);
         assert!(profile
             .filesystem
-            .allow
+            .readwriteexecute
             .contains(&"$HOME/.opencode".to_string()));
         assert!(profile
             .filesystem
-            .allow
+            .readwriteexecute
             .contains(&"$HOME/.local/share/opentui".to_string()));
     }
 

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -242,15 +242,24 @@ mod tests {
     fn test_opencode_profile_includes_tmpdir_and_state_dir() {
         let policy = crate::policy::load_embedded_policy().expect("load embedded policy");
         let opencode = policy.profiles.get("opencode").expect("opencode profile");
+        // The opencode profile bundles its filesystem grants under
+        // `readwriteexecute` so the embedded Bun TUI binary can be mmap-executed
+        // from these dirs. Either `allow` or `readwriteexecute` satisfies the
+        // intent: the path is granted read+write at minimum.
+        let granted = |path: &str| {
+            opencode.filesystem.allow.iter().any(|p| p == path)
+                || opencode
+                    .filesystem
+                    .readwriteexecute
+                    .iter()
+                    .any(|p| p == path)
+        };
         assert!(
-            opencode.filesystem.allow.contains(&"$TMPDIR".to_string()),
+            granted("$TMPDIR"),
             "opencode profile should allow $TMPDIR for Bun TUI runtime extraction"
         );
         assert!(
-            opencode
-                .filesystem
-                .allow
-                .contains(&"$HOME/.local/state/opencode".to_string()),
+            granted("$HOME/.local/state/opencode"),
             "opencode profile should allow $HOME/.local/state/opencode"
         );
     }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -72,6 +72,15 @@ pub struct FilesystemConfig {
     /// or bound. Non-recursive. Implies read+write access on the directory.
     #[serde(default)]
     pub unix_socket_dir_bind: Vec<String>,
+    /// Directories or files with execute access
+    #[serde(default)]
+    pub execute: Vec<String>,
+    /// Directories or files with read+execute access
+    #[serde(default)]
+    pub readexecute: Vec<String>,
+    /// Directories or files with read+write+execute access
+    #[serde(default)]
+    pub readwriteexecute: Vec<String>,
 }
 
 /// Policy patch configuration in a profile.
@@ -93,6 +102,15 @@ pub struct PolicyPatchConfig {
     /// Additional read-write directories to allow.
     #[serde(default)]
     pub add_allow_readwrite: Vec<String>,
+    /// Additional execute directories to allow.
+    #[serde(default)]
+    pub add_allow_execute: Vec<String>,
+    /// Additional read-execute directories to allow.
+    #[serde(default)]
+    pub add_allow_readexecute: Vec<String>,
+    /// Additional read-write-execute directories to allow.
+    #[serde(default)]
+    pub add_allow_readwriteexecute: Vec<String>,
     /// Additional deny.access paths to apply.
     #[serde(default)]
     pub add_deny_access: Vec<String>,
@@ -2053,6 +2071,12 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
                 &base.filesystem.unix_socket_dir_bind,
                 &child.filesystem.unix_socket_dir_bind,
             ),
+            execute: dedup_append(&base.filesystem.execute, &child.filesystem.execute),
+            readexecute: dedup_append(&base.filesystem.readexecute, &child.filesystem.readexecute),
+            readwriteexecute: dedup_append(
+                &base.filesystem.readwriteexecute,
+                &child.filesystem.readwriteexecute,
+            ),
         },
         policy: PolicyPatchConfig {
             exclude_groups: dedup_append(&base.policy.exclude_groups, &child.policy.exclude_groups),
@@ -2064,6 +2088,18 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
             add_allow_readwrite: dedup_append(
                 &base.policy.add_allow_readwrite,
                 &child.policy.add_allow_readwrite,
+            ),
+            add_allow_execute: dedup_append(
+                &base.policy.add_allow_execute,
+                &child.policy.add_allow_execute,
+            ),
+            add_allow_readexecute: dedup_append(
+                &base.policy.add_allow_readexecute,
+                &child.policy.add_allow_readexecute,
+            ),
+            add_allow_readwriteexecute: dedup_append(
+                &base.policy.add_allow_readwriteexecute,
+                &child.policy.add_allow_readwriteexecute,
             ),
             add_deny_access: dedup_append(
                 &base.policy.add_deny_access,
@@ -3789,6 +3825,9 @@ mod tests {
                 allow: vec!["/base/rw".to_string()],
                 read: vec!["/base/read".to_string()],
                 write: vec![],
+                execute: vec![],
+                readexecute: vec![],
+                readwriteexecute: vec![],
                 allow_file: vec![],
                 read_file: vec!["/base/file.txt".to_string()],
                 write_file: vec![],
@@ -3802,6 +3841,9 @@ mod tests {
                 add_allow_read: vec!["/base/policy-read".to_string()],
                 add_allow_write: vec![],
                 add_allow_readwrite: vec![],
+                add_allow_execute: vec![],
+                add_allow_readexecute: vec![],
+                add_allow_readwriteexecute: vec![],
                 add_deny_access: vec!["/base/policy-deny".to_string()],
                 add_deny_commands: vec![],
                 override_deny: vec!["/base/override-deny".to_string()],
@@ -3868,6 +3910,9 @@ mod tests {
                 allow: vec!["/child/rw".to_string()],
                 read: vec![],
                 write: vec![],
+                execute: vec![],
+                readexecute: vec![],
+                readwriteexecute: vec![],
                 allow_file: vec![],
                 read_file: vec![],
                 write_file: vec![],
@@ -3881,6 +3926,9 @@ mod tests {
                 add_allow_read: vec![],
                 add_allow_write: vec!["/child/policy-write".to_string()],
                 add_allow_readwrite: vec!["/child/policy-rw".to_string()],
+                add_allow_execute: vec![],
+                add_allow_readexecute: vec![],
+                add_allow_readwriteexecute: vec![],
                 add_deny_access: vec!["/child/policy-deny".to_string()],
                 add_deny_commands: vec![],
                 override_deny: vec!["/child/override-deny".to_string()],

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -4267,16 +4267,18 @@ mod tests {
 
         let profile = load_from_file(&profile_path).expect("load extended profile");
         assert_eq!(profile.meta.name, "ext-test");
-        // Should inherit codex's filesystem paths
-        assert!(
-            profile.filesystem.allow.len() > 1,
-            "Expected inherited paths from codex, got: {:?}",
-            profile.filesystem.allow
-        );
+        // Child's allow path is preserved.
         assert!(profile
             .filesystem
             .allow
             .contains(&"/tmp/ext-test".to_string()));
+        // Should inherit opencode's filesystem paths (which live under
+        // readwriteexecute so the bundled Bun TUI binary can be mmap-executed).
+        assert!(
+            !profile.filesystem.readwriteexecute.is_empty(),
+            "Expected inherited readwriteexecute paths from opencode, got: {:?}",
+            profile.filesystem.readwriteexecute
+        );
         // extends should be consumed
         assert!(profile.extends.is_none());
     }
@@ -5149,7 +5151,7 @@ mod tests {
         assert!(
             profile
                 .filesystem
-                .allow
+                .readwriteexecute
                 .iter()
                 .any(|path| path == "$HOME/.opencode"),
             "expected filesystem grants from opencode to still be inherited",

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -2354,6 +2354,21 @@ fn resolve_to_manifest(
             true,
         ),
         (
+            &prof.filesystem.execute,
+            manifest::AccessMode::Execute,
+            false,
+        ),
+        (
+            &prof.filesystem.readexecute,
+            manifest::AccessMode::Readexecute,
+            false,
+        ),
+        (
+            &prof.filesystem.readwriteexecute,
+            manifest::AccessMode::Readwriteexecute,
+            false,
+        ),
+        (
             &prof.policy.add_allow_read,
             manifest::AccessMode::Read,
             false,
@@ -2366,6 +2381,21 @@ fn resolve_to_manifest(
         (
             &prof.policy.add_allow_readwrite,
             manifest::AccessMode::Readwrite,
+            false,
+        ),
+        (
+            &prof.policy.add_allow_execute,
+            manifest::AccessMode::Execute,
+            false,
+        ),
+        (
+            &prof.policy.add_allow_readexecute,
+            manifest::AccessMode::Readexecute,
+            false,
+        ),
+        (
+            &prof.policy.add_allow_readwriteexecute,
+            manifest::AccessMode::Readwriteexecute,
             false,
         ),
     ];
@@ -2399,6 +2429,9 @@ fn resolve_to_manifest(
             nono::AccessMode::Read => manifest::AccessMode::Read,
             nono::AccessMode::Write => manifest::AccessMode::Write,
             nono::AccessMode::ReadWrite => manifest::AccessMode::Readwrite,
+            nono::AccessMode::Execute => manifest::AccessMode::Execute,
+            nono::AccessMode::ReadExecute => manifest::AccessMode::Readexecute,
+            nono::AccessMode::ReadWriteExecute => manifest::AccessMode::Readwriteexecute,
         };
         let path_str = cap.resolved.to_string_lossy().into_owned();
         grants.push(make_fs_grant(&path_str, access, cap.is_file)?);
@@ -2667,12 +2700,22 @@ fn wider_access(
     a: nono::manifest::AccessMode,
     b: nono::manifest::AccessMode,
 ) -> nono::manifest::AccessMode {
-    use nono::manifest::AccessMode::{Read, Readwrite, Write};
+    use nono::manifest::AccessMode::{
+        Execute, Read, Readexecute, Readwrite, Readwriteexecute, Write,
+    };
     match (a, b) {
+        (Readwriteexecute, _) | (_, Readwriteexecute) => Readwriteexecute,
+        (Write, Execute) | (Execute, Write) => Readwriteexecute,
+        (Readwrite, Execute) | (Execute, Readwrite) => Readwriteexecute,
+        (Readwrite, Readexecute) | (Readexecute, Readwrite) => Readwriteexecute,
+        (Readexecute, Write) | (Write, Readexecute) => Readwriteexecute,
         (Readwrite, _) | (_, Readwrite) => Readwrite,
         (Read, Write) | (Write, Read) => Readwrite,
+        (Readexecute, _) | (_, Readexecute) => Readexecute,
+        (Read, Execute) | (Execute, Read) => Readexecute,
         (Read, Read) => Read,
         (Write, Write) => Write,
+        (Execute, Execute) => Execute,
     }
 }
 

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -632,6 +632,9 @@ fn build_run_profile_patch(
     let mut allow_file = BTreeSet::new();
     let mut read_file = BTreeSet::new();
     let mut write_file = BTreeSet::new();
+    let mut execute = BTreeSet::new();
+    let mut readexecute = BTreeSet::new();
+    let mut readwriteexecute = BTreeSet::new();
     let mut override_deny = BTreeSet::new();
 
     for (path, grant) in grants {
@@ -659,6 +662,15 @@ fn build_run_profile_patch(
             (AccessMode::ReadWrite, true) => {
                 allow_file.insert(shortened);
             }
+            (AccessMode::Execute, _) => {
+                execute.insert(shortened);
+            }
+            (AccessMode::ReadExecute, _) => {
+                readexecute.insert(shortened);
+            }
+            (AccessMode::ReadWriteExecute, _) => {
+                readwriteexecute.insert(shortened);
+            }
         }
     }
 
@@ -669,6 +681,9 @@ fn build_run_profile_patch(
     patch.filesystem.allow_file = allow_file.into_iter().collect();
     patch.filesystem.read_file = read_file.into_iter().collect();
     patch.filesystem.write_file = write_file.into_iter().collect();
+    patch.filesystem.execute = execute.into_iter().collect();
+    patch.filesystem.readexecute = readexecute.into_iter().collect();
+    patch.filesystem.readwriteexecute = readwriteexecute.into_iter().collect();
     patch.policy.override_deny = override_deny.into_iter().collect();
 
     Ok(Some(patch))

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -140,9 +140,12 @@ pub fn query_path(
 
         let sufficient = matches!(
             (cap.access, requested),
-            (AccessMode::ReadWrite, _)
+            (AccessMode::ReadWriteExecute, _)
+                | (AccessMode::ReadWrite, AccessMode::ReadWrite | AccessMode::Read | AccessMode::Write)
+                | (AccessMode::ReadExecute, AccessMode::ReadExecute | AccessMode::Read | AccessMode::Execute)
                 | (AccessMode::Read, AccessMode::Read)
                 | (AccessMode::Write, AccessMode::Write)
+                | (AccessMode::Execute, AccessMode::Execute)
         );
 
         if sufficient && score >= best_sufficient_score {
@@ -279,12 +282,16 @@ pub(crate) fn suggested_flag_parts(path: &Path, requested: AccessMode) -> (&'sta
             AccessMode::Read => "--read-file",
             AccessMode::Write => "--write-file",
             AccessMode::ReadWrite => "--allow-file",
+            AccessMode::Execute => "--execute-file",
+            AccessMode::ReadExecute | AccessMode::ReadWriteExecute => "--execute-file",
         }
     } else {
         match requested {
             AccessMode::Read => "--read",
             AccessMode::Write => "--write",
             AccessMode::ReadWrite => "--allow",
+            AccessMode::Execute => "--execute",
+            AccessMode::ReadExecute | AccessMode::ReadWriteExecute => "--execute",
         }
     };
 

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -141,8 +141,14 @@ pub fn query_path(
         let sufficient = matches!(
             (cap.access, requested),
             (AccessMode::ReadWriteExecute, _)
-                | (AccessMode::ReadWrite, AccessMode::ReadWrite | AccessMode::Read | AccessMode::Write)
-                | (AccessMode::ReadExecute, AccessMode::ReadExecute | AccessMode::Read | AccessMode::Execute)
+                | (
+                    AccessMode::ReadWrite,
+                    AccessMode::ReadWrite | AccessMode::Read | AccessMode::Write
+                )
+                | (
+                    AccessMode::ReadExecute,
+                    AccessMode::ReadExecute | AccessMode::Read | AccessMode::Execute
+                )
                 | (AccessMode::Read, AccessMode::Read)
                 | (AccessMode::Write, AccessMode::Write)
                 | (AccessMode::Execute, AccessMode::Execute)

--- a/crates/nono-cli/src/sandbox_state.rs
+++ b/crates/nono-cli/src/sandbox_state.rs
@@ -57,6 +57,9 @@ impl SandboxState {
                         AccessMode::Read => "read".to_string(),
                         AccessMode::Write => "write".to_string(),
                         AccessMode::ReadWrite => "readwrite".to_string(),
+                        AccessMode::Execute => "execute".to_string(),
+                        AccessMode::ReadExecute => "readexecute".to_string(),
+                        AccessMode::ReadWriteExecute => "readwriteexecute".to_string(),
                     },
                     is_file: c.is_file,
                 })
@@ -91,6 +94,9 @@ impl SandboxState {
                 "read" => AccessMode::Read,
                 "write" => AccessMode::Write,
                 "readwrite" => AccessMode::ReadWrite,
+                "execute" => AccessMode::Execute,
+                "readexecute" => AccessMode::ReadExecute,
+                "readwriteexecute" => AccessMode::ReadWriteExecute,
                 other => {
                     return Err(NonoError::ConfigParse(format!(
                         "invalid access mode in sandbox state: {other}"

--- a/crates/nono-cli/src/terminal_approval.rs
+++ b/crates/nono-cli/src/terminal_approval.rs
@@ -123,6 +123,9 @@ fn format_access_mode(access: &AccessMode) -> &'static str {
         AccessMode::Read => "read-only",
         AccessMode::Write => "write-only",
         AccessMode::ReadWrite => "read+write",
+        AccessMode::Execute => "execute",
+        AccessMode::ReadExecute => "read+execute",
+        AccessMode::ReadWriteExecute => "read+write+execute",
     }
 }
 

--- a/crates/nono-cli/src/why_runtime.rs
+++ b/crates/nono-cli/src/why_runtime.rs
@@ -91,6 +91,9 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
             Some(WhyOp::Read) => AccessMode::Read,
             Some(WhyOp::Write) => AccessMode::Write,
             Some(WhyOp::ReadWrite) => AccessMode::ReadWrite,
+            Some(WhyOp::Execute) => AccessMode::Execute,
+            Some(WhyOp::ReadExecute) => AccessMode::ReadExecute,
+            Some(WhyOp::ReadWriteExecute) => AccessMode::ReadWriteExecute,
             None => AccessMode::Read,
         };
         query_path(path, op, &caps, &overridden_paths)?

--- a/crates/nono/schema/capability-manifest.schema.json
+++ b/crates/nono/schema/capability-manifest.schema.json
@@ -81,8 +81,8 @@
     },
     "AccessMode": {
       "type": "string",
-      "enum": ["read", "write", "readwrite"],
-      "description": "Filesystem access mode. 'read' grants read-only access, 'write' grants write-only access, 'readwrite' grants both."
+      "enum": ["read", "write", "readwrite", "execute", "readexecute", "readwriteexecute"],
+      "description": "Filesystem access mode. 'read' grants read-only access, 'write' grants write-only access, 'readwrite' grants both. 'execute' grants execute-only, 'readexecute' grants read+execute, 'readwriteexecute' grants all three."
     },
     "FsEntryType": {
       "type": "string",

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -54,6 +54,12 @@ pub enum AccessMode {
     Write,
     /// Read and write access
     ReadWrite,
+    /// Execute access
+    Execute,
+    /// Read and execute access
+    ReadExecute,
+    /// Read, write, and execute access
+    ReadWriteExecute,
 }
 
 impl AccessMode {
@@ -63,10 +69,20 @@ impl AccessMode {
     /// Read contains only Read. Write contains only Write.
     #[must_use]
     pub fn contains(self, required: AccessMode) -> bool {
-        match self {
-            AccessMode::ReadWrite => true,
-            AccessMode::Read => required == AccessMode::Read,
-            AccessMode::Write => required == AccessMode::Write,
+        match (self, required) {
+            (AccessMode::ReadWriteExecute, _) => true,
+            (AccessMode::ReadWrite, AccessMode::ReadWrite | AccessMode::Read | AccessMode::Write) => {
+                true
+            }
+            (AccessMode::ReadExecute, AccessMode::ReadExecute | AccessMode::Read | AccessMode::Execute) => {
+                true
+            }
+            (AccessMode::ReadWrite, _) => false,
+            (AccessMode::ReadExecute, _) => false,
+            (AccessMode::Write, AccessMode::Write) => true,
+            (AccessMode::Read, AccessMode::Read) => true,
+            (AccessMode::Execute, AccessMode::Execute) => true,
+            _ => self == required,
         }
     }
 }
@@ -77,6 +93,9 @@ impl std::fmt::Display for AccessMode {
             AccessMode::Read => write!(f, "read"),
             AccessMode::Write => write!(f, "write"),
             AccessMode::ReadWrite => write!(f, "read+write"),
+            AccessMode::Execute => write!(f, "execute"),
+            AccessMode::ReadExecute => write!(f, "read+execute"),
+            AccessMode::ReadWriteExecute => write!(f, "read+write+execute"),
         }
     }
 }
@@ -1341,12 +1360,23 @@ impl CapabilitySet {
                     cap.access == AccessMode::ReadWrite && existing.access != AccessMode::ReadWrite
                 };
 
-                // Merge complementary access modes (Read + Write = ReadWrite).
-                // When two entries from the same source category have different
-                // non-ReadWrite modes, upgrade the kept entry to ReadWrite.
+                // Merge complementary access modes.
                 let merged_access = match (existing.access, cap.access) {
+                    (AccessMode::ReadWriteExecute, _) | (_, AccessMode::ReadWriteExecute) => {
+                        Some(AccessMode::ReadWriteExecute)
+                    }
                     (AccessMode::Read, AccessMode::Write)
                     | (AccessMode::Write, AccessMode::Read) => Some(AccessMode::ReadWrite),
+                    (AccessMode::Read, AccessMode::Execute)
+                    | (AccessMode::Execute, AccessMode::Read) => Some(AccessMode::ReadExecute),
+                    (AccessMode::ReadWrite, AccessMode::Execute)
+                    | (AccessMode::Execute, AccessMode::ReadWrite)
+                    | (AccessMode::ReadWrite, AccessMode::ReadExecute)
+                    | (AccessMode::ReadExecute, AccessMode::ReadWrite)
+                    | (AccessMode::ReadExecute, AccessMode::Write)
+                    | (AccessMode::Write, AccessMode::ReadExecute) => {
+                        Some(AccessMode::ReadWriteExecute)
+                    }
                     _ => None,
                 };
 

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -71,12 +71,14 @@ impl AccessMode {
     pub fn contains(self, required: AccessMode) -> bool {
         match (self, required) {
             (AccessMode::ReadWriteExecute, _) => true,
-            (AccessMode::ReadWrite, AccessMode::ReadWrite | AccessMode::Read | AccessMode::Write) => {
-                true
-            }
-            (AccessMode::ReadExecute, AccessMode::ReadExecute | AccessMode::Read | AccessMode::Execute) => {
-                true
-            }
+            (
+                AccessMode::ReadWrite,
+                AccessMode::ReadWrite | AccessMode::Read | AccessMode::Write,
+            ) => true,
+            (
+                AccessMode::ReadExecute,
+                AccessMode::ReadExecute | AccessMode::Read | AccessMode::Execute,
+            ) => true,
             (AccessMode::ReadWrite, _) => false,
             (AccessMode::ReadExecute, _) => false,
             (AccessMode::Write, AccessMode::Write) => true,

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -1662,6 +1662,9 @@ fn access_str(access: AccessMode) -> &'static str {
         AccessMode::Read => "read",
         AccessMode::Write => "write",
         AccessMode::ReadWrite => "read+write",
+        AccessMode::Execute => "execute",
+        AccessMode::ReadExecute => "read+execute",
+        AccessMode::ReadWriteExecute => "read+write+execute",
     }
 }
 

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -1711,12 +1711,18 @@ fn suggested_flag_for_existing_target(
             AccessMode::Read => "--read-file",
             AccessMode::Write => "--write-file",
             AccessMode::ReadWrite => "--allow-file",
+            AccessMode::Execute => "",
+            AccessMode::ReadExecute => "",
+            AccessMode::ReadWriteExecute => "",
         }
     } else {
         match requested {
             AccessMode::Read => "--read",
             AccessMode::Write => "--write",
             AccessMode::ReadWrite => "--allow",
+            AccessMode::Execute => "",
+            AccessMode::ReadExecute => "",
+            AccessMode::ReadWriteExecute => "",
         }
     };
 
@@ -1729,12 +1735,18 @@ fn suggested_flag_parts(path: &Path, requested: AccessMode) -> (&'static str, Pa
             AccessMode::Read => "--read-file",
             AccessMode::Write => "--write-file",
             AccessMode::ReadWrite => "--allow-file",
+            AccessMode::Execute => "",
+            AccessMode::ReadExecute => "",
+            AccessMode::ReadWriteExecute => "",
         }
     } else {
         match requested {
             AccessMode::Read => "--read",
             AccessMode::Write => "--write",
             AccessMode::ReadWrite => "--allow",
+            AccessMode::Execute => "",
+            AccessMode::ReadExecute => "",
+            AccessMode::ReadWriteExecute => "",
         }
     };
 

--- a/crates/nono/src/manifest_convert.rs
+++ b/crates/nono/src/manifest_convert.rs
@@ -97,6 +97,9 @@ fn convert_access_mode(mode: AccessMode) -> InternalAccessMode {
         AccessMode::Read => InternalAccessMode::Read,
         AccessMode::Write => InternalAccessMode::Write,
         AccessMode::Readwrite => InternalAccessMode::ReadWrite,
+        AccessMode::Execute => InternalAccessMode::Execute,
+        AccessMode::Readexecute => InternalAccessMode::ReadExecute,
+        AccessMode::Readeriteexecute => InternalAccessMode::ReadWriteExecute,
     }
 }
 

--- a/crates/nono/src/manifest_convert.rs
+++ b/crates/nono/src/manifest_convert.rs
@@ -99,7 +99,7 @@ fn convert_access_mode(mode: AccessMode) -> InternalAccessMode {
         AccessMode::Readwrite => InternalAccessMode::ReadWrite,
         AccessMode::Execute => InternalAccessMode::Execute,
         AccessMode::Readexecute => InternalAccessMode::ReadExecute,
-        AccessMode::Readeriteexecute => InternalAccessMode::ReadWriteExecute,
+        AccessMode::Readwriteexecute => InternalAccessMode::ReadWriteExecute,
     }
 }
 

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -275,7 +275,7 @@ fn access_to_landlock(access: AccessMode, abi: ABI) -> LandlockAccess {
     let available = AccessFs::from_all(abi);
 
     let desired = match access {
-        AccessMode::Read => AccessFs::ReadFile | AccessFs::ReadDir | AccessFs::Execute,
+        AccessMode::Read => AccessFs::ReadFile | AccessFs::ReadDir,
         AccessMode::Write => {
             AccessFs::WriteFile
                 | AccessFs::MakeChar
@@ -296,6 +296,15 @@ fn access_to_landlock(access: AccessMode, abi: ABI) -> LandlockAccess {
             return LandlockAccess {
                 effective: read.effective | write.effective,
                 dropped: read.dropped | write.dropped,
+            };
+        }
+        AccessMode::Execute => AccessFs::Execute.into(),
+        AccessMode::ReadExecute => AccessFs::ReadFile | AccessFs::ReadDir | AccessFs::Execute,
+        AccessMode::ReadWriteExecute => {
+            let rw = access_to_landlock(AccessMode::ReadWrite, abi);
+            return LandlockAccess {
+                effective: rw.effective | (available & AccessFs::Execute),
+                dropped: rw.dropped | (BitFlags::from(AccessFs::Execute) & !available),
             };
         }
     };

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -45,6 +45,9 @@ const EXT_CLASS_READ: &str = "com.apple.app-sandbox.read";
 /// Extension class for read+write access
 const EXT_CLASS_READ_WRITE: &str = "com.apple.app-sandbox.read-write";
 
+/// Extension class for execute access
+const EXT_CLASS_EXECUTE: &str = "com.apple.app-sandbox.execute";
+
 /// Issue a sandbox extension token for a path.
 ///
 /// Called by the unsandboxed supervisor to create a token that a sandboxed
@@ -55,7 +58,7 @@ const EXT_CLASS_READ_WRITE: &str = "com.apple.app-sandbox.read-write";
 ///
 /// # Arguments
 /// * `path` - The filesystem path to grant access to
-/// * `access` - The access mode (Read -> read-only token, Write/ReadWrite -> read-write token)
+/// * `access` - The access mode (Read -> read-only token, Write/ReadWrite -> read-write token, Execute -> execute token)
 ///
 /// # Errors
 /// Returns an error if the path contains null bytes or if the kernel rejects the request.
@@ -63,6 +66,7 @@ pub fn extension_issue_file(path: &Path, access: AccessMode) -> Result<String> {
     let class = match access {
         AccessMode::Read => EXT_CLASS_READ,
         AccessMode::Write | AccessMode::ReadWrite => EXT_CLASS_READ_WRITE,
+        AccessMode::Execute => EXT_CLASS_EXECUTE,
     };
 
     let class_c = CString::new(class)
@@ -464,9 +468,24 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
         profile.push_str("(debug deny)\n");
     }
 
-    // Allow specific process operations needed for execution
-    profile.push_str("(allow process-exec*)\n");
+    // Allow specific process operations needed for process management
     profile.push_str("(allow process-fork)\n");
+
+    // Process execution: scoped to paths with Execute access.
+    // This prevents executing arbitrary binaries outside the granted execute paths.
+    for cap in caps.fs_capabilities() {
+        if matches!(
+            cap.access,
+            AccessMode::Execute
+                | AccessMode::ReadWrite
+                | AccessMode::ReadExecute
+                | AccessMode::ReadWriteExecute
+        ) {
+            for filter in path_filters_for_cap(cap)? {
+                profile.push_str(&format!("(allow process-exec ({}))\n", filter));
+            }
+        }
+    }
 
     // Process info: allow self-inspection and same-sandbox inspection for both
     // Isolated and AllowSameSandbox, matching Linux behaviour where Landlock
@@ -580,11 +599,18 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
         ));
     }
 
-    // Allow mapping executables into memory, restricted to readable paths.
+    // Allow mapping executables into memory, restricted to paths with Read or Execute access.
     // This prevents loading arbitrary shared libraries via DYLD_INSERT_LIBRARIES
-    // from paths outside the sandbox's read set.
+    // from paths outside the sandbox's read/execute set.
     for cap in caps.fs_capabilities() {
-        if matches!(cap.access, AccessMode::Read | AccessMode::ReadWrite) {
+        if matches!(
+            cap.access,
+            AccessMode::Read
+                | AccessMode::ReadWrite
+                | AccessMode::Execute
+                | AccessMode::ReadExecute
+                | AccessMode::ReadWriteExecute
+        ) {
             for filter in path_filters_for_cap(cap)? {
                 profile.push_str(&format!("(allow file-map-executable ({}))\n", filter));
             }
@@ -610,13 +636,16 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
     // (e.g. /tmp vs /private/tmp) so Seatbelt allows traversing symlinks.
     for cap in caps.fs_capabilities() {
         match cap.access {
-            AccessMode::Read | AccessMode::ReadWrite => {
+            AccessMode::Read
+            | AccessMode::ReadWrite
+            | AccessMode::ReadExecute
+            | AccessMode::ReadWriteExecute => {
                 for filter in path_filters_for_cap(cap)? {
                     profile.push_str(&format!("(allow file-read* ({}))\n", filter));
                 }
             }
-            AccessMode::Write => {
-                // Write-only doesn't need read access
+            AccessMode::Write | AccessMode::Execute => {
+                // Write-only or Execute-only doesn't need read access
             }
         }
     }
@@ -630,6 +659,7 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
         profile.push_str("(allow file-read* (extension \"com.apple.app-sandbox.read\"))\n");
         profile.push_str("(allow file-read* (extension \"com.apple.app-sandbox.read-write\"))\n");
         profile.push_str("(allow file-write* (extension \"com.apple.app-sandbox.read-write\"))\n");
+        profile.push_str("(allow process-exec (extension \"com.apple.app-sandbox.execute\"))\n");
     }
 
     // SECURITY: Platform deny rules are placed BETWEEN read and write rules.
@@ -649,13 +679,13 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
     // Emits rules for both original and resolved paths when they differ.
     for cap in caps.fs_capabilities() {
         match cap.access {
-            AccessMode::Write | AccessMode::ReadWrite => {
+            AccessMode::Write | AccessMode::ReadWrite | AccessMode::ReadWriteExecute => {
                 for filter in path_filters_for_cap(cap)? {
                     profile.push_str(&format!("(allow file-write* ({}))\n", filter));
                 }
             }
-            AccessMode::Read => {
-                // Read-only doesn't need write access
+            AccessMode::Read | AccessMode::Execute | AccessMode::ReadExecute => {
+                // Read-only or Execute-only doesn't need write access
             }
         }
     }

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -851,7 +851,7 @@ mod tests {
         caps.add_fs(FsCapability {
             original: PathBuf::from("/test"),
             resolved: PathBuf::from("/test"),
-            access: AccessMode::ReadWrite,
+            access: AccessMode::ReadWriteExecute,
             is_file: false,
             source: CapabilitySource::User,
         });
@@ -861,6 +861,24 @@ mod tests {
         assert!(profile.contains("(allow file-read* (subpath \"/test\"))"));
         assert!(profile.contains("(allow file-write* (subpath \"/test\"))"));
         assert!(profile.contains("(allow file-map-executable (subpath \"/test\"))"));
+    }
+
+    #[test]
+    fn test_readwrite_dir_does_not_grant_executable_mapping() {
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/test"),
+            resolved: PathBuf::from("/test"),
+            access: AccessMode::ReadWrite,
+            is_file: false,
+            source: CapabilitySource::User,
+        });
+
+        let profile = generate_profile(&caps).unwrap();
+
+        assert!(profile.contains("(allow file-read* (subpath \"/test\"))"));
+        assert!(profile.contains("(allow file-write* (subpath \"/test\"))"));
+        assert!(!profile.contains("file-map-executable"));
     }
 
     #[test]

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -476,10 +476,7 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
     for cap in caps.fs_capabilities() {
         if matches!(
             cap.access,
-            AccessMode::Execute
-                | AccessMode::ReadWrite
-                | AccessMode::ReadExecute
-                | AccessMode::ReadWriteExecute
+            AccessMode::Execute | AccessMode::ReadExecute | AccessMode::ReadWriteExecute
         ) {
             for filter in path_filters_for_cap(cap)? {
                 profile.push_str(&format!("(allow process-exec ({}))\n", filter));
@@ -605,11 +602,7 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
     for cap in caps.fs_capabilities() {
         if matches!(
             cap.access,
-            AccessMode::Read
-                | AccessMode::ReadWrite
-                | AccessMode::Execute
-                | AccessMode::ReadExecute
-                | AccessMode::ReadWriteExecute
+            AccessMode::Execute | AccessMode::ReadExecute | AccessMode::ReadWriteExecute
         ) {
             for filter in path_filters_for_cap(cap)? {
                 profile.push_str(&format!("(allow file-map-executable ({}))\n", filter));

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -58,15 +58,21 @@ const EXT_CLASS_EXECUTE: &str = "com.apple.app-sandbox.execute";
 ///
 /// # Arguments
 /// * `path` - The filesystem path to grant access to
-/// * `access` - The access mode (Read -> read-only token, Write/ReadWrite -> read-write token, Execute -> execute token)
+/// * `access` - The access mode. Mapping (Seatbelt only ships three extension
+///   classes): `Read` → read-only, `Write`/`ReadWrite`/`ReadWriteExecute` →
+///   read-write, `Execute`/`ReadExecute` → execute (Apple's execute extension
+///   already implies read). Callers needing write+execute simultaneously must
+///   issue both a read-write token and an execute token.
 ///
 /// # Errors
 /// Returns an error if the path contains null bytes or if the kernel rejects the request.
 pub fn extension_issue_file(path: &Path, access: AccessMode) -> Result<String> {
     let class = match access {
         AccessMode::Read => EXT_CLASS_READ,
-        AccessMode::Write | AccessMode::ReadWrite => EXT_CLASS_READ_WRITE,
-        AccessMode::Execute => EXT_CLASS_EXECUTE,
+        AccessMode::Write | AccessMode::ReadWrite | AccessMode::ReadWriteExecute => {
+            EXT_CLASS_READ_WRITE
+        }
+        AccessMode::Execute | AccessMode::ReadExecute => EXT_CLASS_EXECUTE,
     };
 
     let class_c = CString::new(class)

--- a/crates/nono/tests/capability_manifest_schema.rs
+++ b/crates/nono/tests/capability_manifest_schema.rs
@@ -170,7 +170,7 @@ fn rejects_filesystem_grant_invalid_access_mode() {
         "version": "0.1.0",
         "filesystem": {
             "grants": [
-                { "path": "/tmp", "access": "execute" }
+                { "path": "/tmp", "access": "delete" }
             ]
         }
     }"#;

--- a/docs/cli/features/audit.mdx
+++ b/docs/cli/features/audit.mdx
@@ -5,7 +5,7 @@ description: Session tracking, filtering, and compliance reporting
 
 Every `nono run` session is recorded by default. nono records the command that ran, the audit events observed during the session, optional filesystem changes, and network events outside the sandbox in the trusted parent process. This gives you a history of agent activity for debugging, compliance, and forensics.
 
-The details of how that record is protected are explained in the [Security Model](/docs/cli/internals/security-model): the trusted supervisor records the session, the event log is committed with a Merkleized integrity structure, and optional signing lets a key holder attest to the completed session.
+The details of how that record is protected are explained in the [Security Model](/cli/internals/security-model): the trusted supervisor records the session, the event log is committed with a Merkleized integrity structure, and optional signing lets a key holder attest to the completed session.
 
 ## How It Works
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -258,6 +258,24 @@ Grant write-only access to a single file.
 nono run --write-file ./output.log -- command
 ```
 
+#### `--execute`
+
+Grant execute access to a directory (recursive). Decouples execute permission
+from read permission — pair with `--read` if the sandboxed process also needs
+to read non-binary files in the directory.
+
+```bash
+nono run --execute /usr/bin -- command
+```
+
+#### `--execute-file`
+
+Grant execute access to a single file.
+
+```bash
+nono run --execute-file /usr/local/bin/myapp -- command
+```
+
 ### AF_UNIX Socket Permissions
 
 These flags grant `connect(2)` (and optionally `bind(2)`) on pathname AF_UNIX


### PR DESCRIPTION
Fixes #491 
Closes #491 

### Description
This PR decouples file execution from read access within the nono sandbox to enforce a more robust least-privilege security model. Currently, granting a process permission to read a directory (via --read) inadvertently allows it to execute binaries or load shared libraries from that same path, creating a potential vector for exploitation. By introducing a dedicated AccessMode::Execute variant and corresponding --execute CLI flags, the sandbox can distinguish between data-only paths (like configuration folders) and binary-only paths (like /usr/bin), mapping these granular rights to Linux Landlock’s AccessFs::Execute and macOS Seatbelt’s file-map-executable and process-exec primitives.

### Examples

```sh
hanshal101@lol:~/opsrc/nono$ cat /tmp/hello.sh 
echo "Hello"hanshal101@lol:~/opsrc/nono$ 
hanshal101@lol:~/opsrc/nono$ ./target/debug/nono run --allow /tmp -- /tmp/hello.sh 

  nono v0.26.1
  update 0.27.0 available (current: 0.26.1)
  $ cargo install nono-cli
  https://github.com/always-further/nono/releases/tag/v0.27.0

  Share /home/hanshal101/opsrc/nono with read access?
  use --allow-cwd to skip this prompt
  [y/N] y
  Capabilities:
  ────────────────────────────────────────────────────
   r+w  /tmp (dir)
    r   /home/hanshal101/opsrc/nono (dir)
       + 51 system/group paths (-v to show)
   net  outbound allowed
  ────────────────────────────────────────────────────

   kernel  Landlock V6 (File rename across directories (Refer), File truncation (Truncate), TCP network filtering, Device ioctl filtering, Process scoping)
2026-04-03T07:28:51.281856Z  INFO Landlock available (Landlock V6, features: Basic filesystem access control, File rename across directories (Refer), File truncation (Truncate), TCP network filtering, Device ioctl filtering, Process scoping)
  Applying sandbox...2026-04-03T07:28:51.282217Z  INFO Direct mode: detected Landlock V6
2026-04-03T07:28:51.282226Z  INFO Using Landlock ABI V6
 active

2026-04-03T07:28:51.282407Z  INFO Executing with strategy: Direct, threading: Strict
2026-04-03T07:28:51.282413Z  INFO Executing (direct): /tmp/hello.sh []
2026-04-03T07:28:51.282531Z ERROR Command execution failed: Permission denied (os error 13)
nono: Command execution failed: Permission denied (os error 13)
hanshal101@lol:~/opsrc/nono$ 
hanshal101@lol:~/opsrc/nono$ 
hanshal101@lol:~/opsrc/nono$ ./target/debug/nono run --allow /tmp --execute /tmp -- /tmp/hello.sh 

  nono v0.26.1
  update 0.27.0 available (current: 0.26.1)
  $ cargo install nono-cli
  https://github.com/always-further/nono/releases/tag/v0.27.0

  Share /home/hanshal101/opsrc/nono with read access?
  use --allow-cwd to skip this prompt
  [y/N] y
  Capabilities:
  ────────────────────────────────────────────────────
  r+w+e /tmp (dir)
    r   /home/hanshal101/opsrc/nono (dir)
       + 51 system/group paths (-v to show)
   net  outbound allowed
  ────────────────────────────────────────────────────

   kernel  Landlock V6 (File rename across directories (Refer), File truncation (Truncate), TCP network filtering, Device ioctl filtering, Process scoping)
2026-04-03T07:29:00.472528Z  INFO Landlock available (Landlock V6, features: Basic filesystem access control, File rename across directories (Refer), File truncation (Truncate), TCP network filtering, Device ioctl filtering, Process scoping)
  Applying sandbox...2026-04-03T07:29:00.473046Z  INFO Direct mode: detected Landlock V6
2026-04-03T07:29:00.473060Z  INFO Using Landlock ABI V6
 active

2026-04-03T07:29:00.473328Z  INFO Executing with strategy: Direct, threading: Strict
2026-04-03T07:29:00.473337Z  INFO Executing (direct): /tmp/hello.sh []
Hello
```