### PR TITLE
feat(wsl2): add ABI-aware tests and rolling kernel documentation

### DIFF
--- a/docs/cli/internals/wsl2-feature-matrix.mdx
+++ b/docs/cli/internals/wsl2-feature-matrix.mdx
@@ -3,7 +3,7 @@ title: WSL2 Feature Matrix
 description: Complete feature-by-feature compatibility status for nono on WSL2
 ---
 
-Complete feature compatibility for nono running on WSL2 (kernel 6.6, Landlock V3).
+Complete feature compatibility for nono running on WSL2. Default counts are for the Microsoft kernel (6.6, Landlock V3). See the summary for rolling kernel (V6) numbers.
 
 Legend: **Full** = identical to native Linux | **Blocked (default)** = fails secure, requires profile opt-in | **Unavailable** = not functional on WSL2
 
@@ -20,6 +20,13 @@ Legend: **Full** = identical to native Linux | **Blocked (default)** = fails sec
 | `nono rollback` (list/show/restore/verify/cleanup) | Full | Pure userspace |
 | `nono audit` (list/show) | Full | Pure userspace |
 | `nono trust` (init/sign/verify/list) | Full | keygen/sign-policy require `gnome-keyring` (distro dependency, not WSL2-specific) |
+| `nono ps` | Full | Session listing, pure userspace |
+| `nono stop` | Full | Signal-based session stop |
+| `nono attach` | Full | PTY attach, basic supervised mode |
+| `nono detach` | Full | PTY detach |
+| `nono logs` | Full | Session event logs, pure userspace |
+| `nono inspect` | Full | Session state, pure userspace |
+| `nono prune` | Full | Session cleanup, pure userspace |
 | `nono policy` (groups/profiles/show/diff/validate) | Full | Pure logic |
 | `nono profile` (init/schema/guide) | Full | Pure logic |
 
@@ -200,7 +207,7 @@ Legend: **Full** = identical to native Linux | **Blocked (default)** = fails sec
 
 | Category | Full | Degraded | Unavailable |
 |----------|------|----------|-------------|
-| Subcommands (11) | 11 | 0 | 0 |
+| Subcommands (18) | 18 | 0 | 0 |
 | Filesystem (15) | 14 | 0 | 1 |
 | Network (5) | 2 | 0 | 3 |
 | Credential Proxy (10) | 4 | 0 | 6 |
@@ -214,20 +221,22 @@ Legend: **Full** = identical to native Linux | **Blocked (default)** = fails sec
 | Learn Mode (5) | 5 | 0 | 0 |
 | Output (6) | 6 | 0 | 0 |
 | Environment (4) | 4 | 0 | 0 |
-| **Total (110)** | **92 (84%)** | **0 (0%)** | **18 (16%)** |
+| **Total (117)** | **99 (85%)** | **0 (0%)** | **18 (15%)** |
 
 ### Root causes of all WSL2-specific limitations
 
 | Root Cause | Features Affected | Fix |
 |------------|-------------------|-----|
-| Landlock V4 missing (kernel 6.6 < 6.7) | Per-port network (3) | WSL2 kernel upgrade (automatic) |
-| Landlock V6 missing (kernel 6.6 < 6.12) | signal_mode, process_info_mode, ipc_mode (3) | WSL2 kernel upgrade (automatic) |
-| Landlock V5 missing (kernel 6.6 < 6.10) | Device ioctl filtering (1) | WSL2 kernel upgrade (automatic) |
-| seccomp notify EBUSY | capability_elevation, interactive mode, PTY relay, runtime expansion (4) | microsoft/WSL#9548 fix or eBPF alternative |
+| Landlock V4 missing (kernel 6.6 < 6.7) | Per-port network (3) | [Rolling kernel](https://github.com/Nevuly/WSL2-Linux-Kernel-Rolling) or wait for Microsoft kernel upgrade |
+| Landlock V6 missing (kernel 6.6 < 6.12) | signal_mode, process_info_mode, ipc_mode (3) | Rolling kernel or wait for Microsoft kernel upgrade |
+| Landlock V5 missing (kernel 6.6 < 6.10) | Device ioctl filtering (1) | Rolling kernel or wait for Microsoft kernel upgrade |
+| seccomp notify EBUSY | capability_elevation, interactive mode, PTY relay, runtime expansion (4) | microsoft/WSL#9548 — WSL2 userspace issue, persists regardless of kernel version |
+| Proxy port enforcement (pre-V4) | Credential proxy features (6 blocked by default) | Rolling kernel (V4+ enables native enforcement) or `wsl2_proxy_policy: "insecure_proxy"` opt-in |
+
+**With rolling kernel (6.19+, Landlock V6):** All Landlock-dependent limitations are resolved — **112/117 features (96%) fully available.** Only 5 features remain unavailable, all due to seccomp notify EBUSY (`--capability-elevation` and dependent features). See [WSL2 Support](/cli/internals/wsl2#rolling-release-kernel-community) for install instructions.
 
 ### Distro dependencies (not WSL2-specific)
 
 | Dependency | Features Affected | Fix |
 |------------|-------------------|-----|
 | `gnome-keyring` or `keepassxc` | trust keygen/sign/sign-policy/export-key | `sudo apt install gnome-keyring dbus-x11` |
-| Proxy port enforcement (seccomp notify + Landlock V4) | Credential proxy features (6 blocked by default) | WSL2 kernel upgrade or `wsl2_proxy_policy: "insecure_proxy"` opt-in |

--- a/docs/cli/internals/wsl2.mdx
+++ b/docs/cli/internals/wsl2.mdx
@@ -5,9 +5,9 @@ description: Running nono inside Windows Subsystem for Linux 2 (WSL2) — what w
 
 nono works on WSL2 with most features available. This page documents the compatibility details, known limitations, and workarounds.
 
-For the complete feature-by-feature breakdown (110 features), see the [WSL2 Feature Matrix](/cli/internals/wsl2-feature-matrix).
+For the complete feature-by-feature breakdown (117 features), see the [WSL2 Feature Matrix](/cli/internals/wsl2-feature-matrix).
 
-**At a glance: 84% full, 16% blocked by default (most recoverable with profile opt-in or kernel upgrade).**
+**At a glance: 85% full on Microsoft kernel, 96% with [rolling kernel](/cli/internals/wsl2#rolling-release-kernel-community).**
 
 ## Quick Summary
 
@@ -30,6 +30,7 @@ WSL2 runs a real Linux kernel with Landlock LSM enabled. Core filesystem sandbox
 | Direct mode (`nono wrap`) | Available | No fork, no supervisor |
 | Capability elevation (`--capability-elevation`) | Unavailable | seccomp notify returns `EBUSY` |
 | Snapshots and rollback (`--rollback`) | Available | Pure userspace |
+| Session management (`ps`, `attach`, `detach`, `stop`, `logs`, `inspect`, `prune`) | Available | Pure userspace / PTY relay |
 | Audit trail | Available | Pure userspace |
 | Profiles | Available | All built-in profiles work |
 | `nono setup --check-only` | Available | Reports WSL2 feature matrix |
@@ -135,9 +136,33 @@ When Landlock V4 becomes available on WSL2 (kernel 6.7+), port-level lockdown wi
 
 ## Workarounds
 
+### Rolling Release Kernel (Community)
+
+The [WSL2-Linux-Kernel-Rolling](https://github.com/Nevuly/WSL2-Linux-Kernel-Rolling) project provides pre-built WSL2 kernels tracking upstream Linux stable releases. As of kernel 6.19+, this gives nono full Landlock V6 support:
+
+- Per-port TCP filtering (V4)
+- Device ioctl filtering (V5)
+- Process scoping (V6)
+- Native credential proxy port enforcement (no `wsl2_proxy_policy` opt-in needed)
+
+**Install:**
+
+1. Download `bzImage-x86_64` from the [latest release](https://github.com/Nevuly/WSL2-Linux-Kernel-Rolling/releases/latest)
+2. Add to `%USERPROFILE%\.wslconfig`:
+   ```ini
+   [wsl2]
+   kernel=C:\\path\\to\\bzImage-x86_64
+   ```
+3. Restart WSL: `wsl --shutdown`
+4. Verify: `nono setup --check-only` should report Landlock V6
+
+**Note:** This is a community-maintained project, not officially supported by Microsoft or nono. The kernel combines upstream Linux stable releases with Microsoft's WSL2 patches. Users should understand they are trusting a third-party kernel binary. The seccomp notify limitation (`--capability-elevation`) persists regardless of kernel version as it is a WSL2 userspace issue.
+
+To revert to the Microsoft kernel, comment out or remove the `kernel=` line from `.wslconfig` and restart WSL.
+
 ### Custom WSL2 Kernel
 
-Advanced users can build a custom WSL2 kernel from [microsoft/WSL2-Linux-Kernel](https://github.com/microsoft/WSL2-Linux-Kernel) with a newer Landlock ABI or modified seccomp configuration:
+Advanced users can build a custom WSL2 kernel from [microsoft/WSL2-Linux-Kernel](https://github.com/microsoft/WSL2-Linux-Kernel):
 
 ```bash
 git clone --depth 1 --branch linux-msft-wsl-6.6.y \
@@ -147,20 +172,11 @@ cp arch/x86/configs/config-wsl .config
 make -j$(nproc)
 ```
 
-Then configure WSL2 to use the custom kernel in `%USERPROFILE%\.wslconfig`:
-
-```ini
-[wsl2]
-kernel=C:\\path\\to\\bzImage
-```
-
-Restart WSL2 with `wsl --shutdown`.
-
-Note: Getting Landlock V4 requires rebasing Microsoft's patches onto a 6.7+ upstream kernel or cherry-picking V4 patches into their 6.6 tree.
+Then configure WSL2 to use the custom kernel in `%USERPROFILE%\.wslconfig` as above. Note: Getting Landlock V4+ from the Microsoft source requires rebasing their patches onto a 6.7+ upstream kernel.
 
 ### Block-All Network
 
-If you need guaranteed network isolation (not just proxy routing), use `--block-net` which is fully kernel-enforced on WSL2:
+If you need guaranteed network isolation (not just proxy routing), use `--block-net` which is fully kernel-enforced on WSL2 regardless of kernel version:
 
 ```bash
 nono run --block-net --allow /path/to/project -- your-command
@@ -168,6 +184,5 @@ nono run --block-net --allow /path/to/project -- your-command
 
 ## Future Improvements
 
-- **Landlock V4+**: Will arrive when Microsoft upgrades the WSL2 kernel (no nono changes needed)
-- **eBPF LSM**: WSL2 kernel has `CONFIG_BPF_LSM=y` enabled, which could provide an alternative to seccomp notify for capability elevation
-- **microsoft/WSL#9548**: If Microsoft resolves the seccomp notify conflict, all features will work automatically
+- **Landlock V4+**: Available now via rolling kernel; will arrive on the Microsoft kernel when they upgrade from 6.6 LTS (no nono changes needed)
+- **microsoft/WSL#9548**: If Microsoft resolves the seccomp notify conflict, capability elevation will work automatically. This is a WSL2 userspace issue, not a kernel version issue.

--- a/tests/integration/test_wsl2.sh
+++ b/tests/integration/test_wsl2.sh
@@ -11,6 +11,13 @@ echo -e "${BLUE}=== WSL2 Support Tests ===${NC}"
 
 verify_nono_binary
 
+# Detect whether Landlock has native TCP filtering (V4+).
+# With V4+, per-port network filtering and proxy enforcement work natively.
+# Uses --dry-run to avoid sandbox application or forking.
+has_landlock_network() {
+    "$NONO_BIN" run --dry-run --allow /tmp -- true </dev/null 2>&1 | grep -q "TCP network filtering"
+}
+
 echo ""
 
 # =============================================================================
@@ -114,26 +121,26 @@ echo ""
 echo "--- Per-Port Network Filtering ---"
 
 if is_wsl2; then
-    # On WSL2 with kernel 6.6, per-port filtering requires Landlock V4 (kernel 6.7+)
-    # and seccomp notify (broken on WSL2). Should error clearly.
     TMPDIR3=$(setup_test_dir)
 
-    # --allow-net with a specific port should fail on WSL2 if V4 unavailable
+    # --listen-port tests per-port TCP bind filtering (Landlock V4+)
     TESTS_RUN=$((TESTS_RUN + 1))
     set +e
-    net_output=$("$NONO_BIN" run --allow-net 443 --allow "$TMPDIR3" -- true </dev/null 2>&1)
+    net_output=$("$NONO_BIN" run --listen-port 8080 --allow "$TMPDIR3" -- true </dev/null 2>&1)
     net_exit=$?
     set -e
 
-    if [[ "$net_exit" -ne 0 ]]; then
-        echo -e "  ${GREEN}PASS${NC}: per-port filtering correctly rejected (exit $net_exit)"
+    if [[ "$net_exit" -eq 0 ]]; then
+        if has_landlock_network; then
+            echo -e "  ${GREEN}PASS${NC}: per-port filtering works (Landlock V4+ enforced)"
+        else
+            echo -e "  ${GREEN}PASS${NC}: per-port filtering accepted (best-effort on pre-V4)"
+        fi
         TESTS_PASSED=$((TESTS_PASSED + 1))
     else
-        # If it succeeded, check if this WSL2 has been upgraded to a kernel with V4
-        kernel_version=$(uname -r)
-        echo -e "  ${YELLOW}SKIP${NC}: per-port filtering succeeded (kernel $kernel_version may have V4 support)"
-        TESTS_RUN=$((TESTS_RUN - 1))
-        TESTS_SKIPPED=$((TESTS_SKIPPED + 1))
+        echo -e "  ${RED}FAIL${NC}: per-port filtering command failed (exit $net_exit)"
+        echo "       Output: ${net_output:0:500}"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
     fi
 
     cleanup_test_dir "$TMPDIR3"
@@ -200,41 +207,99 @@ if is_wsl2; then
     else
         TMPDIR_PROXY=$(setup_test_dir)
 
-        # Default policy (error): --credential should fail on WSL2
-        TESTS_RUN=$((TESTS_RUN + 1))
-        set +e
-        proxy_output=$("$NONO_BIN" run --credential github --allow "$TMPDIR_PROXY" -- echo "should fail" </dev/null 2>&1)
-        proxy_exit=$?
-        set -e
+        if has_landlock_network; then
+            # Landlock V4+ — proxy enforcement is native, no fail-secure needed
+            echo "  Landlock V4+ detected — testing native proxy enforcement"
 
-        if [[ "$proxy_exit" -ne 0 ]] && echo "$proxy_output" | grep -q "proxy-only network mode cannot be kernel-enforced"; then
-            echo -e "  ${GREEN}PASS${NC}: default policy rejects ProxyOnly on WSL2 (fail-secure, exit $proxy_exit)"
-            TESTS_PASSED=$((TESTS_PASSED + 1))
-        elif [[ "$proxy_exit" -eq 0 ]]; then
-            echo -e "  ${RED}FAIL${NC}: default policy should reject ProxyOnly on WSL2 but exited 0"
-            echo "       Output: ${proxy_output:0:500}"
-            TESTS_FAILED=$((TESTS_FAILED + 1))
+            # --credential should work without wsl2_proxy_policy opt-in
+            TESTS_RUN=$((TESTS_RUN + 1))
+            set +e
+            proxy_output=$("$NONO_BIN" run --credential github --allow "$TMPDIR_PROXY" -- echo "proxy ok" </dev/null 2>&1)
+            proxy_exit=$?
+            set -e
+
+            # Proxy may fail due to missing credentials (no keystore), but it
+            # should NOT fail with the "cannot be kernel-enforced" error
+            if echo "$proxy_output" | grep -q "proxy-only network mode cannot be kernel-enforced"; then
+                echo -e "  ${RED}FAIL${NC}: proxy rejected despite Landlock V4+ native enforcement"
+                echo "       Output: ${proxy_output:0:500}"
+                TESTS_FAILED=$((TESTS_FAILED + 1))
+            else
+                echo -e "  ${GREEN}PASS${NC}: proxy accepted with native Landlock enforcement"
+                TESTS_PASSED=$((TESTS_PASSED + 1))
+            fi
+
+            # Banner should NOT mention per-port filtering as unavailable
+            TESTS_RUN=$((TESTS_RUN + 1))
+            if echo "$proxy_output" | grep -q "per-port filtering"; then
+                echo -e "  ${RED}FAIL${NC}: banner mentions per-port filtering despite V4+ availability"
+                TESTS_FAILED=$((TESTS_FAILED + 1))
+            else
+                echo -e "  ${GREEN}PASS${NC}: banner correctly omits per-port filtering from degraded list"
+                TESTS_PASSED=$((TESTS_PASSED + 1))
+            fi
+
+            # wsl2_proxy_policy should be irrelevant — verify no error with or without it
+            TESTS_RUN=$((TESTS_RUN + 1))
+            INSECURE_PROFILE="$TMPDIR_PROXY/v4-proxy-test.json"
+            cat > "$INSECURE_PROFILE" <<'PROFILE_EOF'
+{
+  "meta": { "name": "v4-proxy-test", "version": "1.0.0" },
+  "filesystem": { "allow": ["/tmp"] },
+  "network": { "block": false },
+  "security": { "wsl2_proxy_policy": "insecure_proxy" }
+}
+PROFILE_EOF
+            set +e
+            v4_output=$("$NONO_BIN" run --profile "$INSECURE_PROFILE" --credential github --allow "$TMPDIR_PROXY" -- echo "v4 ok" </dev/null 2>&1)
+            set -e
+
+            if echo "$v4_output" | grep -q "proxy-only network mode cannot be kernel-enforced"; then
+                echo -e "  ${RED}FAIL${NC}: insecure_proxy profile rejected despite V4+"
+                TESTS_FAILED=$((TESTS_FAILED + 1))
+            else
+                echo -e "  ${GREEN}PASS${NC}: insecure_proxy profile works (policy is no-op with V4+)"
+                TESTS_PASSED=$((TESTS_PASSED + 1))
+            fi
         else
-            echo -e "  ${RED}FAIL${NC}: default policy should reject ProxyOnly with specific error message"
-            echo "       Exit: $proxy_exit"
-            echo "       Output: ${proxy_output:0:500}"
-            TESTS_FAILED=$((TESTS_FAILED + 1))
-        fi
+            # Pre-V4 — proxy enforcement requires seccomp fallback (EBUSY on WSL2)
+            echo "  Landlock pre-V4 — testing fail-secure proxy policy"
 
-        # Error message should mention the escape hatch
-        TESTS_RUN=$((TESTS_RUN + 1))
-        if echo "$proxy_output" | grep -q "wsl2_proxy_policy"; then
-            echo -e "  ${GREEN}PASS${NC}: error message mentions wsl2_proxy_policy escape hatch"
-            TESTS_PASSED=$((TESTS_PASSED + 1))
-        else
-            echo -e "  ${RED}FAIL${NC}: error message should mention wsl2_proxy_policy"
-            echo "       Output: ${proxy_output:0:500}"
-            TESTS_FAILED=$((TESTS_FAILED + 1))
-        fi
+            # Default policy (error): --credential should fail on WSL2
+            TESTS_RUN=$((TESTS_RUN + 1))
+            set +e
+            proxy_output=$("$NONO_BIN" run --credential github --allow "$TMPDIR_PROXY" -- echo "should fail" </dev/null 2>&1)
+            proxy_exit=$?
+            set -e
 
-        # insecure_proxy policy: create a profile that opts in
-        INSECURE_PROFILE="$TMPDIR_PROXY/insecure-proxy-test.json"
-        cat > "$INSECURE_PROFILE" <<'PROFILE_EOF'
+            if [[ "$proxy_exit" -ne 0 ]] && echo "$proxy_output" | grep -q "proxy-only network mode cannot be kernel-enforced"; then
+                echo -e "  ${GREEN}PASS${NC}: default policy rejects ProxyOnly on WSL2 (fail-secure, exit $proxy_exit)"
+                TESTS_PASSED=$((TESTS_PASSED + 1))
+            elif [[ "$proxy_exit" -eq 0 ]]; then
+                echo -e "  ${RED}FAIL${NC}: default policy should reject ProxyOnly on WSL2 but exited 0"
+                echo "       Output: ${proxy_output:0:500}"
+                TESTS_FAILED=$((TESTS_FAILED + 1))
+            else
+                echo -e "  ${RED}FAIL${NC}: default policy should reject ProxyOnly with specific error message"
+                echo "       Exit: $proxy_exit"
+                echo "       Output: ${proxy_output:0:500}"
+                TESTS_FAILED=$((TESTS_FAILED + 1))
+            fi
+
+            # Error message should mention the escape hatch
+            TESTS_RUN=$((TESTS_RUN + 1))
+            if echo "$proxy_output" | grep -q "wsl2_proxy_policy"; then
+                echo -e "  ${GREEN}PASS${NC}: error message mentions wsl2_proxy_policy escape hatch"
+                TESTS_PASSED=$((TESTS_PASSED + 1))
+            else
+                echo -e "  ${RED}FAIL${NC}: error message should mention wsl2_proxy_policy"
+                echo "       Output: ${proxy_output:0:500}"
+                TESTS_FAILED=$((TESTS_FAILED + 1))
+            fi
+
+            # insecure_proxy policy: create a profile that opts in
+            INSECURE_PROFILE="$TMPDIR_PROXY/insecure-proxy-test.json"
+            cat > "$INSECURE_PROFILE" <<'PROFILE_EOF'
 {
   "meta": { "name": "insecure-proxy-test", "version": "1.0.0" },
   "filesystem": { "allow": ["/tmp"] },
@@ -243,39 +308,35 @@ if is_wsl2; then
 }
 PROFILE_EOF
 
-        TESTS_RUN=$((TESTS_RUN + 1))
-        set +e
-        insecure_output=$("$NONO_BIN" run --profile "$INSECURE_PROFILE" --credential github --allow "$TMPDIR_PROXY" -- echo "insecure ok" </dev/null 2>&1)
-        insecure_exit=$?
-        set -e
+            TESTS_RUN=$((TESTS_RUN + 1))
+            set +e
+            insecure_output=$("$NONO_BIN" run --profile "$INSECURE_PROFILE" --credential github --allow "$TMPDIR_PROXY" -- echo "insecure ok" </dev/null 2>&1)
+            insecure_exit=$?
+            set -e
 
-        if echo "$insecure_output" | grep -q "insecure proxy mode"; then
-            echo -e "  ${GREEN}PASS${NC}: insecure_proxy policy emits degraded-security warning"
-            TESTS_PASSED=$((TESTS_PASSED + 1))
-        elif echo "$insecure_output" | grep -q "proxy-only network mode cannot be kernel-enforced"; then
-            echo -e "  ${RED}FAIL${NC}: insecure_proxy policy was not respected (got fail-secure error)"
-            echo "       Output: ${insecure_output:0:500}"
-            TESTS_FAILED=$((TESTS_FAILED + 1))
-        else
-            # Proxy policy was accepted (no fail-secure error), but credential
-            # loading may have failed before the warning was printed (no keystore).
-            # Verify we at least got past the policy check.
-            if [[ "$insecure_exit" -ne 0 ]] && echo "$insecure_output" | grep -qi "keystore\|credential\|secret"; then
-                echo -e "  ${GREEN}PASS${NC}: insecure_proxy policy accepted (credential loading failed separately)"
+            if echo "$insecure_output" | grep -q "insecure proxy mode"; then
+                echo -e "  ${GREEN}PASS${NC}: insecure_proxy policy emits degraded-security warning"
                 TESTS_PASSED=$((TESTS_PASSED + 1))
-            else
-                echo -e "  ${RED}FAIL${NC}: insecure_proxy policy: unexpected behavior (exit $insecure_exit)"
+            elif echo "$insecure_output" | grep -q "proxy-only network mode cannot be kernel-enforced"; then
+                echo -e "  ${RED}FAIL${NC}: insecure_proxy policy was not respected (got fail-secure error)"
                 echo "       Output: ${insecure_output:0:500}"
                 TESTS_FAILED=$((TESTS_FAILED + 1))
+            else
+                if [[ "$insecure_exit" -ne 0 ]] && echo "$insecure_output" | grep -qi "keystore\|credential\|secret"; then
+                    echo -e "  ${GREEN}PASS${NC}: insecure_proxy policy accepted (credential loading failed separately)"
+                    TESTS_PASSED=$((TESTS_PASSED + 1))
+                else
+                    echo -e "  ${RED}FAIL${NC}: insecure_proxy policy: unexpected behavior (exit $insecure_exit)"
+                    echo "       Output: ${insecure_output:0:500}"
+                    TESTS_FAILED=$((TESTS_FAILED + 1))
+                fi
             fi
         fi
 
         cleanup_test_dir "$TMPDIR_PROXY"
     fi
 else
-    skip_test "default policy rejects ProxyOnly on WSL2" "not running on WSL2"
-    skip_test "error message mentions escape hatch" "not running on WSL2"
-    skip_test "insecure_proxy policy emits warning" "not running on WSL2"
+    skip_test "WSL2 proxy policy tests" "not running on WSL2"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Make WSL2 integration tests adapt to the Landlock ABI version so they pass on both Microsoft kernel (V3) and community rolling kernels (V4-V6)
- Document the [WSL2-Linux-Kernel-Rolling](https://github.com/Nevuly/WSL2-Linux-Kernel-Rolling) project as a workaround for Landlock V4-V6 features
- Update feature matrix root causes with rolling kernel as a fix option

### Test changes

The proxy policy and per-port filtering tests now branch on `has_landlock_network()`:

| Kernel | Per-port test | Proxy policy tests |
|--------|-------------|-------------------|
| Microsoft 6.6 (V3) | Accepted best-effort | Fail-secure default, escape hatch, insecure_proxy |
| Rolling 6.19 (V6) | Enforced natively | Native enforcement, banner correct, policy is no-op |

Verified on:
- Ubuntu 24.04 + Microsoft kernel 6.6.87 (Landlock V3) — 21/21
- Ubuntu 24.04 + Rolling kernel 6.19.11 (Landlock V6) — 21/21
- Arch + Rolling kernel 6.19.11 (Landlock V6) — 21/21

### Key files

- [WSL2 Support Docs](https://github.com/scp7/nono/blob/feat/wsl2-rolling-kernel-tests/docs/cli/internals/wsl2.mdx)
- [Feature Matrix](https://github.com/scp7/nono/blob/feat/wsl2-rolling-kernel-tests/docs/cli/internals/wsl2-feature-matrix.mdx)
- [Integration Tests](https://github.com/scp7/nono/blob/feat/wsl2-rolling-kernel-tests/tests/integration/test_wsl2.sh)

## Test plan

- [x] 21/21 WSL2 integration tests on Microsoft kernel (V3)
- [x] 21/21 WSL2 integration tests on rolling kernel (V6)
- [x] Full CI locally (clippy + fmt + cargo test) — clean
- [x] Cross-distro: Ubuntu 24.04, Arch