### PR TITLE
fix(gpu): add nvidia-uvm-tools to GPU device allowlist

### DIFF
--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -408,6 +408,7 @@ pub(crate) fn maybe_enable_gpu(
                 e.file_name().to_str().is_some_and(|n| {
                     n == "nvidiactl"
                         || n == "nvidia-uvm"
+                        || n == "nvidia-uvm-tools"
                         || (n.starts_with("nvidia")
                             && n[6..].bytes().all(|b| b.is_ascii_digit())
                             && n.len() > 6)
@@ -464,7 +465,7 @@ pub(crate) fn maybe_enable_gpu(
     if gpu_device_count == 0 {
         return Err(NonoError::SandboxInit(
             "--allow-gpu: no GPU devices found (checked /dev/dri/renderD*, \
-             /dev/nvidia*, /dev/kfd, /dev/dxg)"
+             /dev/nvidia*, /dev/nvidia-uvm-tools, /dev/kfd, /dev/dxg)"
                 .to_string(),
         ));
     }


### PR DESCRIPTION
## Summary

Follow-up to #639, fixing an issue found in real-world testing on NVIDIA driver 570 / CUDA 12.8 (A100, native Linux, Landlock V4).

### `nvidia-uvm-tools` not included in GPU device allowlist

The filter in `maybe_enable_gpu()` matches `nvidia-uvm` explicitly but not `nvidia-uvm-tools` — the non-digit suffix causes it to fall through all three branches and never be granted.

NVIDIA driver 570 opens `/dev/nvidia-uvm-tools` (minor 1, alongside `nvidia-uvm` minor 0) during UVM initialization. When `open()` returns `EACCES` from Landlock, the driver treats it as a fatal `cudaErrorOperatingSystem` (Error 304) — even when `/dev/nvidia-uvm` itself is accessible.

```rust
// Before
n == "nvidiactl"
    || n == "nvidia-uvm"
    || (n.starts_with("nvidia") && n[6..].bytes().all(|b| b.is_ascii_digit()) && n.len() > 6)

// After
n == "nvidiactl"
    || n == "nvidia-uvm"
    || n == "nvidia-uvm-tools"   // driver 570+ opens this during UVM init
    || (n.starts_with("nvidia") && n[6..].bytes().all(|b| b.is_ascii_digit()) && n.len() > 6)
```

## Test plan

- [x] `torch.cuda.get_device_capability()` succeeds inside sandbox (previously Error 304)
- [x] `torch.cuda.device_count()` returns correct count

Tested on: Ubuntu 22.04, Landlock V4, NVIDIA A100-SXM4-40GB, driver 570, CUDA 12.8