### PR TITLE
test(macos): align GPU IOKit tests with tightened surface from #635

### DIFF
--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -1694,14 +1694,12 @@ mod tests {
     #[test]
     fn test_platform_rule_validation_accepts_gpu_iokit_rules() {
         let mut caps = CapabilitySet::new();
+        // Minimal IOKit surface: only AGXDeviceUserClient is needed for Metal compute
         assert!(caps
             .add_platform_rule(
                 "(allow iokit-open \
-                    (iokit-connection \"IOGPU\") \
                     (iokit-user-client-class \
-                        \"AGXDeviceUserClient\" \
-                        \"AGXSharedUserClient\" \
-                        \"IOSurfaceRootUserClient\"))"
+                        \"AGXDeviceUserClient\"))"
             )
             .is_ok());
         assert!(caps

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -1694,7 +1694,9 @@ mod tests {
     #[test]
     fn test_platform_rule_validation_accepts_gpu_iokit_rules() {
         let mut caps = CapabilitySet::new();
-        // Minimal IOKit surface: only AGXDeviceUserClient is needed for Metal compute
+        // Minimal IOKit surface: AGXDeviceUserClient is the only class required
+        // for Metal compute on Apple Silicon. IOSurfaceRootUserClient is tried
+        // opportunistically but Metal continues without it when denied.
         assert!(caps
             .add_platform_rule(
                 "(allow iokit-open \

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -850,13 +850,13 @@ mod tests {
     #[test]
     fn test_generate_profile_with_gpu_iokit_rules() {
         let mut caps = CapabilitySet::new();
+        // Minimal IOKit surface: AGXDeviceUserClient is the only class required
+        // for Metal compute on Apple Silicon. IOSurfaceRootUserClient is tried
+        // opportunistically but Metal continues without it when denied.
         caps.add_platform_rule(
             "(allow iokit-open \
-                (iokit-connection \"IOGPU\") \
                 (iokit-user-client-class \
-                    \"AGXDeviceUserClient\" \
-                    \"AGXSharedUserClient\" \
-                    \"IOSurfaceRootUserClient\"))",
+                    \"AGXDeviceUserClient\"))",
         )
         .unwrap();
         caps.add_platform_rule("(allow iokit-get-properties)")
@@ -865,10 +865,9 @@ mod tests {
         let profile = generate_profile(&caps).unwrap();
 
         assert!(profile.contains("(allow iokit-open"));
-        assert!(profile.contains("IOGPU"));
         assert!(profile.contains("AGXDeviceUserClient"));
-        assert!(profile.contains("AGXSharedUserClient"));
-        assert!(profile.contains("IOSurfaceRootUserClient"));
+        assert!(!profile.contains("IOGPU"));
+        assert!(!profile.contains("IOSurfaceRootUserClient"));
         assert!(profile.contains("(allow iokit-get-properties)"));
     }
 

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -867,6 +867,7 @@ mod tests {
         assert!(profile.contains("(allow iokit-open"));
         assert!(profile.contains("AGXDeviceUserClient"));
         assert!(!profile.contains("IOGPU"));
+        assert!(!profile.contains("AGXSharedUserClient"));
         assert!(!profile.contains("IOSurfaceRootUserClient"));
         assert!(profile.contains("(allow iokit-get-properties)"));
     }


### PR DESCRIPTION
## Summary

PR #639 introduced two library-level tests that encoded the pre-#635 broad IOKit rule (IOGPU + AGXDeviceUserClient + AGXSharedUserClient + IOSurfaceRootUserClient). #635 tightened the production rule to just AGXDeviceUserClient, but #639 was written on a branch based on earlier code so these test assertions slipped through.

The production code in `sandbox_prepare.rs` already uses the tightened rule — this change only brings the library-level test fixtures in sync.

- `crates/nono/src/sandbox/macos.rs` — `test_generate_profile_with_gpu_iokit_rules` now uses the minimal rule and asserts `IOGPU`/`IOSurfaceRootUserClient` are **absent** from the generated profile
- `crates/nono/src/capability.rs` — `test_platform_rule_validation_accepts_gpu_iokit_rules` uses the same minimal rule

## Test plan

- [x] `cargo test --lib -p nono` passes both updated tests
- [x] `make test` green
- [x] `make clippy` / `make fmt-check` clean