### PR TITLE
fix(cli): decouple audit trail from rollback

### DIFF
--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1122,7 +1122,7 @@ pub struct RunArgs {
     pub no_diagnostics: bool,
 
     /// Disable the audit trail for this session
-    #[arg(long, conflicts_with = "rollback", help_heading = "OPTIONS")]
+    #[arg(long, help_heading = "OPTIONS")]
     pub no_audit: bool,
 
     /// Disable trust verification (not recommended for production)

--- a/crates/nono-cli/src/rollback_runtime.rs
+++ b/crates/nono-cli/src/rollback_runtime.rs
@@ -10,12 +10,13 @@ pub(crate) struct AuditState {
     pub(crate) session_dir: PathBuf,
 }
 
-pub(crate) type RollbackRuntimeState = (
-    nono::undo::SnapshotManager,
-    nono::undo::SnapshotManifest,
-    Vec<PathBuf>,
-    HashSet<PathBuf>,
-);
+pub(crate) struct RollbackRuntimeState {
+    pub(crate) manager: nono::undo::SnapshotManager,
+    pub(crate) baseline: nono::undo::SnapshotManifest,
+    pub(crate) tracked_paths: Vec<PathBuf>,
+    pub(crate) atomic_temp_before: HashSet<PathBuf>,
+    pub(crate) session_id: String,
+}
 
 pub(crate) struct RollbackExitContext<'a> {
     pub(crate) audit_state: Option<&'a AuditState>,
@@ -123,16 +124,11 @@ fn enforce_rollback_limits(silent: bool) {
     }
 }
 
-pub(crate) fn create_audit_state(
-    rollback_requested: bool,
-    rollback_disabled: bool,
-    audit_disabled: bool,
-    rollback_destination: Option<&PathBuf>,
-) -> Result<Option<AuditState>> {
-    if !rollback_requested || rollback_disabled || audit_disabled {
-        return Ok(None);
-    }
-
+/// Create a new session directory with a unique ID.
+///
+/// Used by both audit and rollback to establish a session storage location.
+/// When both are active, audit creates the dir and rollback shares it.
+fn ensure_session_dir(rollback_destination: Option<&PathBuf>) -> Result<(String, PathBuf)> {
     let session_id = format!(
         "{}-{}",
         chrono::Local::now().format("%Y%m%d-%H%M%S"),
@@ -163,6 +159,19 @@ pub(crate) fn create_audit_state(
             warn!("Failed to set session directory permissions to 0700: {e}");
         }
     }
+
+    Ok((session_id, session_dir))
+}
+
+pub(crate) fn create_audit_state(
+    audit_disabled: bool,
+    rollback_destination: Option<&PathBuf>,
+) -> Result<Option<AuditState>> {
+    if audit_disabled {
+        return Ok(None);
+    }
+
+    let (session_id, session_dir) = ensure_session_dir(rollback_destination)?;
 
     Ok(Some(AuditState {
         session_id,
@@ -206,8 +215,12 @@ pub(crate) fn initialize_rollback_state(
 
     enforce_rollback_limits(silent);
 
-    let Some(audit_state) = audit_state else {
-        return Ok(None);
+    // When audit is active, share its session directory. Otherwise create
+    // a standalone directory so rollback snapshots still have somewhere to
+    // live (handles the --rollback --no-audit case).
+    let (session_id, session_dir) = match audit_state {
+        Some(state) => (state.session_id.clone(), state.session_dir.clone()),
+        None => ensure_session_dir(rollback.destination.as_ref())?,
     };
 
     let tracked_paths: Vec<PathBuf> = caps
@@ -283,7 +296,7 @@ pub(crate) fn initialize_rollback_state(
     }
 
     let mut manager = nono::undo::SnapshotManager::new(
-        audit_state.session_dir.clone(),
+        session_dir.clone(),
         tracked_paths.clone(),
         exclusion,
         nono::undo::WalkBudget::default(),
@@ -294,7 +307,13 @@ pub(crate) fn initialize_rollback_state(
 
     output::print_rollback_tracking(&tracked_paths, silent);
 
-    Ok(Some((manager, baseline, tracked_paths, atomic_temp_before)))
+    Ok(Some(RollbackRuntimeState {
+        manager,
+        baseline,
+        tracked_paths,
+        atomic_temp_before,
+        session_id,
+    }))
 }
 
 pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<()> {
@@ -317,14 +336,19 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<(
 
     let mut audit_saved = false;
 
-    if let Some((mut manager, baseline, tracked_paths, atomic_temp_before)) = rollback_state {
+    if let Some(RollbackRuntimeState {
+        mut manager,
+        baseline,
+        tracked_paths,
+        atomic_temp_before,
+        session_id: rb_session_id,
+    }) = rollback_state
+    {
         let (final_manifest, changes) = manager.create_incremental(&baseline)?;
         let merkle_roots = vec![baseline.merkle_root, final_manifest.merkle_root];
 
         let meta = nono::undo::SessionMetadata {
-            session_id: audit_state
-                .map(|state| state.session_id.clone())
-                .unwrap_or_default(),
+            session_id: rb_session_id,
             started: started.to_string(),
             ended: Some(ended.to_string()),
             command: command.to_vec(),
@@ -348,6 +372,8 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<(
         let _ = manager.cleanup_new_atomic_temp_files(&atomic_temp_before);
     }
 
+    // Audit-only path: no rollback snapshots, just persist session metadata
+    // with network events. This is the default for supervised sessions.
     if !audit_saved {
         if let Some(audit_state) = audit_state {
             let meta = nono::undo::SessionMetadata {
@@ -366,4 +392,72 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_audit_state_returns_none_when_disabled() {
+        let result = create_audit_state(true, None).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn create_audit_state_creates_session_when_enabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().to_path_buf();
+
+        let state = create_audit_state(false, Some(&dest)).unwrap().unwrap();
+
+        assert!(!state.session_id.is_empty());
+        assert!(state.session_dir.exists());
+        assert!(state.session_dir.starts_with(tmp.path()));
+    }
+
+    #[test]
+    fn ensure_session_dir_creates_dir_in_custom_destination() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().to_path_buf();
+
+        let (session_id, session_dir) = ensure_session_dir(Some(&dest)).unwrap();
+
+        assert!(!session_id.is_empty());
+        assert!(session_dir.exists());
+        assert!(session_dir.starts_with(tmp.path()));
+    }
+
+    #[test]
+    fn ensure_session_dir_id_contains_pid() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().to_path_buf();
+
+        let (session_id, _) = ensure_session_dir(Some(&dest)).unwrap();
+
+        let pid = std::process::id().to_string();
+        assert!(
+            session_id.contains(&pid),
+            "session_id '{session_id}' should contain pid '{pid}'"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_session_dir_sets_0700_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().to_path_buf();
+
+        let (_, session_dir) = ensure_session_dir(Some(&dest)).unwrap();
+
+        let mode = std::fs::metadata(&session_dir)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o700, "session dir should have 0700 permissions");
+    }
 }

--- a/crates/nono-cli/src/supervised_runtime.rs
+++ b/crates/nono-cli/src/supervised_runtime.rs
@@ -142,12 +142,7 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
 
     output::print_applying_sandbox(silent);
 
-    let audit_state = create_audit_state(
-        rollback.requested,
-        rollback.disabled,
-        rollback.audit_disabled,
-        rollback.destination.as_ref(),
-    )?;
+    let audit_state = create_audit_state(rollback.audit_disabled, rollback.destination.as_ref())?;
     warn_if_rollback_flags_ignored(rollback, silent);
     let rollback_state = initialize_rollback_state(rollback, caps, audit_state.as_ref(), silent)?;
 

--- a/tests/integration/test_audit.sh
+++ b/tests/integration/test_audit.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Audit Trail Tests
 # Verifies that audit sessions are recorded correctly in all execution scenarios.
-# Audit is only recorded for supervised executions. Plain `nono run` may exec
-# directly, so only runs that require a parent process (for example `--rollback`)
-# are expected to leave session metadata behind.
+# Audit is on by default for all supervised sessions (#269). Plain `nono run`
+# creates an audit session; `--no-audit` opts out. Rollback and audit are
+# orthogonal — `--rollback --no-audit` is a valid combination.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/../lib/test_helpers.sh"
@@ -49,47 +49,47 @@ echo "Rollback root: $ROLLBACK_ROOT"
 echo ""
 
 # =============================================================================
-# Direct execution should not create audit sessions
+# Default execution creates audit sessions (#269)
 # =============================================================================
 
-echo "--- Direct Execution (No Audit Session) ---"
+echo "--- Default Audit (Session Created) ---"
 
-# Test 1: Plain run (no --rollback) should NOT create a session
+# Test 1: Plain run creates an audit session by default
 TESTS_RUN=$((TESTS_RUN + 1))
 run_nono run --silent --allow-cwd --allow "$TMPDIR" -- echo "audit test"
 session_file=$(find_session_for_pid "$LAST_NONO_PID")
-if [[ -z "$session_file" ]]; then
-    echo -e "  ${GREEN}PASS${NC}: plain run does not create audit session"
+if [[ -n "$session_file" && -f "$session_file" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: plain run creates audit session"
     TESTS_PASSED=$((TESTS_PASSED + 1))
 else
-    echo -e "  ${RED}FAIL${NC}: plain run does not create audit session"
-    echo "       Unexpected session: $session_file"
+    echo -e "  ${RED}FAIL${NC}: plain run creates audit session"
+    echo "       PID: $LAST_NONO_PID, session_file: ${session_file:-not found}"
     TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
-# Test 2: Read-only direct run should NOT create a session
+# Test 2: Read-only run creates an audit session
 TESTS_RUN=$((TESTS_RUN + 1))
 run_nono run --silent --allow-cwd --read "$TMPDIR" -- echo "readonly audit"
 session_file=$(find_session_for_pid "$LAST_NONO_PID")
-if [[ -z "$session_file" ]]; then
-    echo -e "  ${GREEN}PASS${NC}: read-only direct run does not create audit session"
+if [[ -n "$session_file" && -f "$session_file" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: read-only run creates audit session"
     TESTS_PASSED=$((TESTS_PASSED + 1))
 else
-    echo -e "  ${RED}FAIL${NC}: read-only direct run does not create audit session"
-    echo "       Unexpected session: $session_file"
+    echo -e "  ${RED}FAIL${NC}: read-only run creates audit session"
+    echo "       PID: $LAST_NONO_PID, session_file: ${session_file:-not found}"
     TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
-# Test 3: Direct run with non-zero exit should NOT create a session
+# Test 3: Non-zero exit still creates an audit session
 TESTS_RUN=$((TESTS_RUN + 1))
 run_nono run --silent --allow-cwd --allow "$TMPDIR" -- sh -c "exit 42"
 session_file=$(find_session_for_pid "$LAST_NONO_PID")
-if [[ -z "$session_file" ]]; then
-    echo -e "  ${GREEN}PASS${NC}: direct run with non-zero exit does not create audit session"
+if [[ -n "$session_file" && -f "$session_file" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: non-zero exit creates audit session"
     TESTS_PASSED=$((TESTS_PASSED + 1))
 else
-    echo -e "  ${RED}FAIL${NC}: direct run with non-zero exit does not create audit session"
-    echo "       Unexpected session: $session_file"
+    echo -e "  ${RED}FAIL${NC}: non-zero exit creates audit session"
+    echo "       PID: $LAST_NONO_PID, session_file: ${session_file:-not found}"
     TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
@@ -100,7 +100,7 @@ fi
 echo ""
 echo "--- Audit Opt-Out (--no-audit) ---"
 
-# Test 4: --no-audit without a supervisor-required feature remains sessionless
+# Test 4: --no-audit suppresses audit session
 TESTS_RUN=$((TESTS_RUN + 1))
 run_nono run --silent --no-audit --allow-cwd --allow "$TMPDIR" -- echo "no audit"
 session_file=$(find_session_for_pid "$LAST_NONO_PID")
@@ -113,12 +113,21 @@ else
     TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
-# Test: --no-audit + --rollback is rejected by clap
-expect_failure "--no-audit conflicts with --rollback" \
-    "$NONO_BIN" run --silent --no-audit --rollback --allow-cwd --allow "$TMPDIR" -- echo "conflict"
+# Test: --no-audit + --rollback is a valid combination (rollback without audit)
+TESTS_RUN=$((TESTS_RUN + 1))
+run_nono run --silent --no-audit --rollback --no-rollback-prompt --allow-cwd --allow "$TMPDIR" -- echo "rollback no audit"
+session_file=$(find_session_for_pid "$LAST_NONO_PID")
+if [[ -n "$session_file" && -f "$session_file" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: --no-audit --rollback creates rollback session without audit"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    echo -e "  ${RED}FAIL${NC}: --no-audit --rollback creates rollback session without audit"
+    echo "       PID: $LAST_NONO_PID, session_file: ${session_file:-not found}"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
 
 # =============================================================================
-# Audit with rollback (forces supervised execution)
+# Audit with rollback
 # =============================================================================
 
 echo ""


### PR DESCRIPTION
## Summary

Decouples the audit trail from the rollback system so that every supervised session persists audit metadata by default, regardless of whether `--rollback` is set or writable tracked paths exist.

Previously, `session.json` was only written inside the `if let Some(...) = rollback_state` block, meaning:
- Sessions without `--rollback` produced no audit trail
- Sessions with only read-only paths (e.g. `--rollback --allow-cwd`) produced no audit trail

Now audit and rollback are orthogonal: audit is on by default (`--no-audit` opts out), rollback remains opt-in (`--rollback`).

Closes #269
Fixes #268

## Changes

- **Extract `ensure_session_dir` helper** — shared by both audit and rollback for session directory creation. When both are active, audit creates the dir and rollback shares it. When only rollback is active (`--rollback --no-audit`), rollback creates its own.
- **Simplify `create_audit_state`** — no longer checks `rollback_requested` or `rollback_disabled`, gates only on `audit_disabled`.
- **Convert `RollbackRuntimeState` to named struct** — rollback now owns its own `session_id` instead of deriving it from `audit_state.map(|s| s.session_id).unwrap_or_default()` (which produced an empty string when audit was off).
- **Add audit-only persistence path in `finalize_supervised_exit`** — when rollback is inactive, audit writes minimal `session.json` with command, timestamps, exit code, and network events.
- **Remove `conflicts_with = "rollback"` from `--no-audit`** — `--rollback --no-audit` is now a valid combination (rollback snapshots without audit metadata).

## Behavior matrix

| Flags | audit_state | rollback_state | Result |
|-------|------------|----------------|--------|
| *(default)* | Some | None | Audit-only `session.json` (new default) |
| `--rollback` | Some | Some (shared dir) | Full audit + rollback snapshots |
| `--no-audit` | None | None | Nothing persisted |
| `--rollback --no-audit` | None | Some (own dir) | Rollback snapshots only (new) |
| `--rollback --allow-cwd` (read-only) | Some | None (no writable paths) | Audit-only `session.json` (was broken) |

## Test plan

- [x] `make check` (clippy + fmt) passes
- [x] `make test` passes
- [x] New unit tests for `create_audit_state` and `ensure_session_dir` (gating logic, directory creation, session ID format, 0700 permissions on unix)
- [x] Manual validation of all 4 flag combinations on Ubuntu with Landlock V6

## Design decisions open for discussion

- **Directory naming**: Audit-only sessions currently live in `~/.nono/rollbacks/`. Should this be renamed to `~/.nono/sessions/` now that it holds more than rollback data? (Breaking change — probably a follow-up.)
- **Audit-only cleanup**: `enforce_rollback_limits` only runs when `--rollback` is set. Audit-only sessions are ~1KB each so storage is negligible, but they accumulate without cleanup. Should there be a lightweight age-based pruning mechanism?
- **`nono shell` audit**: Should `nono shell` also get audit by default, or is this scoped to `nono run` only?
