### PR TITLE
fix(shell): initialize proxy runtime when credentials are configured

### DIFF
--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -3,8 +3,9 @@ use crate::exec_strategy;
 use crate::execution_runtime::execute_sandboxed;
 use crate::launch_runtime::{
     load_configured_detach_sequence, prepare_run_launch_plan, resolve_requested_workdir,
-    ExecutionFlags, LaunchPlan, SessionLaunchOptions,
+    select_exec_strategy, ExecutionFlags, LaunchPlan, SessionLaunchOptions,
 };
+use crate::proxy_runtime::prepare_proxy_launch_options;
 use crate::output;
 use crate::sandbox_prepare::{
     prepare_sandbox, print_allow_gpu_warning, print_allow_launch_services_warning,
@@ -83,16 +84,29 @@ pub(crate) fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
         eprintln!();
     }
 
+    let proxy = prepare_proxy_launch_options(&args.sandbox, &prepared, silent)?;
+    let strategy = select_exec_strategy(
+        false,
+        proxy.active,
+        prepared.capability_elevation,
+        false,
+        false,
+    );
+
     execute_sandboxed(LaunchPlan {
         program: shell_path.into_os_string(),
         cmd_args: vec![],
         caps: prepared.caps,
         loaded_secrets: prepared.secrets,
         flags: ExecutionFlags {
+            strategy,
             workdir: resolve_requested_workdir(args.sandbox.workdir.as_ref()),
             no_diagnostics: true,
             capability_elevation: prepared.capability_elevation,
+            #[cfg(target_os = "linux")]
+            wsl2_proxy_policy: prepared.wsl2_proxy_policy,
             override_deny_paths: prepared.override_deny_paths,
+            proxy,
             session: SessionLaunchOptions {
                 session_name: args.name,
                 detach_sequence: load_configured_detach_sequence()?,

--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -5,8 +5,8 @@ use crate::launch_runtime::{
     load_configured_detach_sequence, prepare_run_launch_plan, resolve_requested_workdir,
     select_exec_strategy, ExecutionFlags, LaunchPlan, SessionLaunchOptions,
 };
-use crate::proxy_runtime::prepare_proxy_launch_options;
 use crate::output;
+use crate::proxy_runtime::prepare_proxy_launch_options;
 use crate::sandbox_prepare::{
     prepare_sandbox, print_allow_gpu_warning, print_allow_launch_services_warning,
     validate_external_proxy_bypass,


### PR DESCRIPTION
## Summary

`nono shell --profile <profile-with-credentials>` fails immediately with:

```
sandbox initialization failed: invalid port in network address
Backtrace:
<input string>:397:26:
    (remote tcp "localhost:0")
```

## Root cause

`run_shell` in `command_runtime.rs` builds the `LaunchPlan` by hand after calling
`prepare_sandbox`, skipping the proxy initialization that `run_sandbox` gets via
`prepare_run_launch_plan`. This leaves the `CapabilitySet` with
`NetworkMode::ProxyOnly { port: 0 }` — the unresolved placeholder — which Seatbelt
rejects because port 0 is not valid in a static profile rule.

The divergence:
- `run_sandbox` → `prepare_run_launch_plan` → `prepare_proxy_launch_options` ✓
- `run_shell` → `prepare_sandbox` → manual `LaunchPlan` → `proxy: ProxyLaunchOptions::default()` (`active: false`) ✗

`execution_runtime` calls `start_proxy_runtime` for all paths, but with `active: false`
it returns immediately without starting anything or updating the port.

## Fix

Call `prepare_proxy_launch_options` and `select_exec_strategy` in `run_shell` before
constructing the `LaunchPlan`, matching the behaviour of `run_sandbox`. Also threads
`wsl2_proxy_policy` through to `ExecutionFlags` for consistency on Linux.

## Reproducing

Save the following as `httpbin-poc.json`:

```json
{
  "network": {
    "credentials": ["httpbin"],
    "custom_credentials": {
      "httpbin": {
        "upstream": "https://httpbin.org",
        "credential_key": "httpbin_token",
        "inject_header": "Authorization",
        "credential_format": "Bearer {}"
      }
    }
  }
}
```

Store a test credential:

```bash
security add-generic-password -s nono -a httpbin_token -w "my-test-bearer-secret"
```

Then:

```bash
# Before patch → fails
nono shell --profile ./httpbin-poc.json

# After patch → proxy starts, injection works
echo 'curl -s -H "Authorization: Bearer $HTTPBIN_TOKEN" "$HTTPBIN_BASE_URL/bearer"; exit' \
  | nono shell --profile ./httpbin-poc.json --silent
# {"authenticated": true, "token": "my-test-bearer-secret"}
```

`nono run` baseline confirmed unaffected. Full test suite passes.

## Workaround (before this fix)

```bash
nono run --profile ./httpbin-poc.json -- bash
```

Signed-off-by: Vincent K <v@kobl.one>