### PR TITLE
feat: add --allow-gpu flag for GPU access on Apple Silicon Macs

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -79,6 +79,13 @@
       ],
       "description": "Opt-in gate for temporary direct LaunchServices opens on macOS. Must be paired with the CLI flag --allow-launch-services. Set to null to inherit from the base profile."
     },
+    "allow_gpu": {
+      "oneOf": [
+        { "type": "boolean" },
+        { "type": "null" }
+      ],
+      "description": "Opt-in gate for GPU access on Apple Silicon Macs through IOKit. Must be paired with the CLI flag --allow-gpu. Set to null to inherit from the base profile."
+    },
     "interactive": {
       "type": "boolean",
       "description": "Deprecated. Parsed for backward compatibility but ignored. Supervised mode preserves TTY by default.",

--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -675,7 +675,6 @@
         "allow_localhost": true
       },
       "allow_launch_services": true,
-      "allow_gpu": true,
       "hooks": {
         "claude-code": {
           "event": "PostToolUseFailure",
@@ -721,7 +720,6 @@
         "allow_localhost": true
       },
       "allow_launch_services": true,
-      "allow_gpu": true,
       "network": { "block": false },
       "workdir": { "access": "readwrite" },
       "interactive": true

--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -675,6 +675,7 @@
         "allow_localhost": true
       },
       "allow_launch_services": true,
+      "allow_gpu": true,
       "hooks": {
         "claude-code": {
           "event": "PostToolUseFailure",
@@ -720,6 +721,7 @@
         "allow_localhost": true
       },
       "allow_launch_services": true,
+      "allow_gpu": true,
       "network": { "block": false },
       "workdir": { "access": "readwrite" },
       "interactive": true

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -833,6 +833,10 @@ pub struct SandboxArgs {
     #[arg(long, help_heading = "OPTIONS")]
     pub allow_launch_services: bool,
 
+    /// Allow GPU access on Apple Silicon Macs through IOKit
+    #[arg(long, help_heading = "OPTIONS")]
+    pub allow_gpu: bool,
+
     /// Capability manifest file (JSON). A fully-resolved sandbox specification —
     /// mutually exclusive with all other sandbox configuration flags.
     #[arg(
@@ -845,7 +849,7 @@ pub struct SandboxArgs {
             "block_net", "allow_net", "network_profile", "allow_proxy",
             "allow_bind", "allow_port", "external_proxy", "proxy_port",
             "proxy_credential", "allow_endpoint", "env_credential", "env_credential_map",
-            "allow_command", "block_command", "allow_launch_services",
+            "allow_command", "block_command", "allow_launch_services", "allow_gpu",
         ],
         help_heading = "OPTIONS"
     )]
@@ -990,6 +994,10 @@ pub struct WrapSandboxArgs {
     #[arg(long, help_heading = "OPTIONS")]
     pub allow_launch_services: bool,
 
+    /// Allow GPU access on Apple Silicon Macs through IOKit
+    #[arg(long, help_heading = "OPTIONS")]
+    pub allow_gpu: bool,
+
     /// Capability manifest file (JSON). A fully-resolved sandbox specification —
     /// mutually exclusive with all other sandbox configuration flags.
     #[arg(
@@ -1001,7 +1009,7 @@ pub struct WrapSandboxArgs {
             "profile", "override_deny", "allow_cwd",
             "block_net", "allow_bind", "allow_port",
             "env_credential", "env_credential_map",
-            "allow_command", "block_command", "allow_launch_services",
+            "allow_command", "block_command", "allow_launch_services", "allow_gpu",
         ],
         help_heading = "OPTIONS"
     )]
@@ -1045,6 +1053,7 @@ impl From<WrapSandboxArgs> for SandboxArgs {
             block_command: args.block_command,
             profile: args.profile,
             allow_launch_services: args.allow_launch_services,
+            allow_gpu: args.allow_gpu,
             config: args.config,
             verbose: args.verbose,
             dry_run: args.dry_run,

--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -7,7 +7,8 @@ use crate::launch_runtime::{
 };
 use crate::output;
 use crate::sandbox_prepare::{
-    prepare_sandbox, print_allow_launch_services_warning, validate_external_proxy_bypass,
+    prepare_sandbox, print_allow_gpu_warning, print_allow_launch_services_warning,
+    validate_external_proxy_bypass,
 };
 use crate::theme;
 use nono::{NonoError, Result};
@@ -69,6 +70,9 @@ pub(crate) fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
 
     if prepared.allow_launch_services_active {
         print_allow_launch_services_warning(silent);
+    }
+    if prepared.allow_gpu_active {
+        print_allow_gpu_warning(silent);
     }
 
     if !silent {
@@ -141,6 +145,9 @@ pub(crate) fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
 
     if prepared.allow_launch_services_active {
         print_allow_launch_services_warning(silent);
+    }
+    if prepared.allow_gpu_active {
+        print_allow_gpu_warning(silent);
     }
 
     execute_sandboxed(LaunchPlan {

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -2,7 +2,7 @@ use crate::cli::RunArgs;
 use crate::config;
 use crate::proxy_runtime::prepare_proxy_launch_options;
 use crate::sandbox_prepare::{
-    prepare_sandbox, print_allow_launch_services_warning, PreparedSandbox,
+    prepare_sandbox, print_allow_gpu_warning, print_allow_launch_services_warning, PreparedSandbox,
 };
 use crate::{exec_strategy, instruction_deny, profile, trust_scan};
 use colored::Colorize;
@@ -142,6 +142,9 @@ pub(crate) fn prepare_run_launch_plan(
 
     if prepared.allow_launch_services_active {
         print_allow_launch_services_warning(silent);
+    }
+    if prepared.allow_gpu_active {
+        print_allow_gpu_warning(silent);
     }
 
     if run_args.capability_elevation {

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -496,4 +496,18 @@ mod tests {
         assert!(!enabled);
         assert!(caps.platform_rules().is_empty());
     }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn test_maybe_enable_macos_gpu_rejects_on_non_macos() {
+        let mut caps = CapabilitySet::new();
+
+        let err =
+            maybe_enable_macos_gpu(&mut caps, true, true).expect_err("should fail on non-macOS");
+
+        assert!(
+            err.to_string().contains("only supported on macOS"),
+            "error should mention macOS support"
+        );
+    }
 }

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -95,6 +95,7 @@ mod tests {
         trust_interception_active,
     };
     use crate::proxy_runtime::{resolve_effective_proxy_settings, EffectiveProxySettings};
+    use crate::sandbox_prepare::maybe_enable_macos_gpu;
     #[cfg(target_os = "macos")]
     use crate::sandbox_prepare::maybe_enable_macos_launch_services;
     use crate::sandbox_prepare::PreparedSandbox;
@@ -203,6 +204,7 @@ mod tests {
             #[cfg(target_os = "linux")]
             wsl2_proxy_policy: crate::profile::Wsl2ProxyPolicy::Error,
             allow_launch_services_active: false,
+            allow_gpu_active: false,
             open_url_origins: Vec::new(),
             open_url_allow_localhost: false,
             override_deny_paths: Vec::new(),
@@ -244,6 +246,7 @@ mod tests {
             #[cfg(target_os = "linux")]
             wsl2_proxy_policy: crate::profile::Wsl2ProxyPolicy::Error,
             allow_launch_services_active: false,
+            allow_gpu_active: false,
             open_url_origins: Vec::new(),
             open_url_allow_localhost: false,
             override_deny_paths: Vec::new(),
@@ -447,5 +450,50 @@ mod tests {
             err.to_string().contains("configure open_urls"),
             "error should mention open_urls"
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_maybe_enable_macos_gpu_adds_rules_when_enabled() {
+        let mut caps = CapabilitySet::new();
+
+        let enabled = maybe_enable_macos_gpu(&mut caps, true, true).expect("gpu gate should apply");
+
+        assert!(enabled);
+        assert!(
+            caps.platform_rules().iter().any(|r| r.contains("IOGPU")),
+            "IOGPU platform rule should be present"
+        );
+        assert!(
+            caps.platform_rules()
+                .iter()
+                .any(|r| r.contains("iokit-get-properties")),
+            "iokit-get-properties rule should be present"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_maybe_enable_macos_gpu_rejects_without_profile_opt_in() {
+        let mut caps = CapabilitySet::new();
+
+        let err = maybe_enable_macos_gpu(&mut caps, true, false)
+            .expect_err("missing profile opt-in should fail");
+
+        assert!(
+            err.to_string().contains("allow_gpu"),
+            "error should mention allow_gpu"
+        );
+    }
+
+    #[test]
+    fn test_maybe_enable_macos_gpu_noop_without_flag() {
+        let mut caps = CapabilitySet::new();
+
+        let enabled =
+            maybe_enable_macos_gpu(&mut caps, false, true).expect("should succeed without flag");
+
+        assert!(!enabled);
+        assert!(caps.platform_rules().is_empty());
     }
 }

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -461,14 +461,16 @@ mod tests {
 
         assert!(enabled);
         assert!(
-            caps.platform_rules().iter().any(|r| r.contains("IOGPU")),
-            "IOGPU platform rule should be present"
+            caps.platform_rules()
+                .iter()
+                .any(|r| r.contains("AGXDeviceUserClient")),
+            "AGXDeviceUserClient platform rule should be present"
         );
         assert!(
             caps.platform_rules()
                 .iter()
-                .any(|r| r.contains("iokit-get-properties")),
-            "iokit-get-properties rule should be present"
+                .any(|r| r.contains("IOSurfaceRootUserClient")),
+            "IOSurfaceRootUserClient platform rule should be present"
         );
     }
 

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -122,6 +122,8 @@ pub struct ProfileDef {
     #[serde(default)]
     pub allow_launch_services: Option<bool>,
     #[serde(default)]
+    pub allow_gpu: Option<bool>,
+    #[serde(default)]
     pub interactive: bool,
 }
 
@@ -152,6 +154,7 @@ impl ProfileDef {
             rollback: self.rollback.clone(),
             open_urls: self.open_urls.clone(),
             allow_launch_services: self.allow_launch_services,
+            allow_gpu: self.allow_gpu,
             interactive: self.interactive,
             skipdirs: Vec::new(),
         }

--- a/crates/nono-cli/src/policy_cmd.rs
+++ b/crates/nono-cli/src/policy_cmd.rs
@@ -818,6 +818,10 @@ fn profile_to_json(
         val["allow_launch_services"] = serde_json::json!(als);
     }
 
+    if let Some(ag) = profile.allow_gpu {
+        val["allow_gpu"] = serde_json::json!(ag);
+    }
+
     val
 }
 
@@ -1197,6 +1201,13 @@ fn cmd_diff(args: PolicyDiffArgs) -> Result<()> {
         t,
     );
 
+    any_diff |= diff_scalar_option(
+        "allow_gpu",
+        &p1.allow_gpu.map(|v| format!("{v}")),
+        &p2.allow_gpu.map(|v| format!("{v}")),
+        t,
+    );
+
     // Env credentials
     let ec1: BTreeSet<(&String, &String)> = p1.env_credentials.mappings.iter().collect();
     let ec2: BTreeSet<(&String, &String)> = p2.env_credentials.mappings.iter().collect();
@@ -1546,6 +1557,11 @@ fn diff_to_json(name1: &str, name2: &str, p1: &Profile, p2: &Profile) -> serde_j
             "profile1": p1.allow_launch_services,
             "profile2": p2.allow_launch_services,
             "changed": p1.allow_launch_services != p2.allow_launch_services,
+        },
+        "allow_gpu": {
+            "profile1": p1.allow_gpu,
+            "profile2": p2.allow_gpu,
+            "changed": p1.allow_gpu != p2.allow_gpu,
         },
     })
 }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -3355,18 +3355,40 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_profiles_allow_gpu_child_overrides_base() {
+    fn test_merge_profiles_allow_gpu() {
+        // 1. Child inherits from base when child's value is None.
         let mut base = base_profile();
         base.allow_gpu = Some(true);
-        let merged = merge_profiles(base, child_profile());
-        assert_eq!(merged.allow_gpu, Some(true));
+        let child = child_profile(); // allow_gpu is None
+        let merged = merge_profiles(base, child);
+        assert_eq!(
+            merged.allow_gpu,
+            Some(true),
+            "Child should inherit allow_gpu from base"
+        );
 
+        // 2. Child overrides base when child has a value.
+        let mut base = base_profile();
+        base.allow_gpu = Some(true);
         let mut child = child_profile();
         child.allow_gpu = Some(false);
-        let mut base = base_profile();
-        base.allow_gpu = Some(true);
         let merged = merge_profiles(base, child);
-        assert_eq!(merged.allow_gpu, Some(false));
+        assert_eq!(
+            merged.allow_gpu,
+            Some(false),
+            "Child should override base allow_gpu"
+        );
+
+        // 3. Child's value is used when base has no value.
+        let base = base_profile(); // allow_gpu is None
+        let mut child = child_profile();
+        child.allow_gpu = Some(true);
+        let merged = merge_profiles(base, child);
+        assert_eq!(
+            merged.allow_gpu,
+            Some(true),
+            "Child value should be used when base is None"
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -981,6 +981,8 @@ pub struct Profile {
     /// When `None`, inherits from the base profile.
     #[serde(default)]
     pub allow_launch_services: Option<bool>,
+    #[serde(default)]
+    pub allow_gpu: Option<bool>,
     /// Deprecated: Parsed for backward compatibility but ignored.
     /// Supervised mode preserves TTY by default, making this unnecessary.
     #[serde(default)]
@@ -1022,6 +1024,8 @@ struct ProfileDeserialize {
     #[serde(default)]
     allow_launch_services: Option<bool>,
     #[serde(default)]
+    allow_gpu: Option<bool>,
+    #[serde(default)]
     interactive: bool,
     #[serde(default)]
     skipdirs: Vec<String>,
@@ -1042,6 +1046,7 @@ impl From<ProfileDeserialize> for Profile {
             rollback: raw.rollback,
             open_urls: raw.open_urls,
             allow_launch_services: raw.allow_launch_services,
+            allow_gpu: raw.allow_gpu,
             interactive: raw.interactive,
             skipdirs: raw.skipdirs,
         }
@@ -1473,6 +1478,7 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
             None => base.open_urls,
         },
         allow_launch_services: child.allow_launch_services.or(base.allow_launch_services),
+        allow_gpu: child.allow_gpu.or(base.allow_gpu),
         interactive: base.interactive || child.interactive,
         skipdirs: dedup_append(&base.skipdirs, &child.skipdirs),
     }
@@ -2668,6 +2674,7 @@ mod tests {
                 allow_localhost: false,
             }),
             allow_launch_services: Some(false),
+            allow_gpu: None,
             interactive: false,
             skipdirs: vec!["vendor".to_string()],
         }
@@ -2736,6 +2743,7 @@ mod tests {
                 allow_localhost: true,
             }),
             allow_launch_services: Some(true),
+            allow_gpu: None,
             interactive: false,
             skipdirs: vec!["dist".to_string()],
         }
@@ -3344,6 +3352,21 @@ mod tests {
         child.allow_launch_services = Some(false);
         let merged = merge_profiles(base_profile(), child);
         assert_eq!(merged.allow_launch_services, Some(false));
+    }
+
+    #[test]
+    fn test_merge_profiles_allow_gpu_child_overrides_base() {
+        let mut base = base_profile();
+        base.allow_gpu = Some(true);
+        let merged = merge_profiles(base, child_profile());
+        assert_eq!(merged.allow_gpu, Some(true));
+
+        let mut child = child_profile();
+        child.allow_gpu = Some(false);
+        let mut base = base_profile();
+        base.allow_gpu = Some(true);
+        let merged = merge_profiles(base, child);
+        assert_eq!(merged.allow_gpu, Some(false));
     }
 
     #[test]

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -256,9 +256,9 @@ fn build_skeleton(args: &ProfileInitArgs) -> serde_json::Value {
         );
         root.insert("rollback".to_string(), serde_json::Value::Object(rollback));
 
-        // NOTE: open_urls and allow_launch_services are intentionally omitted.
-        // Emitting them would replace inherited values from base profiles like
-        // claude-code (which grants OAuth2 origins and launch services).
+        // NOTE: open_urls, allow_launch_services, and allow_gpu are intentionally
+        // omitted. Emitting them would replace inherited values from base profiles
+        // like claude-code (which grants OAuth2 origins and launch services).
         // Absent = inherit from base. Authors who need to override these
         // should add them explicitly.
     }
@@ -533,10 +533,11 @@ mod tests {
         assert!(full_obj.contains_key("hooks"));
         assert!(full_obj.contains_key("rollback"));
 
-        // open_urls and allow_launch_services are intentionally omitted
-        // to avoid silently overriding inherited values from base profiles
+        // open_urls, allow_launch_services, and allow_gpu are intentionally
+        // omitted to avoid silently overriding inherited values from base profiles
         assert!(!full_obj.contains_key("open_urls"));
         assert!(!full_obj.contains_key("allow_launch_services"));
+        assert!(!full_obj.contains_key("allow_gpu"));
 
         assert!(!minimal_obj.contains_key("policy"));
         assert!(!minimal_obj.contains_key("network"));

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -21,6 +21,7 @@ pub(crate) struct PreparedProfile {
     pub(crate) open_url_origins: Vec<String>,
     pub(crate) open_url_allow_localhost: bool,
     pub(crate) allow_launch_services: bool,
+    pub(crate) allow_gpu: bool,
     pub(crate) override_deny_paths: Vec<PathBuf>,
 }
 
@@ -182,6 +183,10 @@ pub(crate) fn prepare_profile(
         allow_launch_services: loaded_profile
             .as_ref()
             .and_then(|profile| profile.allow_launch_services)
+            .unwrap_or(false),
+        allow_gpu: loaded_profile
+            .as_ref()
+            .and_then(|profile| profile.allow_gpu)
             .unwrap_or(false),
         override_deny_paths: collect_override_deny_paths(
             loaded_profile.as_ref(),

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -69,6 +69,7 @@ pub(crate) struct PreparedSandbox {
     #[cfg(target_os = "linux")]
     pub(crate) wsl2_proxy_policy: crate::profile::Wsl2ProxyPolicy,
     pub(crate) allow_launch_services_active: bool,
+    pub(crate) allow_gpu_active: bool,
     pub(crate) open_url_origins: Vec<String>,
     pub(crate) open_url_allow_localhost: bool,
     pub(crate) override_deny_paths: Vec<PathBuf>,
@@ -156,6 +157,61 @@ pub(crate) fn maybe_enable_macos_launch_services(
         ));
     }
     Ok(false)
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn maybe_enable_macos_gpu(
+    caps: &mut CapabilitySet,
+    cli_requested: bool,
+    profile_allowed: bool,
+) -> Result<bool> {
+    if !cli_requested {
+        return Ok(false);
+    }
+
+    if !profile_allowed {
+        return Err(NonoError::ConfigParse(
+            "--allow-gpu requires a profile that opts into allow_gpu".to_string(),
+        ));
+    }
+
+    caps.add_platform_rule(
+        "(allow iokit-open \
+            (iokit-connection \"IOGPU\") \
+            (iokit-user-client-class \
+                \"AGXDeviceUserClient\" \
+                \"AGXSharedUserClient\" \
+                \"IOSurfaceRootUserClient\"))",
+    )?;
+    caps.add_platform_rule("(allow iokit-get-properties)")?;
+    warn!("--allow-gpu enabled: allowing access to GPU");
+    Ok(true)
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn maybe_enable_macos_gpu(
+    _caps: &mut CapabilitySet,
+    cli_requested: bool,
+    _profile_allowed: bool,
+) -> Result<bool> {
+    if cli_requested {
+        return Err(NonoError::ConfigParse(
+            "--allow-gpu is only supported on macOS".to_string(),
+        ));
+    }
+    Ok(false)
+}
+
+pub(crate) fn print_allow_gpu_warning(silent: bool) {
+    if silent {
+        return;
+    }
+
+    eprintln!(
+        "  {}",
+        "WARNING: --allow-gpu permits the sandboxed process to access the GPU.".yellow()
+    );
+    eprintln!("  GPU access may expose additional attack surface. Only use when your workload requires it.");
 }
 
 pub(crate) fn print_allow_launch_services_warning(silent: bool) {
@@ -248,6 +304,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
                 #[cfg(target_os = "linux")]
                 wsl2_proxy_policy: crate::profile::Wsl2ProxyPolicy::default(),
                 allow_launch_services_active: false,
+                allow_gpu_active: false,
                 open_url_origins: Vec::new(),
                 open_url_allow_localhost: false,
                 override_deny_paths: Vec::new(),
@@ -276,6 +333,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         open_url_origins,
         open_url_allow_localhost,
         allow_launch_services: profile_allow_launch_services,
+        allow_gpu: profile_allow_gpu,
         override_deny_paths,
     } = prepared_profile;
 
@@ -319,6 +377,8 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         &open_url_origins,
         open_url_allow_localhost,
     )?;
+
+    let allow_gpu_active = maybe_enable_macos_gpu(&mut caps, args.allow_gpu, profile_allow_gpu)?;
 
     let cwd_access = if let Some(ref access) = profile_workdir_access {
         match access {
@@ -404,6 +464,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
             #[cfg(target_os = "linux")]
             wsl2_proxy_policy,
             allow_launch_services_active,
+            allow_gpu_active,
             open_url_origins,
             open_url_allow_localhost,
             override_deny_paths,

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -171,10 +171,15 @@ pub(crate) fn maybe_enable_macos_gpu(
 
     if !profile_allowed {
         return Err(NonoError::ConfigParse(
-            "--allow-gpu requires a profile that opts into allow_gpu".to_string(),
+            "--allow-gpu requires the selected profile to opt into allow_gpu".to_string(),
         ));
     }
 
+    // These IOKit classes cover Metal on Apple Silicon only. IOAccelerator
+    // exists on Apple Silicon but Seatbelt matches on the leaf class, not
+    // the base, so it is not needed here. Intel Macs require
+    // IntelAccelerator, IOAccelerator, and AMDRadeonX* classes which are
+    // not yet supported.
     caps.add_platform_rule(
         "(allow iokit-open \
             (iokit-connection \"IOGPU\") \
@@ -378,7 +383,11 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         open_url_allow_localhost,
     )?;
 
-    let allow_gpu_active = maybe_enable_macos_gpu(&mut caps, args.allow_gpu, profile_allow_gpu)?;
+    let allow_gpu_active = maybe_enable_macos_gpu(
+        &mut caps,
+        args.allow_gpu,
+        loaded_profile.is_none() || profile_allow_gpu,
+    )?;
 
     let cwd_access = if let Some(ref access) = profile_workdir_access {
         match access {

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -175,20 +175,21 @@ pub(crate) fn maybe_enable_macos_gpu(
         ));
     }
 
-    // These IOKit classes cover Metal on Apple Silicon only. IOAccelerator
-    // exists on Apple Silicon but Seatbelt matches on the leaf class, not
-    // the base, so it is not needed here. Intel Macs require
-    // IntelAccelerator, IOAccelerator, and AMDRadeonX* classes which are
+    // Minimal IOKit surface for Metal compute on Apple Silicon. Verified that
+    // `AGXDeviceUserClient` and `IOSurfaceRootUserClient` are sufficient for
+    // the full pipeline and offscreen rendering. `AGXSharedUserClient` is only
+    // needed for cross process GPU resource sharing (such as WebKit's GPU
+    // process). Adding `iokit-connection "IOGPU"` would cover more user
+    // clients such as `IOGPUSurfaceMTL` and `IOGPUGLDrawableUserClient` which
+    // are needed for display output and OpenGL. Intel Macs require
+    // `IntelAccelerator`, `IOAccelerator`, and `AMDRadeonX*` classes which are
     // not yet supported.
     caps.add_platform_rule(
         "(allow iokit-open \
-            (iokit-connection \"IOGPU\") \
             (iokit-user-client-class \
                 \"AGXDeviceUserClient\" \
-                \"AGXSharedUserClient\" \
                 \"IOSurfaceRootUserClient\"))",
     )?;
-    caps.add_platform_rule("(allow iokit-get-properties)")?;
     warn!("--allow-gpu enabled: allowing access to GPU");
     Ok(true)
 }

--- a/crates/nono-cli/tests/profile_cmd.rs
+++ b/crates/nono-cli/tests/profile_cmd.rs
@@ -109,6 +109,10 @@ fn test_init_full_creates_all_additive_sections() {
         "allow_launch_services should be omitted"
     );
     assert!(
+        val.get("allow_gpu").is_none(),
+        "allow_gpu should be omitted"
+    );
+    assert!(
         val["network"].get("network_profile").is_none(),
         "network_profile should be omitted"
     );

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -644,6 +644,20 @@ nono run --profile claude-code --allow-launch-services -- claude
   `--allow-launch-services` is only supported on macOS. It requires the selected profile to opt into `allow_launch_services` and configure `open_urls`; otherwise nono fails closed with an error.
 </Note>
 
+#### `--allow-gpu`
+
+Allow GPU access on Apple Silicon Macs through IOKit. This enables GPU device creation, command queues, buffer allocation, and shader compilation for workloads like ML inference.
+
+```bash
+# gpu-profile.json: { "allow_gpu": true, "filesystem": { "read": ["."] } }
+# Note: "." exposes the current working directory as read-only to the sandbox
+nono run --profile ./gpu-profile.json --allow-gpu -- llama-cli -m ./model.gguf -p "hello"
+```
+
+<Note>
+  `--allow-gpu` is only supported on macOS. It requires the selected profile to opt into `allow_gpu`; otherwise nono fails closed with an error.
+</Note>
+
 ### Execution Mode Flags
 
 #### `--detached`

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -649,13 +649,11 @@ nono run --profile claude-code --allow-launch-services -- claude
 Allow GPU access on Apple Silicon Macs through IOKit. This enables GPU device creation, command queues, buffer allocation, and shader compilation for workloads like ML inference.
 
 ```bash
-# gpu-profile.json: { "allow_gpu": true, "filesystem": { "read": ["."] } }
-# Note: "." exposes the current working directory as read-only to the sandbox
-nono run --profile ./gpu-profile.json --allow-gpu -- llama-cli -m ./model.gguf -p "hello"
+nono run --allow-gpu -- llama-cli -m ./model.gguf -p "hello"
 ```
 
 <Note>
-  `--allow-gpu` is only supported on macOS. It requires the selected profile to opt into `allow_gpu`; otherwise nono fails closed with an error.
+  `--allow-gpu` is only supported on macOS. When used with a profile, the profile must opt into allow_gpu; otherwise nono fails closed with an error.
 </Note>
 
 ### Execution Mode Flags


### PR DESCRIPTION
Closes #347 and is the result of discussion in #405.

Tested end to end on macOS and ran tests on Linux.

<details>
<summary>Example profile</summary>

```json
{
  "meta": { "name": "gpu-test", "version": "1.0" },
  "allow_gpu": true,
  "filesystem": {
    "read": ["/tmp"]
  }
}
```

</details>

<details>
<summary>Example Metal pipeline code</summary>

```swift
import Metal

guard let device = MTLCreateSystemDefaultDevice() else {
    print("FAIL: no Metal device")
    exit(1)
}
print("OK: \(device.name)")

guard let queue = device.makeCommandQueue() else {
    print("FAIL: no command queue")
    exit(1)
}
print("OK: command queue")

let bufferSize = 1024 * 1024 * 64
guard let buffer = device.makeBuffer(length: bufferSize, options: .storageModeShared) else {
    print("FAIL: buffer allocation")
    exit(1)
}
print("OK: 64MB buffer allocated")

let source = """
#include <metal_stdlib>
using namespace metal;
kernel void add_one(device float* data [[buffer(0)]], uint id [[thread_position_in_grid]]) {
    data[id] = data[id] + 1.0;
}
"""
let library = try! device.makeLibrary(source: source, options: nil)
let function = library.makeFunction(name: "add_one")!
let pipeline = try! device.makeComputePipelineState(function: function)
print("OK: shader compiled")

let floats = buffer.contents().bindMemory(to: Float.self, capacity: 1024)
for i in 0..<1024 { floats[i] = Float(i) }

let cmd = queue.makeCommandBuffer()!
let encoder = cmd.makeComputeCommandEncoder()!
encoder.setComputePipelineState(pipeline)
encoder.setBuffer(buffer, offset: 0, index: 0)
encoder.dispatchThreads(MTLSize(width: 1024, height: 1, depth: 1),
                        threadsPerThreadgroup: MTLSize(width: 64, height: 1, depth: 1))
encoder.endEncoding()
cmd.commit()
cmd.waitUntilCompleted()

let result = buffer.contents().bindMemory(to: Float.self, capacity: 1024)
if result[0] == 1.0 && result[999] == 1000.0 {
    print("OK: compute result verified")
} else {
    print("FAIL: unexpected result \(result[0]), \(result[999])")
}
```

</details>

<details>
<summary>Without --allow-gpu</summary>

```
$ nono run --profile /tmp/gpu-test-profile.json -- /tmp/metal_test

  nono v0.29.1
  Capabilities:
  ────────────────────────────────────────────────────
    r   /private/tmp (dir)
       + 31 system/group paths (-v to show)
   net  outbound allowed
  ────────────────────────────────────────────────────

  mode supervised (supervisor)
  Applying sandbox...
FAIL: no Metal device

NONO DIAGNOSTIC
────────────────────────
The command failed. This may be due to sandbox restrictions. (exit code 1)

Sandbox denied the following operations:
  user-preference-read  kcfpreferencesanyapplication

Next steps:
  Learn: nono learn -- /tmp/metal_test
  Why: nono why --path <path> --op <read|write|readwrite>
```

</details>

<details>
<summary>With --allow-gpu</summary>

```
$ nono run --profile /tmp/gpu-test-profile.json --allow-gpu -- /tmp/metal_test

  nono v0.29.1
  WARNING: --allow-gpu permits the sandboxed process to access the GPU.
  GPU access may expose additional attack surface. Only use when your workload requires it.
  mode supervised (supervisor)
  Applying sandbox...
OK: Apple M1 Max
OK: command queue
OK: 64MB buffer allocated
OK: shader compiled
OK: compute result verified
```

</details>

A few things, first I tried to do everything using existing conventions, verified locally, works perfectly, but only works on Apple Silicon despite the name possibly implying wider support, would you like me to look into Intel or Linux support?

Secondly have you considered shipping a profile specifically for llama.cpp, or vLLM or something, tying it back into the supply chain stuff that caused many people to first learn of nono. I think that could be a real win, I can also look into this because this is basically what I was building locally that turned into a bigger project, but the problem is a lot of things are inherently non portable, like your model folders, etc.

Additionally there's a recently released driver that lets you use some (some?) eGPUs on Apple Silicon, it's by the tinycorp folks and it may be something someone requests at some point, I haven't looked into it at all so I have no idea what the sandbox profile would look like there.

I'm also not convinced this is the tightest the profile could be, particularly `(allow iokit-get-properties)` but Metal queries a lot of different properties and they're read only anyways, so I'm not sure if it's necessarily worth hardening further, something to consider I suppose.

Update: the only class needed for Metal is `AGXDeviceUserClient`, mainly for any LLMs or other people reading for reference guides