### PR TITLE
fix(policy): grant ~/.cache/claude readwrite in claude-code profile

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -663,7 +663,7 @@
         "capability_elevation": false
       },
       "filesystem": {
-        "allow": ["$HOME/.claude"],
+        "allow": ["$HOME/.claude", "$HOME/.cache/claude"],
         "allow_file": ["$HOME/.claude.json", "$HOME/.claude.json.lock"]
       },
       "network": { "block": false },

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -31,6 +31,10 @@ mod tests {
             .security
             .groups
             .contains(&"deny_credentials".to_string()));
+        assert!(profile
+            .filesystem
+            .allow
+            .contains(&"$HOME/.cache/claude".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
Fixes: #524

claude upgrade stages downloads in ~/.cache/claude/staging before replacing the binary. This path is used on both macOS and Linux but was not included in the built-in claude-code profile, causing EPERM.