### PR TITLE
ci: add release automation for downstream SDK repos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,3 +202,26 @@ jobs:
           download-url: "https://github.com/always-further/nono/archive/refs/tags/${{ env.RELEASE_TAG }}.tar.gz"
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_CORE_TOKEN }}
+
+  notify-downstream:
+    name: Notify Downstream Repos
+    needs: [release, publish-crates]
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.inputs.tag || github.ref_name, 'alpha') && !contains(github.event.inputs.tag || github.ref_name, 'beta') && !contains(github.event.inputs.tag || github.ref_name, 'rc') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+          - always-further/nono-py
+          - always-further/nono-ts
+          - always-further/nono-go
+          - always-further/nono-registry
+          - always-further/nono-docs
+    steps:
+      - name: Dispatch to ${{ matrix.repo }}
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
+        with:
+          token: ${{ secrets.DOWNSTREAM_PAT }}
+          repository: ${{ matrix.repo }}
+          event-type: nono-release
+          client-payload: '{"nono_version": "${{ env.RELEASE_TAG }}"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,6 @@ jobs:
           - always-further/nono-py
           - always-further/nono-ts
           - always-further/nono-go
-          - always-further/nono-registry
           - always-further/nono-docs
     steps:
       - name: Dispatch to ${{ matrix.repo }}

--- a/scripts/downstream-workflows/bump-nono-docs.yml
+++ b/scripts/downstream-workflows/bump-nono-docs.yml
@@ -1,0 +1,28 @@
+name: Bump nono docs
+
+on:
+  repository_dispatch:
+    types: [nono-release]
+  workflow_dispatch:
+    inputs:
+      nono_version:
+        description: 'nono version that triggered the rebuild (e.g., v0.33.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  rebuild-docs:
+    name: Rebuild docs for nono ${{ github.event.client_payload.nono_version || github.event.inputs.nono_version }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # Trigger the existing aggregate-docs workflow via dispatch
+      - name: Trigger docs aggregation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run aggregate-docs.yml

--- a/scripts/downstream-workflows/bump-nono-go.yml
+++ b/scripts/downstream-workflows/bump-nono-go.yml
@@ -1,0 +1,149 @@
+name: Bump nono dependency
+
+on:
+  repository_dispatch:
+    types: [nono-release]
+  workflow_dispatch:
+    inputs:
+      nono_version:
+        description: 'nono version to bump to (e.g., v0.33.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  rebuild-libs:
+    name: Rebuild nono-ffi for ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    env:
+      NONO_VERSION: ${{ github.event.client_payload.nono_version || github.event.inputs.nono_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
+            platform: linux_amd64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-22.04
+            platform: linux_arm64
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            platform: darwin_amd64
+          - target: aarch64-apple-darwin
+            os: macos-14
+            platform: darwin_arm64
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Clone nono at release tag
+        run: |
+          git clone --depth 1 --branch "$NONO_VERSION" \
+            https://github.com/always-further/nono.git /tmp/nono
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux' && !matrix.cross
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+
+      - name: Install cross (Linux ARM64)
+        if: matrix.cross
+        run: cargo install cross
+
+      - name: Build libnono_ffi.a
+        run: |
+          cd /tmp/nono
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }} -p nono-ffi
+          else
+            cargo build --release --target ${{ matrix.target }} -p nono-ffi
+          fi
+
+      - name: Upload library artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: libnono-${{ matrix.platform }}
+          path: |
+            /tmp/nono/target/${{ matrix.target }}/release/libnono_ffi.a
+            /tmp/nono/bindings/c/include/nono.h
+
+  create-pr:
+    name: Create bump PR
+    needs: rebuild-libs
+    runs-on: ubuntu-latest
+    env:
+      NONO_VERSION: ${{ github.event.client_payload.nono_version || github.event.inputs.nono_version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Strip v prefix
+        id: version
+        run: |
+          VERSION="${NONO_VERSION#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch=bump-nono-${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if PR already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh pr list --search "bump nono to ${{ steps.version.outputs.version }}" --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "PR #$EXISTING already exists, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download all library artifacts
+        if: steps.check.outputs.skip != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+
+      - name: Update bundled libraries
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          NONO_SHA=$(git ls-remote https://github.com/always-further/nono.git "refs/tags/${NONO_VERSION}" | cut -f1)
+
+          for platform in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64; do
+            cp "artifacts/libnono-${platform}/libnono_ffi.a" "internal/clib/${platform}/libnono_ffi.a"
+            echo "$NONO_SHA" > "internal/clib/${platform}/VERSION"
+          done
+
+          # Update shared header
+          cp artifacts/libnono-darwin_arm64/nono.h internal/clib/nono.h
+
+      - name: Create Pull Request
+        if: steps.check.outputs.skip != 'true'
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ steps.version.outputs.branch }}
+          commit-message: "chore(deps): bump nono to ${{ steps.version.outputs.version }}"
+          title: "chore(deps): bump nono to ${{ steps.version.outputs.version }}"
+          body: |
+            Automated PR to rebuild bundled `libnono_ffi.a` static libraries from nono `${{ env.NONO_VERSION }}`.
+
+            Triggered by [nono ${{ env.NONO_VERSION }}](https://github.com/always-further/nono/releases/tag/${{ env.NONO_VERSION }}).
+
+            ### Updated libraries
+            - `internal/clib/darwin_amd64/libnono_ffi.a`
+            - `internal/clib/darwin_arm64/libnono_ffi.a`
+            - `internal/clib/linux_amd64/libnono_ffi.a`
+            - `internal/clib/linux_arm64/libnono_ffi.a`
+            - `internal/clib/nono.h`
+
+            ## Checklist
+            - [ ] CI passes
+            - [ ] `go test ./...` passes with new libraries
+          labels: dependencies,automated

--- a/scripts/downstream-workflows/bump-nono-go.yml
+++ b/scripts/downstream-workflows/bump-nono-go.yml
@@ -114,6 +114,10 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         run: |
           NONO_SHA=$(git ls-remote https://github.com/always-further/nono.git "refs/tags/${NONO_VERSION}" | cut -f1)
+          if [ -z "$NONO_SHA" ]; then
+            echo "Error: Could not resolve SHA for tag ${NONO_VERSION}"
+            exit 1
+          fi
 
           for platform in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64; do
             cp "artifacts/libnono-${platform}/libnono_ffi.a" "internal/clib/${platform}/libnono_ffi.a"

--- a/scripts/downstream-workflows/bump-nono-py.yml
+++ b/scripts/downstream-workflows/bump-nono-py.yml
@@ -48,8 +48,8 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           # Update nono and nono-proxy crate dependencies
-          sed -i "s/^nono = \"[0-9.]*\"/nono = \"${VERSION}\"/" Cargo.toml
-          sed -i "s/^nono-proxy = \"[0-9.]*\"/nono-proxy = \"${VERSION}\"/" Cargo.toml
+          sed -i "s/^nono[[:space:]]*=[[:space:]]*\"[^\"]*\"/nono = \"${VERSION}\"/" Cargo.toml
+          sed -i "s/^nono-proxy[[:space:]]*=[[:space:]]*\"[^\"]*\"/nono-proxy = \"${VERSION}\"/" Cargo.toml
 
       - name: Create Pull Request
         if: steps.check.outputs.skip != 'true'

--- a/scripts/downstream-workflows/bump-nono-py.yml
+++ b/scripts/downstream-workflows/bump-nono-py.yml
@@ -1,0 +1,70 @@
+name: Bump nono dependency
+
+on:
+  repository_dispatch:
+    types: [nono-release]
+  workflow_dispatch:
+    inputs:
+      nono_version:
+        description: 'nono version to bump to (e.g., v0.33.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    name: Bump nono to ${{ github.event.client_payload.nono_version || github.event.inputs.nono_version }}
+    runs-on: ubuntu-latest
+    env:
+      NONO_VERSION: ${{ github.event.client_payload.nono_version || github.event.inputs.nono_version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Strip v prefix
+        id: version
+        run: |
+          VERSION="${NONO_VERSION#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch=bump-nono-${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if PR already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh pr list --search "bump nono to ${{ steps.version.outputs.version }}" --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "PR #$EXISTING already exists, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update Cargo.toml
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Update nono and nono-proxy crate dependencies
+          sed -i "s/^nono = \"[0-9.]*\"/nono = \"${VERSION}\"/" Cargo.toml
+          sed -i "s/^nono-proxy = \"[0-9.]*\"/nono-proxy = \"${VERSION}\"/" Cargo.toml
+
+      - name: Create Pull Request
+        if: steps.check.outputs.skip != 'true'
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ steps.version.outputs.branch }}
+          commit-message: "chore(deps): bump nono to ${{ steps.version.outputs.version }}"
+          title: "chore(deps): bump nono to ${{ steps.version.outputs.version }}"
+          body: |
+            Automated PR to bump the nono dependency to `${{ steps.version.outputs.version }}`.
+
+            Triggered by [nono ${{ env.NONO_VERSION }}](https://github.com/always-further/nono/releases/tag/${{ env.NONO_VERSION }}).
+
+            ## Checklist
+            - [ ] CI passes
+            - [ ] Test with new nono version
+          labels: dependencies,automated

--- a/scripts/downstream-workflows/bump-nono-registry.yml
+++ b/scripts/downstream-workflows/bump-nono-registry.yml
@@ -48,14 +48,14 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           # Update nono workspace dependency
-          sed -i "s/^nono = \"[0-9.]*\"/nono = \"${VERSION}\"/" Cargo.toml
+          sed -i "s/^nono[[:space:]]*=[[:space:]]*\"[^\"]*\"/nono = \"${VERSION}\"/" Cargo.toml
 
       - name: Update Cargo.lock
         if: steps.check.outputs.skip != 'true'
         run: |
           rustup default stable
-          cargo check --quiet 2>/dev/null || true
-          cargo update -p nono --precise "${{ steps.version.outputs.version }}" 2>/dev/null || true
+          cargo check --quiet
+          cargo update -p nono --precise "${{ steps.version.outputs.version }}"
 
       - name: Create Pull Request
         if: steps.check.outputs.skip != 'true'

--- a/scripts/downstream-workflows/bump-nono-registry.yml
+++ b/scripts/downstream-workflows/bump-nono-registry.yml
@@ -1,0 +1,78 @@
+name: Bump nono dependency
+
+on:
+  repository_dispatch:
+    types: [nono-release]
+  workflow_dispatch:
+    inputs:
+      nono_version:
+        description: 'nono version to bump to (e.g., v0.33.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    name: Bump nono to ${{ github.event.client_payload.nono_version || github.event.inputs.nono_version }}
+    runs-on: ubuntu-latest
+    env:
+      NONO_VERSION: ${{ github.event.client_payload.nono_version || github.event.inputs.nono_version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Strip v prefix
+        id: version
+        run: |
+          VERSION="${NONO_VERSION#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch=bump-nono-${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if PR already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh pr list --search "bump nono to ${{ steps.version.outputs.version }}" --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "PR #$EXISTING already exists, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update Cargo.toml
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Update nono workspace dependency
+          sed -i "s/^nono = \"[0-9.]*\"/nono = \"${VERSION}\"/" Cargo.toml
+
+      - name: Update Cargo.lock
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          rustup default stable
+          cargo check --quiet 2>/dev/null || true
+          cargo update -p nono --precise "${{ steps.version.outputs.version }}" 2>/dev/null || true
+
+      - name: Create Pull Request
+        if: steps.check.outputs.skip != 'true'
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ steps.version.outputs.branch }}
+          commit-message: "chore(deps): bump nono to ${{ steps.version.outputs.version }}"
+          title: "chore(deps): bump nono to ${{ steps.version.outputs.version }}"
+          body: |
+            Automated PR to bump the nono dependency to `${{ steps.version.outputs.version }}`.
+
+            Triggered by [nono ${{ env.NONO_VERSION }}](https://github.com/always-further/nono/releases/tag/${{ env.NONO_VERSION }}).
+
+            **Note:** Merging this PR will trigger an automatic deployment.
+
+            ## Checklist
+            - [ ] CI passes
+            - [ ] Review deployment impact
+          labels: dependencies,automated

--- a/scripts/downstream-workflows/bump-nono-ts.yml
+++ b/scripts/downstream-workflows/bump-nono-ts.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           # Update nono crate dependency
-          sed -i "s/^nono = \"[0-9.]*\"/nono = \"${VERSION}\"/" Cargo.toml
+          sed -i "s/^nono[[:space:]]*=[[:space:]]*\"[^\"]*\"/nono = \"${VERSION}\"/" Cargo.toml
 
       - name: Create Pull Request
         if: steps.check.outputs.skip != 'true'

--- a/scripts/downstream-workflows/bump-nono-ts.yml
+++ b/scripts/downstream-workflows/bump-nono-ts.yml
@@ -1,0 +1,69 @@
+name: Bump nono dependency
+
+on:
+  repository_dispatch:
+    types: [nono-release]
+  workflow_dispatch:
+    inputs:
+      nono_version:
+        description: 'nono version to bump to (e.g., v0.33.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    name: Bump nono to ${{ github.event.client_payload.nono_version || github.event.inputs.nono_version }}
+    runs-on: ubuntu-latest
+    env:
+      NONO_VERSION: ${{ github.event.client_payload.nono_version || github.event.inputs.nono_version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Strip v prefix
+        id: version
+        run: |
+          VERSION="${NONO_VERSION#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch=bump-nono-${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if PR already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh pr list --search "bump nono to ${{ steps.version.outputs.version }}" --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "PR #$EXISTING already exists, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update Cargo.toml
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Update nono crate dependency
+          sed -i "s/^nono = \"[0-9.]*\"/nono = \"${VERSION}\"/" Cargo.toml
+
+      - name: Create Pull Request
+        if: steps.check.outputs.skip != 'true'
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ steps.version.outputs.branch }}
+          commit-message: "chore(deps): bump nono to ${{ steps.version.outputs.version }}"
+          title: "chore(deps): bump nono to ${{ steps.version.outputs.version }}"
+          body: |
+            Automated PR to bump the nono dependency to `${{ steps.version.outputs.version }}`.
+
+            Triggered by [nono ${{ env.NONO_VERSION }}](https://github.com/always-further/nono/releases/tag/${{ env.NONO_VERSION }}).
+
+            ## Checklist
+            - [ ] CI passes
+            - [ ] Test with new nono version
+          labels: dependencies,automated

--- a/scripts/push-downstream-workflows.sh
+++ b/scripts/push-downstream-workflows.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# push-downstream-workflows.sh
+#
+# Creates PRs in downstream repos to add the bump-nono.yml workflow.
+# Requires: gh CLI authenticated with repo scope for always-further org.
+#
+# Usage: ./scripts/push-downstream-workflows.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW_DIR="${SCRIPT_DIR}/downstream-workflows"
+
+declare -A REPOS=(
+  ["nono-py"]="bump-nono-py.yml"
+  ["nono-ts"]="bump-nono-ts.yml"
+  ["nono-go"]="bump-nono-go.yml"
+  ["nono-registry"]="bump-nono-registry.yml"
+  ["nono-docs"]="bump-nono-docs.yml"
+)
+
+BRANCH="add-bump-nono-workflow"
+COMMIT_MSG="ci: add automated nono version bump workflow
+
+Adds a workflow that receives repository_dispatch events from the
+nono release pipeline and creates a PR to bump the nono dependency.
+
+Signed-off-by: nono-release-automation <noreply@nono.sh>"
+
+for repo in "${!REPOS[@]}"; do
+  workflow_file="${REPOS[$repo]}"
+  full_repo="always-further/${repo}"
+
+  echo "==> Processing ${full_repo}..."
+
+  # Check if PR already exists
+  existing=$(gh pr list -R "${full_repo}" --search "add automated nono version bump workflow" --state open --json number --jq '.[0].number' 2>/dev/null || true)
+  if [ -n "$existing" ]; then
+    echo "    PR #${existing} already exists, skipping"
+    continue
+  fi
+
+  # Clone, branch, add workflow, push, PR
+  tmpdir=$(mktemp -d)
+  gh repo clone "${full_repo}" "${tmpdir}" -- --depth 1
+
+  cd "${tmpdir}"
+  git checkout -b "${BRANCH}"
+
+  mkdir -p .github/workflows
+  cp "${WORKFLOW_DIR}/${workflow_file}" .github/workflows/bump-nono.yml
+
+  git add .github/workflows/bump-nono.yml
+  git commit -m "${COMMIT_MSG}"
+  git push origin "${BRANCH}"
+
+  gh pr create \
+    --repo "${full_repo}" \
+    --title "ci: add automated nono version bump workflow" \
+    --body "$(cat <<'EOF'
+## Summary
+
+Adds `.github/workflows/bump-nono.yml` — an automated workflow that:
+
+1. **Listens** for `repository_dispatch` events (type: `nono-release`) from the nono release pipeline
+2. **Creates a PR** to bump the nono dependency to the new version
+3. Can also be triggered manually via `workflow_dispatch`
+
+This is part of the [nono release automation](https://github.com/always-further/nono) that keeps all downstream SDKs and services in sync when a new nono version is released.
+
+### Flow
+```
+nono tag v0.X.0
+  → nono release.yml builds + publishes
+  → dispatches nono-release event to this repo
+  → bump-nono.yml creates a PR with the version bump
+  → maintainer reviews + merges
+  → existing release/deploy workflow runs
+```
+
+### Required setup
+- A `DOWNSTREAM_PAT` secret must be configured in the nono repo with `repo` scope for the `always-further` org
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+  echo "    PR created for ${full_repo}"
+  cd -
+  rm -rf "${tmpdir}"
+done
+
+echo ""
+echo "Done! Remember to add the DOWNSTREAM_PAT secret to always-further/nono."


### PR DESCRIPTION
## Summary

- Adds a `notify-downstream` job to `release.yml` that dispatches `repository_dispatch` events to all downstream repos when a stable nono release is published
- Includes per-repo bump workflow templates in `scripts/downstream-workflows/` for each downstream repo
- Includes a helper script (`scripts/push-downstream-workflows.sh`) to push those workflows as PRs to each downstream repo

### Release flow after this lands

```
nono tag v0.X.0
  → release.yml: build → publish crates.io → create GitHub Release
  → notify-downstream dispatches to:
      nono-py     → bump Cargo.toml nono dep → PR → merge → publish to PyPI
      nono-ts     → bump Cargo.toml nono dep → PR → merge → publish to npm
      nono-go     → rebuild libnono_ffi.a    → PR → merge → tag → Go proxy
      nono-registry → bump Cargo.toml dep    → PR → merge → auto-deploy
      nono-docs   → trigger docs aggregation → auto-rebuild
```

### Downstream repos and what gets bumped

| Repo | Version reference | Bump method |
|------|------------------|-------------|
| nono-py | `Cargo.toml` nono + nono-proxy deps | sed version string |
| nono-ts | `Cargo.toml` nono dep | sed version string |
| nono-go | Bundled `libnono_ffi.a` static libs | Rebuild from nono tag, update VERSION files |
| nono-registry | `Cargo.toml` workspace nono dep | sed version string + cargo update |
| nono-docs | None (aggregates from HEAD) | Triggers existing aggregate workflow |
| agent-sign | Defaults to `"latest"` | No bump needed |

### Required setup
A `DOWNSTREAM_PAT` secret with `repo` scope for the `always-further` org must be added to this repo's Actions secrets.

## Test plan
- [ ] Verify `release.yml` syntax with `gh workflow view release.yml`
- [ ] Dry-run `push-downstream-workflows.sh` against a test org
- [ ] Test dispatch with `gh api repos/always-further/nono-py/dispatches -f event_type=nono-release -f client-payload='{"nono_version":"v0.32.0"}'`
