### PR TITLE
fix(test): handle non-default TMPDIR in linux nested home grant test

### DIFF
--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -2003,20 +2003,22 @@ mod tests {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
+        let original_tmpdir = std::env::var("TMPDIR").unwrap_or("/tmp".to_string());
 
         let _env = crate::test_env::EnvVarGuard::set_all(&[
             ("HOME", home.to_str().expect("home path")),
             ("TMPDIR", temp_root.to_str().expect("tmpdir path")),
         ]);
 
-        let skip_tmp = should_skip_group_allow_path("system_write_linux", Path::new("/tmp"))
-            .expect("check /tmp skip");
+        let skip_tmp =
+            should_skip_group_allow_path("system_write_linux", Path::new(&original_tmpdir))
+                .expect("check original TMPDIR skip");
         let skip_tmpdir = should_skip_group_allow_path("system_write_linux", &temp_root)
-            .expect("check TMPDIR skip");
+            .expect("check new TMPDIR skip");
 
         assert!(
             skip_tmp,
-            "/tmp should be skipped when HOME is nested under it"
+            "original TMPDIR should be skipped when HOME is nested under it"
         );
         assert!(
             skip_tmpdir,


### PR DESCRIPTION
## Summary

Read the actual `$TMPDIR` in `test_should_skip_system_write_linux_tmp_grant_when_home_is_nested` to handle environments where there is an atypical `$TMPDIR` set - for example, in nix's sandbox build the tmp dir is set to somewhere underneath `/build` and not `/tmp`.

This fix should hopefully fix the remaining test failures in the nixpkgs update build for nono (see [recent failures](https://nixpkgs-update-logs.nix-community.org/nono/2026-04-06.log)). The other test failures in this build were already fixed by #608.

## Testing

- [x] `make ci` passes
- [x] All tests pass
- [x] `nix build --option sandbox true` with a dummy flake over this repo successfully builds and tests

## Notes

- It might be useful to think about how to long-term harden nono against implicit env dependencies (across both tests and source). A few potential options we may want to discuss in a new thread:
   - Add a weekly CI build for `nix` to proactively surface any build issues in a nix sandbox
   - Disable running tests for nono in nixpkgs 👎 
   - Make all envvars as test inputs and totally forbid reading any true envvars in tests (option 4 in #567)