### PR TITLE
feat(trust): add file:// backend for trust signing keys

### DIFF
--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1656,11 +1656,15 @@ pub struct TrustSignArgs {
     pub all: bool,
 
     /// Key ID to use from the system keystore (default: "default")
-    #[arg(long, value_name = "KEY_ID", conflicts_with = "keyless")]
+    #[arg(long, value_name = "KEY_ID", conflicts_with_all = ["keyless", "keyref"])]
     pub key: Option<String>,
 
+    /// Key reference URI (keystore://name or file:///path/to/key.pem)
+    #[arg(long, value_name = "URI", conflicts_with_all = ["key", "keyless"])]
+    pub keyref: Option<String>,
+
     /// Use Sigstore keyless signing (Fulcio + Rekor via ambient OIDC)
-    #[arg(long)]
+    #[arg(long, conflicts_with = "keyref")]
     pub keyless: bool,
 
     /// Produce a single .nono-trust.bundle containing all subjects instead of per-file bundles
@@ -1684,8 +1688,12 @@ pub struct TrustSignPolicyArgs {
     pub file: Option<PathBuf>,
 
     /// Key ID to use from the system keystore (default: "default")
-    #[arg(long, value_name = "KEY_ID")]
+    #[arg(long, value_name = "KEY_ID", conflicts_with = "keyref")]
     pub key: Option<String>,
+
+    /// Key reference URI (keystore://name or file:///path/to/key.pem)
+    #[arg(long, value_name = "URI", conflicts_with = "key")]
+    pub keyref: Option<String>,
 
     /// Sign the user-level trust policy at ~/.config/nono/trust-policy.json
     #[arg(long)]
@@ -1724,8 +1732,12 @@ pub struct TrustInitArgs {
     pub include: Vec<String>,
 
     /// Key ID to include as a publisher (default: "default")
-    #[arg(long, value_name = "KEY_ID")]
+    #[arg(long, value_name = "KEY_ID", conflicts_with = "keyref")]
     pub key: Option<String>,
+
+    /// Key reference URI (keystore://name or file:///path/to/key.pem)
+    #[arg(long, value_name = "URI", conflicts_with = "key")]
+    pub keyref: Option<String>,
 
     /// Create a user-level policy at ~/.config/nono/ instead of the current directory
     #[arg(long)]
@@ -1760,8 +1772,17 @@ pub struct TrustListArgs {
 #[command(disable_help_flag = true)]
 pub struct TrustKeygenArgs {
     /// Key identifier (stored in system keystore under this name)
-    #[arg(long, value_name = "NAME", default_value = "default")]
+    #[arg(
+        long,
+        value_name = "NAME",
+        default_value = "default",
+        conflicts_with = "keyref"
+    )]
     pub id: String,
+
+    /// Key reference URI (keystore://name or file:///path/to/key.pem)
+    #[arg(long, value_name = "URI", conflicts_with = "id")]
+    pub keyref: Option<String>,
 
     /// Overwrite existing key with the same ID
     #[arg(long)]
@@ -1776,8 +1797,17 @@ pub struct TrustKeygenArgs {
 #[command(disable_help_flag = true)]
 pub struct TrustExportKeyArgs {
     /// Key identifier to export (default: "default")
-    #[arg(long, value_name = "NAME", default_value = "default")]
+    #[arg(
+        long,
+        value_name = "NAME",
+        default_value = "default",
+        conflicts_with = "keyref"
+    )]
     pub id: String,
+
+    /// Key reference URI (keystore://name or file:///path/to/key.pem)
+    #[arg(long, value_name = "URI", conflicts_with = "id")]
+    pub keyref: Option<String>,
 
     /// Output as PEM instead of base64 DER
     #[arg(long)]

--- a/crates/nono-cli/src/trust_cmd.rs
+++ b/crates/nono-cli/src/trust_cmd.rs
@@ -6,7 +6,7 @@ use crate::cli::{
     TrustArgs, TrustCommands, TrustExportKeyArgs, TrustInitArgs, TrustKeygenArgs, TrustListArgs,
     TrustSignArgs, TrustSignPolicyArgs, TrustVerifyArgs,
 };
-use crate::trust_keystore;
+use crate::trust_keystore::{self, TrustKeyRef};
 use aws_lc_rs::rand::SystemRandom;
 use aws_lc_rs::signature::{EcdsaKeyPair, ECDSA_P256_SHA256_ASN1_SIGNING};
 use colored::Colorize;
@@ -84,8 +84,9 @@ fn run_init(args: TrustInitArgs) -> Result<()> {
     }
 
     // Try to include the public key if a signing key exists
-    let key_id = args.key.as_deref().unwrap_or("default");
-    let publisher = match load_public_key_bytes(key_id) {
+    let key_ref = TrustKeyRef::resolve_key(args.keyref.as_deref(), args.key.as_deref())?;
+    let key_id = key_ref.key_id()?;
+    let publisher = match load_public_key_bytes_for_ref(&key_ref) {
         Ok(pub_bytes) => {
             let b64 = base64_encode(&pub_bytes);
             Some(serde_json::json!({
@@ -95,14 +96,22 @@ fn run_init(args: TrustInitArgs) -> Result<()> {
             }))
         }
         Err(_) => {
+            let backend = trust_keystore::backend_description_for_ref(&key_ref, TRUST_SERVICE);
             eprintln!(
-                "  {} signing key '{}' not found in keystore, skipping publisher entry.",
+                "  {} signing key '{}' not found in {}, skipping publisher entry.",
                 "Note:".cyan(),
-                key_id
+                key_id,
+                backend
             );
+            let keyref_hint = match &key_ref {
+                TrustKeyRef::File(_) => format!(" --keyref {key_id}"),
+                TrustKeyRef::Keystore(_) => String::new(),
+            };
             eprintln!(
                 "  {}",
-                "Run 'nono trust keygen' to generate a key, then re-run 'nono trust init'.".cyan()
+                format!(
+                    "Run 'nono trust keygen{keyref_hint}' to generate a key, then re-run 'nono trust init{keyref_hint}'."
+                ).cyan()
             );
             None
         }
@@ -139,17 +148,28 @@ fn run_init(args: TrustInitArgs) -> Result<()> {
         }
     }
 
+    let keyref_flag = match &key_ref {
+        TrustKeyRef::File(_) => format!(" --keyref {key_id}"),
+        TrustKeyRef::Keystore(_) => String::new(),
+    };
+
     if publishers.is_empty() {
         eprintln!("\n  {}", "Next steps:".bold());
-        eprintln!("  1. nono trust keygen");
-        eprintln!("  2. nono trust init --force");
-        eprintln!("  3. nono trust sign-policy {}", policy_path.display());
-        eprintln!("  4. nono trust sign --all");
+        eprintln!("  1. nono trust keygen{keyref_flag}");
+        eprintln!("  2. nono trust init{keyref_flag} --force");
+        eprintln!(
+            "  3. nono trust sign-policy{keyref_flag} {}",
+            policy_path.display()
+        );
+        eprintln!("  4. nono trust sign{keyref_flag} --all");
     } else {
         eprintln!("\n  {}", "Next steps:".bold());
-        eprintln!("  1. nono trust sign-policy {}", policy_path.display());
+        eprintln!(
+            "  1. nono trust sign-policy{keyref_flag} {}",
+            policy_path.display()
+        );
         if !is_user {
-            eprintln!("  2. nono trust sign --all");
+            eprintln!("  2. nono trust sign{keyref_flag} --all");
         }
     }
 
@@ -161,12 +181,15 @@ fn run_init(args: TrustInitArgs) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 fn run_keygen(args: TrustKeygenArgs) -> Result<()> {
-    let key_id = &args.id;
+    let key_ref = TrustKeyRef::resolve_id(args.keyref.as_deref(), &args.id)?;
+    let key_label = key_ref.key_id()?;
 
     // Check if key already exists
-    if !args.force && trust_keystore::contains_secret(TRUST_SERVICE, key_id)? {
+    if !args.force && trust_keystore::contains_secret_for_ref(&key_ref, TRUST_SERVICE, &key_label)?
+    {
         return Err(nono::NonoError::KeystoreAccess(format!(
-            "key '{key_id}' already exists in keystore (use --force to overwrite)"
+            "key '{key_label}' already exists in {} (use --force to overwrite)",
+            trust_keystore::backend_description_for_ref(&key_ref, TRUST_SERVICE)
         )));
     }
 
@@ -187,20 +210,19 @@ fn run_keygen(args: TrustKeygenArgs) -> Result<()> {
 
     // Store PKCS#8 as base64 in the configured trust keystore.
     let pkcs8_b64 = Zeroizing::new(base64_encode(pkcs8_doc.as_ref()));
-    trust_keystore::store_secret(TRUST_SERVICE, key_id, pkcs8_b64.as_str())?;
+    trust_keystore::store_secret_for_ref(&key_ref, TRUST_SERVICE, &key_label, pkcs8_b64.as_str())?;
 
     // Store public key separately so verification never needs the private key
     let pub_key_b64 = base64_encode(pub_key.as_bytes());
-    trust_keystore::store_secret(TRUST_PUB_SERVICE, key_id, &pub_key_b64)?;
-    store_public_key_cache(key_id, &pub_key_b64)?;
+    store_public_key_for_ref(&key_ref, &key_label, &pub_key_b64)?;
 
     eprintln!("{}", "Signing key generated successfully.".green());
-    eprintln!("  Key ID:      {key_id}");
+    eprintln!("  Key ID:      {key_label}");
     eprintln!("  Fingerprint: {hex_id}");
     eprintln!("  Algorithm:   ECDSA P-256 (SHA-256)");
     eprintln!(
         "  Stored in:   {}",
-        trust_keystore::backend_description(TRUST_SERVICE)
+        trust_keystore::backend_description_for_ref(&key_ref, TRUST_SERVICE)
     );
     eprintln!();
     eprintln!("Public key (base64 DER, for trust-policy.json):");
@@ -217,8 +239,8 @@ fn run_keygen(args: TrustKeygenArgs) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 fn run_export_key(args: TrustExportKeyArgs) -> Result<()> {
-    let key_id = &args.id;
-    let pub_key_bytes = load_public_key_bytes(key_id)?;
+    let key_ref = TrustKeyRef::resolve_id(args.keyref.as_deref(), &args.id)?;
+    let pub_key_bytes = load_public_key_bytes_for_ref(&key_ref)?;
 
     if args.pem {
         let pub_key = trust::DerPublicKey::from(pub_key_bytes);
@@ -239,10 +261,11 @@ fn run_sign(args: TrustSignArgs) -> Result<()> {
         return run_sign_keyless(args);
     }
 
-    let key_id = args.key.as_deref().unwrap_or("default");
+    let key_ref = TrustKeyRef::resolve_key(args.keyref.as_deref(), args.key.as_deref())?;
+    let key_id = key_ref.key_id()?;
 
-    // Load the signing key from keystore
-    let key_pair = load_signing_key(key_id)?;
+    // Load the signing key
+    let key_pair = load_signing_key_for_ref(&key_ref)?;
 
     // Resolve files to sign
     let files = resolve_files(&args.files, args.all, args.policy.as_deref())?;
@@ -253,14 +276,14 @@ fn run_sign(args: TrustSignArgs) -> Result<()> {
     }
 
     if args.multi_subject {
-        return run_sign_multi_keyed(&files, &key_pair, key_id);
+        return run_sign_multi_keyed(&files, &key_pair, &key_id);
     }
 
     let mut success_count = 0u32;
     let mut fail_count = 0u32;
 
     for file_path in &files {
-        match trust::sign_instruction_file(file_path, &key_pair, key_id) {
+        match trust::sign_instruction_file(file_path, &key_pair, &key_id) {
             Ok(bundle_json) => {
                 trust::write_bundle(file_path, &bundle_json)?;
                 let bundle_path = trust::bundle_path_for(file_path);
@@ -576,10 +599,11 @@ fn discover_oidc_token(rt: &tokio::runtime::Runtime) -> Result<sigstore_sign::oi
 // ---------------------------------------------------------------------------
 
 fn run_sign_policy(args: TrustSignPolicyArgs) -> Result<()> {
-    let key_id = args.key.as_deref().unwrap_or("default");
+    let key_ref = TrustKeyRef::resolve_key(args.keyref.as_deref(), args.key.as_deref())?;
+    let key_id = key_ref.key_id()?;
 
-    // Load the signing key from keystore
-    let key_pair = load_signing_key(key_id)?;
+    // Load the signing key
+    let key_pair = load_signing_key_for_ref(&key_ref)?;
 
     // Resolve the policy file path
     let policy_path = match args.file {
@@ -614,7 +638,7 @@ fn run_sign_policy(args: TrustSignPolicyArgs) -> Result<()> {
     // Validate the policy file is well-formed before signing.
     trust::load_policy_from_file(&policy_path)?;
 
-    let bundle_json = trust::sign_policy_file(&policy_path, &key_pair, key_id)?;
+    let bundle_json = trust::sign_policy_file(&policy_path, &key_pair, &key_id)?;
     trust::write_bundle(&policy_path, &bundle_json)?;
     let bundle_path = trust::bundle_path_for(&policy_path);
 
@@ -1019,11 +1043,41 @@ fn run_list(args: TrustListArgs) -> Result<()> {
 // Key loading from system keystore
 // ---------------------------------------------------------------------------
 
-/// Load only the public key bytes for a given key ID from the keystore.
+/// Load only the public key bytes for a given key ID.
+///
+/// Resolution order:
+/// 1. If `key_id` is an absolute path (from a `file://` keygen), load `<path>.pub` directly.
+/// 2. Otherwise, check the on-disk cache.
+/// 3. Fall back to the system keystore (`nono-trust-pub` service).
 ///
 /// Uses the `nono-trust-pub` service to avoid loading private key material
 /// into memory for verification-only operations.
 pub(crate) fn load_public_key_bytes(key_id: &str) -> Result<Vec<u8>> {
+    // file:// keys embed a `file:///path` URI as key_id in the bundle.
+    // Dispatch on the URI scheme for clean, explicit detection — no guessing
+    // from path shape. Validate the URI before using it as a filesystem path.
+    if nono::is_file_uri(key_id) {
+        nono::validate_file_uri(key_id).map_err(|_| {
+            nono::NonoError::KeystoreAccess(format!(
+                "key_id '{key_id}' in bundle is not a valid file URI"
+            ))
+        })?;
+        let path_str = key_id.strip_prefix("file://").ok_or_else(|| {
+            nono::NonoError::KeystoreAccess(format!("invalid file URI: {key_id}"))
+        })?;
+        let pub_path = pub_key_path_for_file(std::path::Path::new(path_str));
+        let b64 = nono::load_secret_file(&pub_path).map_err(|e| match e {
+            nono::NonoError::SecretNotFound(_) => nono::NonoError::SecretNotFound(format!(
+                "public key not found at {} (run 'nono trust keygen' to regenerate)",
+                pub_path.display()
+            )),
+            other => other,
+        })?;
+        debug!("loaded public key from {}", nono::redact_file_uri(key_id));
+        return base64_decode(b64.as_str())
+            .map_err(|e| nono::NonoError::KeystoreAccess(format!("corrupt public key data: {e}")));
+    }
+
     if let Some(b64) = load_public_key_cache(key_id)? {
         return base64_decode(&b64)
             .map_err(|e| nono::NonoError::KeystoreAccess(format!("corrupt public key data: {e}")));
@@ -1060,6 +1114,107 @@ pub(crate) fn load_signing_key(key_id: &str) -> Result<trust::KeyPair> {
     })?);
 
     reconstruct_key_pair(&pkcs8_bytes)
+}
+
+// ---------------------------------------------------------------------------
+// Key loading with TrustKeyRef dispatch
+// ---------------------------------------------------------------------------
+
+/// Load public key bytes for a given key reference.
+fn load_public_key_bytes_for_ref(key_ref: &TrustKeyRef) -> Result<Vec<u8>> {
+    match key_ref {
+        TrustKeyRef::Keystore(name) => load_public_key_bytes(name),
+        TrustKeyRef::File(path) => {
+            let pub_path = pub_key_path_for_file(path);
+            let file_uri = format!("file://{}", pub_path.display());
+            let b64 = nono::load_secret_file(&pub_path).map_err(|e| match e {
+                nono::NonoError::SecretNotFound(_) => nono::NonoError::SecretNotFound(format!(
+                    "public key not found at {} (run 'nono trust keygen' to regenerate)",
+                    pub_path.display()
+                )),
+                other => other,
+            })?;
+            debug!(
+                "loaded public key from {}",
+                nono::redact_file_uri(&file_uri)
+            );
+            base64_decode(b64.as_str()).map_err(|e| {
+                nono::NonoError::KeystoreAccess(format!("corrupt public key data: {e}"))
+            })
+        }
+    }
+}
+
+/// Load signing key for a given key reference.
+fn load_signing_key_for_ref(key_ref: &TrustKeyRef) -> Result<trust::KeyPair> {
+    match key_ref {
+        TrustKeyRef::Keystore(name) => load_signing_key(name),
+        TrustKeyRef::File(path) => {
+            let file_uri = format!("file://{}", path.display());
+            let pkcs8_b64 = nono::load_secret_file(path).map_err(|e| match e {
+                nono::NonoError::SecretNotFound(_) => nono::NonoError::SecretNotFound(format!(
+                    "signing key not found at {} (run 'nono trust keygen' first)",
+                    path.display()
+                )),
+                other => other,
+            })?;
+            debug!(
+                "loaded signing key from {}",
+                nono::redact_file_uri(&file_uri)
+            );
+            let pkcs8_bytes = Zeroizing::new(base64_decode(pkcs8_b64.as_str()).map_err(|e| {
+                nono::NonoError::KeystoreAccess(format!(
+                    "corrupt key data in {}: {e}",
+                    path.display()
+                ))
+            })?);
+            reconstruct_key_pair(&pkcs8_bytes)
+        }
+    }
+}
+
+/// Store the public key for a key reference.
+///
+/// For keystore refs, stores in `TRUST_PUB_SERVICE` and the disk cache.
+/// For file refs, stores at `<path>.pub`.
+fn store_public_key_for_ref(
+    key_ref: &TrustKeyRef,
+    key_label: &str,
+    pub_key_b64: &str,
+) -> Result<()> {
+    match key_ref {
+        TrustKeyRef::Keystore(name) => {
+            trust_keystore::store_secret_for_ref(key_ref, TRUST_PUB_SERVICE, name, pub_key_b64)?;
+            store_public_key_cache(name, pub_key_b64)?;
+            Ok(())
+        }
+        TrustKeyRef::File(path) => {
+            let pub_path = pub_key_path_for_file(path);
+            nono::store_secret_file(&pub_path, pub_key_b64).map_err(|e| match e {
+                nono::NonoError::KeystoreAccess(_) => nono::NonoError::KeystoreAccess(format!(
+                    "failed to store public key at {}",
+                    pub_path.display()
+                )),
+                other => other,
+            })?;
+            debug!(
+                "stored public key at {}",
+                nono::redact_file_uri(&format!("file://{}", pub_path.display()))
+            );
+            // Suppress unused variable warning for key_label in file path
+            let _ = key_label;
+            Ok(())
+        }
+    }
+}
+
+/// Derive the public key file path from a private key file path.
+///
+/// `file:///path/to/key.pem` → `/path/to/key.pem.pub`
+fn pub_key_path_for_file(private_key_path: &Path) -> PathBuf {
+    let mut pub_path = private_key_path.as_os_str().to_owned();
+    pub_path.push(".pub");
+    PathBuf::from(pub_path)
 }
 
 pub(crate) fn reconstruct_key_pair(pkcs8_bytes: &[u8]) -> Result<trust::KeyPair> {
@@ -1268,45 +1423,21 @@ fn public_key_cache_path(key_id: &str) -> Result<PathBuf> {
 
 fn load_public_key_cache(key_id: &str) -> Result<Option<String>> {
     let path = public_key_cache_path(key_id)?;
-    match std::fs::read_to_string(&path) {
-        Ok(contents) => Ok(Some(contents.trim().to_string())),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(e) => Err(nono::NonoError::KeystoreAccess(format!(
-            "failed to read cached public key '{}': {}",
-            path.display(),
-            e
-        ))),
+    if !path.exists() {
+        return Ok(None);
+    }
+    // Reuse load_secret_file for consistent whitespace handling (trims one trailing newline).
+    match nono::load_secret_file(&path) {
+        Ok(secret) => Ok(Some(secret.to_string())),
+        Err(nono::NonoError::SecretNotFound(_)) => Ok(None),
+        Err(e) => Err(e),
     }
 }
 
 fn store_public_key_cache(key_id: &str, public_key_b64: &str) -> Result<()> {
     let path = public_key_cache_path(key_id)?;
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| nono::NonoError::ConfigWrite {
-            path: parent.to_path_buf(),
-            source: e,
-        })?;
-    }
-
-    std::fs::write(&path, format!("{public_key_b64}\n")).map_err(|e| {
-        nono::NonoError::ConfigWrite {
-            path: path.clone(),
-            source: e,
-        }
-    })?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).map_err(|e| {
-            nono::NonoError::ConfigWrite {
-                path: path.clone(),
-                source: e,
-            }
-        })?;
-    }
-
-    Ok(())
+    // Reuse store_secret_file for atomic 0600 permissions (never momentarily world-readable).
+    nono::store_secret_file(&path, public_key_b64)
 }
 
 fn hex_component(value: &[u8]) -> String {

--- a/crates/nono-cli/src/trust_keystore.rs
+++ b/crates/nono-cli/src/trust_keystore.rs
@@ -1,43 +1,196 @@
 //! Trust signing key storage backends.
 //!
-//! Trust commands use the OS keyring by default. Integration tests can opt
-//! into a file-backed store by setting `NONO_TRUST_TEST_KEYSTORE_DIR`, which
-//! avoids interactive keychain prompts on local machines and in CI.
+//! Trust commands use the OS keyring by default (`keystore://`). A file-backed
+//! backend (`file://`) is available for headless, containerized, and CI
+//! environments where the system keystore is unavailable or impractical.
+//!
+//! Integration tests can also opt into a directory-backed store by setting
+//! `NONO_TRUST_TEST_KEYSTORE_DIR`, which avoids interactive keychain prompts.
+
+#[cfg(feature = "test-trust-overrides")]
+use std::path::Path;
+use std::path::PathBuf;
 
 use nono::{NonoError, Result};
-#[cfg(feature = "test-trust-overrides")]
-use std::path::{Path, PathBuf};
 use zeroize::Zeroizing;
 
-/// Test-only override for trust key storage.
+/// Test-only override for trust key storage directory.
 #[cfg(feature = "test-trust-overrides")]
 pub(crate) const TEST_KEYSTORE_DIR_ENV: &str = "NONO_TRUST_TEST_KEYSTORE_DIR";
 
-enum TrustKeyStore {
-    System,
-    #[cfg(feature = "test-trust-overrides")]
+// ---------------------------------------------------------------------------
+// TrustKeyRef — user-facing key reference
+// ---------------------------------------------------------------------------
+
+const KEYSTORE_URI_PREFIX: &str = "keystore://";
+
+/// A parsed reference to a trust signing key.
+///
+/// Constructed from `--keyref <uri>` or from the legacy `--id <name>` flag.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TrustKeyRef {
+    /// System keyring (macOS Keychain / Linux Secret Service).
+    /// Parsed from `keystore://<name>` or bare `--id <name>`.
+    Keystore(String),
+    /// File-backed key at an explicit absolute path.
+    /// Parsed from `file:///absolute/path/to/key.pem`.
     File(PathBuf),
 }
 
+impl TrustKeyRef {
+    /// Parse a `--keyref` value into a [`TrustKeyRef`].
+    ///
+    /// Accepted forms:
+    /// - `keystore://<name>` → [`TrustKeyRef::Keystore`]
+    /// - `file:///absolute/path` → [`TrustKeyRef::File`]
+    pub(crate) fn parse(uri: &str) -> Result<Self> {
+        if let Some(name) = uri.strip_prefix(KEYSTORE_URI_PREFIX) {
+            if name.is_empty() {
+                return Err(NonoError::ConfigParse(
+                    "keystore:// URI has empty key name".to_string(),
+                ));
+            }
+            // Key names must be simple identifiers — no path separators or shell-special chars.
+            if let Some(bad) = name
+                .chars()
+                .find(|c| !c.is_ascii_alphanumeric() && *c != '-' && *c != '_')
+            {
+                return Err(NonoError::ConfigParse(format!(
+                    "keystore:// key name contains invalid character {bad:?}: {uri}"
+                )));
+            }
+            Ok(Self::Keystore(name.to_string()))
+        } else if nono::is_file_uri(uri) {
+            nono::validate_file_uri(uri)?;
+            let path_str = uri
+                .strip_prefix("file://")
+                .ok_or_else(|| NonoError::ConfigParse(format!("invalid file URI: {uri}")))?;
+            Ok(Self::File(PathBuf::from(path_str)))
+        } else {
+            Err(NonoError::ConfigParse(format!(
+                "unrecognized key reference scheme: {uri} \
+                 (expected keystore://<name> or file:///path)"
+            )))
+        }
+    }
+
+    /// Return the key identifier string embedded in bundles and trust policies.
+    ///
+    /// For keystore refs this is the key name (e.g. `"default"`).
+    /// For file refs this is the full `file:///path` URI, so that the verify
+    /// path can dispatch on the URI scheme instead of guessing from path shape.
+    ///
+    /// Returns an error if a file path is not valid UTF-8.
+    pub(crate) fn key_id(&self) -> Result<String> {
+        match self {
+            Self::Keystore(name) => Ok(name.clone()),
+            Self::File(path) => {
+                let path_str = path.to_str().ok_or_else(|| {
+                    NonoError::ConfigParse(format!(
+                        "key path is not valid UTF-8: {}",
+                        path.display()
+                    ))
+                })?;
+                Ok(format!("file://{path_str}"))
+            }
+        }
+    }
+
+    /// Build a [`TrustKeyRef`] from a bare `--id` value (legacy compat).
+    pub(crate) fn from_id(id: &str) -> Self {
+        Self::Keystore(id.to_string())
+    }
+
+    /// Resolve from `--keyref` or `--id` (used by keygen, export-key).
+    ///
+    /// If `keyref` is `Some`, parse it. Otherwise fall back to `id`.
+    pub(crate) fn resolve_id(keyref: Option<&str>, id: &str) -> Result<Self> {
+        match keyref {
+            Some(uri) => Self::parse(uri),
+            None => Ok(Self::from_id(id)),
+        }
+    }
+
+    /// Resolve from `--keyref` or `--key` (used by sign, sign-policy, init).
+    ///
+    /// If `keyref` is `Some`, parse it. Otherwise fall back to `key`
+    /// (defaulting to `"default"` when `key` is `None`).
+    pub(crate) fn resolve_key(keyref: Option<&str>, key: Option<&str>) -> Result<Self> {
+        match keyref {
+            Some(uri) => Self::parse(uri),
+            None => Ok(Self::from_id(key.unwrap_or("default"))),
+        }
+    }
+}
+
+impl std::fmt::Display for TrustKeyRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Keystore(name) => write!(f, "keystore://{name}"),
+            Self::File(path) => {
+                debug_assert!(
+                    path.is_absolute(),
+                    "TrustKeyRef::File must hold an absolute path"
+                );
+                write!(f, "file://{}", path.display())
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TrustKeyStore — internal backend dispatcher
+// ---------------------------------------------------------------------------
+
+enum TrustKeyStore {
+    /// OS keyring (Keychain / Secret Service).
+    System,
+    /// File-backed store using a directory with hex-encoded service/account paths.
+    /// Used by tests (`NONO_TRUST_TEST_KEYSTORE_DIR`).
+    #[cfg(feature = "test-trust-overrides")]
+    Directory(PathBuf),
+    /// Direct file path — the user specifies the exact file for each key.
+    /// Used by `file://` key references.
+    DirectFile(PathBuf),
+}
+
 impl TrustKeyStore {
+    /// Select a backend from a [`TrustKeyRef`].
+    ///
+    /// The test directory override only applies to `Keystore` refs — `File`
+    /// refs always use the direct file path so that integration tests exercise
+    /// the `DirectFile` code path.
+    fn from_ref(key_ref: &TrustKeyRef) -> Self {
+        match key_ref {
+            TrustKeyRef::Keystore(_) => {
+                #[cfg(feature = "test-trust-overrides")]
+                if let Some(dir) = std::env::var_os(TEST_KEYSTORE_DIR_ENV).filter(|d| !d.is_empty())
+                {
+                    return Self::Directory(PathBuf::from(dir));
+                }
+                Self::System
+            }
+            TrustKeyRef::File(path) => Self::DirectFile(path.clone()),
+        }
+    }
+
+    /// Select the default backend (system keystore, or test override).
     fn selected() -> Self {
         #[cfg(feature = "test-trust-overrides")]
         match std::env::var_os(TEST_KEYSTORE_DIR_ENV) {
-            Some(dir) if !dir.is_empty() => Self::File(PathBuf::from(dir)),
-            _ => Self::System,
+            Some(dir) if !dir.is_empty() => return Self::Directory(PathBuf::from(dir)),
+            _ => {}
         }
 
-        #[cfg(not(feature = "test-trust-overrides"))]
-        {
-            Self::System
-        }
+        Self::System
     }
 
     fn description(&self, service: &str) -> String {
         match self {
             Self::System => format!("system keystore (service: {service})"),
             #[cfg(feature = "test-trust-overrides")]
-            Self::File(root) => format!("test keystore directory ({})", root.display()),
+            Self::Directory(root) => format!("file keystore directory ({})", root.display()),
+            Self::DirectFile(path) => format!("file ({})", path.display()),
         }
     }
 
@@ -56,7 +209,8 @@ impl TrustKeyStore {
                 }
             }
             #[cfg(feature = "test-trust-overrides")]
-            Self::File(root) => Ok(file_path(root, service, account).exists()),
+            Self::Directory(root) => Ok(directory_path(root, service, account).exists()),
+            Self::DirectFile(path) => Ok(path.exists()),
         }
     }
 
@@ -79,11 +233,11 @@ impl TrustKeyStore {
                     })
             }
             #[cfg(feature = "test-trust-overrides")]
-            Self::File(root) => {
-                let path = file_path(root, service, account);
+            Self::Directory(root) => {
+                let path = directory_path(root, service, account);
                 nono::load_secret_file(&path).map_err(|e| match e {
                     NonoError::SecretNotFound(_) => NonoError::SecretNotFound(format!(
-                        "key '{account}' not found in test keystore"
+                        "key '{account}' not found in file keystore"
                     )),
                     NonoError::KeystoreAccess(_) => NonoError::KeystoreAccess(format!(
                         "failed to load key '{account}' from {}",
@@ -92,6 +246,15 @@ impl TrustKeyStore {
                     other => other,
                 })
             }
+            Self::DirectFile(path) => nono::load_secret_file(path).map_err(|e| match e {
+                NonoError::SecretNotFound(_) => {
+                    NonoError::SecretNotFound(format!("key not found at {}", path.display()))
+                }
+                NonoError::KeystoreAccess(_) => {
+                    NonoError::KeystoreAccess(format!("failed to load key from {}", path.display()))
+                }
+                other => other,
+            }),
         }
     }
 
@@ -106,8 +269,8 @@ impl TrustKeyStore {
                     .map_err(|e| NonoError::KeystoreAccess(format!("failed to store key: {e}")))
             }
             #[cfg(feature = "test-trust-overrides")]
-            Self::File(root) => {
-                let path = file_path(root, service, account);
+            Self::Directory(root) => {
+                let path = directory_path(root, service, account);
                 nono::store_secret_file(&path, secret).map_err(|e| match e {
                     NonoError::KeystoreAccess(_) => NonoError::KeystoreAccess(format!(
                         "failed to store key '{account}' at {}",
@@ -116,12 +279,22 @@ impl TrustKeyStore {
                     other => other,
                 })
             }
+            Self::DirectFile(path) => nono::store_secret_file(path, secret).map_err(|e| match e {
+                NonoError::KeystoreAccess(_) => {
+                    NonoError::KeystoreAccess(format!("failed to store key at {}", path.display()))
+                }
+                other => other,
+            }),
         }
     }
 }
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 #[cfg(feature = "test-trust-overrides")]
-fn file_path(root: &Path, service: &str, account: &str) -> PathBuf {
+fn directory_path(root: &Path, service: &str, account: &str) -> PathBuf {
     root.join(hex_component(service))
         .join(hex_component(account))
 }
@@ -135,33 +308,152 @@ fn hex_component(value: &str) -> String {
     encoded
 }
 
-pub(crate) fn backend_description(service: &str) -> String {
-    TrustKeyStore::selected().description(service)
+// ---------------------------------------------------------------------------
+// Public API — used by trust_cmd.rs
+// ---------------------------------------------------------------------------
+
+/// Human-readable description of the backend for a given key reference.
+pub(crate) fn backend_description_for_ref(key_ref: &TrustKeyRef, service: &str) -> String {
+    TrustKeyStore::from_ref(key_ref).description(service)
 }
 
-pub(crate) fn contains_secret(service: &str, account: &str) -> Result<bool> {
-    TrustKeyStore::selected().contains(service, account)
+/// Check whether a key exists for the given reference.
+pub(crate) fn contains_secret_for_ref(
+    key_ref: &TrustKeyRef,
+    service: &str,
+    account: &str,
+) -> Result<bool> {
+    TrustKeyStore::from_ref(key_ref).contains(service, account)
 }
+
+/// Store a secret for the given key reference.
+pub(crate) fn store_secret_for_ref(
+    key_ref: &TrustKeyRef,
+    service: &str,
+    account: &str,
+    secret: &str,
+) -> Result<()> {
+    TrustKeyStore::from_ref(key_ref).store(service, account, secret)
+}
+
+// Legacy API — used by `load_signing_key` and `load_public_key_bytes` which are
+// called from the `Keystore` branch of the `_for_ref` dispatchers in trust_cmd.rs.
 
 pub(crate) fn load_secret(service: &str, account: &str) -> Result<Zeroizing<String>> {
     TrustKeyStore::selected().load(service, account)
 }
 
-pub(crate) fn store_secret(service: &str, account: &str, secret: &str) -> Result<()> {
-    TrustKeyStore::selected().store(service, account, secret)
-}
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
-#[cfg(all(test, feature = "test-trust-overrides"))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
+    // -- TrustKeyRef parsing ------------------------------------------------
+
     #[test]
-    fn file_backend_roundtrips_secret() {
+    fn parse_keystore_uri() {
+        let key_ref = TrustKeyRef::parse("keystore://default").ok();
+        assert_eq!(key_ref, Some(TrustKeyRef::Keystore("default".to_string())));
+    }
+
+    #[test]
+    fn parse_keystore_uri_with_hyphens_and_underscores() {
+        let key_ref = TrustKeyRef::parse("keystore://my-key_2").ok();
+        assert_eq!(key_ref, Some(TrustKeyRef::Keystore("my-key_2".to_string())));
+    }
+
+    #[test]
+    fn parse_keystore_uri_empty_name_rejected() {
+        assert!(TrustKeyRef::parse("keystore://").is_err());
+    }
+
+    #[test]
+    fn parse_keystore_uri_bad_chars_rejected() {
+        assert!(TrustKeyRef::parse("keystore://foo/bar").is_err());
+        assert!(TrustKeyRef::parse("keystore://foo bar").is_err());
+        assert!(TrustKeyRef::parse("keystore://foo;bar").is_err());
+    }
+
+    #[test]
+    fn parse_file_uri() {
+        let key_ref = TrustKeyRef::parse("file:///home/user/.config/nono/trust/key.pem").ok();
+        assert_eq!(
+            key_ref,
+            Some(TrustKeyRef::File(PathBuf::from(
+                "/home/user/.config/nono/trust/key.pem"
+            )))
+        );
+    }
+
+    #[test]
+    fn parse_file_uri_relative_rejected() {
+        assert!(TrustKeyRef::parse("file://relative/path").is_err());
+    }
+
+    #[test]
+    fn parse_file_uri_traversal_rejected() {
+        assert!(TrustKeyRef::parse("file:///home/user/../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn parse_file_uri_empty_path_rejected() {
+        assert!(TrustKeyRef::parse("file:///").is_err());
+    }
+
+    #[test]
+    fn parse_unknown_scheme_rejected() {
+        assert!(TrustKeyRef::parse("s3://bucket/key").is_err());
+        assert!(TrustKeyRef::parse("just-a-name").is_err());
+    }
+
+    #[test]
+    fn from_id_produces_keystore_ref() {
+        assert_eq!(
+            TrustKeyRef::from_id("default"),
+            TrustKeyRef::Keystore("default".to_string())
+        );
+    }
+
+    #[test]
+    fn key_id_returns_name_for_keystore() {
+        let key_ref = TrustKeyRef::Keystore("default".to_string());
+        assert_eq!(key_ref.key_id().ok().as_deref(), Some("default"));
+    }
+
+    #[test]
+    fn key_id_returns_file_uri_for_file() {
+        let key_ref = TrustKeyRef::File(PathBuf::from("/home/user/key.pem"));
+        assert_eq!(
+            key_ref.key_id().ok().as_deref(),
+            Some("file:///home/user/key.pem")
+        );
+    }
+
+    #[test]
+    fn display_roundtrip_keystore() {
+        let key_ref = TrustKeyRef::Keystore("default".to_string());
+        assert_eq!(key_ref.to_string(), "keystore://default");
+    }
+
+    #[test]
+    fn display_roundtrip_file() {
+        let key_ref = TrustKeyRef::File(PathBuf::from("/tmp/key.pem"));
+        assert_eq!(key_ref.to_string(), "file:///tmp/key.pem");
+    }
+
+    // -- Directory file backend ---------------------------------------------
+
+    #[test]
+    #[cfg(feature = "test-trust-overrides")]
+    fn directory_backend_roundtrips_secret() {
         let dir = match tempfile::tempdir() {
             Ok(dir) => dir,
             Err(e) => panic!("failed to create tempdir: {e}"),
         };
-        let store = TrustKeyStore::File(dir.path().to_path_buf());
+        let store = TrustKeyStore::Directory(dir.path().to_path_buf());
 
         assert!(!store.contains("service", "account").unwrap_or(true));
         assert!(store.store("service", "account", "secret-value").is_ok());
@@ -175,12 +467,13 @@ mod tests {
     }
 
     #[test]
-    fn file_backend_missing_secret_is_not_found() {
+    #[cfg(feature = "test-trust-overrides")]
+    fn directory_backend_missing_secret_is_not_found() {
         let dir = match tempfile::tempdir() {
             Ok(dir) => dir,
             Err(e) => panic!("failed to create tempdir: {e}"),
         };
-        let store = TrustKeyStore::File(dir.path().to_path_buf());
+        let store = TrustKeyStore::Directory(dir.path().to_path_buf());
 
         match store.load("service", "missing") {
             Err(NonoError::SecretNotFound(msg)) => {
@@ -192,12 +485,13 @@ mod tests {
     }
 
     #[test]
-    fn file_backend_separates_service_namespaces() {
+    #[cfg(feature = "test-trust-overrides")]
+    fn directory_backend_separates_service_namespaces() {
         let dir = match tempfile::tempdir() {
             Ok(dir) => dir,
             Err(e) => panic!("failed to create tempdir: {e}"),
         };
-        let store = TrustKeyStore::File(dir.path().to_path_buf());
+        let store = TrustKeyStore::Directory(dir.path().to_path_buf());
 
         assert!(store.store("service-a", "account", "secret-a").is_ok());
         assert!(store.store("service-b", "account", "secret-b").is_ok());
@@ -213,5 +507,43 @@ mod tests {
 
         assert_eq!(a.as_str(), "secret-a");
         assert_eq!(b.as_str(), "secret-b");
+    }
+
+    // -- Direct file backend ------------------------------------------------
+
+    #[test]
+    fn direct_file_backend_roundtrips_secret() {
+        let dir = match tempfile::tempdir() {
+            Ok(dir) => dir,
+            Err(e) => panic!("failed to create tempdir: {e}"),
+        };
+        let path = dir.path().join("key.pem");
+        let store = TrustKeyStore::DirectFile(path.clone());
+
+        assert!(!store.contains("ignored", "ignored").unwrap_or(true));
+        assert!(store.store("ignored", "ignored", "my-secret-key").is_ok());
+        assert!(store.contains("ignored", "ignored").unwrap_or(false));
+
+        let loaded = match store.load("ignored", "ignored") {
+            Ok(loaded) => loaded,
+            Err(e) => panic!("failed to load secret: {e}"),
+        };
+        assert_eq!(loaded.as_str(), "my-secret-key");
+    }
+
+    #[test]
+    fn direct_file_backend_missing_file_is_not_found() {
+        let dir = match tempfile::tempdir() {
+            Ok(dir) => dir,
+            Err(e) => panic!("failed to create tempdir: {e}"),
+        };
+        let path = dir.path().join("nonexistent.pem");
+        let store = TrustKeyStore::DirectFile(path);
+
+        match store.load("ignored", "ignored") {
+            Err(NonoError::SecretNotFound(_)) => {}
+            Err(e) => panic!("unexpected error: {e}"),
+            Ok(_) => panic!("expected missing file to fail"),
+        }
     }
 }

--- a/crates/nono/src/keystore.rs
+++ b/crates/nono/src/keystore.rs
@@ -915,7 +915,7 @@ pub fn redact_apple_password_uri(uri: &str) -> String {
 /// Redact a file:// URI for safe logging.
 /// Keeps the directory structure but replaces the filename.
 /// `file:///run/secrets/api-token` → `file:///run/secrets/[REDACTED]`
-fn redact_file_uri(uri: &str) -> String {
+pub fn redact_file_uri(uri: &str) -> String {
     if let Some(path) = uri.strip_prefix(FILE_URI_PREFIX) {
         if let Some(last_slash) = path.rfind('/') {
             return format!("{}{}[REDACTED]", FILE_URI_PREFIX, &path[..=last_slash]);

--- a/crates/nono/src/lib.rs
+++ b/crates/nono/src/lib.rs
@@ -70,10 +70,10 @@ pub use diagnostic::{
 };
 pub use error::{NonoError, Result};
 pub use keystore::{
-    is_apple_password_uri, is_env_uri, is_op_uri, load_secret_by_ref, load_secret_file,
-    load_secrets, redact_apple_password_uri, redact_op_uri, store_secret_file,
-    validate_apple_password_uri, validate_destination_env_var, validate_env_uri, validate_op_uri,
-    LoadedSecret,
+    is_apple_password_uri, is_env_uri, is_file_uri, is_op_uri, load_secret_by_ref,
+    load_secret_file, load_secrets, redact_apple_password_uri, redact_file_uri, redact_op_uri,
+    store_secret_file, validate_apple_password_uri, validate_destination_env_var, validate_env_uri,
+    validate_file_uri, validate_op_uri, LoadedSecret,
 };
 pub use net_filter::{FilterResult, HostFilter};
 #[cfg(target_os = "linux")]

--- a/docs/cli/features/trust.mdx
+++ b/docs/cli/features/trust.mdx
@@ -13,7 +13,11 @@ Nono's trust system verifies the **provenance** and **integrity** of files befor
 nono trust keygen
 ```
 
-Creates an ECDSA P-256 key pair in the system keystore (macOS Keychain / Linux Secret Service).
+Creates an ECDSA P-256 key pair in the system keystore (macOS Keychain / Linux Secret Service). On headless or containerized systems where the system keystore is unavailable, use `--keyref file://` to store the key as a file instead:
+
+```bash
+nono trust keygen --keyref file:///home/user/.config/nono/trust/default.pem
+```
 
 ### 2. Create and sign a trust policy
 
@@ -50,6 +54,26 @@ nono trust verify --all
 
 When you run `nono run`, the pre-exec scan automatically verifies all files matching the policy before the agent launches.
 
+### Headless Quick Start (file-backed keys)
+
+On headless Linux, containers, or SSH-only hosts where the system keystore is unavailable, use `--keyref file://` throughout:
+
+```bash
+KEYREF="file://$HOME/.config/nono/trust/default.pem"
+
+nono trust keygen --keyref "$KEYREF"
+nono trust init --include "SKILLS.md" --include "CLAUDE.md" --keyref "$KEYREF"
+nono trust sign-policy --keyref "$KEYREF"
+nono trust sign --all --keyref "$KEYREF"
+nono trust verify --all
+```
+
+Verify does not need `--keyref` — it uses the public key embedded in `trust-policy.json` by `init`.
+
+<Note>
+  The trust policy records the full file path as the signer identity (e.g. `file:///home/user/.config/nono/trust/default.pem`). If you move the key to a different path, re-run `nono trust init` with the new `--keyref` to update the policy. The same key material at a different path is treated as a different signer. Use a stable, conventional path (e.g. `$HOME/.config/nono/trust/default.pem`) to avoid this.
+</Note>
+
 ## CLI Commands
 
 ### nono trust init
@@ -60,6 +84,7 @@ Create a `trust-policy.json` in the current directory.
 nono trust init --include "*.md"                    # single pattern
 nono trust init --include "*.md" --include "*.py"   # multiple patterns
 nono trust init --include "SKILLS*" --key my-key    # with specific signing key
+nono trust init --keyref file:///path/to/key.pem    # with file-backed key
 nono trust init --user                              # user-level policy (~/.config/nono/)
 nono trust init --force                             # overwrite existing policy
 ```
@@ -72,7 +97,8 @@ Sign files. Any file can be signed — no trust policy is required for explicit 
 
 ```bash
 nono trust sign SKILLS.md                  # keyed (default key), creates SKILLS.md.bundle
-nono trust sign SKILLS.md --key my-key     # keyed (specific key)
+nono trust sign SKILLS.md --key my-key     # keyed (specific key from keystore)
+nono trust sign SKILLS.md --keyref file:///path/to/key.pem  # keyed (file-backed key)
 nono trust sign SKILLS.md CLAUDE.md        # per-file .bundle sidecars
 nono trust sign --all                      # all files matching policy (per-file)
 nono trust sign --all --multi-subject      # single .nono-trust.bundle for all files
@@ -117,17 +143,22 @@ nono trust list
 Generate an ECDSA P-256 signing key pair.
 
 ```bash
-nono trust keygen                          # default key ID ("default")
-nono trust keygen --id my-signing-key      # named key
+nono trust keygen                          # default key ID ("default") in system keystore
+nono trust keygen --id my-signing-key      # named key in system keystore
+nono trust keygen --keyref file:///path/to/key.pem  # file-backed key
+nono trust keygen --keyref file:///path/to/key.pem --force  # overwrite existing file
 ```
+
+The `--keyref` flag accepts `keystore://name` (explicit keystore reference) or `file:///path` (file-backed). When using `file://`, the private key is stored at the specified path and the public key at `<path>.pub`, both with owner-only permissions (0600).
 
 ### nono trust export-key
 
 Export the public key in base64 DER format for use in trust policy `public_key` fields.
 
 ```bash
-nono trust export-key                      # export default key
-nono trust export-key --id my-signing-key  # export named key
+nono trust export-key                      # export default key from keystore
+nono trust export-key --id my-signing-key  # export named key from keystore
+nono trust export-key --keyref file:///path/to/key.pem  # export from file-backed key
 nono trust export-key --pem                # output as PEM instead of base64 DER
 ```
 
@@ -138,7 +169,8 @@ Sign the trust policy file. Required after every modification to `trust-policy.j
 ```bash
 nono trust sign-policy                     # sign trust-policy.json in CWD
 nono trust sign-policy --user              # sign user-level trust policy (~/.config/nono/)
-nono trust sign-policy --key my-key        # specific key
+nono trust sign-policy --key my-key        # specific key from keystore
+nono trust sign-policy --keyref file:///path/to/key.pem  # file-backed key
 ```
 
 ## Development Override
@@ -184,7 +216,8 @@ Trust policy is defined in `trust-policy.json`, separate from the sandbox policy
 To get the public key in base64 format for a manual policy:
 
 ```bash
-nono trust export-key --id default
+nono trust export-key --id default                     # from system keystore
+nono trust export-key --keyref file:///path/to/key.pem # from file-backed key
 ```
 
 ### includes
@@ -336,9 +369,11 @@ This policy declares: only trust files signed by a GitHub Actions workflow in `m
 
 ## Signing Modes
 
-There are two signing modes:
+There are two signing modes, with two key storage backends for keyed signing:
 
-**Keyed signing** — A private key stored in the system keystore (macOS Keychain / Linux Secret Service). Suitable for individual developers and local workflows.
+**Keyed signing (keystore)** — A private key stored in the system keystore (macOS Keychain / Linux Secret Service). The default for desktop environments. Use `--key <name>` or `--keyref keystore://<name>`.
+
+**Keyed signing (file)** — A private key stored as a local file with owner-only permissions (0600). Designed for headless Linux, containers, SSH-only hosts, and environments where the system keystore is unavailable. Use `--keyref file:///path/to/key.pem`.
 
 **Keyless signing** — Ephemeral key + OIDC identity + Fulcio certificate + Rekor transparency log. Suitable for CI/CD pipelines with ambient OIDC tokens (e.g., GitHub Actions with `permissions: id-token: write`). The signer's identity is cryptographically bound to the signature via the OIDC token.
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -950,6 +950,7 @@ nono trust init                            # Scan root directory only
 nono trust init -r                         # Scan recursively
 nono trust init -r --exclude-dirs tmp logs # Exclude extra directories
 nono trust init --key my-key --force       # Specific key, overwrite existing
+nono trust init --keyref file:///path/to/key.pem  # File-backed key
 ```
 
 | Option | Description |
@@ -957,6 +958,7 @@ nono trust init --key my-key --force       # Specific key, overwrite existing
 | `-r`, `--recursive` | Scan subdirectories recursively |
 | `--exclude-dirs <DIR...>` | Additional directories to exclude (on top of `.gitignore` and built-in list) |
 | `--key <KEY_ID>` | Key ID to include as publisher (default: "default") |
+| `--keyref <URI>` | Key reference URI (`keystore://name` or `file:///path`). Conflicts with `--key` |
 | `--force` | Overwrite existing `trust-policy.json` |
 
 <Note>
@@ -971,12 +973,14 @@ Sign files, producing bundles for verification.
 nono trust sign <FILES...>                 # Sign specific files
 nono trust sign --all                      # Sign all instruction files in CWD
 nono trust sign SKILLS.md --key my-key     # Use a specific key
+nono trust sign SKILLS.md --keyref file:///path/to/key.pem  # File-backed key
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--all` | Sign all instruction files matching trust policy patterns |
 | `--key <KEY_ID>` | Key ID from system keystore (default: "default") |
+| `--keyref <URI>` | Key reference URI (`keystore://name` or `file:///path`). Conflicts with `--key` and `--keyless` |
 | `--keyless` | Use Sigstore keyless signing (CI environments only) |
 | `--policy <FILE>` | Trust policy file (default: auto-discover) |
 
@@ -993,12 +997,14 @@ nono trust sign-policy                     # Sign trust-policy.json in CWD
 nono trust sign-policy --user              # Sign user-level trust policy (~/.config/nono/)
 nono trust sign-policy path/to/policy.json # Sign specific file
 nono trust sign-policy --key my-key        # Use a specific key
+nono trust sign-policy --keyref file:///path/to/key.pem  # File-backed key
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--user` | Sign the user-level trust policy at `~/.config/nono/trust-policy.json`. The user-level policy anchors trust — without it, project-level policies are not authoritative |
 | `--key <KEY_ID>` | Key ID from system keystore (default: "default") |
+| `--keyref <URI>` | Key reference URI (`keystore://name` or `file:///path`). Conflicts with `--key` |
 
 ### `nono trust verify`
 
@@ -1021,12 +1027,19 @@ nono trust list --json                     # JSON output
 
 ### `nono trust keygen`
 
-Generate an ECDSA P-256 signing key pair and store it in the system keystore.
+Generate an ECDSA P-256 signing key pair.
 
 ```bash
-nono trust keygen                          # Default key ID ("default")
-nono trust keygen --id my-signing-key      # Named key
+nono trust keygen                          # Default key ID ("default") in system keystore
+nono trust keygen --id my-signing-key      # Named key in system keystore
+nono trust keygen --keyref file:///path/to/key.pem  # File-backed key
 ```
+
+| Option | Description |
+|--------|-------------|
+| `--id <NAME>` | Key identifier in system keystore (default: "default") |
+| `--keyref <URI>` | Key reference URI (`keystore://name` or `file:///path`). Conflicts with `--id` |
+| `--force` | Overwrite existing key |
 
 ### `nono trust export-key`
 
@@ -1035,8 +1048,15 @@ Export the public key for use in trust policy `public_key` fields.
 ```bash
 nono trust export-key                      # Export default key (base64 DER)
 nono trust export-key --id my-key          # Export named key
+nono trust export-key --keyref file:///path/to/key.pem  # Export from file-backed key
 nono trust export-key --pem                # Output as PEM format
 ```
+
+| Option | Description |
+|--------|-------------|
+| `--id <NAME>` | Key identifier in system keystore (default: "default") |
+| `--keyref <URI>` | Key reference URI (`keystore://name` or `file:///path`). Conflicts with `--id` |
+| `--pem` | Output as PEM instead of base64 DER |
 
 ## `nono setup` Options
 

--- a/tests/integration/test_trust_cli.sh
+++ b/tests/integration/test_trust_cli.sh
@@ -413,6 +413,90 @@ expect_output_contains "export-key shows base64 public key" "MF" \
     with_test_env "$NONO_BIN" trust export-key --id "$KEY_ID"
 
 # =============================================================================
+# file:// backend (headless key storage)
+# =============================================================================
+
+echo ""
+echo "--- file:// Backend ---"
+
+FILE_DIR="$TMPDIR/file-backend"
+FILE_KEY_DIR="$TMPDIR/file-keys"
+mkdir -p "$FILE_DIR" "$FILE_KEY_DIR"
+
+FILE_KEYREF="file://$FILE_KEY_DIR/trust-key.pem"
+
+printf '# Test file-backed signing\n' > "$FILE_DIR/SKILLS.md"
+
+expect_success "trust keygen --keyref file:// creates key pair" \
+    with_test_env "$NONO_BIN" trust keygen --keyref "$FILE_KEYREF"
+
+run_test "file:// private key exists" 0 test -f "$FILE_KEY_DIR/trust-key.pem"
+run_test "file:// public key exists" 0 test -f "$FILE_KEY_DIR/trust-key.pem.pub"
+
+# Verify permissions are 0600
+PRIV_PERMS=$(stat -c '%a' "$FILE_KEY_DIR/trust-key.pem" 2>/dev/null || stat -f '%Lp' "$FILE_KEY_DIR/trust-key.pem")
+run_test "file:// private key has 0600 permissions" 0 test "$PRIV_PERMS" = "600"
+
+expect_failure "trust keygen --keyref file:// rejects duplicate without --force" \
+    with_test_env "$NONO_BIN" trust keygen --keyref "$FILE_KEYREF"
+
+expect_success "trust keygen --keyref file:// --force overwrites" \
+    with_test_env "$NONO_BIN" trust keygen --keyref "$FILE_KEYREF" --force
+
+expect_output_contains "trust export-key --keyref file:// returns base64" "MF" \
+    with_test_env "$NONO_BIN" trust export-key --keyref "$FILE_KEYREF"
+
+expect_output_contains "trust export-key --keyref file:// --pem returns PEM" "BEGIN PUBLIC KEY" \
+    with_test_env "$NONO_BIN" trust export-key --keyref "$FILE_KEYREF" --pem
+
+expect_in_dir_success "trust init --keyref file:// creates policy" "$FILE_DIR" \
+    with_test_env "$NONO_BIN" trust init --include SKILLS.md --keyref "$FILE_KEYREF"
+
+expect_file_contains "file:// init embeds publisher public key" "$FILE_DIR/trust-policy.json" '"public_key"'
+expect_file_contains "file:// init embeds file URI as key_id" "$FILE_DIR/trust-policy.json" "file://$FILE_KEY_DIR/trust-key.pem"
+
+expect_in_dir_success "trust sign-policy --keyref file:// succeeds" "$FILE_DIR" \
+    with_test_env "$NONO_BIN" trust sign-policy --keyref "$FILE_KEYREF"
+
+run_test "file:// sign-policy creates bundle" 0 test -f "$FILE_DIR/trust-policy.json.bundle"
+
+expect_success "trust sign --keyref file:// creates bundle" \
+    with_test_env "$NONO_BIN" trust sign "$FILE_DIR/SKILLS.md" --keyref "$FILE_KEYREF"
+
+run_test "file:// sign creates bundle" 0 test -f "$FILE_DIR/SKILLS.md.bundle"
+
+expect_in_dir_success_contains "trust verify succeeds with file:// signed artifacts" "$FILE_DIR" "VERIFIED" \
+    with_test_env "$NONO_BIN" trust verify SKILLS.md
+
+# Tamper detection
+printf '# tampered\n' >> "$FILE_DIR/SKILLS.md"
+expect_in_dir_failure_contains "trust verify detects tampering on file:// signed file" "$FILE_DIR" "digest" \
+    with_test_env "$NONO_BIN" trust verify SKILLS.md
+
+# Re-sign after edit
+expect_success "trust sign --keyref file:// re-signs after edit" \
+    with_test_env "$NONO_BIN" trust sign "$FILE_DIR/SKILLS.md" --keyref "$FILE_KEYREF"
+
+expect_in_dir_success_contains "trust verify succeeds after re-sign" "$FILE_DIR" "VERIFIED" \
+    with_test_env "$NONO_BIN" trust verify SKILLS.md
+
+# Key relocation: same key material at a different path is a different signer.
+# The trust policy records the full file:// URI as the publisher key_id, so
+# signing with a relocated copy fails publisher matching even though the
+# cryptographic key is identical. This is by design — use a stable path.
+RELOCATED_KEY_DIR="$TMPDIR/file-keys-relocated"
+mkdir -p "$RELOCATED_KEY_DIR"
+cp "$FILE_KEY_DIR/trust-key.pem" "$RELOCATED_KEY_DIR/trust-key.pem"
+cp "$FILE_KEY_DIR/trust-key.pem.pub" "$RELOCATED_KEY_DIR/trust-key.pem.pub"
+RELOCATED_KEYREF="file://$RELOCATED_KEY_DIR/trust-key.pem"
+
+expect_success "trust sign with relocated key succeeds (signing is key-material only)" \
+    with_test_env "$NONO_BIN" trust sign "$FILE_DIR/SKILLS.md" --keyref "$RELOCATED_KEYREF"
+
+expect_in_dir_failure_contains "trust verify rejects relocated-key signer (path-dependent identity)" "$FILE_DIR" "not in trusted publishers" \
+    with_test_env "$NONO_BIN" trust verify SKILLS.md
+
+# =============================================================================
 # Summary
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- Adds a `file://` key storage backend for `nono trust` commands, enabling keyed signing on headless Linux, containers, and SSH-only hosts where the system keystore (Keychain / Secret Service) is unavailable
- Introduces `--keyref` flag on `keygen`, `sign`, `sign-policy`, `export-key`, and `init` commands, accepting `keystore://name` or `file:///path/to/key.pem`
- Backward compatible: existing `--id` / `--key` workflows are unchanged

### What's included

- **`TrustKeyRef` type and parser** with validation reusing `validate_file_uri` from the core crate
- **`DirectFile` backend** in `TrustKeyStore` — stores private key at the specified path, public key at `<path>.pub`, both with 0600 permissions
- **URI-based key_id** — bundles and policies embed `file:///path` URIs, verify dispatches on `is_file_uri()` (not path heuristics)
- **Redacted debug logging** — file paths in debug logs use `redact_file_uri`, matching the credential implementation
- **Path traversal protection** — `validate_file_uri` rejects `..`, forbidden characters, and relative paths
- **Backend-aware UX** — init next-step messages include `--keyref` when file backend is used; error messages name the actual backend
- **Documentation** — headless quick start, `--keyref` examples on all trust commands, signing modes section, flags reference
- **Integration tests** — 16 new tests covering keygen, sign, verify, tamper detection, key relocation behavior

### Motivation

`nono trust keygen` fails on fresh headless Linux accounts where Secret Service has no `login` collection. This blocks trust usage on headless VMs, JupyterHub, containers, and CI environments. The `file://` backend gives these environments a native key storage path without requiring D-Bus, GNOME Keyring, or desktop sessions.

Tested end-to-end on a headless GCP VM (Ubuntu 22.04, no desktop session, no keyring).

### Known limitation

The trust policy records the full file path as the signer identity. Moving a key to a different path requires re-running `trust init` with the new `--keyref`. Documented in the trust feature guide.

## Test plan

- [x] 19 unit tests (TrustKeyRef parsing, backend roundtrip, validation, key_id, display)
- [x] 10 trust_cmd tests pass (including public key cache)
- [x] 54 CLI arg tests pass (including conflict detection)
- [x] 16 new integration tests in `test_trust_cli.sh` (file:// happy path + relocation)
- [x] `cargo clippy --all-features -D warnings -D clippy::unwrap_used` clean
- [x] End-to-end on headless GCP VM: keygen, init, sign-policy, sign, verify, tamper detection, re-sign
- [x] Pre-existing keystore:// workflows unaffected

Closes #464