### PR TITLE
feat: add keyring:// URI scheme for custom-service credential lookup

### DIFF
--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -2098,6 +2098,19 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_env_credentials_accepts_keyring_uri_with_decode() {
+        let json_str = r#"{
+            "meta": { "name": "test-profile" },
+            "env_credentials": {
+                "keyring://gh:github.com/alice?decode=go-keyring": "GH_TOKEN"
+            }
+        }"#;
+
+        let profile: Profile = serde_json::from_str(json_str).expect("Failed to parse profile");
+        assert!(validate_env_credential_keys(&profile).is_ok());
+    }
+
+    #[test]
     fn test_validate_env_credentials_rejects_invalid_keyring_uri() {
         let json_str = r#"{
             "meta": { "name": "test-profile" },

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -620,7 +620,7 @@ fn validate_profile_custom_credentials(profile: &Profile) -> Result<()> {
 /// Validate env_credentials keys in a profile.
 ///
 /// Keys can be keyring account names, `op://` URIs, `apple-password://` URIs,
-/// `env://` URIs, or `file://` URIs.
+/// `keyring://` URIs, `env://` URIs, or `file://` URIs.
 /// Keyring account names are validated at load time by the keyring crate itself,
 /// but URI entries need structural validation upfront.
 fn validate_env_credential_keys(profile: &Profile) -> Result<()> {
@@ -635,6 +635,10 @@ fn validate_env_credential_keys(profile: &Profile) -> Result<()> {
                     "invalid Apple Passwords URI in env_credentials: {}",
                     e
                 ))
+            })?;
+        } else if nono::keystore::is_keyring_uri(key) {
+            nono::keystore::validate_keyring_uri(key).map_err(|e| {
+                NonoError::ProfileParse(format!("invalid keyring URI in env_credentials: {}", e))
             })?;
         } else if nono::keystore::is_env_uri(key) {
             nono::keystore::validate_env_uri(key).map_err(|e| {
@@ -2078,6 +2082,33 @@ mod tests {
         let profile: Profile = serde_json::from_str(json_str).expect("Failed to parse profile");
         let err = validate_env_credential_keys(&profile).expect_err("should reject");
         assert!(err.to_string().contains("Apple Passwords URI"));
+    }
+
+    #[test]
+    fn test_validate_env_credentials_accepts_keyring_uri() {
+        let json_str = r#"{
+            "meta": { "name": "test-profile" },
+            "env_credentials": {
+                "keyring://gh:github.com/alice": "GH_TOKEN"
+            }
+        }"#;
+
+        let profile: Profile = serde_json::from_str(json_str).expect("Failed to parse profile");
+        assert!(validate_env_credential_keys(&profile).is_ok());
+    }
+
+    #[test]
+    fn test_validate_env_credentials_rejects_invalid_keyring_uri() {
+        let json_str = r#"{
+            "meta": { "name": "test-profile" },
+            "env_credentials": {
+                "keyring://gh:github.com": "GH_TOKEN"
+            }
+        }"#;
+
+        let profile: Profile = serde_json::from_str(json_str).expect("Failed to parse profile");
+        let err = validate_env_credential_keys(&profile).expect_err("should reject");
+        assert!(err.to_string().contains("keyring URI"));
     }
 
     #[test]

--- a/crates/nono/src/keystore.rs
+++ b/crates/nono/src/keystore.rs
@@ -341,21 +341,44 @@ pub fn is_keyring_uri(credential_ref: &str) -> bool {
     credential_ref.starts_with(KEYRING_URI_PREFIX)
 }
 
-/// Maximum byte length for a `keyring://` URI (scheme + service + account).
+/// Maximum byte length for a `keyring://` URI (scheme + service + account + query).
 ///
 /// Generous enough for real service/account names but prevents accidentally
 /// passing absurdly long strings to OS keyring APIs.
 const KEYRING_URI_MAX_LEN: usize = 1024;
 
+/// Post-load decoding to apply to a keyring value.
+///
+/// Some tools wrap stored credentials in their own encoding. This enum
+/// represents the supported `?decode=` transforms that can be requested
+/// via the `keyring://` URI query string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KeyringDecode {
+    /// No transform — return the raw stored value.
+    None,
+    /// Strip the `go-keyring-base64:` prefix and base64-decode the remainder.
+    ///
+    /// Used by Go tools built with `github.com/zalando/go-keyring` (e.g., `gh`).
+    GoKeyring,
+}
+
+/// The prefix that `zalando/go-keyring` prepends to stored values.
+const GO_KEYRING_PREFIX: &str = "go-keyring-base64:";
+
+/// Allowed values for the `?decode=` query parameter.
+const KEYRING_DECODE_GO_KEYRING: &str = "go-keyring";
+
 /// Validate a `keyring://` URI.
 ///
 /// Accepted formats:
 /// - `keyring://service/account` — look up by service and account
+/// - `keyring://service/account?decode=go-keyring` — with post-load decoding
 ///
 /// Rejects:
 /// - Empty service or account
 /// - Characters that could enable argument injection
-/// - URIs with query strings or fragments
+/// - Unknown query parameters or values
+/// - Fragment identifiers
 /// - Missing account segment
 /// - URIs exceeding 1024 bytes
 pub fn validate_keyring_uri(uri: &str) -> Result<()> {
@@ -373,21 +396,33 @@ pub fn validate_keyring_uri(uri: &str) -> Result<()> {
         ))
     })?;
 
-    if let Some(bad) = path.chars().find(|c| FORBIDDEN_URI_CHARS.contains(c)) {
+    // Reject fragments unconditionally.
+    if path.contains('#') {
+        return Err(NonoError::ConfigParse(format!(
+            "keyring URI must not contain fragment identifiers: {}",
+            uri
+        )));
+    }
+
+    // Split off the query string (if any) before validating the path.
+    let (path_part, query_part) = match path.split_once('?') {
+        Some((p, q)) => (p, Some(q)),
+        None => (path, None),
+    };
+
+    // Validate query parameters against the allowlist.
+    if let Some(query) = query_part {
+        validate_keyring_query(query, uri)?;
+    }
+
+    if let Some(bad) = path_part.chars().find(|c| FORBIDDEN_URI_CHARS.contains(c)) {
         return Err(NonoError::ConfigParse(format!(
             "keyring URI contains forbidden character {:?}: {}",
             bad, uri
         )));
     }
 
-    if path.contains('?') || path.contains('#') {
-        return Err(NonoError::ConfigParse(format!(
-            "keyring URI must not contain query strings or fragments: {}",
-            uri
-        )));
-    }
-
-    let segments: Vec<&str> = path.split('/').collect();
+    let segments: Vec<&str> = path_part.split('/').collect();
     if segments.len() != 2 {
         return Err(NonoError::ConfigParse(format!(
             "keyring URI must be 'keyring://service/account': {}",
@@ -405,7 +440,50 @@ pub fn validate_keyring_uri(uri: &str) -> Result<()> {
     Ok(())
 }
 
-fn parse_keyring_uri(uri: &str) -> Result<(&str, &str)> {
+/// Validate the query string of a `keyring://` URI.
+///
+/// Only `decode=go-keyring` is accepted. Unknown keys or values are rejected
+/// to prevent silent misconfiguration.
+fn validate_keyring_query(query: &str, full_uri: &str) -> Result<()> {
+    for param in query.split('&') {
+        let (key, value) = param.split_once('=').ok_or_else(|| {
+            NonoError::ConfigParse(format!(
+                "keyring URI query parameter missing value: '{}' in {}",
+                param, full_uri
+            ))
+        })?;
+
+        match key {
+            "decode" => match value {
+                KEYRING_DECODE_GO_KEYRING => {}
+                _ => {
+                    return Err(NonoError::ConfigParse(format!(
+                        "keyring URI has unknown decode value '{}'. \
+                         Supported: {}",
+                        value, KEYRING_DECODE_GO_KEYRING
+                    )));
+                }
+            },
+            _ => {
+                return Err(NonoError::ConfigParse(format!(
+                    "keyring URI has unknown query parameter '{}'. \
+                     Supported: decode",
+                    key
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Parsed components of a `keyring://` URI.
+struct KeyringUriParts<'a> {
+    service: &'a str,
+    account: &'a str,
+    decode: KeyringDecode,
+}
+
+fn parse_keyring_uri(uri: &str) -> Result<KeyringUriParts<'_>> {
     validate_keyring_uri(uri)?;
     let path = uri.strip_prefix(KEYRING_URI_PREFIX).ok_or_else(|| {
         NonoError::ConfigParse(format!(
@@ -413,25 +491,52 @@ fn parse_keyring_uri(uri: &str) -> Result<(&str, &str)> {
             uri
         ))
     })?;
-    let mut segments = path.splitn(2, '/');
+
+    // Split off query string before parsing path segments.
+    let (path_part, query_part) = match path.split_once('?') {
+        Some((p, q)) => (p, Some(q)),
+        None => (path, None),
+    };
+
+    let mut segments = path_part.splitn(2, '/');
     let service = segments.next().ok_or_else(|| {
         NonoError::ConfigParse(format!("keyring URI missing service segment: {}", uri))
     })?;
     let account = segments.next().ok_or_else(|| {
         NonoError::ConfigParse(format!("keyring URI missing account segment: {}", uri))
     })?;
-    Ok((service, account))
+
+    let decode = match query_part {
+        Some(q) if q.contains(KEYRING_DECODE_GO_KEYRING) => KeyringDecode::GoKeyring,
+        _ => KeyringDecode::None,
+    };
+
+    Ok(KeyringUriParts {
+        service,
+        account,
+        decode,
+    })
 }
 
 /// Redact the account segment of a `keyring://` URI for safe logging.
 ///
 /// `keyring://service/account` → `keyring://service/<redacted>`
+/// `keyring://service/account?decode=go-keyring` → `keyring://service/<redacted>?decode=go-keyring`
 pub fn redact_keyring_uri(uri: &str) -> String {
     if let Some(path) = uri.strip_prefix(KEYRING_URI_PREFIX) {
-        let mut segments = path.splitn(2, '/');
+        // Split off query string so we can preserve it.
+        let (path_part, query_part) = match path.split_once('?') {
+            Some((p, q)) => (p, Some(q)),
+            None => (path, None),
+        };
+        let mut segments = path_part.splitn(2, '/');
         if let Some(service) = segments.next() {
             if !service.is_empty() && segments.next().is_some() {
-                return format!("keyring://{}/<redacted>", service);
+                let suffix = match query_part {
+                    Some(q) => format!("?{}", q),
+                    None => String::new(),
+                };
+                return format!("keyring://{}/<redacted>{}", service, suffix);
             }
         }
     }
@@ -942,12 +1047,15 @@ fn load_from_apple_password(uri: &str) -> Result<Zeroizing<String>> {
 /// Uses the `keyring` crate with the service and account parsed from a
 /// `keyring://service/account` URI. This is cross-platform: macOS Keychain
 /// (generic passwords), Linux Secret Service, Windows Credential Manager.
+///
+/// If `?decode=go-keyring` is specified, the stored value is unwrapped from
+/// the `go-keyring-base64:` encoding used by `github.com/zalando/go-keyring`.
 fn load_from_keyring_uri(uri: &str) -> Result<Zeroizing<String>> {
-    let (service, account) = parse_keyring_uri(uri)?;
+    let parts = parse_keyring_uri(uri)?;
     let redacted = redact_keyring_uri(uri);
     tracing::debug!("Loading secret from system keyring: {}", redacted);
 
-    let entry = keyring::Entry::new(service, account).map_err(|e| {
+    let entry = keyring::Entry::new(parts.service, parts.account).map_err(|e| {
         NonoError::KeystoreAccess(format!(
             "Failed to access keyring for '{}': {}",
             redacted, e
@@ -957,7 +1065,8 @@ fn load_from_keyring_uri(uri: &str) -> Result<Zeroizing<String>> {
     match entry.get_password() {
         Ok(password) => {
             tracing::debug!("Successfully loaded secret '{}'", redacted);
-            Ok(Zeroizing::new(password))
+            let decoded = apply_keyring_decode(password, parts.decode, &redacted)?;
+            Ok(decoded)
         }
         Err(keyring::Error::NoEntry) => Err(NonoError::SecretNotFound(format!(
             "keyring entry not found: '{}'. \
@@ -973,6 +1082,39 @@ fn load_from_keyring_uri(uri: &str) -> Result<Zeroizing<String>> {
             "Cannot access '{}': {}",
             redacted, e
         ))),
+    }
+}
+
+/// Apply the requested post-load decoding to a keyring value.
+fn apply_keyring_decode(
+    raw: String,
+    decode: KeyringDecode,
+    redacted_uri: &str,
+) -> Result<Zeroizing<String>> {
+    match decode {
+        KeyringDecode::None => Ok(Zeroizing::new(raw)),
+        KeyringDecode::GoKeyring => {
+            let encoded = raw.strip_prefix(GO_KEYRING_PREFIX).ok_or_else(|| {
+                NonoError::ConfigParse(format!(
+                    "keyring value for '{}' does not have the expected '{}' prefix. \
+                     Remove ?decode=go-keyring if this credential was not stored by a Go tool.",
+                    redacted_uri, GO_KEYRING_PREFIX
+                ))
+            })?;
+            let bytes = crate::trust::base64::base64_decode(encoded).map_err(|e| {
+                NonoError::ConfigParse(format!(
+                    "failed to base64-decode go-keyring value for '{}': {}",
+                    redacted_uri, e
+                ))
+            })?;
+            let decoded = String::from_utf8(bytes).map_err(|_| {
+                NonoError::ConfigParse(format!(
+                    "go-keyring decoded value for '{}' is not valid UTF-8",
+                    redacted_uri
+                ))
+            })?;
+            Ok(Zeroizing::new(decoded))
+        }
     }
 }
 
@@ -1639,10 +1781,44 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_keyring_uri_query_string_rejected() {
+    fn test_validate_keyring_uri_unknown_query_param_rejected() {
         let err = validate_keyring_uri("keyring://service/account?foo=bar")
-            .expect_err("should reject query string");
-        assert!(err.to_string().contains("query strings"), "got: {}", err);
+            .expect_err("should reject unknown query param");
+        assert!(
+            err.to_string().contains("unknown query parameter"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_validate_keyring_uri_unknown_decode_value_rejected() {
+        let err = validate_keyring_uri("keyring://service/account?decode=unknown")
+            .expect_err("should reject unknown decode value");
+        assert!(
+            err.to_string().contains("unknown decode value"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_validate_keyring_uri_fragment_rejected() {
+        let err = validate_keyring_uri("keyring://service/account#frag")
+            .expect_err("should reject fragment");
+        assert!(err.to_string().contains("fragment"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_validate_keyring_uri_decode_go_keyring_accepted() {
+        assert!(validate_keyring_uri("keyring://gh:github.com/alice?decode=go-keyring").is_ok());
+    }
+
+    #[test]
+    fn test_validate_keyring_uri_query_param_missing_value() {
+        let err = validate_keyring_uri("keyring://service/account?decode")
+            .expect_err("should reject param without value");
+        assert!(err.to_string().contains("missing value"), "got: {}", err);
     }
 
     #[test]
@@ -1659,6 +1835,14 @@ mod tests {
         assert_eq!(
             redact_keyring_uri("keyring://gh:github.com/alice"),
             "keyring://gh:github.com/<redacted>"
+        );
+    }
+
+    #[test]
+    fn test_redact_keyring_uri_with_decode_query() {
+        assert_eq!(
+            redact_keyring_uri("keyring://gh:github.com/alice?decode=go-keyring"),
+            "keyring://gh:github.com/<redacted>?decode=go-keyring"
         );
     }
 
@@ -1680,6 +1864,59 @@ mod tests {
         assert_eq!(redact_keyring_uri("not-a-keyring-uri"), "keyring://***");
     }
 
+    // --- keyring:// ?decode=go-keyring tests ---
+
+    #[test]
+    fn test_apply_keyring_decode_none_passthrough() {
+        let result = apply_keyring_decode("raw-secret".to_string(), KeyringDecode::None, "test")
+            .expect("None decode should passthrough");
+        assert_eq!(result.as_str(), "raw-secret");
+    }
+
+    #[test]
+    fn test_apply_keyring_decode_go_keyring_valid() {
+        // "gho_testtoken" base64-encoded is "Z2hvX3Rlc3R0b2tlbg=="
+        let raw = "go-keyring-base64:Z2hvX3Rlc3R0b2tlbg==".to_string();
+        let result = apply_keyring_decode(raw, KeyringDecode::GoKeyring, "test")
+            .expect("should decode go-keyring value");
+        assert_eq!(result.as_str(), "gho_testtoken");
+    }
+
+    #[test]
+    fn test_apply_keyring_decode_go_keyring_missing_prefix() {
+        let err = apply_keyring_decode("plain-value".to_string(), KeyringDecode::GoKeyring, "test")
+            .expect_err("should reject missing go-keyring prefix");
+        assert!(
+            err.to_string().contains("go-keyring-base64:"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_apply_keyring_decode_go_keyring_invalid_base64() {
+        let raw = "go-keyring-base64:!!!not-base64!!!".to_string();
+        let err = apply_keyring_decode(raw, KeyringDecode::GoKeyring, "test")
+            .expect_err("should reject invalid base64");
+        assert!(err.to_string().contains("base64-decode"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_parse_keyring_uri_decode_go_keyring() {
+        let parts = parse_keyring_uri("keyring://gh:github.com/alice?decode=go-keyring")
+            .expect("should parse with decode param");
+        assert_eq!(parts.service, "gh:github.com");
+        assert_eq!(parts.account, "alice");
+        assert_eq!(parts.decode, KeyringDecode::GoKeyring);
+    }
+
+    #[test]
+    fn test_parse_keyring_uri_no_decode() {
+        let parts = parse_keyring_uri("keyring://gh:github.com/alice")
+            .expect("should parse without decode param");
+        assert_eq!(parts.decode, KeyringDecode::None);
+    }
+
     // --- keyring:// build_mappings_from_pairs tests ---
 
     #[test]
@@ -1691,6 +1928,20 @@ mod tests {
         let mappings = build_mappings_from_pairs(&pairs).expect("should accept valid keyring URI");
         assert_eq!(
             mappings.get("keyring://gh:github.com/alice"),
+            Some(&"GH_TOKEN".to_string())
+        );
+    }
+
+    #[test]
+    fn test_build_pairs_keyring_uri_with_decode() {
+        let pairs = vec![(
+            "keyring://gh:github.com/alice?decode=go-keyring".to_string(),
+            "GH_TOKEN".to_string(),
+        )];
+        let mappings =
+            build_mappings_from_pairs(&pairs).expect("should accept keyring URI with decode");
+        assert_eq!(
+            mappings.get("keyring://gh:github.com/alice?decode=go-keyring"),
             Some(&"GH_TOKEN".to_string())
         );
     }

--- a/crates/nono/src/keystore.rs
+++ b/crates/nono/src/keystore.rs
@@ -1,16 +1,18 @@
 //! Secure credential loading from system keystore, 1Password, Apple Passwords, and environment
 //!
 //! This module provides functionality to load secrets from the system keystore
-//! (macOS Keychain / Linux Secret Service), 1Password (via the `op` CLI), or
-//! Apple Passwords (via macOS `security`) or environment variables (via the
-//! `env://` scheme) and return them as zeroized strings.
+//! (macOS Keychain / Linux Secret Service), 1Password (via the `op` CLI),
+//! Apple Passwords (via macOS `security`), custom keyring entries (via the
+//! `keyring` crate), or environment variables (via the `env://` scheme) and
+//! return them as zeroized strings.
 //!
 //! Credential references are dispatched by URI scheme:
 //! - `env://VAR_NAME` — reads from the current process environment
 //! - `file:///path/to/secret` — reads from a local file (before sandbox activation)
 //! - `op://vault/item/field` — loaded via the 1Password CLI
 //! - `apple-password://server/account` — loaded via macOS `security`
-//! - Everything else — loaded from the system keyring
+//! - `keyring://service/account` — loaded from the system keyring with a custom service name
+//! - Everything else — loaded from the system keyring (service name `nono`)
 //!
 //! All secrets are wrapped in `Zeroizing<String>` to ensure they are securely
 //! cleared from memory after use.
@@ -47,6 +49,9 @@ const APPLE_PASSWORD_URI_PREFIX: &str = "apple-password://";
 
 /// Alias prefix for Apple Passwords backend.
 const APPLE_PASSWORDS_URI_PREFIX: &str = "apple-passwords://";
+
+/// The `keyring://` URI scheme prefix, indicating a custom-service keyring lookup.
+const KEYRING_URI_PREFIX: &str = "keyring://";
 
 /// The `env://` URI scheme prefix, indicating environment variable backend.
 const ENV_URI_PREFIX: &str = "env://";
@@ -97,13 +102,14 @@ const FORBIDDEN_URI_CHARS: &[char] = &[
     ';', '|', '&', '$', '`', '(', ')', '{', '}', '<', '>', '!', '\\', '"', '\'', '\n', '\r', '\0',
 ];
 
-/// Load secrets from the system keystore, 1Password, or Apple Passwords
+/// Load secrets from the system keystore, 1Password, Apple Passwords, or keyring
 ///
 /// Credential references with URI schemes are dispatched to their backend:
 /// - `op://` -> 1Password CLI
 /// - `apple-password://` -> macOS security CLI
+/// - `keyring://` -> system keyring with custom service name
 /// - `env://` -> parent process environment
-/// - everything else -> system keyring
+/// - everything else -> system keyring (service name `nono`)
 ///
 /// # Arguments
 /// * `service` - The service name in the keystore (e.g., "nono")
@@ -153,7 +159,8 @@ pub fn load_secrets(
 /// 2. `env://VAR` — reads from the process environment
 /// 3. `op://vault/item/field` — delegates to the 1Password CLI
 /// 4. `apple-password://server/account` — delegates to macOS `security`
-/// 5. Everything else — loads from the system keyring
+/// 5. `keyring://service/account` — loads from system keyring with custom service
+/// 6. Everything else — loads from the system keyring (service name `nono`)
 ///
 /// # Arguments
 /// * `service` - Keyring service name (only used for keyring backend)
@@ -176,6 +183,8 @@ pub fn load_secret_by_ref(service: &str, credential_ref: &str) -> Result<Zeroizi
         load_from_op(credential_ref)
     } else if is_apple_password_uri(credential_ref) {
         load_from_apple_password(credential_ref)
+    } else if is_keyring_uri(credential_ref) {
+        load_from_keyring_uri(credential_ref)
     } else {
         load_single_secret(service, credential_ref)
     }
@@ -324,6 +333,109 @@ fn parse_apple_password_uri(uri: &str) -> Result<(&str, &str)> {
         ))
     })?;
     Ok((server, account))
+}
+
+/// Returns true if the credential reference is a `keyring://` URI.
+#[must_use]
+pub fn is_keyring_uri(credential_ref: &str) -> bool {
+    credential_ref.starts_with(KEYRING_URI_PREFIX)
+}
+
+/// Maximum byte length for a `keyring://` URI (scheme + service + account).
+///
+/// Generous enough for real service/account names but prevents accidentally
+/// passing absurdly long strings to OS keyring APIs.
+const KEYRING_URI_MAX_LEN: usize = 1024;
+
+/// Validate a `keyring://` URI.
+///
+/// Accepted formats:
+/// - `keyring://service/account` — look up by service and account
+///
+/// Rejects:
+/// - Empty service or account
+/// - Characters that could enable argument injection
+/// - URIs with query strings or fragments
+/// - Missing account segment
+/// - URIs exceeding 1024 bytes
+pub fn validate_keyring_uri(uri: &str) -> Result<()> {
+    if uri.len() > KEYRING_URI_MAX_LEN {
+        return Err(NonoError::ConfigParse(format!(
+            "keyring URI exceeds maximum length of {} bytes",
+            KEYRING_URI_MAX_LEN
+        )));
+    }
+
+    let path = uri.strip_prefix(KEYRING_URI_PREFIX).ok_or_else(|| {
+        NonoError::ConfigParse(format!(
+            "credential reference '{}' does not start with '{}'",
+            uri, KEYRING_URI_PREFIX
+        ))
+    })?;
+
+    if let Some(bad) = path.chars().find(|c| FORBIDDEN_URI_CHARS.contains(c)) {
+        return Err(NonoError::ConfigParse(format!(
+            "keyring URI contains forbidden character {:?}: {}",
+            bad, uri
+        )));
+    }
+
+    if path.contains('?') || path.contains('#') {
+        return Err(NonoError::ConfigParse(format!(
+            "keyring URI must not contain query strings or fragments: {}",
+            uri
+        )));
+    }
+
+    let segments: Vec<&str> = path.split('/').collect();
+    if segments.len() != 2 {
+        return Err(NonoError::ConfigParse(format!(
+            "keyring URI must be 'keyring://service/account': {}",
+            uri
+        )));
+    }
+
+    if segments.iter().any(|s| s.is_empty()) {
+        return Err(NonoError::ConfigParse(format!(
+            "keyring URI has empty service/account segment: {}",
+            uri
+        )));
+    }
+
+    Ok(())
+}
+
+fn parse_keyring_uri(uri: &str) -> Result<(&str, &str)> {
+    validate_keyring_uri(uri)?;
+    let path = uri.strip_prefix(KEYRING_URI_PREFIX).ok_or_else(|| {
+        NonoError::ConfigParse(format!(
+            "credential reference '{}' is not a keyring URI",
+            uri
+        ))
+    })?;
+    let mut segments = path.splitn(2, '/');
+    let service = segments.next().ok_or_else(|| {
+        NonoError::ConfigParse(format!("keyring URI missing service segment: {}", uri))
+    })?;
+    let account = segments.next().ok_or_else(|| {
+        NonoError::ConfigParse(format!("keyring URI missing account segment: {}", uri))
+    })?;
+    Ok((service, account))
+}
+
+/// Redact the account segment of a `keyring://` URI for safe logging.
+///
+/// `keyring://service/account` → `keyring://service/<redacted>`
+pub fn redact_keyring_uri(uri: &str) -> String {
+    if let Some(path) = uri.strip_prefix(KEYRING_URI_PREFIX) {
+        let mut segments = path.splitn(2, '/');
+        if let Some(service) = segments.next() {
+            if !service.is_empty() && segments.next().is_some() {
+                return format!("keyring://{}/<redacted>", service);
+            }
+        }
+    }
+    "keyring://***".to_string()
 }
 
 /// Returns true if the credential reference is an `env://` URI.
@@ -825,6 +937,45 @@ fn load_from_apple_password(uri: &str) -> Result<Zeroizing<String>> {
     }
 }
 
+/// Load a secret from the system keyring using a custom service name.
+///
+/// Uses the `keyring` crate with the service and account parsed from a
+/// `keyring://service/account` URI. This is cross-platform: macOS Keychain
+/// (generic passwords), Linux Secret Service, Windows Credential Manager.
+fn load_from_keyring_uri(uri: &str) -> Result<Zeroizing<String>> {
+    let (service, account) = parse_keyring_uri(uri)?;
+    let redacted = redact_keyring_uri(uri);
+    tracing::debug!("Loading secret from system keyring: {}", redacted);
+
+    let entry = keyring::Entry::new(service, account).map_err(|e| {
+        NonoError::KeystoreAccess(format!(
+            "Failed to access keyring for '{}': {}",
+            redacted, e
+        ))
+    })?;
+
+    match entry.get_password() {
+        Ok(password) => {
+            tracing::debug!("Successfully loaded secret '{}'", redacted);
+            Ok(Zeroizing::new(password))
+        }
+        Err(keyring::Error::NoEntry) => Err(NonoError::SecretNotFound(format!(
+            "keyring entry not found: '{}'. \
+             Verify the service and account match the stored credential.",
+            redacted
+        ))),
+        Err(keyring::Error::Ambiguous(creds)) => Err(NonoError::KeystoreAccess(format!(
+            "Multiple entries ({}) found for '{}' - please resolve manually",
+            creds.len(),
+            redacted
+        ))),
+        Err(e) => Err(NonoError::KeystoreAccess(format!(
+            "Cannot access '{}': {}",
+            redacted, e
+        ))),
+    }
+}
+
 /// Classify `op` CLI errors into actionable error messages.
 fn classify_op_error(stderr: &str, uri: &str) -> NonoError {
     let redacted = redact_op_uri(uri);
@@ -989,9 +1140,10 @@ fn wait_with_timeout(
 ///
 /// Bare URI entries without explicit target variables are rejected.
 ///
-/// Apple Passwords references (`apple-password://...`) are not supported in
-/// this list-based parser. Use `build_mappings_from_pairs` (CLI:
-/// `--env-credential-map <CREDENTIAL_REF> <ENV_VAR>`) for explicit mapping.
+/// Apple Passwords references (`apple-password://...`) and keyring references
+/// (`keyring://...`) are not supported in this list-based parser. Use
+/// `build_mappings_from_pairs` (CLI: `--env-credential-map <CREDENTIAL_REF>
+/// <ENV_VAR>`) for explicit mapping.
 ///
 /// Environment URIs (`env://...`) auto-derive the target variable name from the source
 /// when `=` is omitted: `env://GITHUB_TOKEN` maps to env var `GITHUB_TOKEN`.
@@ -999,8 +1151,8 @@ fn wait_with_timeout(
 /// # Errors
 ///
 /// Returns an error if a URI-based secret manager entry is provided without an
-/// explicit target variable suffix, if an Apple Passwords URI is provided in
-/// list mode, or if any URI fails validation.
+/// explicit target variable suffix, if an Apple Passwords or keyring URI is
+/// provided in list mode, or if any URI fails validation.
 ///
 /// # Example
 ///
@@ -1108,6 +1260,12 @@ pub fn build_mappings_from_list(accounts: &str) -> Result<HashMap<String, String
                  Use --env-credential-map 'apple-password://server/account' MY_VAR",
                 redact_apple_password_uri(entry)
             )));
+        } else if is_keyring_uri(entry) {
+            return Err(NonoError::ConfigParse(format!(
+                "keyring credential '{}' is not supported in --env-credential. \
+                 Use --env-credential-map 'keyring://service/account' MY_VAR",
+                redact_keyring_uri(entry)
+            )));
         } else {
             // Keyring name: auto-uppercase to env var name
             let env_var = entry.to_uppercase();
@@ -1150,6 +1308,8 @@ pub fn build_mappings_from_pairs(pairs: &[(String, String)]) -> Result<HashMap<S
             validate_op_uri(credential_ref)?;
         } else if is_apple_password_uri(credential_ref) {
             validate_apple_password_uri(credential_ref)?;
+        } else if is_keyring_uri(credential_ref) {
+            validate_keyring_uri(credential_ref)?;
         } else if credential_ref.starts_with(ENV_URI_PREFIX) {
             validate_env_uri(credential_ref)?;
         }
@@ -1177,7 +1337,8 @@ pub fn build_mappings_from_pairs(pairs: &[(String, String)]) -> Result<HashMap<S
 ///
 /// Returns an error if a URI-based credential in `cli_secrets` is missing
 /// an explicit target variable suffix (`=VAR_NAME` for `op://`), if
-/// `apple-password://` appears in list mode, or if URI/env-var validation fails.
+/// `apple-password://` or `keyring://` appears in list mode, or if
+/// URI/env-var validation fails.
 pub fn build_secret_mappings(
     cli_secrets: Option<&str>,
     cli_secret_mappings: &[(String, String)],
@@ -1385,6 +1546,173 @@ mod tests {
             "got: {}",
             err
         );
+    }
+
+    // --- keyring:// URI handling in build_mappings_from_list ---
+
+    #[test]
+    fn test_build_mappings_keyring_uri_rejected_in_list_mode() {
+        let err = build_mappings_from_list("keyring://gh:github.com/alice")
+            .expect_err("should reject keyring URI in list mode");
+        assert!(
+            err.to_string().contains("--env-credential-map"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_build_mappings_keyring_uri_with_inline_var_rejected_in_list_mode() {
+        let err = build_mappings_from_list("keyring://gh:github.com/alice=>GH_TOKEN")
+            .expect_err("should reject inline keyring var syntax");
+        assert!(
+            err.to_string().contains("--env-credential-map"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_build_mappings_keyring_uri_legacy_equals_suffix_rejected() {
+        let err = build_mappings_from_list("keyring://gh:github.com/alice=GH_TOKEN")
+            .expect_err("should reject legacy inline keyring suffix");
+        assert!(
+            err.to_string().contains("--env-credential-map"),
+            "got: {}",
+            err
+        );
+    }
+
+    // --- keyring:// URI validation tests ---
+
+    #[test]
+    fn test_validate_keyring_uri_valid() {
+        assert!(validate_keyring_uri("keyring://gh:github.com/alice").is_ok());
+    }
+
+    #[test]
+    fn test_validate_keyring_uri_valid_with_special_service() {
+        // Service names can contain colons, dots, etc.
+        assert!(validate_keyring_uri("keyring://com.example.app/user@example.com").is_ok());
+    }
+
+    #[test]
+    fn test_validate_keyring_uri_missing_prefix() {
+        let err = validate_keyring_uri("gh:github.com/alice").expect_err("should reject");
+        assert!(
+            err.to_string().contains("does not start with"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_validate_keyring_uri_missing_account() {
+        let err = validate_keyring_uri("keyring://gh:github.com")
+            .expect_err("should reject missing account");
+        assert!(err.to_string().contains("service/account"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_validate_keyring_uri_empty_segment() {
+        let err = validate_keyring_uri("keyring://gh:github.com/")
+            .expect_err("should reject empty account");
+        assert!(err.to_string().contains("empty"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_validate_keyring_uri_empty_service() {
+        let err =
+            validate_keyring_uri("keyring:///alice").expect_err("should reject empty service");
+        assert!(err.to_string().contains("empty"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_validate_keyring_uri_forbidden_char() {
+        let err = validate_keyring_uri("keyring://gh:github.com/alice;rm -rf")
+            .expect_err("should reject forbidden char");
+        assert!(
+            err.to_string().contains("forbidden character"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_validate_keyring_uri_query_string_rejected() {
+        let err = validate_keyring_uri("keyring://service/account?foo=bar")
+            .expect_err("should reject query string");
+        assert!(err.to_string().contains("query strings"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_validate_keyring_uri_too_many_segments() {
+        let err = validate_keyring_uri("keyring://service/account/extra")
+            .expect_err("should reject extra segments");
+        assert!(err.to_string().contains("service/account"), "got: {}", err);
+    }
+
+    // --- keyring:// URI redaction tests ---
+
+    #[test]
+    fn test_redact_keyring_uri_normal() {
+        assert_eq!(
+            redact_keyring_uri("keyring://gh:github.com/alice"),
+            "keyring://gh:github.com/<redacted>"
+        );
+    }
+
+    #[test]
+    fn test_redact_keyring_uri_malformed() {
+        assert_eq!(redact_keyring_uri("keyring://"), "keyring://***");
+    }
+
+    #[test]
+    fn test_redact_keyring_uri_service_only() {
+        assert_eq!(
+            redact_keyring_uri("keyring://gh:github.com"),
+            "keyring://***"
+        );
+    }
+
+    #[test]
+    fn test_redact_keyring_uri_non_prefix_input() {
+        assert_eq!(redact_keyring_uri("not-a-keyring-uri"), "keyring://***");
+    }
+
+    // --- keyring:// build_mappings_from_pairs tests ---
+
+    #[test]
+    fn test_build_pairs_keyring_uri_valid() {
+        let pairs = vec![(
+            "keyring://gh:github.com/alice".to_string(),
+            "GH_TOKEN".to_string(),
+        )];
+        let mappings = build_mappings_from_pairs(&pairs).expect("should accept valid keyring URI");
+        assert_eq!(
+            mappings.get("keyring://gh:github.com/alice"),
+            Some(&"GH_TOKEN".to_string())
+        );
+    }
+
+    #[test]
+    fn test_build_pairs_keyring_uri_invalid() {
+        let pairs = vec![(
+            "keyring://gh:github.com".to_string(),
+            "GH_TOKEN".to_string(),
+        )];
+        let err = build_mappings_from_pairs(&pairs).expect_err("should reject missing account");
+        assert!(err.to_string().contains("service/account"), "got: {}", err);
+    }
+
+    // --- keyring:// length limit test ---
+
+    #[test]
+    fn test_validate_keyring_uri_too_long() {
+        let long_account = "a".repeat(1024);
+        let uri = format!("keyring://service/{}", long_account);
+        let err = validate_keyring_uri(&uri).expect_err("should reject oversized URI");
+        assert!(err.to_string().contains("maximum length"), "got: {}", err);
     }
 
     // --- op:// URI validation tests ---

--- a/crates/nono/src/lib.rs
+++ b/crates/nono/src/lib.rs
@@ -70,10 +70,10 @@ pub use diagnostic::{
 };
 pub use error::{NonoError, Result};
 pub use keystore::{
-    is_apple_password_uri, is_env_uri, is_file_uri, is_op_uri, load_secret_by_ref,
-    load_secret_file, load_secrets, redact_apple_password_uri, redact_file_uri, redact_op_uri,
-    store_secret_file, validate_apple_password_uri, validate_destination_env_var, validate_env_uri,
-    validate_file_uri, validate_op_uri, LoadedSecret,
+    is_apple_password_uri, is_env_uri, is_file_uri, is_keyring_uri, is_op_uri, load_secret_by_ref,
+    load_secret_file, load_secrets, redact_apple_password_uri, redact_file_uri, redact_keyring_uri,
+    redact_op_uri, store_secret_file, validate_apple_password_uri, validate_destination_env_var,
+    validate_env_uri, validate_file_uri, validate_keyring_uri, validate_op_uri, LoadedSecret,
 };
 pub use net_filter::{FilterResult, HostFilter};
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary

This adds a new `keyring://service/account` URI scheme for `env_credentials` that lets users load secrets from the system keyring using a custom service name.

**Motivation:** Tools like `gh` store OAuth tokens as generic keychain passwords with their own service names (e.g., `gh:github.com`). The existing `apple-password://` scheme only supports internet passwords via `find-internet-password`, and the bare keyring fallback hardcodes the service name to `nono`. This fills that gap using the cross-platform `keyring` crate that's already a dependency.

### What's included

- **URI validation** — forbidden chars, structural checks, 1024-byte length limit
- **Account redaction** — `keyring://gh:github.com/alice` → `keyring://gh:github.com/<redacted>` in logs
- **Dispatch** in `load_secret_by_ref` via the existing `keyring` crate (`Entry::new(service, account)`)
- **List-mode rejection** — requires `--env-credential-map` (same as `apple-password://`)
- **Pair-mode validation** in `build_mappings_from_pairs`
- **Profile validation** in `validate_env_credential_keys`
- **`?decode=go-keyring`** — opt-in post-load decoding for Go tools that use `zalando/go-keyring` (e.g., `gh`), which wraps stored values with `go-keyring-base64:` prefix + base64 encoding
- **32 new tests** covering validation, redaction, decode transform, list/pair modes, and edge cases

### Usage

Profile:
```json
{
  "env_credentials": {
    "keyring://gh:github.com/alice": "GH_TOKEN"
  }
}
```

With Go-keyring decoding (for `gh` and other Go CLI tools):
```json
{
  "env_credentials": {
    "keyring://gh:github.com/alice?decode=go-keyring": "GH_TOKEN"
  }
}
```

CLI:
```bash
nono --env-credential-map 'keyring://gh:github.com/alice?decode=go-keyring' GH_TOKEN -- gh auth status
```

### Cross-platform

No `#[cfg]` gates needed — the `keyring` crate abstracts over macOS Keychain (generic passwords), Linux Secret Service (GNOME Keyring/KWallet), and Windows Credential Manager.

### Design decisions

- **Opt-in decoding** via query params rather than auto-detection — safer, extensible, and explicit about what transform is applied
- **Query param allowlist** — unknown params/values are rejected to prevent silent misconfiguration
- **No new dependencies** — base64 decoding uses the existing `trust::base64` module

### Files changed

- `crates/nono/src/keystore.rs` — URI scheme implementation + tests
- `crates/nono/src/lib.rs` — re-exports
- `crates/nono-cli/src/profile/mod.rs` — profile validation + tests

## Test plan

- [x] `make clippy` — clean
- [x] `make fmt-check` — clean
- [x] `make test` — all new tests pass (135 keystore, 11 profile)
- [x] Manual test: loaded `gh` OAuth token from macOS Keychain via `keyring://gh:github.com/<account>?decode=go-keyring` into a sandboxed nono session, then used the decoded token to create this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)