### PR TITLE
fix(macos): keychain DB seatbelt allow must use specific op to override deny

### DIFF
--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -793,15 +793,24 @@ pub fn apply_macos_keychain_db_exception(caps: &mut CapabilitySet) {
             }
         };
         let filter = format!("literal \"{}\"", escaped);
+        // Emit specific ops (file-read-data, file-write-data) in addition to the
+        // wildcards. In Apple's Seatbelt evaluator, a wildcard-op allow does not
+        // override an earlier specific-op deny on an overlapping path (the broad
+        // `deny_keychains_macos` group emits `(deny file-read-data (subpath ...))`).
+        // Emitting the specific op with a literal path ensures the override wins.
         match access {
             AccessMode::Read => {
+                allow_rules.push(format!("(allow file-read-data ({}))", filter));
                 allow_rules.push(format!("(allow file-read* ({}))", filter));
             }
             AccessMode::Write => {
+                allow_rules.push(format!("(allow file-write-data ({}))", filter));
                 allow_rules.push(format!("(allow file-write* ({}))", filter));
             }
             AccessMode::ReadWrite => {
+                allow_rules.push(format!("(allow file-read-data ({}))", filter));
                 allow_rules.push(format!("(allow file-read* ({}))", filter));
+                allow_rules.push(format!("(allow file-write-data ({}))", filter));
                 allow_rules.push(format!("(allow file-write* ({}))", filter));
             }
         }
@@ -838,16 +847,22 @@ pub fn apply_macos_keychain_db_exception(caps: &mut CapabilitySet) {
             ),
         ];
 
+        // See comment above: emit specific ops alongside wildcards so they override
+        // the specific-op denies from deny_keychains_macos.
         for filter in filters {
             match access {
                 AccessMode::Read => {
+                    allow_rules.push(format!("(allow file-read-data ({}))", filter));
                     allow_rules.push(format!("(allow file-read* ({}))", filter));
                 }
                 AccessMode::Write => {
+                    allow_rules.push(format!("(allow file-write-data ({}))", filter));
                     allow_rules.push(format!("(allow file-write* ({}))", filter));
                 }
                 AccessMode::ReadWrite => {
+                    allow_rules.push(format!("(allow file-read-data ({}))", filter));
                     allow_rules.push(format!("(allow file-read* ({}))", filter));
+                    allow_rules.push(format!("(allow file-write-data ({}))", filter));
                     allow_rules.push(format!("(allow file-write* ({}))", filter));
                 }
             }
@@ -2647,6 +2662,25 @@ mod tests {
             "expected login keychain DB write rule, got: {}",
             rules
         );
+        // Specific-op rules must also be emitted so they override the specific-op
+        // deny from deny_keychains_macos: (deny file-read-data (subpath "...Keychains")).
+        // A file-read* wildcard allow does not override a file-read-data specific deny.
+        assert!(
+            rules.contains(&format!(
+                "(allow file-read-data (literal \"{}\"))",
+                escape_seatbelt_path(login_db.to_str().expect("utf8 path")).expect("escaped path")
+            )),
+            "expected login keychain DB file-read-data rule (to override specific deny), got: {}",
+            rules
+        );
+        assert!(
+            rules.contains(&format!(
+                "(allow file-write-data (literal \"{}\"))",
+                escape_seatbelt_path(login_db.to_str().expect("utf8 path")).expect("escaped path")
+            )),
+            "expected login keychain DB file-write-data rule (to override specific deny), got: {}",
+            rules
+        );
     }
 
     #[cfg(target_os = "macos")]
@@ -2682,6 +2716,24 @@ mod tests {
                     .expect("escaped path")
             )),
             "expected metadata keychain DB write rule, got: {}",
+            rules
+        );
+        assert!(
+            rules.contains(&format!(
+                "(allow file-read-data (literal \"{}\"))",
+                escape_seatbelt_path(metadata_db.to_str().expect("utf8 path"))
+                    .expect("escaped path")
+            )),
+            "expected metadata keychain DB file-read-data rule (to override specific deny), got: {}",
+            rules
+        );
+        assert!(
+            rules.contains(&format!(
+                "(allow file-write-data (literal \"{}\"))",
+                escape_seatbelt_path(metadata_db.to_str().expect("utf8 path"))
+                    .expect("escaped path")
+            )),
+            "expected metadata keychain DB file-write-data rule (to override specific deny), got: {}",
             rules
         );
     }


### PR DESCRIPTION
## Summary

Since v0.34.0 (#672), Keychain reads from inside a sandbox using the built-in `claude-code` profile fail with `SecKeychainSearchCopyNext: The specified item could not be found in the keychain` — even for a brand-new generic-password entry. v0.33.0 works identically under the same profile.

Root cause: a single-token change in `apply_macos_keychain_db_exception` (`crates/nono-cli/src/policy.rs`) from `file-read-data` to `file-read*`. Apple's Seatbelt evaluator does not let a wildcard-op allow override an earlier specific-op deny on an overlapping path, and the `deny_keychains_macos` group emits `(deny file-read-data (subpath "~/Library/Keychains"))`. The wildcard allow silently loses to it.

Existing tests pass because they only assert the emitted rule text, not runtime Seatbelt behavior — so the regression wasn't caught.

## Repro (macOS arm64)

No Claude Code required. With nono installed from master:

```bash
security add-generic-password -s "nono-keychain-test" -a "me" -w "secret"

# 0.33.0 — succeeds
nono run --profile claude-code -- \
    security find-generic-password -s "nono-keychain-test" -w
# → secret

# 0.34.0+ — fails
nono run --profile claude-code -- \
    security find-generic-password -s "nono-keychain-test" -w
# → security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.

security delete-generic-password -s "nono-keychain-test"
```

Also surfaces end-to-end with Claude Code: `claude --print "hi"` inside the sandbox returns `Not logged in · Please run /login` whenever the user's only auth source is Keychain.

Version bisection: 0.30.1 ✓, 0.33.0 ✓, **0.34.0 ✗**, 0.35.0 ✗, 0.37.0 ✗.

## Diagnosis

Seatbelt rule dump (`RUST_LOG=debug nono run --profile claude-code -- echo hi | grep -i keychain`):

**0.33.0 (works):**
```
(deny file-read-data (subpath "/Users/me/Library/Keychains"))
...
(allow file-read-data (literal "/Users/me/Library/Keychains/login.keychain-db"))
```

**0.34.0+ (broken):**
```
(deny file-read-data (subpath "/Users/me/Library/Keychains"))
...
(allow file-read* (literal "/Users/me/Library/Keychains/login.keychain-db"))
```

Same rule ordering, same path, same Mach IPC skip (`has_explicit_keychain_db_access(caps)` correctly returns `true`, so the `securityd`/`secd`/`keychaind` denies are not emitted). The only difference is the allow-side operation token, and Apple Seatbelt's specific-beats-wildcard precedence is what causes the read-data call to be blocked when securityd tries to open the DB file.

## Fix

Emit both the specific op (`file-read-data` / `file-write-data`) and the wildcard in `apply_macos_keychain_db_exception`. The specific op matches the specific deny's operation token and overrides it; the wildcard still covers the rest of the family. Applied to both the explicit keychain DB paths and the regex-based runtime keychain files (`.fl<UUID>`, `<UUID>/*.db`, `user.kb`).

Minimal change in `crates/nono-cli/src/policy.rs`, plus new test assertions so this cannot regress silently again.

## Test plan

- [x] Full `cargo test --release -p nono-cli` passes (768 tests, 0 fail)
- [x] Existing `test_apply_macos_keychain_db_exception_adds_*` assertions still hold (wildcard rules unchanged)
- [x] New assertions added for `file-read-data` / `file-write-data` literal rules
- [x] Live sandbox repro: `security find-generic-password` now returns the value from within `nono run --profile claude-code`
- [x] Live sandbox repro: `claude --print "hi"` returns a response instead of `Not logged in`

## Suggestion for follow-up

Consider adding an integration test that actually spawns `security find-generic-password` (or similar) inside a real sandbox and asserts the read succeeds. Assertions on emitted rule text don't catch Seatbelt precedence issues like this one.