### PR TITLE
fix(macos): tighten GPU IOKit surface to AGXDeviceUserClient only

### DIFF
--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -466,12 +466,6 @@ mod tests {
                 .any(|r| r.contains("AGXDeviceUserClient")),
             "AGXDeviceUserClient platform rule should be present"
         );
-        assert!(
-            caps.platform_rules()
-                .iter()
-                .any(|r| r.contains("IOSurfaceRootUserClient")),
-            "IOSurfaceRootUserClient platform rule should be present"
-        );
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -175,20 +175,18 @@ pub(crate) fn maybe_enable_macos_gpu(
         ));
     }
 
-    // Minimal IOKit surface for Metal compute on Apple Silicon. Verified that
-    // `AGXDeviceUserClient` and `IOSurfaceRootUserClient` are sufficient for
-    // the full pipeline and offscreen rendering. `AGXSharedUserClient` is only
-    // needed for cross process GPU resource sharing (such as WebKit's GPU
-    // process). Adding `iokit-connection "IOGPU"` would cover more user
-    // clients such as `IOGPUSurfaceMTL` and `IOGPUGLDrawableUserClient` which
-    // are needed for display output and OpenGL. Intel Macs require
-    // `IntelAccelerator`, `IOAccelerator`, and `AMDRadeonX*` classes which are
-    // not yet supported.
+    // Minimal IOKit surface for Metal compute on Apple Silicon.
+    // `AGXDeviceUserClient` is the only class required. Verified with
+    // Metal compute, offscreen rendering, llama.cpp inference, and GUI
+    // apps. `IOSurfaceRootUserClient` is tried opportunistically by
+    // Metal but continues without it when denied. Intel Macs use
+    // `IGAccelDevice` and `IGAccelSharedUserClient` (via `IntelAccelerator`)
+    // for integrated GPUs, and `AMDRadeonX*` classes for discrete GPUs,
+    // both of which are not yet supported.
     caps.add_platform_rule(
         "(allow iokit-open \
             (iokit-user-client-class \
-                \"AGXDeviceUserClient\" \
-                \"IOSurfaceRootUserClient\"))",
+                \"AGXDeviceUserClient\"))",
     )?;
     warn!("--allow-gpu enabled: allowing access to GPU");
     Ok(true)


### PR DESCRIPTION
When I started off with a blank deny all seatbelt profile and ran a metal binary I got:

```
  ... 0xae877    Error       0x0                  0      0    kernel: (Sandbox) Sandbox: metal_test(5393) deny(1) iokit-open-user-client IOSurfaceRootUserClient
```

So I added `(allow iokit-open (iokit-user-client-class "IOSurfaceRootUserClient")` and ran it again. (I ran into some intermittent issues during testing where I wasn't getting any more denial logs, so I started trying to find user clients that looked relevant to AGX, after some more proper testing and rule minimisation after we rescoped it to just be metal compute, I got it down to two classes, one for the device and one for managing GPU memory buffers. I was very happy!

It turns out `IOSurfaceRootUserClient` is just not needed, if you deny it, it appears to silently degrade, despite this most binaries (`llama-cpp`, my terminal emulator, random system daemons, application helpers) request it (**and get it!**), the only process I found that didn't have one currently open on my system was `zsh`.

Interestingly, the graphics comm page setup happens on the `IOSurface` connection (selectors 13 and 44 before AGX setup and 32 after), so you'd assume one was a prerequisite for the other:

```
    connection 0xa03  (3 calls)
      IOSurface`___ioSurfaceConnectInternal_block_invoke  (2 calls)
        selector 13    (method 1)
        selector 44    (method 1)
      IOSurface`IOSurfaceGetGraphicsCommPageAddress  (1 calls)
        selector 32    (method 1)
```

Which map to the raw calls we see IOKit make:
```
    OPEN svc=0x1e0f type=515 ret=0 // IOSurface open
    CALL port=0xc03 sel=13 // IOSurface setup
    CALL port=0xc03 sel=44 // IOSurface setup
    MATCH IOAccelerator // AGX matching
    OPEN svc=0x2503 type=515 ret=0 // AGX open
    ...
    CALL port=0xc03 sel=32 // IOSurfaceGetGraphicsCommPageAddress
```
(Port numbers vary across runs, one from a much earlier basic version of the script, and one from a newer version, but selectors are consistent)

But if you deny `IOSurfaceRootUserClient` and allow `AGXDeviceUserClient` then Metal continues fine. I've tried everything I can think of to get it to crash but it seems to genuinely just not need it, I tried offscreen rendering: didn't need it, rendering an image: didn't need it, opening a graphical user interface: didn't need it.

It seems to use it opportunistically though I'm not sure what actually changes, I'm still looking into it because I'm curious now.

The end result is we have literally the smallest possible GPU attack surface now for `--allow-gpu` that should just cover... everything users will want on Apple Silicon? Including graphical apps, which I think is pretty huge.

I also dug out the proper class names for Intel and removed the IOGPU reference because we genuinely don't need it for Apple Silicon and for Intel I found the proper class names (which I should have done at the time, sorry!) so if someone decides to pick up Intel/AMD work they have a better grounding point than an undocumented seatbelt filter predicate.