### PR TITLE
fix(gpu): add nvidia-uvm-tools to GPU device allowlist

### DIFF
--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -408,6 +408,7 @@ pub(crate) fn maybe_enable_gpu(
                 e.file_name().to_str().is_some_and(|n| {
                     n == "nvidiactl"
                         || n == "nvidia-uvm"
+                        || n == "nvidia-uvm-tools"
                         || (n.starts_with("nvidia")
                             && n[6..].bytes().all(|b| b.is_ascii_digit())
                             && n.len() > 6)
@@ -464,7 +465,7 @@ pub(crate) fn maybe_enable_gpu(
     if gpu_device_count == 0 {
         return Err(NonoError::SandboxInit(
             "--allow-gpu: no GPU devices found (checked /dev/dri/renderD*, \
-             /dev/nvidia*, /dev/kfd, /dev/dxg)"
+             /dev/nvidia*, /dev/nvidia-uvm-tools, /dev/kfd, /dev/dxg)"
                 .to_string(),
         ));
     }

--- a/profiles/claude-code-autoresearch.json
+++ b/profiles/claude-code-autoresearch.json
@@ -1,0 +1,10 @@
+{
+  "meta": { "name": "claude-code-autoresearch", "version": "1.0.0", "description": "Claude Code + GPU for autoresearch" },
+  "extends": "claude-code",
+  "allow_gpu": true,
+  "filesystem": {
+    "allow": ["$HOME/.cache/autoresearch", "$HOME/.cache/torch", "$HOME/.cache/uv", "$HOME/.cache/huggingface", "$HOME/.local/share/uv", "$HOME/.nv", "$HOME/.triton/cache", "/tmp", "/dev/shm", "/proc"],
+    "allow_file": ["$HOME/.gitconfig", "$HOME/.config/git/config"],
+    "read": ["$HOME/shared-libs", "$HOME/.nvm", "/usr/include", "/usr/local/cuda/include"]
+  }
+}


### PR DESCRIPTION
NVIDIA driver 570 (CUDA 12.8) opens /dev/nvidia-uvm-tools during UVM initialization. Without it, open() returns EACCES inside the Landlock sandbox, which the driver treats as a fatal cudaErrorOperatingSystem (Error 304) even when /dev/nvidia-uvm is accessible.

Add explicit nvidia-uvm-tools match alongside the existing nvidia-uvm entry in maybe_enable_gpu(). Also update the error message to mention the device so diagnostics are accurate.

Also add claude-code-autoresearch profile with paths needed for PyTorch/Triton GPU training workloads (HuggingFace cache, Triton cache, system headers for JIT compilation, /proc r+w for driver thread naming).