### PR TITLE
feat(macos): make parent-of-protected-root relaxation opt-in via profile

### DIFF
--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -367,6 +367,23 @@ Use `add_deny_access` to prevent an agent from reaching the Docker daemon or sim
 
 On macOS, `add_deny_access` on a socket path also emits a Seatbelt `network-outbound` deny — Seatbelt treats `connect(2)` as a network operation so a file deny alone won't block it. Prefer path- and network-based controls; `add_deny_commands` remains as deprecated startup-only compatibility behavior and is visible in `nono policy show` under **Policy patches**.
 
+### Allowing parent-of-protected-root grants (macOS only)
+
+By default, granting a parent directory of `~/.nono` (e.g. `--allow ~`) is rejected because it would expose nono's internal state. On macOS, Seatbelt can express deny-within-allow rules, so this restriction can be relaxed when the profile opts in with `allow_parent_of_protected`:
+
+```json
+{
+  "extends": "claude-code",
+  "meta": {
+    "name": "home-access",
+    "description": "Claude Code with full home directory access"
+  },
+  "allow_parent_of_protected": true
+}
+```
+
+When `allow_parent_of_protected` is `true` and the platform is macOS, nono permits the parent grant and emits Seatbelt deny rules that protect `~/.nono` from reads and writes. On Linux this field is ignored — Landlock cannot deny a child of an allowed parent, so the pre-flight check always rejects parent-of-protected grants.
+
 ### Profile with group exclusion
 
 Remove an inherited deny group that is too restrictive for your use case:

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -628,7 +628,7 @@ impl CapabilitySetExt for CapabilitySet {
         caps.set_ipc_mode_mut(ipc_mode);
 
         // Apply CLI overrides (CLI args take precedence)
-        add_cli_overrides(&mut caps, args)?;
+        add_cli_overrides(&mut caps, args, allow_parent_of_protected)?;
 
         // Expand profile-level override_deny paths for finalize_caps
         let mut profile_overrides = Vec::with_capacity(profile.policy.override_deny.len());
@@ -728,26 +728,30 @@ fn apply_cli_network_mode(caps: &mut CapabilitySet, args: &SandboxArgs) {
 /// a profile or group capability. The subsequent `deduplicate()` call resolves
 /// conflicts using source priority (User wins over Group/System) and merges
 /// complementary access modes (Read + Write = ReadWrite).
-fn add_cli_overrides(caps: &mut CapabilitySet, args: &SandboxArgs) -> Result<()> {
+fn add_cli_overrides(
+    caps: &mut CapabilitySet,
+    args: &SandboxArgs,
+    allow_parent_of_protected: bool,
+) -> Result<()> {
     let protected_roots = ProtectedRoots::from_defaults()?;
 
     // Additional directories from CLI
     for path in &args.allow {
-        validate_requested_dir(path, "CLI", &protected_roots, false)?;
+        validate_requested_dir(path, "CLI", &protected_roots, allow_parent_of_protected)?;
         if let Some(cap) = try_new_dir(path, AccessMode::ReadWrite, "Skipping non-existent path")? {
             caps.add_fs(cap);
         }
     }
 
     for path in &args.read {
-        validate_requested_dir(path, "CLI", &protected_roots, false)?;
+        validate_requested_dir(path, "CLI", &protected_roots, allow_parent_of_protected)?;
         if let Some(cap) = try_new_dir(path, AccessMode::Read, "Skipping non-existent path")? {
             caps.add_fs(cap);
         }
     }
 
     for path in &args.write {
-        validate_requested_dir(path, "CLI", &protected_roots, false)?;
+        validate_requested_dir(path, "CLI", &protected_roots, allow_parent_of_protected)?;
         if let Some(cap) = try_new_dir(path, AccessMode::Write, "Skipping non-existent path")? {
             caps.add_fs(cap);
         }
@@ -755,7 +759,7 @@ fn add_cli_overrides(caps: &mut CapabilitySet, args: &SandboxArgs) -> Result<()>
 
     // Additional files from CLI
     for path in &args.allow_file {
-        validate_requested_file(path, "CLI", &protected_roots, false)?;
+        validate_requested_file(path, "CLI", &protected_roots, allow_parent_of_protected)?;
         if let Some(cap) = try_new_file(path, AccessMode::ReadWrite, "Skipping non-existent file")?
         {
             caps.add_fs(cap);
@@ -763,14 +767,14 @@ fn add_cli_overrides(caps: &mut CapabilitySet, args: &SandboxArgs) -> Result<()>
     }
 
     for path in &args.read_file {
-        validate_requested_file(path, "CLI", &protected_roots, false)?;
+        validate_requested_file(path, "CLI", &protected_roots, allow_parent_of_protected)?;
         if let Some(cap) = try_new_file(path, AccessMode::Read, "Skipping non-existent file")? {
             caps.add_fs(cap);
         }
     }
 
     for path in &args.write_file {
-        validate_requested_file(path, "CLI", &protected_roots, false)?;
+        validate_requested_file(path, "CLI", &protected_roots, allow_parent_of_protected)?;
         if let Some(cap) = try_new_file(path, AccessMode::Write, "Skipping non-existent file")? {
             caps.add_fs(cap);
         }

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -45,11 +45,12 @@ fn try_new_profile_exact_path(
     access: AccessMode,
     label: &str,
     protected_roots: &ProtectedRoots,
+    allow_parent_of_protected: bool,
 ) -> Result<Option<FsCapability>> {
-    validate_requested_file(path, "Profile", protected_roots)?;
+    validate_requested_file(path, "Profile", protected_roots, allow_parent_of_protected)?;
     match try_new_file(path, access, label) {
         Err(NonoError::ExpectedFile(_)) => {
-            handle_exact_directory_path(path, access, protected_roots)
+            handle_exact_directory_path(path, access, protected_roots, allow_parent_of_protected)
         }
         result => result,
     }
@@ -60,8 +61,9 @@ fn handle_exact_directory_path(
     path: &Path,
     access: AccessMode,
     protected_roots: &ProtectedRoots,
+    allow_parent_of_protected: bool,
 ) -> Result<Option<FsCapability>> {
-    validate_requested_dir(path, "Profile", protected_roots)?;
+    validate_requested_dir(path, "Profile", protected_roots, allow_parent_of_protected)?;
     let resolved = path.canonicalize().map_err(|source| {
         if source.kind() == std::io::ErrorKind::NotFound {
             NonoError::PathNotFound(path.to_path_buf())
@@ -95,6 +97,7 @@ fn handle_exact_directory_path(
     path: &Path,
     _access: AccessMode,
     _protected_roots: &ProtectedRoots,
+    _allow_parent_of_protected: bool,
 ) -> Result<Option<FsCapability>> {
     Err(NonoError::ExpectedFile(path.to_path_buf()))
 }
@@ -226,10 +229,11 @@ fn apply_profile_dir_allows(
     protected_roots: &ProtectedRoots,
     caps: &mut CapabilitySet,
     label_prefix: &str,
+    allow_parent_of_protected: bool,
 ) -> Result<()> {
     for path_template in path_templates {
         let path = expand_vars(path_template, workdir)?;
-        validate_requested_dir(&path, "Profile", protected_roots)?;
+        validate_requested_dir(&path, "Profile", protected_roots, allow_parent_of_protected)?;
         let label = format!(
             "{label_prefix} '{}' does not exist, skipping",
             path_template
@@ -246,12 +250,14 @@ fn validate_requested_dir(
     path: &Path,
     source: &str,
     protected_roots: &ProtectedRoots,
+    allow_parent_of_protected: bool,
 ) -> Result<()> {
     protected_paths::validate_requested_path_against_protected_roots(
         path,
         false,
         source,
         protected_roots.as_paths(),
+        allow_parent_of_protected,
     )
 }
 
@@ -259,12 +265,14 @@ fn validate_requested_file(
     path: &Path,
     source: &str,
     protected_roots: &ProtectedRoots,
+    allow_parent_of_protected: bool,
 ) -> Result<()> {
     protected_paths::validate_requested_path_against_protected_roots(
         path,
         true,
         source,
         protected_roots.as_paths(),
+        allow_parent_of_protected,
     )
 }
 
@@ -310,7 +318,7 @@ impl CapabilitySetExt for CapabilitySet {
 
         // Directory permissions (canonicalize handles existence check atomically)
         for path in &args.allow {
-            validate_requested_dir(path, "CLI", &protected_roots)?;
+            validate_requested_dir(path, "CLI", &protected_roots, false)?;
             if let Some(cap) =
                 try_new_dir(path, AccessMode::ReadWrite, "Skipping non-existent path")?
             {
@@ -319,14 +327,14 @@ impl CapabilitySetExt for CapabilitySet {
         }
 
         for path in &args.read {
-            validate_requested_dir(path, "CLI", &protected_roots)?;
+            validate_requested_dir(path, "CLI", &protected_roots, false)?;
             if let Some(cap) = try_new_dir(path, AccessMode::Read, "Skipping non-existent path")? {
                 caps.add_fs(cap);
             }
         }
 
         for path in &args.write {
-            validate_requested_dir(path, "CLI", &protected_roots)?;
+            validate_requested_dir(path, "CLI", &protected_roots, false)?;
             if let Some(cap) = try_new_dir(path, AccessMode::Write, "Skipping non-existent path")? {
                 caps.add_fs(cap);
             }
@@ -334,7 +342,7 @@ impl CapabilitySetExt for CapabilitySet {
 
         // Single file permissions
         for path in &args.allow_file {
-            validate_requested_file(path, "CLI", &protected_roots)?;
+            validate_requested_file(path, "CLI", &protected_roots, false)?;
             if let Some(cap) =
                 try_new_file(path, AccessMode::ReadWrite, "Skipping non-existent file")?
             {
@@ -343,14 +351,14 @@ impl CapabilitySetExt for CapabilitySet {
         }
 
         for path in &args.read_file {
-            validate_requested_file(path, "CLI", &protected_roots)?;
+            validate_requested_file(path, "CLI", &protected_roots, false)?;
             if let Some(cap) = try_new_file(path, AccessMode::Read, "Skipping non-existent file")? {
                 caps.add_fs(cap);
             }
         }
 
         for path in &args.write_file {
-            validate_requested_file(path, "CLI", &protected_roots)?;
+            validate_requested_file(path, "CLI", &protected_roots, false)?;
             if let Some(cap) = try_new_file(path, AccessMode::Write, "Skipping non-existent file")?
             {
                 caps.add_fs(cap);
@@ -385,6 +393,7 @@ impl CapabilitySetExt for CapabilitySet {
     ) -> Result<(CapabilitySet, bool)> {
         let mut caps = CapabilitySet::new();
         let protected_roots = ProtectedRoots::from_defaults()?;
+        let allow_parent_of_protected = profile.allow_parent_of_protected.unwrap_or(false);
 
         // Resolve policy groups from the already-finalized profile.
         let loaded_policy = policy::load_embedded_policy()?;
@@ -401,7 +410,12 @@ impl CapabilitySetExt for CapabilitySet {
         // Directories with read+write access
         for path_template in &fs.allow {
             let path = expand_vars(path_template, workdir)?;
-            validate_requested_dir(&path, "Profile", &protected_roots)?;
+            validate_requested_dir(
+                &path,
+                "Profile",
+                &protected_roots,
+                allow_parent_of_protected,
+            )?;
             let label = format!("Profile path '{}' does not exist, skipping", path_template);
             if let Some(mut cap) = try_new_dir(&path, AccessMode::ReadWrite, &label)? {
                 cap.source = CapabilitySource::Profile;
@@ -419,10 +433,20 @@ impl CapabilitySetExt for CapabilitySet {
                 .unwrap_or(false);
 
             let maybe_cap = if reads_file {
-                validate_requested_file(&path, "Profile", &protected_roots)?;
+                validate_requested_file(
+                    &path,
+                    "Profile",
+                    &protected_roots,
+                    allow_parent_of_protected,
+                )?;
                 try_new_file(&path, AccessMode::Read, &label)?
             } else {
-                validate_requested_dir(&path, "Profile", &protected_roots)?;
+                validate_requested_dir(
+                    &path,
+                    "Profile",
+                    &protected_roots,
+                    allow_parent_of_protected,
+                )?;
                 try_new_dir(&path, AccessMode::Read, &label)?
             };
 
@@ -435,7 +459,12 @@ impl CapabilitySetExt for CapabilitySet {
         // Directories with write-only access
         for path_template in &fs.write {
             let path = expand_vars(path_template, workdir)?;
-            validate_requested_dir(&path, "Profile", &protected_roots)?;
+            validate_requested_dir(
+                &path,
+                "Profile",
+                &protected_roots,
+                allow_parent_of_protected,
+            )?;
             let label = format!("Profile path '{}' does not exist, skipping", path_template);
             if let Some(mut cap) = try_new_dir(&path, AccessMode::Write, &label)? {
                 cap.source = CapabilitySource::Profile;
@@ -447,9 +476,13 @@ impl CapabilitySetExt for CapabilitySet {
         for path_template in &fs.allow_file {
             let path = expand_vars(path_template, workdir)?;
             let label = format!("Profile file '{}' does not exist, skipping", path_template);
-            if let Some(mut cap) =
-                try_new_profile_exact_path(&path, AccessMode::ReadWrite, &label, &protected_roots)?
-            {
+            if let Some(mut cap) = try_new_profile_exact_path(
+                &path,
+                AccessMode::ReadWrite,
+                &label,
+                &protected_roots,
+                allow_parent_of_protected,
+            )? {
                 // Also allow atomic-write temp files (e.g. .claude.json.tmp.PID.TS).
                 // Many tools write to a temp file then rename for crash safety.
                 add_atomic_write_rule(&mut caps, &cap)?;
@@ -462,9 +495,13 @@ impl CapabilitySetExt for CapabilitySet {
         for path_template in &fs.read_file {
             let path = expand_vars(path_template, workdir)?;
             let label = format!("Profile file '{}' does not exist, skipping", path_template);
-            if let Some(mut cap) =
-                try_new_profile_exact_path(&path, AccessMode::Read, &label, &protected_roots)?
-            {
+            if let Some(mut cap) = try_new_profile_exact_path(
+                &path,
+                AccessMode::Read,
+                &label,
+                &protected_roots,
+                allow_parent_of_protected,
+            )? {
                 cap.source = CapabilitySource::Profile;
                 caps.add_fs(cap);
             }
@@ -474,9 +511,13 @@ impl CapabilitySetExt for CapabilitySet {
         for path_template in &fs.write_file {
             let path = expand_vars(path_template, workdir)?;
             let label = format!("Profile file '{}' does not exist, skipping", path_template);
-            if let Some(mut cap) =
-                try_new_profile_exact_path(&path, AccessMode::Write, &label, &protected_roots)?
-            {
+            if let Some(mut cap) = try_new_profile_exact_path(
+                &path,
+                AccessMode::Write,
+                &label,
+                &protected_roots,
+                allow_parent_of_protected,
+            )? {
                 add_atomic_write_rule(&mut caps, &cap)?;
                 cap.source = CapabilitySource::Profile;
                 caps.add_fs(cap);
@@ -491,6 +532,7 @@ impl CapabilitySetExt for CapabilitySet {
             &protected_roots,
             &mut caps,
             "Profile policy path",
+            allow_parent_of_protected,
         )?;
         apply_profile_dir_allows(
             &profile.policy.add_allow_read,
@@ -499,6 +541,7 @@ impl CapabilitySetExt for CapabilitySet {
             &protected_roots,
             &mut caps,
             "Profile policy path",
+            allow_parent_of_protected,
         )?;
         apply_profile_dir_allows(
             &profile.policy.add_allow_write,
@@ -507,6 +550,7 @@ impl CapabilitySetExt for CapabilitySet {
             &protected_roots,
             &mut caps,
             "Profile policy path",
+            allow_parent_of_protected,
         )?;
 
         for path_template in &profile.policy.add_deny_access {
@@ -689,21 +733,21 @@ fn add_cli_overrides(caps: &mut CapabilitySet, args: &SandboxArgs) -> Result<()>
 
     // Additional directories from CLI
     for path in &args.allow {
-        validate_requested_dir(path, "CLI", &protected_roots)?;
+        validate_requested_dir(path, "CLI", &protected_roots, false)?;
         if let Some(cap) = try_new_dir(path, AccessMode::ReadWrite, "Skipping non-existent path")? {
             caps.add_fs(cap);
         }
     }
 
     for path in &args.read {
-        validate_requested_dir(path, "CLI", &protected_roots)?;
+        validate_requested_dir(path, "CLI", &protected_roots, false)?;
         if let Some(cap) = try_new_dir(path, AccessMode::Read, "Skipping non-existent path")? {
             caps.add_fs(cap);
         }
     }
 
     for path in &args.write {
-        validate_requested_dir(path, "CLI", &protected_roots)?;
+        validate_requested_dir(path, "CLI", &protected_roots, false)?;
         if let Some(cap) = try_new_dir(path, AccessMode::Write, "Skipping non-existent path")? {
             caps.add_fs(cap);
         }
@@ -711,7 +755,7 @@ fn add_cli_overrides(caps: &mut CapabilitySet, args: &SandboxArgs) -> Result<()>
 
     // Additional files from CLI
     for path in &args.allow_file {
-        validate_requested_file(path, "CLI", &protected_roots)?;
+        validate_requested_file(path, "CLI", &protected_roots, false)?;
         if let Some(cap) = try_new_file(path, AccessMode::ReadWrite, "Skipping non-existent file")?
         {
             caps.add_fs(cap);
@@ -719,14 +763,14 @@ fn add_cli_overrides(caps: &mut CapabilitySet, args: &SandboxArgs) -> Result<()>
     }
 
     for path in &args.read_file {
-        validate_requested_file(path, "CLI", &protected_roots)?;
+        validate_requested_file(path, "CLI", &protected_roots, false)?;
         if let Some(cap) = try_new_file(path, AccessMode::Read, "Skipping non-existent file")? {
             caps.add_fs(cap);
         }
     }
 
     for path in &args.write_file {
-        validate_requested_file(path, "CLI", &protected_roots)?;
+        validate_requested_file(path, "CLI", &protected_roots, false)?;
         if let Some(cap) = try_new_file(path, AccessMode::Write, "Skipping non-existent file")? {
             caps.add_fs(cap);
         }

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -155,6 +155,7 @@ impl ProfileDef {
             open_urls: self.open_urls.clone(),
             allow_launch_services: self.allow_launch_services,
             allow_gpu: self.allow_gpu,
+            allow_parent_of_protected: None,
             interactive: self.interactive,
             skipdirs: Vec::new(),
         }
@@ -243,7 +244,7 @@ fn should_skip_resolved_deny_target(resolved: &Path) -> bool {
 ///
 /// Non-UTF-8 paths would produce incorrect Seatbelt rules via lossy conversion,
 /// potentially targeting the wrong path in deny rules.
-fn path_to_utf8(path: &Path) -> Result<&str> {
+pub(crate) fn path_to_utf8(path: &Path) -> Result<&str> {
     path.to_str().ok_or_else(|| {
         NonoError::ConfigParse(format!("Path contains non-UTF-8 bytes: {}", path.display()))
     })
@@ -255,7 +256,7 @@ fn path_to_utf8(path: &Path) -> Result<&str> {
 /// are the significant characters. Control characters are rejected (not stripped)
 /// to match the library's escape_path behavior — silently stripping could cause
 /// deny rules to target wrong paths.
-fn escape_seatbelt_path(path: &str) -> Result<String> {
+pub(crate) fn escape_seatbelt_path(path: &str) -> Result<String> {
     let mut result = String::with_capacity(path.len());
     for c in path.chars() {
         if c.is_control() {

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1001,6 +1001,11 @@ pub struct Profile {
     /// When `None`, inherits from the base profile.
     #[serde(default)]
     pub allow_gpu: Option<bool>,
+    /// Opt-in to allow parent-of-protected-root grants on macOS.
+    /// When `true` (and on macOS), `--allow ~` is permitted because Seatbelt deny
+    /// rules protect `~/.nono`. Ignored on Linux. Default is `false`.
+    #[serde(default)]
+    pub allow_parent_of_protected: Option<bool>,
     /// Deprecated: Parsed for backward compatibility but ignored.
     /// Supervised mode preserves TTY by default, making this unnecessary.
     #[serde(default)]
@@ -1043,6 +1048,7 @@ struct ProfileDeserialize {
     allow_launch_services: Option<bool>,
     #[serde(default)]
     allow_gpu: Option<bool>,
+    allow_parent_of_protected: Option<bool>,
     #[serde(default)]
     interactive: bool,
     #[serde(default)]
@@ -1065,6 +1071,7 @@ impl From<ProfileDeserialize> for Profile {
             open_urls: raw.open_urls,
             allow_launch_services: raw.allow_launch_services,
             allow_gpu: raw.allow_gpu,
+            allow_parent_of_protected: raw.allow_parent_of_protected,
             interactive: raw.interactive,
             skipdirs: raw.skipdirs,
         }
@@ -1497,6 +1504,9 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
         },
         allow_launch_services: child.allow_launch_services.or(base.allow_launch_services),
         allow_gpu: child.allow_gpu.or(base.allow_gpu),
+        allow_parent_of_protected: child
+            .allow_parent_of_protected
+            .or(base.allow_parent_of_protected),
         interactive: base.interactive || child.interactive,
         skipdirs: dedup_append(&base.skipdirs, &child.skipdirs),
     }
@@ -2689,6 +2699,7 @@ mod tests {
             }),
             allow_launch_services: Some(false),
             allow_gpu: Some(false),
+            allow_parent_of_protected: None,
             interactive: false,
             skipdirs: vec!["vendor".to_string()],
         }
@@ -2758,6 +2769,7 @@ mod tests {
             }),
             allow_launch_services: Some(true),
             allow_gpu: Some(true),
+            allow_parent_of_protected: Some(true),
             interactive: false,
             skipdirs: vec!["dist".to_string()],
         }
@@ -3405,6 +3417,17 @@ mod tests {
             Some(true),
             "Child value should be used when base is None"
         );
+    }
+
+    #[test]
+    fn test_merge_profiles_allow_parent_of_protected_child_overrides_base() {
+        let merged = merge_profiles(base_profile(), child_profile());
+        assert_eq!(merged.allow_parent_of_protected, Some(true));
+
+        let mut child = child_profile();
+        child.allow_parent_of_protected = Some(false);
+        let merged = merge_profiles(base_profile(), child);
+        assert_eq!(merged.allow_parent_of_protected, Some(false));
     }
 
     #[test]

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -22,6 +22,7 @@ pub(crate) struct PreparedProfile {
     pub(crate) open_url_allow_localhost: bool,
     pub(crate) allow_launch_services: bool,
     pub(crate) allow_gpu: bool,
+    pub(crate) allow_parent_of_protected: bool,
     pub(crate) override_deny_paths: Vec<PathBuf>,
 }
 
@@ -195,6 +196,10 @@ fn prepare_profile_with_options(
         allow_gpu: loaded_profile
             .as_ref()
             .and_then(|profile| profile.allow_gpu)
+            .unwrap_or(false),
+        allow_parent_of_protected: loaded_profile
+            .as_ref()
+            .and_then(|profile| profile.allow_parent_of_protected)
             .unwrap_or(false),
         override_deny_paths: collect_override_deny_paths(
             loaded_profile.as_ref(),

--- a/crates/nono-cli/src/protected_paths.rs
+++ b/crates/nono-cli/src/protected_paths.rs
@@ -42,6 +42,7 @@ impl ProtectedRoots {
 pub fn validate_caps_against_protected_roots(
     caps: &CapabilitySet,
     protected_roots: &[PathBuf],
+    allow_parent_of_protected: bool,
 ) -> Result<()> {
     for cap in caps.fs_capabilities() {
         validate_requested_path_against_protected_roots(
@@ -49,6 +50,7 @@ pub fn validate_caps_against_protected_roots(
             cap.is_file,
             &cap.source.to_string(),
             protected_roots,
+            allow_parent_of_protected,
         )?;
     }
 
@@ -59,11 +61,18 @@ pub fn validate_caps_against_protected_roots(
 ///
 /// This catches protected-root overlaps even when requested paths don't exist
 /// yet and are later skipped during capability creation.
+///
+/// On macOS, `parent_of_protected` is allowed because Seatbelt can express
+/// deny-within-allow via rule specificity. The caller must emit deny rules
+/// for the protected roots via [`emit_protected_root_deny_rules`].
+/// On Linux, `parent_of_protected` remains a hard error because Landlock
+/// is strictly allow-list and cannot express deny-within-allow.
 pub fn validate_requested_path_against_protected_roots(
     path: &Path,
     is_file: bool,
     source: &str,
     protected_roots: &[PathBuf],
+    allow_parent_of_protected: bool,
 ) -> Result<()> {
     let requested_path = resolve_path(path);
     let resolved_roots: Vec<PathBuf> = protected_roots.iter().map(|p| resolve_path(p)).collect();
@@ -71,7 +80,20 @@ pub fn validate_requested_path_against_protected_roots(
     for protected_root in &resolved_roots {
         let inside_protected = requested_path.starts_with(protected_root);
         let parent_of_protected = !is_file && protected_root.starts_with(&requested_path);
-        if inside_protected || parent_of_protected {
+
+        // inside_protected is always a hard error on all platforms
+        if inside_protected {
+            return Err(NonoError::SandboxInit(format!(
+                "Refusing to grant '{}' (source: {}) because it overlaps protected nono state root '{}'.",
+                requested_path.display(),
+                source,
+                protected_root.display(),
+            )));
+        }
+
+        // parent_of_protected: on macOS with opt-in, Seatbelt deny rules protect the root;
+        // on Linux, Landlock cannot express deny-within-allow so we must reject.
+        if parent_of_protected && !(cfg!(target_os = "macos") && allow_parent_of_protected) {
             return Err(NonoError::SandboxInit(format!(
                 "Refusing to grant '{}' (source: {}) because it overlaps protected nono state root '{}'.",
                 requested_path.display(),
@@ -85,6 +107,17 @@ pub fn validate_requested_path_against_protected_roots(
 }
 
 /// Return the protected root overlapped by a requested path, if any.
+///
+/// On macOS, only `inside_protected` is flagged because Seatbelt deny rules
+/// protect the root from parent grants. On Linux, both `inside_protected` and
+/// `parent_of_protected` are flagged.
+///
+/// Unlike [`validate_requested_path_against_protected_roots`], this function
+/// does **not** take an `allow_parent_of_protected` flag. It is called by the
+/// supervisor at runtime, after Seatbelt deny rules have already been emitted,
+/// so the unconditional macOS relaxation is safe here. The pre-flight
+/// validation (which does respect the opt-in flag) has already rejected the
+/// grant if the profile did not opt in.
 #[must_use]
 pub fn overlapping_protected_root(
     path: &Path,
@@ -96,13 +129,65 @@ pub fn overlapping_protected_root(
 
     for protected_root in &resolved_roots {
         let inside_protected = requested_path.starts_with(protected_root);
+        if inside_protected {
+            return Some(protected_root.clone());
+        }
+
         let parent_of_protected = !is_file && protected_root.starts_with(&requested_path);
-        if inside_protected || parent_of_protected {
+        if parent_of_protected && !cfg!(target_os = "macos") {
             return Some(protected_root.clone());
         }
     }
 
     None
+}
+
+/// Emit Seatbelt deny rules for all protected roots.
+///
+/// On macOS, this adds `(deny file-read-data ...)` and `(deny file-write* ...)`
+/// platform rules for each protected root, preventing the sandboxed child from
+/// accessing `~/.nono` even when a parent directory is granted.
+///
+/// On non-macOS, this is a no-op — Landlock does not support deny-within-allow,
+/// so the pre-flight validation rejects parent grants instead.
+pub(crate) fn emit_protected_root_deny_rules(
+    protected_roots: &[PathBuf],
+    caps: &mut CapabilitySet,
+) -> Result<()> {
+    if !cfg!(target_os = "macos") {
+        return Ok(());
+    }
+
+    for root in protected_roots {
+        let resolved = resolve_path(root);
+        emit_deny_rules_for_path(&resolved, caps)?;
+
+        // Also emit for the canonical path if it differs (important on macOS
+        // where paths like /var resolve to /private/var).
+        if let Ok(canonical) = resolved.canonicalize() {
+            if canonical != resolved {
+                emit_deny_rules_for_path(&canonical, caps)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Emit Seatbelt deny rules for a single path.
+#[cfg(target_os = "macos")]
+fn emit_deny_rules_for_path(path: &Path, caps: &mut CapabilitySet) -> Result<()> {
+    let escaped = crate::policy::escape_seatbelt_path(crate::policy::path_to_utf8(path)?)?;
+    let filter = format!("subpath \"{}\"", escaped);
+    caps.add_platform_rule(format!("(allow file-read-metadata ({}))", filter))?;
+    caps.add_platform_rule(format!("(deny file-read-data ({}))", filter))?;
+    caps.add_platform_rule(format!("(deny file-write* ({}))", filter))?;
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn emit_deny_rules_for_path(_path: &Path, _caps: &mut CapabilitySet) -> Result<()> {
+    Ok(())
 }
 
 /// Resolve path by canonicalizing the full path, or canonicalizing the longest
@@ -144,7 +229,7 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
-    fn blocks_parent_directory_capability() {
+    fn parent_directory_capability_blocked_without_opt_in() {
         let tmp = TempDir::new().expect("tmpdir");
         let parent = tmp.path().to_path_buf();
         let protected = parent.join(".nono");
@@ -153,7 +238,88 @@ mod tests {
         let cap = FsCapability::new_dir(&parent, AccessMode::ReadWrite).expect("dir cap");
         caps.add_fs(cap);
 
-        let err = validate_caps_against_protected_roots(&caps, &[protected]).expect_err("blocked");
+        // Without opt-in, parent grant is always rejected
+        let err =
+            validate_caps_against_protected_roots(&caps, &[protected], false).expect_err("blocked");
+        assert!(
+            err.to_string()
+                .contains("overlaps protected nono state root"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn parent_directory_capability_allowed_with_opt_in_on_macos() {
+        let tmp = TempDir::new().expect("tmpdir");
+        let parent = tmp.path().to_path_buf();
+        let protected = parent.join(".nono");
+
+        let mut caps = CapabilitySet::new();
+        let cap = FsCapability::new_dir(&parent, AccessMode::ReadWrite).expect("dir cap");
+        caps.add_fs(cap);
+
+        // With opt-in on macOS, parent grant is allowed (Seatbelt deny rules protect the root)
+        validate_caps_against_protected_roots(&caps, &[protected], true)
+            .expect("allowed on macOS with opt-in");
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn parent_directory_capability_blocked_even_with_opt_in_on_linux() {
+        let tmp = TempDir::new().expect("tmpdir");
+        let parent = tmp.path().to_path_buf();
+        let protected = parent.join(".nono");
+
+        let mut caps = CapabilitySet::new();
+        let cap = FsCapability::new_dir(&parent, AccessMode::ReadWrite).expect("dir cap");
+        caps.add_fs(cap);
+
+        // On Linux, parent grant is always rejected even with opt-in
+        // (Landlock cannot express deny-within-allow)
+        let err = validate_caps_against_protected_roots(&caps, &[protected], true)
+            .expect_err("blocked on Linux even with opt-in");
+        assert!(
+            err.to_string()
+                .contains("overlaps protected nono state root"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn inside_protected_root_always_blocked() {
+        let tmp = TempDir::new().expect("tmpdir");
+        let protected = tmp.path().join(".nono");
+        std::fs::create_dir_all(&protected).expect("mkdir");
+        let inside = protected.join("state.db");
+        std::fs::write(&inside, b"").expect("create file");
+
+        // File inside protected root — blocked on all platforms
+        let err = validate_requested_path_against_protected_roots(
+            &inside,
+            true,
+            "test",
+            std::slice::from_ref(&protected),
+            false,
+        )
+        .expect_err("blocked");
+        assert!(
+            err.to_string()
+                .contains("overlaps protected nono state root"),
+            "unexpected error: {err}",
+        );
+
+        // Directory inside protected root — blocked on all platforms
+        let subdir = protected.join("rollbacks");
+        std::fs::create_dir_all(&subdir).expect("mkdir");
+        let err = validate_requested_path_against_protected_roots(
+            &subdir,
+            false,
+            "test",
+            std::slice::from_ref(&protected),
+            false,
+        )
+        .expect_err("blocked");
         assert!(
             err.to_string()
                 .contains("overlaps protected nono state root"),
@@ -172,7 +338,7 @@ mod tests {
         let cap = FsCapability::new_dir(&child, AccessMode::ReadWrite).expect("dir cap");
         caps.add_fs(cap);
 
-        validate_caps_against_protected_roots(&caps, &[protected]).expect_err("blocked");
+        validate_caps_against_protected_roots(&caps, &[protected], false).expect_err("blocked");
     }
 
     #[test]
@@ -186,7 +352,7 @@ mod tests {
         let cap = FsCapability::new_dir(&workspace, AccessMode::ReadWrite).expect("dir cap");
         caps.add_fs(cap);
 
-        validate_caps_against_protected_roots(&caps, &[protected]).expect("allowed");
+        validate_caps_against_protected_roots(&caps, &[protected], false).expect("allowed");
     }
 
     #[test]
@@ -196,9 +362,14 @@ mod tests {
         std::fs::create_dir_all(&protected).expect("mkdir");
         let child = protected.join("rollbacks").join("future-session");
 
-        let err =
-            validate_requested_path_against_protected_roots(&child, false, "CLI", &[protected])
-                .expect_err("blocked");
+        let err = validate_requested_path_against_protected_roots(
+            &child,
+            false,
+            "CLI",
+            &[protected],
+            false,
+        )
+        .expect_err("blocked");
         assert!(
             err.to_string()
                 .contains("overlaps protected nono state root"),
@@ -213,9 +384,61 @@ mod tests {
         std::fs::create_dir_all(&protected).expect("mkdir");
         let child = protected.join("rollbacks");
 
+        // inside_protected is always reported
         let overlap = overlapping_protected_root(&child, false, std::slice::from_ref(&protected));
         let expected = std::fs::canonicalize(&protected).unwrap_or(protected);
 
         assert_eq!(overlap, Some(expected));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn overlapping_protected_root_parent_not_flagged_on_macos() {
+        let tmp = TempDir::new().expect("tmpdir");
+        let parent = tmp.path().to_path_buf();
+        let protected = parent.join(".nono");
+
+        let overlap = overlapping_protected_root(&parent, false, std::slice::from_ref(&protected));
+        // macOS: parent-of-protected is not flagged (Seatbelt deny rules handle it)
+        assert_eq!(overlap, None, "parent should not be flagged on macOS");
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn overlapping_protected_root_parent_flagged_on_linux() {
+        let tmp = TempDir::new().expect("tmpdir");
+        let parent = tmp.path().to_path_buf();
+        let protected = parent.join(".nono");
+
+        let overlap = overlapping_protected_root(&parent, false, std::slice::from_ref(&protected));
+        // Linux: parent-of-protected is flagged
+        assert!(overlap.is_some(), "parent should be flagged on Linux");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn emit_protected_root_deny_rules_adds_platform_rules() {
+        let tmp = TempDir::new().expect("tmpdir");
+        let protected = tmp.path().join(".nono");
+        std::fs::create_dir_all(&protected).expect("mkdir");
+
+        let mut caps = CapabilitySet::new();
+        emit_protected_root_deny_rules(&[protected], &mut caps).expect("emit rules");
+
+        let rules = caps.platform_rules();
+        assert!(!rules.is_empty(), "should have platform rules");
+        let joined = rules.join("\n");
+        assert!(
+            joined.contains("deny file-read-data"),
+            "should deny reads: {joined}"
+        );
+        assert!(
+            joined.contains("deny file-write*"),
+            "should deny writes: {joined}"
+        );
+        assert!(
+            joined.contains("allow file-read-metadata"),
+            "should allow metadata: {joined}"
+        );
     }
 }

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -553,9 +553,14 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
             }
         }
 
-        let caps = CapabilitySet::try_from(&manifest)?;
+        let mut caps = CapabilitySet::try_from(&manifest)?;
         let protected_roots = protected_paths::ProtectedRoots::from_defaults()?;
-        protected_paths::validate_caps_against_protected_roots(&caps, protected_roots.as_paths())?;
+        protected_paths::validate_caps_against_protected_roots(
+            &caps,
+            protected_roots.as_paths(),
+            false,
+        )?;
+        protected_paths::emit_protected_root_deny_rules(protected_roots.as_paths(), &mut caps)?;
 
         let (rollback_exclude_patterns, rollback_exclude_globs) =
             if let Some(ref rb) = manifest.rollback {
@@ -622,6 +627,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         open_url_allow_localhost,
         allow_launch_services: profile_allow_launch_services,
         allow_gpu: profile_allow_gpu,
+        allow_parent_of_protected: profile_allow_parent_of_protected,
         override_deny_paths,
     } = prepared_profile;
 
@@ -737,7 +743,13 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
     let deny_paths = policy::resolve_deny_paths_for_groups(&loaded_policy, &active_groups)?;
     policy::validate_deny_overlaps(&deny_paths, &caps)?;
     let protected_roots = protected_paths::ProtectedRoots::from_defaults()?;
-    protected_paths::validate_caps_against_protected_roots(&caps, protected_roots.as_paths())?;
+    let allow_parent_of_protected = profile_allow_parent_of_protected;
+    protected_paths::validate_caps_against_protected_roots(
+        &caps,
+        protected_roots.as_paths(),
+        allow_parent_of_protected,
+    )?;
+    protected_paths::emit_protected_root_deny_rules(protected_roots.as_paths(), &mut caps)?;
 
     if needs_unlink_overrides {
         policy::apply_unlink_overrides(&mut caps);


### PR DESCRIPTION
It's often useful to run nono in $HOME (for local admin tasks and development across many repos)

Relates to https://github.com/always-further/nono/issues/568

  On macOS, profiles can now opt in to broad filesystem grants (e.g. `--allow /` or `--allow ~`) that overlap nono's protected state root. Seatbelt's rule specificity allows deny-within-allow, so we emit
  explicit deny rules for `~/.nono` to maintain protection. Profiles opt in via `allow_parent_of_protected: true`.

  On Linux this remains a hard error — Landlock is strictly allow-list and cannot express deny-within-allow.

  - Adds `allow_parent_of_protected` profile field (default `false`)
  - Emits Seatbelt deny rules for protected roots