### PR TITLE
fix(cli): issue with claude code profiles and CLAUDE_CONFIG_DIR variable

### DIFF
--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -1011,6 +1011,14 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         command_blocking_deprecation::print_warnings(&profile_warnings, silent);
     }
 
+    // Ensure CLAUDE_CONFIG_DIR is set so Claude Code writes config
+    #[cfg(unix)]
+    if std::env::var_os("CLAUDE_CONFIG_DIR").is_none() {
+        let home = config::validated_home()?;
+        #[allow(clippy::disallowed_methods)] // Single-threaded before fork.
+        std::env::set_var("CLAUDE_CONFIG_DIR", Path::new(&home).join(".claude"));
+    }
+
     #[cfg(unix)]
     if args.profile.as_deref() == Some("claude-code") {
         let home = config::validated_home()?;
@@ -1034,48 +1042,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
             }
         };
 
-        precreate(&home_path.join(".claude.json.lock"), false);
         precreate(&home_path.join(".cache/claude-cli-nodejs"), true);
-
-        // Claude Code writes ~/.claude.json atomically via temp files named
-        // ~/.claude.json.tmp.<pid>.<timestamp>.  Landlock/Seatbelt cannot
-        // grant permission for these dynamically-named files in ~/, so token
-        // refreshes silently fail and the user is logged out.
-        //
-        // Fix: redirect ~/.claude.json to ~/.claude/claude.json via a
-        // symlink.  Claude Code resolves symlinks before computing the temp
-        // file path, so temp files land in ~/.claude/ (already readwrite)
-        // instead of ~/ (not writable inside the sandbox).
-        let claude_json = home_path.join(".claude.json");
-        let claude_dir = home_path.join(".claude");
-        let redirect_target = claude_dir.join("claude.json");
-
-        if let Err(e) = std::fs::create_dir_all(&claude_dir) {
-            warn!("Failed to create ~/.claude: {}", e);
-        } else if !claude_json.is_symlink() {
-            if claude_json.exists() {
-                // Regular file present — move it into ~/.claude/ then symlink.
-                if let Err(e) = std::fs::rename(&claude_json, &redirect_target) {
-                    warn!(
-                        "Failed to move ~/.claude.json to ~/.claude/claude.json: {}",
-                        e
-                    );
-                } else if let Err(e) =
-                    std::os::unix::fs::symlink(".claude/claude.json", &claude_json)
-                {
-                    warn!("Failed to create ~/.claude.json symlink: {}", e);
-                }
-            } else {
-                // File doesn't exist yet — pre-create the target so the
-                // sandbox can attach a path rule to it, then symlink.
-                precreate(&redirect_target, false);
-                if let Err(e) = std::os::unix::fs::symlink(".claude/claude.json", &claude_json) {
-                    if e.kind() != std::io::ErrorKind::AlreadyExists {
-                        warn!("Failed to create ~/.claude.json symlink: {}", e);
-                    }
-                }
-            }
-        }
     }
 
     let (mut caps, needs_unlink_overrides) = if let Some(ref profile) = loaded_profile {


### PR DESCRIPTION
Hey! 
v0.34 broke profile extentions and CLAUDE_CONFIG_DIR support for nono.

As far as I can see, the issue is that it was already broken on linux and #654 brokes it on macOS. 

The issue is here https://github.com/always-further/nono/blob/main/crates/nono-cli/src/sandbox_prepare.rs#L1015 

```rust
if args.profile.as_deref() == Some("claude-code") {
```

The profile name shouldn't be hardcoded, while it breaks the whole flow for all extended profiles

Also, symlink may be not a correct way to do all this authentication dance, while some users (like me) can use multiple claude profiles and rely on CLAUDE_CONFIG_DIR variable.

**Proposal:** 

If CLAUDE_CONFIG_DIR variable is set, it automatically uses files from inside CLAUDE_CONFIG_DIR directory. So this variable can be set for all profiles (I guess it will be not used in different tools, still maybe there is a better way to do it)

So we can set this variable and it will force claude-code to create claude.json and locks inside CLAUDE_CONFIG_DIR (which will be ~/.claude by default) and also it will respect CLAUDE_CONFIG_DIR

