### PR TITLE
fix(gpu): make --allow-gpu functional for CUDA on Linux driver 570+

### DIFF
--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -647,6 +647,49 @@ fn missing_cwd_prompt_must_fail(
     silent || (detached_launch && detached_prompt_response.is_none())
 }
 
+/// Grant the procfs paths that the NVIDIA driver needs for CUDA initialisation.
+///
+/// Scoped narrowly to the NVIDIA stack — not called on pure DRM render-node,
+/// AMD ROCm, or WSL `/dev/dxg` setups.
+///
+/// - `/proc/driver/nvidia`, `/proc/driver/nvidia-uvm` (read, when present):
+///   CUDA's UVM subsystem reads these during init. We grant each individually
+///   rather than the parent `/proc/driver` to avoid exposing metadata about
+///   unrelated kernel drivers.
+/// - `/proc/self` (read): CUDA init reads `/proc/self/maps`, `/proc/self/status`
+///   and other per-process files.
+/// - `/proc/self/task` (read+write): NVIDIA driver 570+ writes to
+///   `/proc/self/task/<tid>/comm` during thread startup to set thread names.
+///   Without write access this returns EACCES and the driver treats it as a
+///   fatal OS error, surfacing as CUDA Error 304 (`cudaErrorOperatingSystem`).
+///   Narrowing write access to the `task` subtree keeps other per-process
+///   procfs entries read-only.
+#[cfg(target_os = "linux")]
+fn grant_nvidia_gpu_procfs(caps: &mut CapabilitySet) -> Result<()> {
+    for name in ["nvidia", "nvidia-uvm"] {
+        let path = std::path::PathBuf::from("/proc/driver").join(name);
+        if path.is_dir() {
+            let cap = FsCapability::new_dir(&path, AccessMode::Read)?;
+            caps.add_fs(cap);
+        }
+    }
+
+    // /proc/self and /proc/self/task are guaranteed on Linux; propagate any
+    // error rather than silently skipping (fail-secure: if the kernel ever
+    // fails to present these, the sandbox should fail rather than grant
+    // less-than-intended access).
+    caps.add_fs(FsCapability::new_dir(
+        std::path::Path::new("/proc/self"),
+        AccessMode::Read,
+    )?);
+    caps.add_fs(FsCapability::new_dir(
+        std::path::Path::new("/proc/self/task"),
+        AccessMode::ReadWrite,
+    )?);
+
+    Ok(())
+}
+
 /// Returns true for `/dev/` filenames that correspond to NVIDIA compute device
 /// nodes that should be granted by `--allow-gpu`.
 ///
@@ -724,6 +767,7 @@ pub(crate) fn maybe_enable_gpu(
     // Note: nvidia-uvm has been the target of privilege escalation CVEs
     // (e.g. CVE-2024-0090). We grant it because CUDA doesn't work without it,
     // but this is a higher-risk surface than DRM render nodes.
+    let mut have_nvidia = false;
     if let Ok(dev_entries) = std::fs::read_dir("/dev") {
         let nvidia_devices: Vec<_> = dev_entries
             .filter_map(|e| e.ok())
@@ -731,6 +775,9 @@ pub(crate) fn maybe_enable_gpu(
             .map(|e| e.path())
             .collect();
         gpu_device_count = gpu_device_count.saturating_add(nvidia_devices.len());
+        if !nvidia_devices.is_empty() {
+            have_nvidia = true;
+        }
         for dev in &nvidia_devices {
             let cap = FsCapability::new_file(dev.clone(), AccessMode::ReadWrite)?;
             caps.add_fs(cap);
@@ -748,6 +795,11 @@ pub(crate) fn maybe_enable_gpu(
             caps_found += 1;
         }
         gpu_device_count = gpu_device_count.saturating_add(caps_found);
+        // MIG-only hosts (no plain /dev/nvidia* node, caps only) still need
+        // the NVIDIA procfs grants for CUDA init.
+        if caps_found > 0 {
+            have_nvidia = true;
+        }
     }
 
     // AMD KFD (Kernel Fusion Driver) for ROCm/HIP compute.
@@ -796,6 +848,11 @@ pub(crate) fn maybe_enable_gpu(
         }
     }
 
+    // NVIDIA-only procfs grants (see grant_nvidia_gpu_procfs for rationale).
+    if have_nvidia {
+        grant_nvidia_gpu_procfs(caps)?;
+    }
+
     warn!(
         "--allow-gpu enabled: allowing {} GPU device(s) on Linux",
         gpu_device_count
@@ -827,7 +884,10 @@ pub(crate) fn print_allow_gpu_warning(silent: bool) {
                 .yellow()
         );
         eprintln!(
-            "  This grants read/write access to /dev/dri/renderD* and NVIDIA compute devices."
+            "  This grants read/write access to /dev/dri/renderD* and NVIDIA compute devices.\n  \
+             On NVIDIA systems, additionally: read access to /proc/driver/nvidia,\n  \
+             /proc/driver/nvidia-uvm, and /proc/self; read/write access to\n  \
+             /proc/self/task (for CUDA thread-name initialisation)."
         );
     }
 }

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -708,6 +708,7 @@ pub(crate) fn maybe_enable_gpu(
                 e.file_name().to_str().is_some_and(|n| {
                     n == "nvidiactl"
                         || n == "nvidia-uvm"
+                        || n == "nvidia-uvm-tools"
                         || (n.starts_with("nvidia")
                             && n[6..].bytes().all(|b| b.is_ascii_digit())
                             && n.len() > 6)
@@ -764,7 +765,7 @@ pub(crate) fn maybe_enable_gpu(
     if gpu_device_count == 0 {
         return Err(NonoError::SandboxInit(
             "--allow-gpu: no GPU devices found (checked /dev/dri/renderD*, \
-             /dev/nvidia*, /dev/kfd, /dev/dxg)"
+             /dev/nvidia*, /dev/nvidia-uvm-tools, /dev/kfd, /dev/dxg)"
                 .to_string(),
         ));
     }

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -647,6 +647,29 @@ fn missing_cwd_prompt_must_fail(
     silent || (detached_launch && detached_prompt_response.is_none())
 }
 
+/// Returns true for `/dev/` filenames that correspond to NVIDIA compute device
+/// nodes that should be granted by `--allow-gpu`.
+///
+/// Matches:
+///   - `nvidiactl` — control device, required for all CUDA operations
+///   - `nvidia-uvm` — Unified Virtual Memory, required for CUDA managed memory
+///   - `nvidia-uvm-tools` — opened by driver 570+ during UVM init
+///   - `nvidia<N>` where `N` is one or more ASCII digits — per-GPU device nodes
+///
+/// Deliberately rejects `nvidia-modeset` (display, not compute) and any other
+/// non-enumerated `nvidia-*` suffix. Keep in sync with the comment block in
+/// `maybe_enable_gpu`.
+#[cfg(target_os = "linux")]
+fn is_nvidia_compute_device(name: &str) -> bool {
+    if name == "nvidiactl" || name == "nvidia-uvm" || name == "nvidia-uvm-tools" {
+        return true;
+    }
+    if let Some(suffix) = name.strip_prefix("nvidia") {
+        return !suffix.is_empty() && suffix.bytes().all(|b| b.is_ascii_digit());
+    }
+    false
+}
+
 #[cfg(target_os = "linux")]
 pub(crate) fn maybe_enable_gpu(
     caps: &mut CapabilitySet,
@@ -704,16 +727,7 @@ pub(crate) fn maybe_enable_gpu(
     if let Ok(dev_entries) = std::fs::read_dir("/dev") {
         let nvidia_devices: Vec<_> = dev_entries
             .filter_map(|e| e.ok())
-            .filter(|e| {
-                e.file_name().to_str().is_some_and(|n| {
-                    n == "nvidiactl"
-                        || n == "nvidia-uvm"
-                        || n == "nvidia-uvm-tools"
-                        || (n.starts_with("nvidia")
-                            && n[6..].bytes().all(|b| b.is_ascii_digit())
-                            && n.len() > 6)
-                })
-            })
+            .filter(|e| e.file_name().to_str().is_some_and(is_nvidia_compute_device))
             .map(|e| e.path())
             .collect();
         gpu_device_count = gpu_device_count.saturating_add(nvidia_devices.len());
@@ -765,7 +779,8 @@ pub(crate) fn maybe_enable_gpu(
     if gpu_device_count == 0 {
         return Err(NonoError::SandboxInit(
             "--allow-gpu: no GPU devices found (checked /dev/dri/renderD*, \
-             /dev/nvidia*, /dev/nvidia-uvm-tools, /dev/kfd, /dev/dxg)"
+             /dev/nvidia* (incl. nvidiactl, nvidia-uvm, nvidia-uvm-tools), \
+             /dev/nvidia-caps/*, /dev/kfd, /dev/dxg)"
                 .to_string(),
         ));
     }
@@ -1137,6 +1152,44 @@ mod tests {
     #[cfg(target_os = "macos")]
     use std::fs;
     use tempfile::tempdir;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn nvidia_compute_device_predicate_accepts_known_names() {
+        for name in [
+            "nvidiactl",
+            "nvidia-uvm",
+            "nvidia-uvm-tools",
+            "nvidia0",
+            "nvidia7",
+            "nvidia15",
+        ] {
+            assert!(
+                is_nvidia_compute_device(name),
+                "expected {name} to be granted"
+            );
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn nvidia_compute_device_predicate_rejects_non_compute_and_unknown() {
+        for name in [
+            "nvidia",           // bare prefix, no digits
+            "nvidia-modeset",   // display, not compute
+            "nvidia-nvswitch0", // not yet supported
+            "nvidia-uvm-other", // unknown -tools-style suffix
+            "nvidiaX",          // non-digit suffix
+            "nvidia0a",         // mixed suffix
+            "not-nvidia",       // wrong prefix
+            "",                 // empty
+        ] {
+            assert!(
+                !is_nvidia_compute_device(name),
+                "expected {name} to be rejected"
+            );
+        }
+    }
 
     #[cfg(target_os = "macos")]
     #[test]

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -1233,6 +1233,75 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
+    fn grant_nvidia_gpu_procfs_scopes_proc_self_reads_with_task_writes() {
+        // Regression test for the NVIDIA-scoped procfs grants:
+        //   /proc/self       Read        (CUDA init reads maps/status/etc.)
+        //   /proc/self/task  ReadWrite   (driver writes task/<tid>/comm)
+        // Plus any of /proc/driver/{nvidia,nvidia-uvm} that exist.
+        //
+        // /proc/self and /proc/self/task always exist on Linux, so those
+        // checks are unconditional. /proc/driver/nvidia entries are only
+        // present when the NVIDIA kernel module is loaded, so we just
+        // assert no unexpected /proc/driver parent grant was added.
+        //
+        // FsCapability.original is used instead of path_covered_with_access:
+        // /proc/self is a symlink to /proc/<pid> which canonicalizes
+        // per-process, and we want to verify the grant intent.
+        let mut caps = CapabilitySet::default();
+        grant_nvidia_gpu_procfs(&mut caps).expect("grant_nvidia_gpu_procfs failed");
+
+        let find = |p: &str| -> Option<&nono::FsCapability> {
+            caps.fs_capabilities()
+                .iter()
+                .find(|c| c.original == std::path::Path::new(p))
+        };
+
+        let proc_self = find("/proc/self")
+            .expect("/proc/self must be granted read so CUDA init can read maps/status");
+        assert_eq!(
+            proc_self.access,
+            AccessMode::Read,
+            "/proc/self must be read-only (writes are scoped to /proc/self/task)"
+        );
+        assert!(!proc_self.is_file);
+
+        let proc_self_task = find("/proc/self/task").expect(
+            "/proc/self/task must be granted read+write so the NVIDIA driver \
+             can write task/<tid>/comm (CUDA Error 304 root cause)",
+        );
+        assert_eq!(
+            proc_self_task.access,
+            AccessMode::ReadWrite,
+            "/proc/self/task must be granted read+write"
+        );
+        assert!(!proc_self_task.is_file);
+
+        // Least-privilege regression guard: no parent /proc/driver grant.
+        // Only /proc/driver/nvidia and /proc/driver/nvidia-uvm should appear
+        // (and only when their subdirectories exist).
+        assert!(
+            find("/proc/driver").is_none(),
+            "/proc/driver must not be granted as a parent (would leak other drivers)"
+        );
+        for entry in caps.fs_capabilities() {
+            if entry.original.starts_with("/proc/driver/") {
+                let name = entry
+                    .original
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("");
+                assert!(
+                    matches!(name, "nvidia" | "nvidia-uvm"),
+                    "unexpected /proc/driver grant: {}",
+                    entry.original.display()
+                );
+                assert_eq!(entry.access, AccessMode::Read);
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
     fn nvidia_compute_device_predicate_rejects_non_compute_and_unknown() {
         for name in [
             "nvidia",           // bare prefix, no digits

--- a/tests/integration/test_gpu.sh
+++ b/tests/integration/test_gpu.sh
@@ -224,6 +224,61 @@ print(f'OK: opened {len(caps)} nvidia-caps devices')
     else
         skip_test "nvidia-caps (MIG) access" "no /dev/nvidia-caps/ found"
     fi
+
+    # NVIDIA procfs grants — regression tests for the --allow-gpu CUDA-init
+    # fix. These paths are only granted when NVIDIA devices are present; the
+    # probes live inside has_nvidia_devices to match the scope of the grant.
+    echo ""
+    echo "--- NVIDIA procfs Grant Tests ---"
+
+    # /proc/self/task/<tid>/comm write — CUDA Error 304 root cause.
+    expect_failure "/proc/self/task/<tid>/comm write denied without --allow-gpu" \
+        "$NONO_BIN" run --silent --allow-cwd --allow "$TMPDIR" -- \
+        python3 -c "
+import os, sys
+tid = os.gettid() if hasattr(os, 'gettid') else os.getpid()
+try:
+    with open(f'/proc/self/task/{tid}/comm', 'wb') as f:
+        f.write(b'probe\n')
+    sys.exit(0)  # should not reach here
+except PermissionError:
+    sys.exit(1)  # expected: sandbox denied the write
+"
+    expect_success "/proc/self/task/<tid>/comm write allowed with --allow-gpu" \
+        "$NONO_BIN" run --silent --allow-cwd --allow "$TMPDIR" --allow-gpu -- \
+        python3 -c "
+import os
+tid = os.gettid() if hasattr(os, 'gettid') else os.getpid()
+with open(f'/proc/self/task/{tid}/comm', 'wb') as f:
+    f.write(b'probe\n')
+print('OK: wrote thread comm under --allow-gpu')
+"
+
+    # /proc/driver/nvidia — CUDA UVM init read. Only test if the driver is
+    # loaded (the grant itself skips the path when it doesn't exist).
+    if [[ -d /proc/driver/nvidia ]]; then
+        expect_failure "/proc/driver/nvidia read denied without --allow-gpu" \
+            "$NONO_BIN" run --silent --allow-cwd --allow "$TMPDIR" -- \
+            ls /proc/driver/nvidia
+        expect_success "/proc/driver/nvidia read allowed with --allow-gpu" \
+            "$NONO_BIN" run --silent --allow-cwd --allow "$TMPDIR" --allow-gpu -- \
+            ls /proc/driver/nvidia
+    else
+        skip_test "/proc/driver/nvidia read probe" "/proc/driver/nvidia not present (driver not loaded?)"
+    fi
+
+    # Least-privilege regression guard: --allow-gpu must NOT grant the
+    # parent /proc/driver directory (would expose metadata about unrelated
+    # kernel drivers). Listing /proc/driver should still fail.
+    #
+    # Caveat: `ls` exercises Landlock's READ_DIR access, which is distinct
+    # from READ_FILE under the current ABI. A future ABI that splits or
+    # renames these bits could change what this probe observes. The assertion
+    # remains valid for today's ABI; revisit if the kernel evolves its
+    # filesystem access vocabulary.
+    expect_failure "/proc/driver parent read denied even with --allow-gpu" \
+        "$NONO_BIN" run --silent --allow-cwd --allow "$TMPDIR" --allow-gpu -- \
+        ls /proc/driver
 else
     skip_test "NVIDIA device tests" "no /dev/nvidia0 found"
 fi


### PR DESCRIPTION
Supersedes #651, which is a necessary but not sufficient piece of the same fix.

## Problem

`nono run --allow-gpu` on Linux with NVIDIA driver 570+ fails to initialise CUDA with Error 304 (`cudaErrorOperatingSystem`), even after #651 adds `/dev/nvidia-uvm-tools` to the device allowlist. Empirically reproduced on Ubuntu 22.04 / kernel 6.8-gcp / driver 570.211.01 / A100-SXM4-40GB: the device allowlist fix alone does not unblock CUDA.

Two independent procfs accesses by the driver are denied under the current `--allow-gpu`:

1. **`/proc/self/task/<tid>/comm` write** — driver 570+ writes thread names during init. EACCES here is treated as a fatal OS error by the driver and surfaces as CUDA Error 304. This is the root cause the error message obscures.
2. **`/proc/driver/nvidia` and `/proc/driver/nvidia-uvm` read** — CUDA's UVM subsystem reads these sibling directories during init.

## Fix

Extends `maybe_enable_gpu` to grant those procfs paths, scoped carefully:

- Grants only applied when the NVIDIA stack is detected (`/dev/nvidia*` compute devices **or** `/dev/nvidia-caps/*` MIG entries). Pure DRM render-node, AMD ROCm, and WSL `/dev/dxg` setups are untouched — least-privilege intact for those configurations.
- `/proc/driver/nvidia` and `/proc/driver/nvidia-uvm` granted individually rather than the parent `/proc/driver`, so metadata for unrelated kernel drivers (e.g. `nvme`, `i915`) is not exposed.
- `/proc/self` granted read-only. Write access narrowed to `/proc/self/task` where the driver actually writes. Landlock merges rules, so CUDA init can read everywhere under `/proc/self` with writes confined to the task subtree.

Also extracts the existing `nvidia-uvm-tools` filename filter into a named `is_nvidia_compute_device` helper, and expands the zero-device error message to enumerate what was looked for.

## Commits

1. `a4563cd` — @Kexin-xu-01's original fix adding `nvidia-uvm-tools` to the device allowlist (unchanged from #651).
2. `28461f4` — extract `is_nvidia_compute_device` predicate + positive/negative unit tests. Pure refactor; guards against the regression class (driver-introduced device names silently failing a digit-suffix check) that #651 patched.
3. `ac661da` — the procfs grants described above, plus `have_nvidia` detection and banner update.
4. `512ec81` — unit + integration test coverage:
    - Unit test in `sandbox_prepare::tests` inspecting `grant_nvidia_gpu_procfs`'s capability intent (including a least-privilege regression guard that no parent `/proc/driver` grant is added).
    - Matched negative/positive integration pairs in `tests/integration/test_gpu.sh` for `/proc/self/task/<tid>/comm` write and `/proc/driver/nvidia` read, plus a guard that `/proc/driver` (parent) remains denied even under `--allow-gpu`.

All commits are DCO signed and pass `cargo fmt --check`, `cargo clippy -D warnings -D clippy::unwrap_used`, and `cargo test --workspace`.

## Validation

**On Linux / A100 / driver 570** (GCP `a2-highgpu-1g`, kernel 6.8-gcp):

- `cargo test sandbox_prepare::tests` — 11/11 pass, including the 3 new ones.
- `tests/integration/test_gpu.sh` — 10 pass / 0 fail / 5 legitimate skips. The 5 new procfs cases all pass (write pair, read pair, parent-denied regression guard).
- PyTorch `torch.cuda.is_available()` + `matmul` under `nono run --allow-gpu --read <venv> --read /usr --read /etc` succeeds end-to-end — no extra `--allow` flags for procfs needed.

**Regression check against earlier branch state**: confirmed that without any of the procfs grants, CUDA still fails with Error 304 on this box; with them, it works. The `nvidia-uvm-tools` device fix alone is not enough on this kernel/driver combination.

## Scope deliberately **not** included

These are tracked separately in #658:

- Sysfs topology / NUMA reads (`/sys/module/nvidia`, `/sys/bus/pci/devices`, `/sys/devices/system/node`).
- Multi-GPU device nodes (`nvidia-nvswitch*`, `nvidia-nvlink`, `nvidia-vgpu*`).
- IPC surface (`/dev/shm`, `/dev/infiniband/*`, `nvidia-persistenced` / MPS sockets).
- ROCm sysfs (`/sys/class/kfd`).
- Diagnostics / UX (video/render group preflight, structured device-grant logging).
- CUDA caches (profile-layer policy, arguably).

Each has its own security / design tradeoff and deserves standalone review.

Closes #651.

Credit to @Kexin-xu-01 for the original report, reproduction, and root-cause analysis — the initial `nvidia-uvm-tools` commit and the `/proc/self` / `/proc/driver` diagnosis both came from her weekend work on the same kernel/driver configuration.