### PR TITLE
fix(hooks): invoke bash via env

### DIFF
--- a/crates/nono-cli/data/hooks/nono-hook.sh
+++ b/crates/nono-cli/data/hooks/nono-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # nono-hook.sh - Claude Code hook for nono sandbox diagnostics
 # Version: 0.0.1
 #


### PR DESCRIPTION
The read hook hardcodes the path to bash, which means it fails on distributions like NixOS that use a non-standard filesystem layout (that doesn't include symlinks for compatibility, like every distribution using the /usr layout).

This can be worked around by updating the shebang locally, but nono will overwrite it on every new session, removing the workaround.