### PR TITLE
feat(cli): --allow-unix-socket flag family + AF_UNIX fixes for Linux V2 and macOS

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -7,7 +7,10 @@ use crate::cli::SandboxArgs;
 use crate::policy;
 use crate::profile::{expand_vars, Profile};
 use crate::protected_paths::{self, ProtectedRoots};
-use nono::{AccessMode, CapabilitySet, CapabilitySource, FsCapability, NonoError, Result};
+use nono::{
+    AccessMode, CapabilitySet, CapabilitySource, FsCapability, NonoError, Result,
+    UnixSocketCapability, UnixSocketMode,
+};
 use std::path::{Path, PathBuf};
 use tracing::{debug, warn};
 
@@ -32,6 +35,162 @@ fn try_new_file(path: &Path, access: AccessMode, label: &str) -> Result<Option<F
         Err(NonoError::PathNotFound(_)) => handle_missing_file_capability(path, access, label),
         Err(e) => Err(e),
     }
+}
+
+/// Try to create a single-file AF_UNIX socket capability.
+///
+/// Both modes accept non-existent paths:
+/// - `Connect`: via the library's NotFound warn-and-skip path (useful
+///   for profile grants that only exist in some environments).
+/// - `ConnectBind`: via the library's parent-canonicalise fallback.
+///   `bind(2)` creates the socket file, so granting before the file
+///   exists is the normal workflow; the caller must separately widen
+///   the implied filesystem grant to the parent directory in that
+///   case — see [`add_cli_unix_socket_caps`].
+fn try_new_unix_socket_file(
+    path: &Path,
+    mode: UnixSocketMode,
+    label: &str,
+) -> Result<Option<UnixSocketCapability>> {
+    match UnixSocketCapability::new_file(path, mode) {
+        Ok(cap) => Ok(Some(cap)),
+        Err(NonoError::PathNotFound(_)) => {
+            warn!("{}: {}", label, path.display());
+            Ok(None)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Try to create a directory-scoped AF_UNIX socket capability.
+fn try_new_unix_socket_dir(
+    path: &Path,
+    mode: UnixSocketMode,
+    label: &str,
+) -> Result<Option<UnixSocketCapability>> {
+    match UnixSocketCapability::new_dir(path, mode) {
+        Ok(cap) => Ok(Some(cap)),
+        Err(NonoError::PathNotFound(_)) => {
+            warn!("{}: {}", label, path.display());
+            Ok(None)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Apply all four `--allow-unix-socket*` flag groups to `caps`.
+///
+/// Each flag adds a [`UnixSocketCapability`] and auto-registers the
+/// implied [`FsCapability`] (CLI-side sugar per #696). The socket-level
+/// grant is non-recursive (enforced by `UnixSocketCapability::covers`);
+/// the fs grant for directory forms is recursive by design — that's
+/// Landlock's only expressible granularity.
+fn add_cli_unix_socket_caps(
+    caps: &mut CapabilitySet,
+    args: &SandboxArgs,
+    protected_roots: &ProtectedRoots,
+    allow_parent_of_protected: bool,
+) -> Result<()> {
+    const LBL_SOCK_FILE: &str = "Skipping non-existent unix socket (connect grant)";
+    const LBL_SOCK_FILE_BIND: &str = "Skipping non-existent unix socket (connect+bind grant)";
+    const LBL_SOCK_DIR: &str = "Skipping non-existent unix socket directory (connect grant)";
+    const LBL_SOCK_DIR_BIND: &str =
+        "Skipping non-existent unix socket directory (connect+bind grant)";
+    const LBL_FS_FILE_IMPLIED: &str = "Skipping implied fs grant for non-existent unix socket";
+    const LBL_FS_DIR_IMPLIED: &str =
+        "Skipping implied fs grant for non-existent unix socket directory";
+    const LBL_FS_DIR_IMPLIED_BIND_PARENT: &str =
+        "Skipping implied fs grant on parent of pending unix socket bind path";
+
+    for path in &args.allow_unix_socket {
+        validate_requested_file(path, "CLI", protected_roots, allow_parent_of_protected)?;
+        let sock_cap = try_new_unix_socket_file(path, UnixSocketMode::Connect, LBL_SOCK_FILE)?;
+        if let Some(cap) = sock_cap {
+            caps.add_unix_socket(cap);
+            // Only register the implied fs grant when the socket grant
+            // itself was accepted — otherwise we'd silently add a
+            // filesystem permission on a path the user is also asking
+            // to connect to, without the corresponding unix-socket
+            // grant (the two must stay coupled).
+            if let Some(cap) = try_new_file(path, AccessMode::Read, LBL_FS_FILE_IMPLIED)? {
+                caps.add_fs(cap);
+            }
+        }
+    }
+
+    for path in &args.allow_unix_socket_bind {
+        validate_requested_file(path, "CLI", protected_roots, allow_parent_of_protected)?;
+
+        // Dangling symlink guard: a symlink that exists on disk but
+        // whose target doesn't is NOT the normal "future socket file"
+        // case — `bind(2)` would punch through the symlink to create
+        // at the target, which might be a different path than the
+        // operator supplied. Reject loudly; users with a legitimate
+        // dangling-symlink workflow can unlink the symlink first.
+        //
+        // `path.symlink_metadata().is_ok()` checks the link itself,
+        // `path.exists()` follows it. The combination is: link exists
+        // (symlink_metadata ok) but target doesn't (exists false).
+        if path.symlink_metadata().is_ok() && !path.exists() {
+            return Err(NonoError::SandboxInit(format!(
+                "connect+bind unix socket grant rejects dangling symlink \
+                 (bind would create at the symlink's target path, which is \
+                 not what operators usually intend): {}",
+                path.display()
+            )));
+        }
+
+        let sock_cap =
+            try_new_unix_socket_file(path, UnixSocketMode::ConnectBind, LBL_SOCK_FILE_BIND)?;
+        if let Some(cap) = sock_cap {
+            caps.add_unix_socket(cap);
+            // Implied fs grant: ReadWrite. If the path exists, grant
+            // file-scoped — narrow. If it doesn't, widen to the parent
+            // directory because `bind(2)` needs write on the parent to
+            // create the inode. Landlock/Seatbelt can't express a
+            // per-file "create at this exact path" grant; operators
+            // who want tighter scope should prefer
+            // `--allow-unix-socket-dir-bind` with a scoped directory.
+            if path.exists() {
+                if let Some(cap) = try_new_file(path, AccessMode::ReadWrite, LBL_FS_FILE_IMPLIED)? {
+                    caps.add_fs(cap);
+                }
+            } else if let Some(parent) = path.parent() {
+                if let Some(cap) = try_new_dir(
+                    parent,
+                    AccessMode::ReadWrite,
+                    LBL_FS_DIR_IMPLIED_BIND_PARENT,
+                )? {
+                    caps.add_fs(cap);
+                }
+            }
+        }
+    }
+
+    for path in &args.allow_unix_socket_dir {
+        validate_requested_dir(path, "CLI", protected_roots, allow_parent_of_protected)?;
+        let sock_cap = try_new_unix_socket_dir(path, UnixSocketMode::Connect, LBL_SOCK_DIR)?;
+        if let Some(cap) = sock_cap {
+            caps.add_unix_socket(cap);
+            if let Some(cap) = try_new_dir(path, AccessMode::Read, LBL_FS_DIR_IMPLIED)? {
+                caps.add_fs(cap);
+            }
+        }
+    }
+
+    for path in &args.allow_unix_socket_dir_bind {
+        validate_requested_dir(path, "CLI", protected_roots, allow_parent_of_protected)?;
+        let sock_cap =
+            try_new_unix_socket_dir(path, UnixSocketMode::ConnectBind, LBL_SOCK_DIR_BIND)?;
+        if let Some(cap) = sock_cap {
+            caps.add_unix_socket(cap);
+            if let Some(cap) = try_new_dir(path, AccessMode::ReadWrite, LBL_FS_DIR_IMPLIED)? {
+                caps.add_fs(cap);
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Create a profile capability for an exact path that is usually expected to be a file.
@@ -365,6 +524,11 @@ impl CapabilitySetExt for CapabilitySet {
             }
         }
 
+        // AF_UNIX socket capabilities (issue #685 / #696). See
+        // add_cli_unix_socket_caps for the full flag handling + implied
+        // fs-grant sugar.
+        add_cli_unix_socket_caps(&mut caps, args, &protected_roots, false)?;
+
         apply_cli_network_mode(&mut caps, args);
 
         // Localhost IPC ports
@@ -521,6 +685,127 @@ impl CapabilitySetExt for CapabilitySet {
                 add_atomic_write_rule(&mut caps, &cap)?;
                 cap.source = CapabilitySource::Profile;
                 caps.add_fs(cap);
+            }
+        }
+
+        // AF_UNIX socket capabilities from profile (issue #685 / #696).
+        //
+        // Mirrors the CLI-side sugar in from_args: each unix_socket*
+        // field adds a UnixSocketCapability and auto-registers the
+        // implied FsCapability with matching access mode. Source is
+        // marked as Profile so `--dry-run -v` can show provenance.
+        for path_template in &fs.unix_socket {
+            let path = expand_vars(path_template, workdir)?;
+            validate_requested_file(
+                &path,
+                "Profile",
+                &protected_roots,
+                allow_parent_of_protected,
+            )?;
+            let label = format!(
+                "Profile unix socket '{}' does not exist, skipping",
+                path_template
+            );
+            if let Some(mut cap) = try_new_unix_socket_file(&path, UnixSocketMode::Connect, &label)?
+            {
+                cap.source = CapabilitySource::Profile;
+                caps.add_unix_socket(cap);
+                // Implied fs grant only when the socket grant itself
+                // was accepted — the two must stay coupled so we never
+                // add an fs grant for a path with no matching socket
+                // grant.
+                if let Some(mut cap) = try_new_file(&path, AccessMode::Read, &label)? {
+                    cap.source = CapabilitySource::Profile;
+                    caps.add_fs(cap);
+                }
+            }
+        }
+
+        for path_template in &fs.unix_socket_bind {
+            let path = expand_vars(path_template, workdir)?;
+            validate_requested_file(
+                &path,
+                "Profile",
+                &protected_roots,
+                allow_parent_of_protected,
+            )?;
+            // Dangling-symlink guard — see add_cli_unix_socket_caps.
+            if path.symlink_metadata().is_ok() && !path.exists() {
+                return Err(NonoError::SandboxInit(format!(
+                    "Profile unix_socket_bind rejects dangling symlink \
+                     (bind would punch through to the link target): '{}'",
+                    path_template
+                )));
+            }
+            let label = format!(
+                "Profile unix socket '{}' does not exist, skipping",
+                path_template
+            );
+            if let Some(mut cap) =
+                try_new_unix_socket_file(&path, UnixSocketMode::ConnectBind, &label)?
+            {
+                cap.source = CapabilitySource::Profile;
+                caps.add_unix_socket(cap);
+                // Implied fs grant. See add_cli_unix_socket_caps for the
+                // parent-widening rationale.
+                if path.exists() {
+                    if let Some(mut cap) = try_new_file(&path, AccessMode::ReadWrite, &label)? {
+                        cap.source = CapabilitySource::Profile;
+                        caps.add_fs(cap);
+                    }
+                } else if let Some(parent) = path.parent() {
+                    if let Some(mut cap) = try_new_dir(parent, AccessMode::ReadWrite, &label)? {
+                        cap.source = CapabilitySource::Profile;
+                        caps.add_fs(cap);
+                    }
+                }
+            }
+        }
+
+        for path_template in &fs.unix_socket_dir {
+            let path = expand_vars(path_template, workdir)?;
+            validate_requested_dir(
+                &path,
+                "Profile",
+                &protected_roots,
+                allow_parent_of_protected,
+            )?;
+            let label = format!(
+                "Profile unix socket dir '{}' does not exist, skipping",
+                path_template
+            );
+            if let Some(mut cap) = try_new_unix_socket_dir(&path, UnixSocketMode::Connect, &label)?
+            {
+                cap.source = CapabilitySource::Profile;
+                caps.add_unix_socket(cap);
+                if let Some(mut cap) = try_new_dir(&path, AccessMode::Read, &label)? {
+                    cap.source = CapabilitySource::Profile;
+                    caps.add_fs(cap);
+                }
+            }
+        }
+
+        for path_template in &fs.unix_socket_dir_bind {
+            let path = expand_vars(path_template, workdir)?;
+            validate_requested_dir(
+                &path,
+                "Profile",
+                &protected_roots,
+                allow_parent_of_protected,
+            )?;
+            let label = format!(
+                "Profile unix socket dir '{}' does not exist, skipping",
+                path_template
+            );
+            if let Some(mut cap) =
+                try_new_unix_socket_dir(&path, UnixSocketMode::ConnectBind, &label)?
+            {
+                cap.source = CapabilitySource::Profile;
+                caps.add_unix_socket(cap);
+                if let Some(mut cap) = try_new_dir(&path, AccessMode::ReadWrite, &label)? {
+                    cap.source = CapabilitySource::Profile;
+                    caps.add_fs(cap);
+                }
             }
         }
 
@@ -752,6 +1037,9 @@ fn add_cli_overrides(
             caps.add_fs(cap);
         }
     }
+
+    // AF_UNIX socket capabilities from CLI overrides.
+    add_cli_unix_socket_caps(caps, args, &protected_roots, allow_parent_of_protected)?;
 
     // CLI network flags override profile network settings.
     apply_cli_network_mode(caps, args);
@@ -2065,5 +2353,295 @@ mod tests {
             caps.platform_rules().is_empty(),
             "read-only file should not get atomic write rule"
         );
+    }
+
+    // --- --allow-unix-socket* flag tests (issue #685 / #696) -----------------
+
+    #[test]
+    fn test_allow_unix_socket_adds_cap_and_implied_read_fs_grant() {
+        let dir = tempdir().expect("tempdir");
+        let sock = dir.path().join("a.sock");
+        std::fs::write(&sock, b"").expect("create socket stub");
+
+        let args = SandboxArgs {
+            allow_unix_socket: vec![sock.clone()],
+            ..sandbox_args()
+        };
+
+        let (caps, _) = from_args_locked(&args).expect("from_args");
+
+        // One UnixSocketCapability with mode=Connect.
+        let socks = caps.unix_socket_capabilities();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::Connect);
+        assert!(!socks[0].is_directory);
+
+        // Exactly one implied FsCapability at Read.
+        let fs_matches: Vec<_> = caps
+            .fs_capabilities()
+            .iter()
+            .filter(|c| c.is_file && c.resolved == sock.canonicalize().expect("canonicalize sock"))
+            .collect();
+        assert_eq!(fs_matches.len(), 1);
+        assert_eq!(fs_matches[0].access, AccessMode::Read);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_allow_unix_socket_bind_rejects_dangling_symlink() {
+        // A dangling symlink is not a typical "future socket file" — bind(2)
+        // follows the link and creates at the target, which is usually not
+        // what the operator intended. Must reject loudly.
+        let dir = tempdir().expect("tempdir");
+        let link = dir.path().join("dangling.sock");
+        let missing_target = dir.path().join("does-not-exist");
+        std::os::unix::fs::symlink(&missing_target, &link).expect("create dangling symlink");
+
+        let args = SandboxArgs {
+            allow_unix_socket_bind: vec![link],
+            ..sandbox_args()
+        };
+
+        let err = from_args_locked(&args)
+            .expect_err("dangling symlink must be rejected by the bind guard");
+        assert!(
+            format!("{err}").contains("dangling symlink"),
+            "error message should mention dangling symlink"
+        );
+    }
+
+    #[test]
+    fn test_allow_unix_socket_missing_skips_both_socket_and_fs_grants() {
+        // On macOS, try_new_file's handle_missing_file_capability can
+        // manufacture an exact-file FsCapability even when the path
+        // doesn't exist. The unix-socket branch must NOT register that
+        // fs grant when the socket grant itself was skipped — otherwise
+        // the user gets a filesystem permission for a path they can't
+        // `connect()` to anyway.
+        let dir = tempdir().expect("tempdir");
+        let missing = dir.path().join("never-exists.sock");
+
+        let args = SandboxArgs {
+            allow_unix_socket: vec![missing.clone()],
+            ..sandbox_args()
+        };
+
+        let (caps, _) = from_args_locked(&args).expect("from_args");
+
+        assert!(
+            caps.unix_socket_capabilities().is_empty(),
+            "no unix-socket grant for missing path"
+        );
+        assert!(
+            !caps
+                .fs_capabilities()
+                .iter()
+                .any(|c| c.original == missing || c.resolved == missing),
+            "no implied fs grant when the socket grant was skipped"
+        );
+    }
+
+    #[test]
+    fn test_allow_unix_socket_bind_accepts_nonexistent_path_and_widens_fs_to_parent() {
+        // The normal bind(2) workflow: grant is registered before the
+        // socket file exists. The UnixSocketCapability is added
+        // (ConnectBind, file-scoped, canonical parent + filename), and
+        // the implied fs grant widens to ReadWrite on the parent
+        // directory since the kernel needs write on the parent to
+        // create the new inode.
+        let dir = tempdir().expect("tempdir");
+        let pending = dir.path().join("future.sock");
+        assert!(!pending.exists(), "test precondition: path must not exist");
+
+        let args = SandboxArgs {
+            allow_unix_socket_bind: vec![pending.clone()],
+            ..sandbox_args()
+        };
+
+        let (caps, _) = from_args_locked(&args).expect("from_args");
+
+        let socks = caps.unix_socket_capabilities();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
+        assert!(!socks[0].is_directory);
+
+        // Implied fs grant should cover the parent dir with ReadWrite.
+        let canonical_parent = dir.path().canonicalize().expect("canonicalize dir");
+        let parent_grant = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| !c.is_file && c.resolved == canonical_parent)
+            .expect("implied parent-dir fs grant missing");
+        assert_eq!(parent_grant.access, AccessMode::ReadWrite);
+    }
+
+    #[test]
+    fn test_allow_unix_socket_bind_existing_grants_readwrite_fs() {
+        let dir = tempdir().expect("tempdir");
+        let sock = dir.path().join("b.sock");
+        std::fs::write(&sock, b"").expect("create socket stub");
+
+        let args = SandboxArgs {
+            allow_unix_socket_bind: vec![sock.clone()],
+            ..sandbox_args()
+        };
+
+        let (caps, _) = from_args_locked(&args).expect("from_args");
+
+        let socks = caps.unix_socket_capabilities();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
+
+        let fs_match = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| c.is_file && c.resolved == sock.canonicalize().expect("canonicalize sock"))
+            .expect("implied fs cap not found");
+        assert_eq!(fs_match.access, AccessMode::ReadWrite);
+    }
+
+    #[test]
+    fn test_allow_unix_socket_dir_bind_directory_grants_readwrite_fs() {
+        // The tsx case (#685): runtime-generated socket filenames inside a
+        // known directory.
+        let dir = tempdir().expect("tempdir");
+
+        let args = SandboxArgs {
+            allow_unix_socket_dir_bind: vec![dir.path().to_path_buf()],
+            ..sandbox_args()
+        };
+
+        let (caps, _) = from_args_locked(&args).expect("from_args");
+
+        let socks = caps.unix_socket_capabilities();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
+        assert!(socks[0].is_directory);
+
+        let fs_match = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| {
+                !c.is_file && c.resolved == dir.path().canonicalize().expect("canonicalize dir")
+            })
+            .expect("implied fs dir cap not found");
+        assert_eq!(fs_match.access, AccessMode::ReadWrite);
+    }
+
+    #[test]
+    fn test_allow_unix_socket_dir_implies_read_fs_grant() {
+        let dir = tempdir().expect("tempdir");
+
+        let args = SandboxArgs {
+            allow_unix_socket_dir: vec![dir.path().to_path_buf()],
+            ..sandbox_args()
+        };
+
+        let (caps, _) = from_args_locked(&args).expect("from_args");
+
+        let socks = caps.unix_socket_capabilities();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::Connect);
+        assert!(socks[0].is_directory);
+
+        let fs_match = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| {
+                !c.is_file && c.resolved == dir.path().canonicalize().expect("canonicalize dir")
+            })
+            .expect("implied fs dir cap not found");
+        assert_eq!(fs_match.access, AccessMode::Read);
+    }
+
+    /// Build a minimal profile JSON with a single filesystem field set,
+    /// then parse it into a [`crate::profile::Profile`].
+    fn profile_with_fs_field(field: &str, value: &str) -> crate::profile::Profile {
+        let json = format!(
+            r#"{{
+                "meta": {{ "name": "test-unix-socket" }},
+                "security": {{ "groups": [] }},
+                "filesystem": {{ "{field}": ["{value}"] }}
+            }}"#
+        );
+        serde_json::from_str(&json).expect("parse profile")
+    }
+
+    #[test]
+    fn test_profile_unix_socket_field_connect_file() {
+        let dir = tempdir().expect("tempdir");
+        let sock = dir.path().join("a.sock");
+        std::fs::write(&sock, b"").expect("create socket stub");
+        let profile = profile_with_fs_field("unix_socket", &sock.display().to_string());
+
+        let (caps, _) =
+            from_profile_locked(&profile, dir.path(), &sandbox_args()).expect("from_profile");
+
+        let socks: Vec<_> = caps
+            .unix_socket_capabilities()
+            .iter()
+            .filter(|c| c.source == CapabilitySource::Profile)
+            .collect();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::Connect);
+        assert!(!socks[0].is_directory);
+    }
+
+    #[test]
+    fn test_profile_unix_socket_field_connect_bind_file() {
+        let dir = tempdir().expect("tempdir");
+        let sock = dir.path().join("b.sock");
+        std::fs::write(&sock, b"").expect("create socket stub");
+        let profile = profile_with_fs_field("unix_socket_bind", &sock.display().to_string());
+
+        let (caps, _) =
+            from_profile_locked(&profile, dir.path(), &sandbox_args()).expect("from_profile");
+
+        let socks: Vec<_> = caps
+            .unix_socket_capabilities()
+            .iter()
+            .filter(|c| c.source == CapabilitySource::Profile)
+            .collect();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
+        assert!(!socks[0].is_directory);
+    }
+
+    #[test]
+    fn test_profile_unix_socket_field_connect_dir() {
+        let dir = tempdir().expect("tempdir");
+        let profile = profile_with_fs_field("unix_socket_dir", &dir.path().display().to_string());
+
+        let (caps, _) =
+            from_profile_locked(&profile, dir.path(), &sandbox_args()).expect("from_profile");
+
+        let socks: Vec<_> = caps
+            .unix_socket_capabilities()
+            .iter()
+            .filter(|c| c.source == CapabilitySource::Profile)
+            .collect();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::Connect);
+        assert!(socks[0].is_directory);
+    }
+
+    #[test]
+    fn test_profile_unix_socket_field_connect_bind_dir() {
+        // The tsx (#685) case, expressed via profile JSON.
+        let dir = tempdir().expect("tempdir");
+        let profile =
+            profile_with_fs_field("unix_socket_dir_bind", &dir.path().display().to_string());
+
+        let (caps, _) =
+            from_profile_locked(&profile, dir.path(), &sandbox_args()).expect("from_profile");
+
+        let socks: Vec<_> = caps
+            .unix_socket_capabilities()
+            .iter()
+            .filter(|c| c.source == CapabilitySource::Profile)
+            .collect();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
+        assert!(socks[0].is_directory);
     }
 }

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -862,6 +862,30 @@ pub struct SandboxArgs {
     #[arg(long, value_name = "FILE", help_heading = "FILESYSTEM")]
     pub write_file: Vec<PathBuf>,
 
+    /// Allow connect() to an AF_UNIX socket at this path (implies --read-file)
+    #[arg(long, value_name = "SOCKET", help_heading = "FILESYSTEM")]
+    pub allow_unix_socket: Vec<PathBuf>,
+
+    /// Allow connect() and bind() on an AF_UNIX socket at this path.
+    /// If the path exists, implies --allow-file on the socket. If it
+    /// does not yet exist (the typical bind(2) case), implies --allow
+    /// on the parent directory so the kernel can create the socket
+    /// file. Prefer --allow-unix-socket-dir-bind for runtime-generated
+    /// filenames.
+    #[arg(long, value_name = "SOCKET", help_heading = "FILESYSTEM")]
+    pub allow_unix_socket_bind: Vec<PathBuf>,
+
+    /// Allow connect() to any AF_UNIX socket directly within this directory
+    /// (non-recursive; implies --read)
+    #[arg(long, value_name = "DIR", help_heading = "FILESYSTEM")]
+    pub allow_unix_socket_dir: Vec<PathBuf>,
+
+    /// Allow connect() and bind() on any AF_UNIX socket directly within this
+    /// directory (non-recursive; implies --allow). Use for runtime-generated
+    /// socket filenames (PID-derived paths, etc.).
+    #[arg(long, value_name = "DIR", help_heading = "FILESYSTEM")]
+    pub allow_unix_socket_dir_bind: Vec<PathBuf>,
+
     /// Override a deny rule for a path. Pair with --allow/--read/--write grant
     #[arg(long, value_name = "PATH", help_heading = "FILESYSTEM")]
     pub override_deny: Vec<PathBuf>,
@@ -1048,6 +1072,8 @@ pub struct SandboxArgs {
         value_name = "FILE",
         conflicts_with_all = &[
             "allow", "read", "write", "allow_file", "read_file", "write_file",
+            "allow_unix_socket", "allow_unix_socket_bind",
+            "allow_unix_socket_dir", "allow_unix_socket_dir_bind",
             "profile", "override_deny", "allow_cwd",
             "block_net", "allow_net", "network_profile", "allow_proxy",
             "allow_bind", "allow_port", "external_proxy", "proxy_port",
@@ -1110,6 +1136,30 @@ pub struct WrapSandboxArgs {
     /// Allow write-only access to a single file
     #[arg(long, value_name = "FILE", help_heading = "FILESYSTEM")]
     pub write_file: Vec<PathBuf>,
+
+    /// Allow connect() to an AF_UNIX socket at this path (implies --read-file)
+    #[arg(long, value_name = "SOCKET", help_heading = "FILESYSTEM")]
+    pub allow_unix_socket: Vec<PathBuf>,
+
+    /// Allow connect() and bind() on an AF_UNIX socket at this path.
+    /// If the path exists, implies --allow-file on the socket. If it
+    /// does not yet exist (the typical bind(2) case), implies --allow
+    /// on the parent directory so the kernel can create the socket
+    /// file. Prefer --allow-unix-socket-dir-bind for runtime-generated
+    /// filenames.
+    #[arg(long, value_name = "SOCKET", help_heading = "FILESYSTEM")]
+    pub allow_unix_socket_bind: Vec<PathBuf>,
+
+    /// Allow connect() to any AF_UNIX socket directly within this directory
+    /// (non-recursive; implies --read)
+    #[arg(long, value_name = "DIR", help_heading = "FILESYSTEM")]
+    pub allow_unix_socket_dir: Vec<PathBuf>,
+
+    /// Allow connect() and bind() on any AF_UNIX socket directly within this
+    /// directory (non-recursive; implies --allow). Use for runtime-generated
+    /// socket filenames (PID-derived paths, etc.).
+    #[arg(long, value_name = "DIR", help_heading = "FILESYSTEM")]
+    pub allow_unix_socket_dir_bind: Vec<PathBuf>,
 
     /// Override a deny rule for a path. Pair with --allow/--read/--write grant
     #[arg(long, value_name = "PATH", help_heading = "FILESYSTEM")]
@@ -1209,6 +1259,8 @@ pub struct WrapSandboxArgs {
         value_name = "FILE",
         conflicts_with_all = &[
             "allow", "read", "write", "allow_file", "read_file", "write_file",
+            "allow_unix_socket", "allow_unix_socket_bind",
+            "allow_unix_socket_dir", "allow_unix_socket_dir_bind",
             "profile", "override_deny", "allow_cwd",
             "block_net", "allow_bind", "allow_port",
             "env_credential", "env_credential_map",
@@ -1236,6 +1288,10 @@ impl From<WrapSandboxArgs> for SandboxArgs {
             allow_file: args.allow_file,
             read_file: args.read_file,
             write_file: args.write_file,
+            allow_unix_socket: args.allow_unix_socket,
+            allow_unix_socket_bind: args.allow_unix_socket_bind,
+            allow_unix_socket_dir: args.allow_unix_socket_dir,
+            allow_unix_socket_dir_bind: args.allow_unix_socket_dir_bind,
             override_deny: args.override_deny,
             allow_cwd: args.allow_cwd,
             workdir: args.workdir,

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -981,6 +981,7 @@ mod tests {
                 detach_sequence: None,
                 open_url_origins: &[],
                 open_url_allow_localhost: false,
+                audit_recorder: None,
                 allow_launch_services_active: false,
                 proxy_port,
                 proxy_bind_ports,

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -532,15 +532,130 @@ pub(super) fn handle_seccomp_notification(
     Ok(())
 }
 
+/// Decision produced by [`decide_network_notification`].
+///
+/// Split out as an explicit type so the (testable) policy logic is decoupled
+/// from the (untestable) seccomp-notify response plumbing. Callers translate
+/// `Allow` to `continue_notif(…)` and `Deny` to `respond_notif_errno(…, EACCES)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum NetworkDecision {
+    /// Let the kernel proceed with the already-copied sockaddr
+    /// (`SECCOMP_USER_NOTIF_FLAG_CONTINUE`).
+    Allow,
+    /// Fail the syscall with `EACCES`.
+    Deny,
+}
+
+/// Pure policy function: given a trapped syscall and the sockaddr the child
+/// passed in, decide whether the supervisor should allow or deny it.
+///
+/// Factored out of [`handle_network_notification`] so it can be unit-tested
+/// without a live seccomp-notify fd.
+///
+/// Policy:
+///
+/// 1. **Pathname `AF_UNIX` is allowed** (issue #685). Filesystem-backed Unix
+///    sockets like `/tmp/test.sock` are IPC bound to a real path, so
+///    Landlock's filesystem rules decide access: a bind/connect succeeds
+///    only if the path is inside an allowed grant, and fails otherwise.
+///    This restores parity with Landlock V4+, where `LANDLOCK_ACCESS_NET_*`
+///    only scopes TCP and pathname `AF_UNIX` is governed by fs rules.
+///
+///    **Abstract and unnamed `AF_UNIX` are denied.** The abstract namespace
+///    (`sun_path[0] == '\0'`) lives outside the filesystem, so Landlock has
+///    no way to mediate it — a blanket allow would open a covert IPC
+///    channel that bypasses the sandbox. Unnamed sockets (addrlen == 2)
+///    have no path to check and no use case that motivated this fix.
+///    Future work (#696) may add an explicit allowlist for abstract paths.
+///
+/// 2. For `AF_INET`/`AF_INET6`:
+///    - `connect()` is allowed only to `127.0.0.1:proxy_port` (the nono proxy).
+///    - `bind()` is allowed only on ports in `proxy_bind_ports`.
+///    - Everything else is denied.
+pub(super) fn decide_network_notification(
+    syscall: i32,
+    sockaddr: &nono::sandbox::SockaddrInfo,
+    config: &SupervisorConfig<'_>,
+) -> NetworkDecision {
+    use nono::sandbox::{UnixSocketKind, SYS_BIND, SYS_CONNECT};
+
+    // AF_UNIX: allow only filesystem-backed (pathname) sockets — Landlock's
+    // filesystem rules will then decide whether the specific path is
+    // reachable. Abstract/unnamed sockets bypass fs rules, so deny them.
+    if sockaddr.family == libc::AF_UNIX as u16 {
+        match sockaddr.unix_kind {
+            Some(UnixSocketKind::Pathname) => {
+                debug!(
+                    "Proxy seccomp: allowing AF_UNIX pathname syscall (nr={}); \
+                     governed by Landlock fs rules",
+                    syscall
+                );
+                return NetworkDecision::Allow;
+            }
+            Some(UnixSocketKind::Abstract) => {
+                debug!(
+                    "Proxy seccomp: denying AF_UNIX abstract-namespace syscall (nr={}); \
+                     not mediated by Landlock fs rules",
+                    syscall
+                );
+                return NetworkDecision::Deny;
+            }
+            Some(UnixSocketKind::Unnamed) | None => {
+                debug!(
+                    "Proxy seccomp: denying AF_UNIX unnamed/unclassified syscall (nr={})",
+                    syscall
+                );
+                return NetworkDecision::Deny;
+            }
+        }
+    }
+
+    match syscall {
+        SYS_CONNECT => {
+            // Allow connect only to loopback + proxy port
+            if sockaddr.is_loopback && sockaddr.port == config.proxy_port {
+                debug!(
+                    "Proxy seccomp: allowing connect to loopback:{}",
+                    sockaddr.port
+                );
+                NetworkDecision::Allow
+            } else {
+                debug!(
+                    "Proxy seccomp: denying connect to family={} port={} loopback={}",
+                    sockaddr.family, sockaddr.port, sockaddr.is_loopback
+                );
+                NetworkDecision::Deny
+            }
+        }
+        SYS_BIND => {
+            // Allow bind only on configured bind ports
+            if config.proxy_bind_ports.contains(&sockaddr.port) {
+                debug!("Proxy seccomp: allowing bind on port {}", sockaddr.port);
+                NetworkDecision::Allow
+            } else {
+                debug!(
+                    "Proxy seccomp: denying bind on port {} (allowed: {:?})",
+                    sockaddr.port, config.proxy_bind_ports
+                );
+                NetworkDecision::Deny
+            }
+        }
+        other => {
+            warn!(
+                "Unexpected syscall {} in proxy seccomp handler, denying",
+                other
+            );
+            NetworkDecision::Deny
+        }
+    }
+}
+
 /// Handle a seccomp notification for connect() or bind() syscalls.
 ///
 /// This is the proxy-only fallback for kernels without Landlock AccessNet.
 /// The BPF filter routes connect/bind to USER_NOTIF; this function reads
-/// the sockaddr from the child's memory and allows or denies based on
-/// the configured proxy port and bind ports.
-///
-/// For connect: allow only loopback + proxy port. Deny everything else.
-/// For bind: allow only ports in the bind_ports list. Deny everything else.
+/// the sockaddr from the child's memory and delegates the allow/deny
+/// decision to [`decide_network_notification`].
 ///
 /// Uses SECCOMP_USER_NOTIF_FLAG_CONTINUE on approval (safe for connect/bind
 /// because the kernel has already copied sockaddr into kernel memory).
@@ -551,7 +666,7 @@ pub(super) fn handle_network_notification(
 ) -> nono::error::Result<()> {
     use nono::sandbox::{
         continue_notif, deny_notif, notif_id_valid, read_notif_sockaddr, recv_notif,
-        respond_notif_errno, SYS_BIND, SYS_CONNECT,
+        respond_notif_errno,
     };
 
     let notif = recv_notif(notify_fd)?;
@@ -579,58 +694,20 @@ pub(super) fn handle_network_notification(
         return Ok(());
     }
 
-    let allowed = match notif.data.nr {
-        SYS_CONNECT => {
-            // Allow connect only to loopback + proxy port
-            let port_match = sockaddr.port == config.proxy_port;
-            if sockaddr.is_loopback && port_match {
-                debug!(
-                    "Proxy seccomp: allowing connect to loopback:{}",
-                    sockaddr.port
-                );
-                true
-            } else {
-                debug!(
-                    "Proxy seccomp: denying connect to family={} port={} loopback={}",
-                    sockaddr.family, sockaddr.port, sockaddr.is_loopback
-                );
-                false
+    match decide_network_notification(notif.data.nr, &sockaddr, config) {
+        NetworkDecision::Allow => {
+            // SECCOMP_USER_NOTIF_FLAG_CONTINUE: let the kernel proceed with its
+            // already-copied sockaddr. Safe for connect/bind (move_addr_to_kernel).
+            if let Err(e) = continue_notif(notify_fd, notif.id) {
+                debug!("continue_notif failed for network notification: {}", e);
+                // Must respond to avoid leaving the child blocked. Propagate if
+                // deny also fails — the notification is orphaned.
+                return deny_notif(notify_fd, notif.id);
             }
         }
-        SYS_BIND => {
-            // Allow bind only on configured bind ports
-            let port_allowed = config.proxy_bind_ports.contains(&sockaddr.port);
-            if port_allowed {
-                debug!("Proxy seccomp: allowing bind on port {}", sockaddr.port);
-                true
-            } else {
-                debug!(
-                    "Proxy seccomp: denying bind on port {} (allowed: {:?})",
-                    sockaddr.port, config.proxy_bind_ports
-                );
-                false
-            }
+        NetworkDecision::Deny => {
+            respond_notif_errno(notify_fd, notif.id, libc::EACCES)?;
         }
-        other => {
-            warn!(
-                "Unexpected syscall {} in proxy seccomp handler, denying",
-                other
-            );
-            false
-        }
-    };
-
-    if allowed {
-        // SECCOMP_USER_NOTIF_FLAG_CONTINUE: let the kernel proceed with its
-        // already-copied sockaddr. Safe for connect/bind (move_addr_to_kernel).
-        if let Err(e) = continue_notif(notify_fd, notif.id) {
-            debug!("continue_notif failed for network notification: {}", e);
-            // Must respond to avoid leaving the child blocked. Propagate if
-            // deny also fails — the notification is orphaned.
-            return deny_notif(notify_fd, notif.id);
-        }
-    } else {
-        respond_notif_errno(notify_fd, notif.id, libc::EACCES)?;
     }
 
     Ok(())
@@ -860,5 +937,188 @@ mod tests {
             ),
             InitialCapabilityMatch::Insufficient(_)
         ));
+    }
+
+    // --- decide_network_notification tests (issue #685) ---------------------
+    //
+    // These exercise the proxy-only seccomp fallback path that runs on
+    // Landlock < V4 kernels. The key invariant: `AF_UNIX` must be allowed
+    // through so Landlock's filesystem rules decide access, matching V4+
+    // behavior where `LANDLOCK_ACCESS_NET_*` only scopes TCP.
+
+    mod network_decision {
+        use super::super::{decide_network_notification, NetworkDecision, SupervisorConfig};
+        use nix::libc;
+        use nono::sandbox::{SockaddrInfo, UnixSocketKind, SYS_BIND, SYS_CONNECT};
+        use nono::supervisor::{ApprovalDecision, CapabilityRequest};
+        use nono::ApprovalBackend;
+
+        struct DenyAllBackend;
+        impl ApprovalBackend for DenyAllBackend {
+            fn request_capability(
+                &self,
+                _req: &CapabilityRequest,
+            ) -> nono::Result<ApprovalDecision> {
+                Ok(ApprovalDecision::Denied {
+                    reason: "test".to_string(),
+                })
+            }
+            fn backend_name(&self) -> &str {
+                "deny-all-test"
+            }
+        }
+
+        fn make_config<'a>(
+            backend: &'a DenyAllBackend,
+            proxy_port: u16,
+            proxy_bind_ports: Vec<u16>,
+        ) -> SupervisorConfig<'a> {
+            SupervisorConfig {
+                protected_roots: &[],
+                approval_backend: backend,
+                session_id: "test-net-decision",
+                attach_initial_client: false,
+                detach_sequence: None,
+                open_url_origins: &[],
+                open_url_allow_localhost: false,
+                allow_launch_services_active: false,
+                proxy_port,
+                proxy_bind_ports,
+            }
+        }
+
+        fn unix_pathname() -> SockaddrInfo {
+            // Matches what read_notif_sockaddr() produces for a
+            // filesystem-backed AF_UNIX socket (e.g. /tmp/test.sock).
+            SockaddrInfo {
+                family: libc::AF_UNIX as u16,
+                port: 0,
+                is_loopback: true,
+                unix_kind: Some(UnixSocketKind::Pathname),
+            }
+        }
+
+        fn unix_abstract() -> SockaddrInfo {
+            SockaddrInfo {
+                family: libc::AF_UNIX as u16,
+                port: 0,
+                is_loopback: true,
+                unix_kind: Some(UnixSocketKind::Abstract),
+            }
+        }
+
+        fn unix_unnamed() -> SockaddrInfo {
+            SockaddrInfo {
+                family: libc::AF_UNIX as u16,
+                port: 0,
+                is_loopback: true,
+                unix_kind: Some(UnixSocketKind::Unnamed),
+            }
+        }
+
+        fn inet_loopback(port: u16) -> SockaddrInfo {
+            SockaddrInfo {
+                family: libc::AF_INET as u16,
+                port,
+                is_loopback: true,
+                unix_kind: None,
+            }
+        }
+
+        fn inet_external(port: u16) -> SockaddrInfo {
+            SockaddrInfo {
+                family: libc::AF_INET as u16,
+                port,
+                is_loopback: false,
+                unix_kind: None,
+            }
+        }
+
+        /// Regression test for #685: pathname `bind(AF_UNIX, "/tmp/…")` was
+        /// being denied because `SockaddrInfo.port` is 0 for unix sockets
+        /// and port 0 is never in `proxy_bind_ports`. It must now allow so
+        /// Landlock's filesystem rules decide whether the path is reachable.
+        #[test]
+        fn af_unix_pathname_bind_is_allowed() {
+            let backend = DenyAllBackend;
+            let config = make_config(&backend, 0, Vec::new());
+            assert_eq!(
+                decide_network_notification(SYS_BIND, &unix_pathname(), &config),
+                NetworkDecision::Allow,
+                "pathname AF_UNIX bind must be allowed so Landlock fs rules govern access"
+            );
+        }
+
+        /// Regression test for #685: pathname `connect(AF_UNIX, "/tmp/…")`
+        /// was the failure mode for `tsx`'s IPC pipe and other runtimes.
+        #[test]
+        fn af_unix_pathname_connect_is_allowed() {
+            let backend = DenyAllBackend;
+            let config = make_config(&backend, 8080, Vec::new());
+            assert_eq!(
+                decide_network_notification(SYS_CONNECT, &unix_pathname(), &config),
+                NetworkDecision::Allow,
+                "pathname AF_UNIX connect must be allowed independent of proxy_port"
+            );
+        }
+
+        /// Scope-limit test: abstract-namespace AF_UNIX (`sun_path[0] == 0`)
+        /// is *not* governed by Landlock filesystem rules, so a blanket
+        /// allow would open a covert IPC channel that bypasses the sandbox.
+        /// #685 is explicitly about filesystem-path sockets; abstract stays
+        /// denied pending #696 (explicit allowlist).
+        #[test]
+        fn af_unix_abstract_is_denied() {
+            let backend = DenyAllBackend;
+            let config = make_config(&backend, 0, Vec::new());
+            assert_eq!(
+                decide_network_notification(SYS_BIND, &unix_abstract(), &config),
+                NetworkDecision::Deny,
+                "abstract AF_UNIX must be denied — Landlock fs rules do not reach it"
+            );
+            assert_eq!(
+                decide_network_notification(SYS_CONNECT, &unix_abstract(), &config),
+                NetworkDecision::Deny,
+            );
+        }
+
+        /// Unnamed AF_UNIX (`addrlen == 2`) has no path to check, so fail
+        /// closed — consistent with abstract handling and outside #685's
+        /// scope.
+        #[test]
+        fn af_unix_unnamed_is_denied() {
+            let backend = DenyAllBackend;
+            let config = make_config(&backend, 0, Vec::new());
+            assert_eq!(
+                decide_network_notification(SYS_BIND, &unix_unnamed(), &config),
+                NetworkDecision::Deny
+            );
+        }
+
+        /// Security-critical: the `AF_UNIX → Allow` short-circuit must not
+        /// leak into AF_INET. A child connecting to an external host on
+        /// `proxy_port` must still be denied — otherwise the proxy could be
+        /// bypassed.
+        #[test]
+        fn af_inet_connect_to_external_host_denied() {
+            let backend = DenyAllBackend;
+            let config = make_config(&backend, 8080, Vec::new());
+            assert_eq!(
+                decide_network_notification(SYS_CONNECT, &inet_external(8080), &config),
+                NetworkDecision::Deny
+            );
+        }
+
+        /// Proves the refactor didn't collapse AF_INET bind to unconditional
+        /// Allow. A port not in `proxy_bind_ports` must still fail.
+        #[test]
+        fn af_inet_bind_on_disallowed_port_denied() {
+            let backend = DenyAllBackend;
+            let config = make_config(&backend, 0, vec![3000]);
+            assert_eq!(
+                decide_network_notification(SYS_BIND, &inet_loopback(4000), &config),
+                NetworkDecision::Deny
+            );
+        }
     }
 }

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -112,6 +112,58 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
         }
     }
 
+    // AF_UNIX socket capabilities (issue #685 / #696)
+    let unix_caps = caps.unix_socket_capabilities();
+    if !unix_caps.is_empty() {
+        let (user_caps, hidden_count) = if verbose > 0 {
+            (unix_caps.to_vec(), 0)
+        } else {
+            let user: Vec<_> = unix_caps
+                .iter()
+                .filter(|c| c.source.is_user_intent())
+                .cloned()
+                .collect();
+            let hidden = unix_caps.len() - user.len();
+            (user, hidden)
+        };
+
+        for cap in &user_caps {
+            let mode_badge = format_unix_socket_mode_badge(cap.mode);
+            let scope_suffix = if cap.is_directory {
+                "  (directory grant — sockets inside only, non-recursive)"
+            } else {
+                ""
+            };
+            if verbose > 0 {
+                let source_str = format!("{}", cap.source);
+                eprintln!(
+                    "  {} {} {}{}",
+                    mode_badge,
+                    theme::fg(&cap.resolved.display().to_string(), t.text),
+                    theme::fg(&format!("[{source_str}]"), t.subtext),
+                    theme::fg(scope_suffix, t.subtext),
+                );
+            } else {
+                eprintln!(
+                    "  {} {}{}",
+                    mode_badge,
+                    theme::fg(&cap.resolved.display().to_string(), t.text),
+                    theme::fg(scope_suffix, t.subtext),
+                );
+            }
+        }
+
+        if hidden_count > 0 {
+            eprintln!(
+                "       {}",
+                theme::fg(
+                    &format!("+ {hidden_count} system/group unix sockets (-v to show)"),
+                    t.subtext
+                )
+            );
+        }
+    }
+
     // Network status
     match caps.network_mode() {
         NetworkMode::Blocked => {
@@ -172,6 +224,15 @@ fn format_access_badge(access: &AccessMode) -> String {
         AccessMode::Read => theme::badge("  r  ", t.green, BADGE_FG_DARK),
         AccessMode::Write => theme::badge("  w  ", t.yellow, BADGE_FG_DARK),
         AccessMode::ReadWrite => theme::badge(" r+w ", t.brand, BADGE_FG_DARK),
+    }
+}
+
+/// Format a Unix socket mode as a fixed-width colored badge.
+fn format_unix_socket_mode_badge(mode: nono::UnixSocketMode) -> String {
+    let t = theme::current();
+    match mode {
+        nono::UnixSocketMode::Connect => theme::badge("sock ", t.green, BADGE_FG_DARK),
+        nono::UnixSocketMode::ConnectBind => theme::badge("sock+", t.brand, BADGE_FG_DARK),
     }
 }
 
@@ -757,9 +818,12 @@ pub fn print_profile_hint(program: &str, profile: &str, silent: bool) {
 #[cfg(test)]
 mod tests {
     use super::{
-        finish_status_line_for_handoff, normalize_terminal_line_endings, print_applying_sandbox,
+        finish_status_line_for_handoff, format_unix_socket_mode_badge,
+        normalize_terminal_line_endings, print_applying_sandbox, print_capabilities,
         print_profile_hint, render_diagnostic_footer, take_pending_status_line,
     };
+    use nono::{CapabilitySet, UnixSocketMode};
+    use tempfile::tempdir;
 
     #[test]
     fn normalize_terminal_line_endings_uses_crlf() {
@@ -792,5 +856,37 @@ mod tests {
         print_applying_sandbox(false);
         assert!(take_pending_status_line());
         assert!(!take_pending_status_line());
+    }
+
+    #[test]
+    fn unix_socket_mode_badges_are_fixed_width_and_distinct() {
+        let connect = format_unix_socket_mode_badge(UnixSocketMode::Connect);
+        let bind = format_unix_socket_mode_badge(UnixSocketMode::ConnectBind);
+        // Same rendered-width contract as format_access_badge (5 chars).
+        // We can't `strip_ansi` cleanly here, so check the printable payload
+        // is present rather than the raw length.
+        assert!(connect.contains("sock "));
+        assert!(bind.contains("sock+"));
+        assert_ne!(connect, bind);
+    }
+
+    #[test]
+    fn print_capabilities_with_unix_socket_does_not_panic() {
+        // Smoke test: constructing a CapabilitySet with both connect and
+        // connect+bind unix socket grants (one file, one directory) and
+        // rendering it must not panic. Silent=true keeps stderr quiet in
+        // test output. Dry-run-style `verbose=1` path is also exercised.
+        let dir = tempdir().expect("tempdir");
+        let sock = dir.path().join("a.sock");
+        std::fs::write(&sock, b"").expect("create socket stub");
+
+        let caps = CapabilitySet::new()
+            .allow_unix_socket(&sock, UnixSocketMode::Connect)
+            .expect("connect grant")
+            .allow_unix_socket_dir(dir.path(), UnixSocketMode::ConnectBind)
+            .expect("bind dir grant");
+
+        print_capabilities(&caps, 0, true);
+        print_capabilities(&caps, 1, true);
     }
 }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -51,6 +51,27 @@ pub struct FilesystemConfig {
     /// Single files with write-only access
     #[serde(default)]
     pub write_file: Vec<String>,
+    /// Single AF_UNIX socket paths — connect only.
+    /// Implies read access on the socket path. See issue #685.
+    #[serde(default)]
+    pub unix_socket: Vec<String>,
+    /// Single AF_UNIX socket paths — connect and bind.
+    /// Implies read+write access on the socket path when it exists, or
+    /// on its parent directory when it does not yet exist (the normal
+    /// `bind(2)` workflow — the syscall creates the socket file).
+    /// Dangling symlinks are rejected at grant time. For runtime-generated
+    /// filenames (e.g. PID-suffixed paths) prefer `unix_socket_dir_bind`
+    /// so the implied fs grant stays scoped to a dedicated directory.
+    #[serde(default)]
+    pub unix_socket_bind: Vec<String>,
+    /// Directories where any direct-child AF_UNIX socket may be connected to.
+    /// Non-recursive. Implies read access on the directory.
+    #[serde(default)]
+    pub unix_socket_dir: Vec<String>,
+    /// Directories where any direct-child AF_UNIX socket may be connected to
+    /// or bound. Non-recursive. Implies read+write access on the directory.
+    #[serde(default)]
+    pub unix_socket_dir_bind: Vec<String>,
 }
 
 /// Policy patch configuration in a profile.
@@ -1744,6 +1765,19 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
             allow_file: dedup_append(&base.filesystem.allow_file, &child.filesystem.allow_file),
             read_file: dedup_append(&base.filesystem.read_file, &child.filesystem.read_file),
             write_file: dedup_append(&base.filesystem.write_file, &child.filesystem.write_file),
+            unix_socket: dedup_append(&base.filesystem.unix_socket, &child.filesystem.unix_socket),
+            unix_socket_bind: dedup_append(
+                &base.filesystem.unix_socket_bind,
+                &child.filesystem.unix_socket_bind,
+            ),
+            unix_socket_dir: dedup_append(
+                &base.filesystem.unix_socket_dir,
+                &child.filesystem.unix_socket_dir,
+            ),
+            unix_socket_dir_bind: dedup_append(
+                &base.filesystem.unix_socket_dir_bind,
+                &child.filesystem.unix_socket_dir_bind,
+            ),
         },
         policy: PolicyPatchConfig {
             exclude_groups: dedup_append(&base.policy.exclude_groups, &child.policy.exclude_groups),
@@ -3362,6 +3396,10 @@ mod tests {
                 allow_file: vec![],
                 read_file: vec!["/base/file.txt".to_string()],
                 write_file: vec![],
+                unix_socket: vec![],
+                unix_socket_bind: vec![],
+                unix_socket_dir: vec![],
+                unix_socket_dir_bind: vec![],
             },
             policy: PolicyPatchConfig {
                 exclude_groups: vec!["base_excluded".to_string()],
@@ -3435,6 +3473,10 @@ mod tests {
                 allow_file: vec![],
                 read_file: vec![],
                 write_file: vec![],
+                unix_socket: vec![],
+                unix_socket_bind: vec![],
+                unix_socket_dir: vec![],
+                unix_socket_dir_bind: vec![],
             },
             policy: PolicyPatchConfig {
                 exclude_groups: vec!["child_excluded".to_string()],

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -291,24 +291,24 @@ impl UnixSocketCapability {
                 if !mode.permits_bind() {
                     return Err(NonoError::PathNotFound(path.to_path_buf()));
                 }
-                let parent = path.parent().ok_or_else(|| {
-                    NonoError::PathCanonicalization {
+                let parent = path
+                    .parent()
+                    .ok_or_else(|| NonoError::PathCanonicalization {
                         path: path.to_path_buf(),
                         source: std::io::Error::new(
                             std::io::ErrorKind::InvalidInput,
                             "socket path has no parent directory",
                         ),
-                    }
-                })?;
-                let file_name = path.file_name().ok_or_else(|| {
-                    NonoError::PathCanonicalization {
-                        path: path.to_path_buf(),
-                        source: std::io::Error::new(
-                            std::io::ErrorKind::InvalidInput,
-                            "socket path has no final component",
-                        ),
-                    }
-                })?;
+                    })?;
+                let file_name =
+                    path.file_name()
+                        .ok_or_else(|| NonoError::PathCanonicalization {
+                            path: path.to_path_buf(),
+                            source: std::io::Error::new(
+                                std::io::ErrorKind::InvalidInput,
+                                "socket path has no final component",
+                            ),
+                        })?;
                 let resolved_parent = parent.canonicalize().map_err(|parent_err| {
                     if parent_err.kind() == std::io::ErrorKind::NotFound {
                         NonoError::PathNotFound(parent.to_path_buf())
@@ -370,8 +370,7 @@ impl UnixSocketCapability {
 
         if resolved.parent().is_none() {
             return Err(NonoError::SandboxInit(
-                "unix socket directory grant at filesystem root is not permitted"
-                    .to_string(),
+                "unix socket directory grant at filesystem root is not permitted".to_string(),
             ));
         }
 
@@ -405,13 +404,7 @@ impl UnixSocketCapability {
 impl std::fmt::Display for UnixSocketCapability {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let scope = if self.is_directory { "dir " } else { "" };
-        write!(
-            f,
-            "{}{} ({})",
-            scope,
-            self.resolved.display(),
-            self.mode
-        )
+        write!(f, "{}{} ({})", scope, self.resolved.display(), self.mode)
     }
 }
 
@@ -1400,6 +1393,103 @@ impl CapabilitySet {
         for idx in to_remove {
             self.fs.remove(idx);
         }
+
+        self.deduplicate_unix_sockets();
+    }
+
+    /// Deduplicate [`UnixSocketCapability`] entries in-place.
+    ///
+    /// Two entries collide when they share `(resolved, is_directory)`.
+    /// Merge rules match [`Self::deduplicate`]'s user-intent policy:
+    ///
+    /// - **User-intent beats system/group.** When a user- or profile-
+    ///   sourced entry collides with a system/group entry, the user entry
+    ///   is kept with *its own* mode unchanged. A user choosing `Connect`
+    ///   for a path is deliberately narrowing the grant; dedup must not
+    ///   silently re-widen it to `ConnectBind` just because an
+    ///   unsolicited system grant also covers the path.
+    /// - **Same-provenance collisions merge to the superset.** Two user-
+    ///   intent entries (or two system entries) differing in mode end up
+    ///   as `ConnectBind`, since `Connect` is a subset. This is the
+    ///   socket-layer analog of the fs dedup's `Read + Write → ReadWrite`
+    ///   rule, but one-directional: `Connect` never strengthens a
+    ///   `ConnectBind` grant.
+    fn deduplicate_unix_sockets(&mut self) {
+        use std::collections::HashMap;
+
+        let mut seen: HashMap<(PathBuf, bool), usize> = HashMap::new();
+        let mut to_remove: Vec<usize> = Vec::new();
+        let mut mode_upgrades: Vec<(usize, UnixSocketMode)> = Vec::new();
+        let mut original_updates: Vec<(usize, PathBuf)> = Vec::new();
+
+        for (i, cap) in self.unix_sockets.iter().enumerate() {
+            let key = (cap.resolved.clone(), cap.is_directory);
+            if let Some(&existing_idx) = seen.get(&key) {
+                let existing = &self.unix_sockets[existing_idx];
+
+                let new_is_user = cap.source.is_user_intent();
+                let existing_is_user = existing.source.is_user_intent();
+
+                // Only merge modes when both entries share provenance.
+                // Across tiers, the user-intent entry's literal mode wins
+                // — a user narrowing to Connect must not be silently
+                // upgraded because a group also granted ConnectBind.
+                let same_provenance = new_is_user == existing_is_user;
+                let merged_mode = if same_provenance
+                    && (existing.mode.permits_bind() || cap.mode.permits_bind())
+                {
+                    UnixSocketMode::ConnectBind
+                } else {
+                    // Keep whichever mode the retained entry had; decided
+                    // per-branch below.
+                    UnixSocketMode::Connect
+                };
+
+                let keep_new = match (new_is_user, existing_is_user) {
+                    (true, false) => true,
+                    (false, true) => false,
+                    // Same provenance: prefer the stronger-mode entry, or
+                    // the existing one when modes are equal.
+                    _ => cap.mode.permits_bind() && !existing.mode.permits_bind(),
+                };
+
+                if keep_new {
+                    to_remove.push(existing_idx);
+                    seen.insert(key, i);
+                    if cap.original == cap.resolved && existing.original != existing.resolved {
+                        original_updates.push((i, existing.original.clone()));
+                    }
+                    // Mode upgrade only applies in the same-provenance
+                    // case; otherwise cap.mode stays as-is.
+                    if same_provenance && merged_mode != cap.mode {
+                        mode_upgrades.push((i, merged_mode));
+                    }
+                } else {
+                    if existing.original == existing.resolved && cap.original != cap.resolved {
+                        original_updates.push((existing_idx, cap.original.clone()));
+                    }
+                    to_remove.push(i);
+                    if same_provenance && merged_mode != existing.mode {
+                        mode_upgrades.push((existing_idx, merged_mode));
+                    }
+                }
+            } else {
+                seen.insert(key, i);
+            }
+        }
+
+        for (idx, original) in original_updates {
+            self.unix_sockets[idx].original = original;
+        }
+        for (idx, mode) in mode_upgrades {
+            self.unix_sockets[idx].mode = mode;
+        }
+
+        to_remove.sort_unstable();
+        to_remove.reverse();
+        for idx in to_remove {
+            self.unix_sockets.remove(idx);
+        }
     }
 
     /// Check if the given path is already covered by an existing directory capability.
@@ -1439,6 +1529,19 @@ impl CapabilitySet {
                     cap.resolved.display(),
                     cap.access,
                     kind
+                ));
+            }
+        }
+
+        if !self.unix_sockets.is_empty() {
+            lines.push("Unix sockets:".to_string());
+            for cap in &self.unix_sockets {
+                let scope = if cap.is_directory { "dir" } else { "file" };
+                lines.push(format!(
+                    "  {} [{}] ({})",
+                    cap.resolved.display(),
+                    cap.mode,
+                    scope
                 ));
             }
         }
@@ -2558,7 +2661,8 @@ mod tests {
         assert!(rendered.contains("connect"));
         assert!(!rendered.starts_with("dir"));
 
-        let dir_cap = UnixSocketCapability::new_dir(dir.path(), UnixSocketMode::ConnectBind).unwrap();
+        let dir_cap =
+            UnixSocketCapability::new_dir(dir.path(), UnixSocketMode::ConnectBind).unwrap();
         let rendered = format!("{dir_cap}");
         assert!(rendered.contains("connect+bind"));
         assert!(rendered.starts_with("dir "));
@@ -2578,7 +2682,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(caps.unix_socket_capabilities().len(), 2);
-        assert_eq!(caps.unix_socket_capabilities()[0].mode, UnixSocketMode::Connect);
+        assert_eq!(
+            caps.unix_socket_capabilities()[0].mode,
+            UnixSocketMode::Connect
+        );
         assert_eq!(
             caps.unix_socket_capabilities()[1].mode,
             UnixSocketMode::ConnectBind
@@ -2603,11 +2710,7 @@ mod tests {
             .unwrap();
 
         let resolved_connect = connect_sock.canonicalize().unwrap();
-        let resolved_bind = dir
-            .path()
-            .canonicalize()
-            .unwrap()
-            .join("bind.sock");
+        let resolved_bind = dir.path().canonicalize().unwrap().join("bind.sock");
 
         // Connect-only entry: connect ok, bind denied.
         assert!(caps.unix_socket_allowed(&resolved_connect, UnixSocketOp::Connect));
@@ -2638,5 +2741,122 @@ mod tests {
         assert!(caps.unix_socket_allowed(&direct_child, UnixSocketOp::Connect));
         assert!(!caps.unix_socket_allowed(&grandchild, UnixSocketOp::Connect));
         assert!(!caps.unix_socket_allowed(&direct_child, UnixSocketOp::Bind));
+    }
+
+    #[test]
+    fn test_deduplicate_unix_sockets_merges_identical_grants() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("a.sock");
+        fs::write(&sock, b"").unwrap();
+
+        let mut caps = CapabilitySet::new()
+            .allow_unix_socket(&sock, UnixSocketMode::Connect)
+            .unwrap()
+            .allow_unix_socket(&sock, UnixSocketMode::Connect)
+            .unwrap();
+        assert_eq!(caps.unix_socket_capabilities().len(), 2);
+
+        caps.deduplicate();
+        assert_eq!(caps.unix_socket_capabilities().len(), 1);
+    }
+
+    #[test]
+    fn test_deduplicate_unix_sockets_promotes_connect_to_connect_bind() {
+        // When Connect and ConnectBind grants collide on the same resolved
+        // path, the retained entry ends up as ConnectBind (superset).
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("a.sock");
+        fs::write(&sock, b"").unwrap();
+
+        let mut caps = CapabilitySet::new()
+            .allow_unix_socket(&sock, UnixSocketMode::Connect)
+            .unwrap()
+            .allow_unix_socket(&sock, UnixSocketMode::ConnectBind)
+            .unwrap();
+
+        caps.deduplicate();
+        let socks = caps.unix_socket_capabilities();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
+    }
+
+    #[test]
+    fn test_deduplicate_unix_sockets_does_not_widen_user_intent() {
+        // Security-critical: a user explicitly narrowing a path to
+        // Connect must not be silently upgraded to ConnectBind just
+        // because a group/default also covers it.
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("a.sock");
+        fs::write(&sock, b"").unwrap();
+
+        let group_cap = UnixSocketCapability {
+            original: sock.clone(),
+            resolved: sock.canonicalize().unwrap(),
+            is_directory: false,
+            mode: UnixSocketMode::ConnectBind,
+            source: CapabilitySource::Group("example_group".to_string()),
+        };
+        let user_cap = UnixSocketCapability {
+            original: sock.clone(),
+            resolved: sock.canonicalize().unwrap(),
+            is_directory: false,
+            mode: UnixSocketMode::Connect,
+            source: CapabilitySource::User,
+        };
+
+        let mut caps = CapabilitySet::new();
+        caps.add_unix_socket(group_cap);
+        caps.add_unix_socket(user_cap);
+        caps.deduplicate();
+
+        let socks = caps.unix_socket_capabilities();
+        assert_eq!(socks.len(), 1);
+        assert_eq!(
+            socks[0].mode,
+            UnixSocketMode::Connect,
+            "user-intent Connect must not be upgraded to ConnectBind by dedup"
+        );
+        assert!(matches!(socks[0].source, CapabilitySource::User));
+    }
+
+    #[test]
+    fn test_deduplicate_unix_sockets_keeps_file_and_dir_grants_separate() {
+        // File grant on /path/foo.sock and dir grant on /path/ are
+        // different keys — both should survive.
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("a.sock");
+        fs::write(&sock, b"").unwrap();
+
+        let mut caps = CapabilitySet::new()
+            .allow_unix_socket(&sock, UnixSocketMode::Connect)
+            .unwrap()
+            .allow_unix_socket_dir(dir.path(), UnixSocketMode::Connect)
+            .unwrap();
+
+        caps.deduplicate();
+        assert_eq!(caps.unix_socket_capabilities().len(), 2);
+    }
+
+    #[test]
+    fn test_summary_includes_unix_sockets() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("a.sock");
+        fs::write(&sock, b"").unwrap();
+
+        let caps = CapabilitySet::new()
+            .allow_unix_socket(&sock, UnixSocketMode::Connect)
+            .unwrap()
+            .allow_unix_socket_dir(dir.path(), UnixSocketMode::ConnectBind)
+            .unwrap();
+
+        let summary = caps.summary();
+        assert!(
+            summary.contains("Unix sockets:"),
+            "summary must include unix socket section: {summary}"
+        );
+        assert!(summary.contains("connect"));
+        assert!(summary.contains("connect+bind"));
+        assert!(summary.contains("file"));
+        assert!(summary.contains("dir"));
     }
 }

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -173,6 +173,248 @@ impl std::fmt::Display for FsCapability {
     }
 }
 
+/// Which operations are permitted on a pathname AF_UNIX socket.
+///
+/// Mirrors [`AccessMode`] for files: `Connect` is the read-analog
+/// (client-side use of an existing socket), `ConnectBind` is the write-analog
+/// (also permits `bind(2)`, which creates the socket file — i.e. offering a
+/// service at that path). Default grants should omit bind; use `ConnectBind`
+/// only when the sandboxed program creates the socket itself (e.g. `tsx`'s
+/// self-IPC pipe in issue #685).
+///
+/// Invariant `separate-read-write` (see `proj/invariants.yaml`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum UnixSocketMode {
+    /// Allow `connect(2)` only. The socket must already exist.
+    Connect,
+    /// Allow both `connect(2)` and `bind(2)`. `bind(2)` creates the socket
+    /// file at grant time so the path need not exist yet.
+    ConnectBind,
+}
+
+impl UnixSocketMode {
+    /// True if this mode permits `bind(2)` on the granted path.
+    #[must_use]
+    pub fn permits_bind(self) -> bool {
+        matches!(self, UnixSocketMode::ConnectBind)
+    }
+}
+
+impl std::fmt::Display for UnixSocketMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UnixSocketMode::Connect => write!(f, "connect"),
+            UnixSocketMode::ConnectBind => write!(f, "connect+bind"),
+        }
+    }
+}
+
+/// Operation being queried against a [`UnixSocketCapability`].
+///
+/// Kept distinct from [`UnixSocketMode`] so the grant-side (what a
+/// capability permits) and the query-side (what the caller is about to
+/// do) are not conflated. The supervisor's seccomp-notify handler maps
+/// `SYS_CONNECT` → `Connect`, `SYS_BIND` → `Bind`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnixSocketOp {
+    /// About to call `connect(2)`.
+    Connect,
+    /// About to call `bind(2)`.
+    Bind,
+}
+
+impl std::fmt::Display for UnixSocketOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UnixSocketOp::Connect => write!(f, "connect"),
+            UnixSocketOp::Bind => write!(f, "bind"),
+        }
+    }
+}
+
+/// A capability granting AF_UNIX socket access on a filesystem path.
+///
+/// Only pathname sockets (filesystem-backed) are grantable through this
+/// type. Abstract-namespace sockets (`sun_path[0] == '\0'`) and unnamed
+/// sockets are never covered by a grant — see issue #685 for the design
+/// note. Those kinds are denied by the sandbox's `decide_network_notification`
+/// policy on Linux and have no analog on macOS.
+///
+/// Invariants:
+/// - `path-canonicalize`: canonicalised at construction. For `ConnectBind`
+///   grants where the socket itself doesn't yet exist, we canonicalise the
+///   parent directory and re-append the final component (bind creates the
+///   socket file).
+/// - `lib-policy-free`: this is a pure data type. Policy coupling (e.g.
+///   auto-granting an implied `FsCapability`) lives in `nono-cli`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnixSocketCapability {
+    /// Original path as specified by the caller, pre-canonicalisation.
+    /// Retained for diagnostic output and for macOS dual-path emission
+    /// (`/tmp/foo.sock` vs `/private/tmp/foo.sock`).
+    pub original: PathBuf,
+    /// Canonical absolute path.
+    pub resolved: PathBuf,
+    /// If `true`, the grant covers any pathname socket *directly* within
+    /// `resolved` (non-recursive: children only, not grandchildren).
+    /// If `false`, the grant is file-scoped and matches only `resolved`.
+    pub is_directory: bool,
+    /// Which socket operations are permitted.
+    pub mode: UnixSocketMode,
+    /// Where this capability originated.
+    #[serde(default)]
+    pub source: CapabilitySource,
+}
+
+impl UnixSocketCapability {
+    /// Grant for a single socket file.
+    ///
+    /// If `mode == Connect`, the path must already exist and must not be
+    /// a directory.
+    ///
+    /// If `mode == ConnectBind`, the path may not yet exist (bind creates
+    /// it). In that case the parent directory must exist; canonicalisation
+    /// resolves the parent and re-appends the final path component.
+    pub fn new_file(path: impl AsRef<Path>, mode: UnixSocketMode) -> Result<Self> {
+        let path = path.as_ref();
+
+        let resolved = match path.canonicalize() {
+            Ok(p) if p.is_dir() => {
+                return Err(NonoError::ExpectedFile(path.to_path_buf()));
+            }
+            Ok(p) => p,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // ConnectBind is allowed to grant paths that do not exist
+                // yet — bind(2) will create the socket file. Canonicalise
+                // the parent and re-append the final component so the
+                // resolved path is anchored in a real directory.
+                if !mode.permits_bind() {
+                    return Err(NonoError::PathNotFound(path.to_path_buf()));
+                }
+                let parent = path.parent().ok_or_else(|| {
+                    NonoError::PathCanonicalization {
+                        path: path.to_path_buf(),
+                        source: std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            "socket path has no parent directory",
+                        ),
+                    }
+                })?;
+                let file_name = path.file_name().ok_or_else(|| {
+                    NonoError::PathCanonicalization {
+                        path: path.to_path_buf(),
+                        source: std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            "socket path has no final component",
+                        ),
+                    }
+                })?;
+                let resolved_parent = parent.canonicalize().map_err(|parent_err| {
+                    if parent_err.kind() == std::io::ErrorKind::NotFound {
+                        NonoError::PathNotFound(parent.to_path_buf())
+                    } else {
+                        NonoError::PathCanonicalization {
+                            path: parent.to_path_buf(),
+                            source: parent_err,
+                        }
+                    }
+                })?;
+                if !resolved_parent.is_dir() {
+                    return Err(NonoError::ExpectedDirectory(parent.to_path_buf()));
+                }
+                resolved_parent.join(file_name)
+            }
+            Err(e) => {
+                return Err(NonoError::PathCanonicalization {
+                    path: path.to_path_buf(),
+                    source: e,
+                });
+            }
+        };
+
+        Ok(Self {
+            original: path.to_path_buf(),
+            resolved,
+            is_directory: false,
+            mode,
+            source: CapabilitySource::User,
+        })
+    }
+
+    /// Grant for any pathname socket directly within a directory.
+    ///
+    /// Non-recursive: a socket one level deeper (e.g. `<dir>/subdir/foo.sock`)
+    /// is not covered. The directory itself must already exist.
+    ///
+    /// Rejects the filesystem root (`/`) as defence-in-depth against
+    /// accidental grants that would cover sockets anywhere at top level
+    /// (cf. [`validate_platform_rule`]'s rejection of root-level subpath
+    /// grants for filesystem rules). Use explicit subdirectory paths.
+    pub fn new_dir(path: impl AsRef<Path>, mode: UnixSocketMode) -> Result<Self> {
+        let path = path.as_ref();
+
+        let resolved = path.canonicalize().map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                NonoError::PathNotFound(path.to_path_buf())
+            } else {
+                NonoError::PathCanonicalization {
+                    path: path.to_path_buf(),
+                    source: e,
+                }
+            }
+        })?;
+
+        if !resolved.is_dir() {
+            return Err(NonoError::ExpectedDirectory(path.to_path_buf()));
+        }
+
+        if resolved.parent().is_none() {
+            return Err(NonoError::SandboxInit(
+                "unix socket directory grant at filesystem root is not permitted"
+                    .to_string(),
+            ));
+        }
+
+        Ok(Self {
+            original: path.to_path_buf(),
+            resolved,
+            is_directory: true,
+            mode,
+            source: CapabilitySource::User,
+        })
+    }
+
+    /// True if `sockaddr_path` is covered by this grant.
+    ///
+    /// - File grants: `sockaddr_path == resolved` exactly.
+    /// - Directory grants: `sockaddr_path`'s parent equals `resolved`,
+    ///   component-wise (non-recursive). Subdirectories are not covered.
+    ///
+    /// Uses `Path` component semantics; never string prefix
+    /// (`path-component-compare` invariant).
+    #[must_use]
+    pub fn covers(&self, sockaddr_path: &Path) -> bool {
+        if self.is_directory {
+            sockaddr_path.parent() == Some(self.resolved.as_path())
+        } else {
+            sockaddr_path == self.resolved.as_path()
+        }
+    }
+}
+
+impl std::fmt::Display for UnixSocketCapability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let scope = if self.is_directory { "dir " } else { "" };
+        write!(
+            f,
+            "{}{} ({})",
+            scope,
+            self.resolved.display(),
+            self.mode
+        )
+    }
+}
+
 /// Validate a platform-specific rule for obvious security issues.
 ///
 /// Rejects rules that:
@@ -512,6 +754,9 @@ impl std::fmt::Display for NetworkMode {
 pub struct CapabilitySet {
     /// Filesystem capabilities
     fs: Vec<FsCapability>,
+    /// AF_UNIX socket capabilities (pathname grants only; see
+    /// [`UnixSocketCapability`] and issue #685).
+    unix_sockets: Vec<UnixSocketCapability>,
     /// Network access mode (default: AllowAll)
     network_mode: NetworkMode,
     /// Per-port TCP connect allowlist (Linux Landlock V4+ only).
@@ -577,6 +822,35 @@ impl CapabilitySet {
     pub fn allow_file(mut self, path: impl AsRef<Path>, mode: AccessMode) -> Result<Self> {
         let cap = FsCapability::new_file(path, mode)?;
         self.fs.push(cap);
+        Ok(self)
+    }
+
+    /// Add a file-scoped AF_UNIX socket capability (builder pattern).
+    ///
+    /// The path is canonicalized. If `mode` is [`UnixSocketMode::Connect`],
+    /// the path must exist; if `mode` is [`UnixSocketMode::ConnectBind`],
+    /// the path may not exist yet (bind creates it) but the parent must.
+    pub fn allow_unix_socket(
+        mut self,
+        path: impl AsRef<Path>,
+        mode: UnixSocketMode,
+    ) -> Result<Self> {
+        let cap = UnixSocketCapability::new_file(path, mode)?;
+        self.unix_sockets.push(cap);
+        Ok(self)
+    }
+
+    /// Add a directory-scoped AF_UNIX socket capability (builder pattern).
+    ///
+    /// Grants cover any pathname socket directly within the directory
+    /// (non-recursive). The directory must exist at grant time.
+    pub fn allow_unix_socket_dir(
+        mut self,
+        path: impl AsRef<Path>,
+        mode: UnixSocketMode,
+    ) -> Result<Self> {
+        let cap = UnixSocketCapability::new_dir(path, mode)?;
+        self.unix_sockets.push(cap);
         Ok(self)
     }
 
@@ -763,6 +1037,15 @@ impl CapabilitySet {
         self.fs.push(cap);
     }
 
+    /// Add an AF_UNIX socket capability directly.
+    ///
+    /// Mirrors [`Self::add_fs`]; used by `SandboxState::to_caps` and other
+    /// programmatic callers that already hold a constructed
+    /// [`UnixSocketCapability`].
+    pub fn add_unix_socket(&mut self, cap: UnixSocketCapability) {
+        self.unix_sockets.push(cap);
+    }
+
     /// Set network blocking state
     ///
     /// `true` sets `NetworkMode::Blocked`, `false` sets `NetworkMode::AllowAll`.
@@ -862,6 +1145,29 @@ impl CapabilitySet {
     #[must_use]
     pub fn fs_capabilities(&self) -> &[FsCapability] {
         &self.fs
+    }
+
+    /// Get AF_UNIX socket capabilities.
+    #[must_use]
+    pub fn unix_socket_capabilities(&self) -> &[UnixSocketCapability] {
+        &self.unix_sockets
+    }
+
+    /// True if any AF_UNIX socket capability covers `sockaddr_path` and
+    /// permits `op` on it.
+    ///
+    /// Used by the Linux supervisor's seccomp-notify handler:
+    /// `SYS_CONNECT` → [`UnixSocketOp::Connect`], `SYS_BIND`
+    /// → [`UnixSocketOp::Bind`].
+    #[must_use]
+    pub fn unix_socket_allowed(&self, sockaddr_path: &Path, op: UnixSocketOp) -> bool {
+        self.unix_sockets.iter().any(|cap| {
+            cap.covers(sockaddr_path)
+                && match op {
+                    UnixSocketOp::Connect => true, // any grant allows connect
+                    UnixSocketOp::Bind => cap.mode.permits_bind(),
+                }
+        })
     }
 
     /// Rewrite self-referential procfs capabilities for a specific process.
@@ -2083,5 +2389,254 @@ mod tests {
         assert_eq!(removed, 1);
         assert_eq!(caps.fs_capabilities().len(), 1);
         assert!(!caps.fs_capabilities()[0].is_file);
+    }
+
+    // --- UnixSocketCapability / UnixSocketMode tests -------------------------
+
+    #[test]
+    fn test_unix_socket_mode_permits_bind() {
+        assert!(!UnixSocketMode::Connect.permits_bind());
+        assert!(UnixSocketMode::ConnectBind.permits_bind());
+    }
+
+    #[test]
+    fn test_unix_socket_connect_requires_existing_path() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("ghost.sock");
+
+        let result = UnixSocketCapability::new_file(&missing, UnixSocketMode::Connect);
+        assert!(
+            matches!(result, Err(NonoError::PathNotFound(_))),
+            "connect grant on non-existent path must fail: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_unix_socket_connect_on_existing_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("existing.sock");
+        fs::write(&path, b"").unwrap(); // stand-in for a real socket file
+
+        let cap = UnixSocketCapability::new_file(&path, UnixSocketMode::Connect).unwrap();
+        assert_eq!(cap.mode, UnixSocketMode::Connect);
+        assert!(!cap.is_directory);
+        assert!(cap.resolved.is_absolute());
+    }
+
+    #[test]
+    fn test_unix_socket_connect_bind_allows_nonexistent_path() {
+        // The #685 use case: tsx grants `/tmp/tsx-1000/<pid>.pipe` before
+        // the process has even started. Path doesn't exist yet; parent does.
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("pending.sock");
+
+        let cap = UnixSocketCapability::new_file(&missing, UnixSocketMode::ConnectBind).unwrap();
+        assert_eq!(cap.mode, UnixSocketMode::ConnectBind);
+        assert!(!cap.is_directory);
+        // Resolved path is canonical-parent + final component
+        assert_eq!(cap.resolved.file_name().unwrap(), "pending.sock");
+        assert!(cap.resolved.parent().unwrap().is_absolute());
+    }
+
+    #[test]
+    fn test_unix_socket_connect_bind_fails_when_parent_missing() {
+        let result = UnixSocketCapability::new_file(
+            "/definitely/does/not/exist/12345/x.sock",
+            UnixSocketMode::ConnectBind,
+        );
+        assert!(
+            matches!(result, Err(NonoError::PathNotFound(_))),
+            "bind grant must fail when parent is missing: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_unix_socket_file_rejects_directory_path() {
+        let dir = tempdir().unwrap();
+
+        let result = UnixSocketCapability::new_file(dir.path(), UnixSocketMode::Connect);
+        assert!(
+            matches!(result, Err(NonoError::ExpectedFile(_))),
+            "new_file must reject a directory path: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_unix_socket_dir_on_existing_directory() {
+        let dir = tempdir().unwrap();
+
+        let cap = UnixSocketCapability::new_dir(dir.path(), UnixSocketMode::Connect).unwrap();
+        assert!(cap.is_directory);
+        assert!(cap.resolved.is_absolute());
+    }
+
+    #[test]
+    fn test_unix_socket_dir_rejects_file_path() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("regular.txt");
+        fs::write(&file, "not a dir").unwrap();
+
+        let result = UnixSocketCapability::new_dir(&file, UnixSocketMode::Connect);
+        assert!(
+            matches!(result, Err(NonoError::ExpectedDirectory(_))),
+            "new_dir must reject a file path: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_unix_socket_dir_nonexistent() {
+        let result = UnixSocketCapability::new_dir(
+            "/nonexistent/dir/for/tests/99999",
+            UnixSocketMode::Connect,
+        );
+        assert!(matches!(result, Err(NonoError::PathNotFound(_))));
+    }
+
+    #[test]
+    fn test_unix_socket_dir_rejects_filesystem_root() {
+        let result = UnixSocketCapability::new_dir("/", UnixSocketMode::Connect);
+        assert!(
+            matches!(result, Err(NonoError::SandboxInit(_))),
+            "filesystem root must be rejected as a directory grant: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_unix_socket_covers_file_exact_match() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("a.sock");
+        fs::write(&path, b"").unwrap();
+        let cap = UnixSocketCapability::new_file(&path, UnixSocketMode::Connect).unwrap();
+
+        // Exact match covers; anything else does not.
+        assert!(cap.covers(&cap.resolved));
+        assert!(!cap.covers(&dir.path().canonicalize().unwrap()));
+        let sibling = dir.path().canonicalize().unwrap().join("b.sock");
+        assert!(!cap.covers(&sibling));
+    }
+
+    #[test]
+    fn test_unix_socket_covers_directory_one_level() {
+        let dir = tempdir().unwrap();
+        let cap = UnixSocketCapability::new_dir(dir.path(), UnixSocketMode::Connect).unwrap();
+
+        // Direct child is covered.
+        let child = cap.resolved.join("x.sock");
+        assert!(cap.covers(&child), "direct child should be covered");
+
+        // Grandchild is NOT (non-recursive).
+        let grandchild = cap.resolved.join("sub").join("x.sock");
+        assert!(!cap.covers(&grandchild), "grandchild must not be covered");
+
+        // The directory itself, with no filename component, isn't a socket.
+        assert!(!cap.covers(&cap.resolved));
+    }
+
+    #[test]
+    fn test_unix_socket_covers_does_not_string_prefix() {
+        // Regression: a directory grant for /tmp/foo must NOT cover
+        // /tmp/foobar/x.sock, which a naive string starts_with would match.
+        let dir = tempdir().unwrap();
+        let foo = dir.path().join("foo");
+        let foobar = dir.path().join("foobar");
+        fs::create_dir(&foo).unwrap();
+        fs::create_dir(&foobar).unwrap();
+
+        let cap = UnixSocketCapability::new_dir(&foo, UnixSocketMode::Connect).unwrap();
+        let evil = foobar.canonicalize().unwrap().join("x.sock");
+        assert!(!cap.covers(&evil), "string-prefix match must not leak");
+    }
+
+    #[test]
+    fn test_unix_socket_display() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("a.sock");
+        fs::write(&path, b"").unwrap();
+
+        let file_cap = UnixSocketCapability::new_file(&path, UnixSocketMode::Connect).unwrap();
+        let rendered = format!("{file_cap}");
+        assert!(rendered.contains("connect"));
+        assert!(!rendered.starts_with("dir"));
+
+        let dir_cap = UnixSocketCapability::new_dir(dir.path(), UnixSocketMode::ConnectBind).unwrap();
+        let rendered = format!("{dir_cap}");
+        assert!(rendered.contains("connect+bind"));
+        assert!(rendered.starts_with("dir "));
+    }
+
+    #[test]
+    fn test_capability_set_allow_unix_socket_accumulates() {
+        let dir = tempdir().unwrap();
+        let a = dir.path().join("a.sock");
+        let b = dir.path().join("b.sock");
+        fs::write(&a, b"").unwrap();
+
+        let caps = CapabilitySet::new()
+            .allow_unix_socket(&a, UnixSocketMode::Connect)
+            .unwrap()
+            .allow_unix_socket(&b, UnixSocketMode::ConnectBind)
+            .unwrap();
+
+        assert_eq!(caps.unix_socket_capabilities().len(), 2);
+        assert_eq!(caps.unix_socket_capabilities()[0].mode, UnixSocketMode::Connect);
+        assert_eq!(
+            caps.unix_socket_capabilities()[1].mode,
+            UnixSocketMode::ConnectBind
+        );
+    }
+
+    #[test]
+    fn test_capability_set_unix_socket_allowed_mode_split() {
+        // Invariant `separate-read-write`: Connect entries must not
+        // accidentally permit bind.
+        let dir = tempdir().unwrap();
+        let connect_sock = dir.path().join("connect-only.sock");
+        let bind_sock = dir.path().join("bind.sock");
+        fs::write(&connect_sock, b"").unwrap();
+        // bind_sock deliberately does not exist — allow_unix_socket with
+        // ConnectBind must accept that.
+
+        let caps = CapabilitySet::new()
+            .allow_unix_socket(&connect_sock, UnixSocketMode::Connect)
+            .unwrap()
+            .allow_unix_socket(&bind_sock, UnixSocketMode::ConnectBind)
+            .unwrap();
+
+        let resolved_connect = connect_sock.canonicalize().unwrap();
+        let resolved_bind = dir
+            .path()
+            .canonicalize()
+            .unwrap()
+            .join("bind.sock");
+
+        // Connect-only entry: connect ok, bind denied.
+        assert!(caps.unix_socket_allowed(&resolved_connect, UnixSocketOp::Connect));
+        assert!(!caps.unix_socket_allowed(&resolved_connect, UnixSocketOp::Bind));
+
+        // ConnectBind entry: both ok.
+        assert!(caps.unix_socket_allowed(&resolved_bind, UnixSocketOp::Connect));
+        assert!(caps.unix_socket_allowed(&resolved_bind, UnixSocketOp::Bind));
+
+        // Unrelated path: nothing allowed.
+        let other = dir.path().canonicalize().unwrap().join("other.sock");
+        assert!(!caps.unix_socket_allowed(&other, UnixSocketOp::Connect));
+        assert!(!caps.unix_socket_allowed(&other, UnixSocketOp::Bind));
+    }
+
+    #[test]
+    fn test_capability_set_unix_socket_allowed_directory_grant() {
+        let dir = tempdir().unwrap();
+
+        let caps = CapabilitySet::new()
+            .allow_unix_socket_dir(dir.path(), UnixSocketMode::Connect)
+            .unwrap();
+
+        let resolved_dir = dir.path().canonicalize().unwrap();
+        let direct_child = resolved_dir.join("x.sock");
+        let grandchild = resolved_dir.join("sub").join("x.sock");
+
+        assert!(caps.unix_socket_allowed(&direct_child, UnixSocketOp::Connect));
+        assert!(!caps.unix_socket_allowed(&grandchild, UnixSocketOp::Connect));
+        assert!(!caps.unix_socket_allowed(&direct_child, UnixSocketOp::Bind));
     }
 }

--- a/crates/nono/src/lib.rs
+++ b/crates/nono/src/lib.rs
@@ -62,7 +62,7 @@ pub mod undo;
 // Re-exports for convenience
 pub use capability::{
     AccessMode, CapabilitySet, CapabilitySource, FsCapability, IpcMode, NetworkMode,
-    ProcessInfoMode, SignalMode,
+    ProcessInfoMode, SignalMode, UnixSocketCapability, UnixSocketMode, UnixSocketOp,
 };
 pub use diagnostic::{
     CommandContext, DenialReason, DenialRecord, DiagnosticFormatter, DiagnosticMode,

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -2776,8 +2776,7 @@ mod tests {
         // emitted ERRNO, which skipped the supervisor entirely.
         assert_eq!(filter[17].code, BPF_RET | BPF_K);
         assert_eq!(
-            filter[17].k,
-            SECCOMP_RET_USER_NOTIF,
+            filter[17].k, SECCOMP_RET_USER_NOTIF,
             "bind must route to USER_NOTIF regardless of has_bind_ports so \
              the supervisor can permit AF_UNIX pathname bind (#685)"
         );
@@ -3072,10 +3071,7 @@ mod tests {
 
         // Unique per-test socket path under /tmp so parallel tests don't
         // collide.
-        let sock_path = format!(
-            "/tmp/nono-integ-af-unix-bind-{}.sock",
-            std::process::id()
-        );
+        let sock_path = format!("/tmp/nono-integ-af-unix-bind-{}.sock", std::process::id());
         let _ = std::fs::remove_file(&sock_path);
 
         let mut report_pipe = [0i32; 2];
@@ -3096,11 +3092,7 @@ mod tests {
                     // Seccomp unavailable — skip via sentinel.
                     let sentinel: [u8; 2] = [2, 2];
                     unsafe {
-                        libc::write(
-                            report_pipe[1],
-                            sentinel.as_ptr().cast(),
-                            sentinel.len(),
-                        );
+                        libc::write(report_pipe[1], sentinel.as_ptr().cast(), sentinel.len());
                         libc::close(report_pipe[1]);
                         libc::_exit(0);
                     }
@@ -3153,13 +3145,8 @@ mod tests {
             }
             let addrlen = (std::mem::size_of::<u16>() + bytes.len() + 1) as libc::socklen_t;
 
-            let rc = unsafe {
-                libc::bind(
-                    sock,
-                    (&addr as *const libc::sockaddr_un).cast(),
-                    addrlen,
-                )
-            };
+            let rc =
+                unsafe { libc::bind(sock, (&addr as *const libc::sockaddr_un).cast(), addrlen) };
             let errno = if rc < 0 {
                 std::io::Error::last_os_error().raw_os_error().unwrap_or(-1)
             } else {

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -1522,6 +1522,49 @@ pub fn deny_notif(notify_fd: std::os::fd::RawFd, notif_id: u64) -> Result<()> {
 // port on localhost, blocking all other network activity.
 // ==========================================================================
 
+/// Kind of AF_UNIX socket, determined from `sun_path` and `addrlen`.
+///
+/// See `unix(7)`. This distinction matters for policy because only
+/// [`UnixSocketKind::Pathname`] sockets are governed by filesystem rules.
+/// Abstract and unnamed sockets live in a separate namespace that Landlock's
+/// filesystem rules cannot reach, so the supervisor must decide them
+/// explicitly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnixSocketKind {
+    /// Filesystem-backed: `sun_path` is a null-terminated filesystem path
+    /// (e.g. `/tmp/test.sock`). Access is governed by filesystem permissions
+    /// and — in our case — by Landlock's filesystem rules.
+    Pathname,
+    /// Linux abstract namespace: `sun_path[0] == '\0'` and bytes `[1..]` form
+    /// the abstract name. Not backed by any filesystem, so Landlock's
+    /// filesystem rules do not apply.
+    Abstract,
+    /// Unnamed socket: `addrlen` is `offsetof(sockaddr_un, sun_path)` (i.e.
+    /// 2 — `sa_family` only). Produced by `socketpair(2)` and autobinding
+    /// `bind(fd, NULL, 2)`.
+    Unnamed,
+}
+
+/// Classify an AF_UNIX sockaddr buffer.
+///
+/// `sun_path_first_byte` should be `buf[2]` for `addrlen >= 3`, or `None` if
+/// the sockaddr is only 2 bytes (unnamed). Pure function so it is unit-tested
+/// without the `/proc/PID/mem` plumbing.
+#[must_use]
+pub fn classify_af_unix(addrlen: u64, sun_path_first_byte: Option<u8>) -> UnixSocketKind {
+    // offsetof(sockaddr_un, sun_path) == 2 on Linux.
+    if addrlen <= 2 {
+        return UnixSocketKind::Unnamed;
+    }
+    match sun_path_first_byte {
+        Some(0) => UnixSocketKind::Abstract,
+        Some(_) => UnixSocketKind::Pathname,
+        // addrlen > 2 but we couldn't read sun_path[0] — treat as unnamed
+        // (fail-closed: callers that deny non-pathname will deny this too).
+        None => UnixSocketKind::Unnamed,
+    }
+}
+
 /// Parsed sockaddr from a seccomp notification.
 ///
 /// Extracted from `/proc/PID/mem` at the pointer in the connect/bind args.
@@ -1533,6 +1576,9 @@ pub struct SockaddrInfo {
     pub port: u16,
     /// Whether the address is a loopback address (127.0.0.1 or ::1)
     pub is_loopback: bool,
+    /// For `AF_UNIX`: kind of socket (pathname / abstract / unnamed). `None`
+    /// for non-UNIX address families.
+    pub unix_kind: Option<UnixSocketKind>,
 }
 
 /// Seccomp network fallback mode determined during sandbox apply.
@@ -1585,22 +1631,31 @@ pub fn seccomp_network_fallback_mode(caps: &CapabilitySet) -> SeccompNetFallback
 
 /// Build a BPF filter for proxy-only network mode.
 ///
-/// Routes connect() to `SECCOMP_RET_USER_NOTIF` so the supervisor can
-/// inspect the sockaddr and allow only localhost:proxy_port.
+/// Routes `connect()` and `bind()` to `SECCOMP_RET_USER_NOTIF` so the
+/// supervisor can inspect the sockaddr and make a per-family decision:
 ///
-/// When `has_bind_ports` is true, bind() is also routed to `USER_NOTIF`.
-/// Otherwise, bind() is denied with EACCES.
+/// - `AF_INET`/`AF_INET6`: allow connect to `localhost:proxy_port`;
+///   allow bind on ports in the configured bind-ports list; deny others.
+/// - pathname `AF_UNIX` (#685): allow both connect and bind. Landlock's
+///   filesystem rules are the upstream gate on which paths are reachable.
+/// - abstract/unnamed `AF_UNIX`: deny (see `decide_network_notification`).
 ///
-/// socket() is allowed only for AF_UNIX, AF_INET, AF_INET6.
-/// socketpair() is allowed only for AF_UNIX.
-/// io_uring_setup() is denied.
+/// `has_bind_ports` is retained for API compatibility but no longer
+/// influences filter routing — a previous version routed bind directly to
+/// ERRNO when no TCP bind ports were configured, which unconditionally
+/// failed AF_UNIX bind (regression on Landlock V2 kernels where this
+/// fallback fires). The supervisor is the sole arbiter now.
+///
+/// `socket()` is allowed only for `AF_UNIX`, `AF_INET`, `AF_INET6`.
+/// `socketpair()` is allowed only for `AF_UNIX`.
+/// `io_uring_setup()` is denied.
 ///
 /// Instruction layout (19 instructions, jt = jump offset from next insn):
 /// ```text
 ///  0: ld  [nr]
 ///  1: jeq SYS_SOCKET     jt=+6  (-> 8: load socket family)
 ///  2: jeq SYS_CONNECT    jt=+13 (-> 16: notify)
-///  3: jeq SYS_BIND       jt=+13 (-> 17: bind_action)
+///  3: jeq SYS_BIND       jt=+13 (-> 17: notify)
 ///  4: jeq SYS_SOCKETPAIR jt=+8  (-> 13: load socketpair family)
 ///  5: jeq SYS_IO_URING   jt=+1  (-> 7: errno)
 ///  6: ret ALLOW
@@ -1614,17 +1669,22 @@ pub fn seccomp_network_fallback_mode(caps: &CapabilitySet) -> SeccompNetFallback
 /// 14: jeq AF_UNIX  jt=+3 (-> 18: allow)
 /// 15: ret ERRNO(EACCES)         ; bad socketpair family
 /// 16: ret USER_NOTIF            ; connect
-/// 17: ret bind_action           ; bind (USER_NOTIF or ERRNO)
+/// 17: ret USER_NOTIF            ; bind
 /// 18: ret ALLOW                 ; allowed socket/socketpair
 /// ```
-fn build_seccomp_proxy_filter(has_bind_ports: bool) -> Vec<SockFilterInsn> {
+fn build_seccomp_proxy_filter(_has_bind_ports: bool) -> Vec<SockFilterInsn> {
     let errno_ret = SECCOMP_RET_ERRNO | (libc::EACCES as u32);
 
-    let bind_action = if has_bind_ports {
-        SECCOMP_RET_USER_NOTIF
-    } else {
-        errno_ret
-    };
+    // bind() always routes to USER_NOTIF so the supervisor can make the
+    // per-family decision (deny AF_INET to non-allowed TCP ports; allow
+    // pathname AF_UNIX per issue #685). The previous variant took a
+    // has_bind_ports short-circuit to ERRNO when no TCP bind ports were
+    // configured, which unconditionally failed AF_UNIX bind — a real
+    // regression that only manifested on Landlock V2 kernels (where this
+    // seccomp fallback fires). The has_bind_ports parameter is retained
+    // for API compatibility but no longer gates filter routing; the
+    // supervisor's `decide_network_notification` is the sole arbiter.
+    let bind_action = SECCOMP_RET_USER_NOTIF;
 
     // Target instruction index table (jt/jf are offsets from next insn):
     //  0: ld [nr]
@@ -1932,6 +1992,7 @@ pub fn read_notif_sockaddr(pid: u32, addr_ptr: u64, addrlen: u64) -> Result<Sock
                 family,
                 port,
                 is_loopback,
+                unix_kind: None,
             })
         }
         libc::AF_INET6 => {
@@ -1955,17 +2016,25 @@ pub fn read_notif_sockaddr(pid: u32, addr_ptr: u64, addrlen: u64) -> Result<Sock
                 family,
                 port,
                 is_loopback: is_loopback || is_v4_mapped_loopback,
+                unix_kind: None,
             })
         }
-        libc::AF_UNIX => Ok(SockaddrInfo {
-            family,
-            port: 0,
-            is_loopback: true, // Unix sockets are always local
-        }),
+        libc::AF_UNIX => {
+            // sun_path starts at offset 2. buf has `n` bytes total; we need
+            // addrlen to distinguish unnamed from path-bearing sockets.
+            let sun_path_first_byte = if n >= 3 { Some(buf[2]) } else { None };
+            Ok(SockaddrInfo {
+                family,
+                port: 0,
+                is_loopback: true, // Unix sockets are always local
+                unix_kind: Some(classify_af_unix(addrlen, sun_path_first_byte)),
+            })
+        }
         _ => Ok(SockaddrInfo {
             family,
             port: 0,
             is_loopback: false,
+            unix_kind: None,
         }),
     }
 }
@@ -2687,20 +2756,31 @@ mod tests {
         assert_eq!(filter[16].code, BPF_RET | BPF_K);
         assert_eq!(filter[16].k, SECCOMP_RET_USER_NOTIF);
 
-        // Instruction 17 should be USER_NOTIF (bind with has_bind_ports=true)
+        // Instruction 17 should be USER_NOTIF (bind; supervisor decides).
         assert_eq!(filter[17].code, BPF_RET | BPF_K);
         assert_eq!(filter[17].k, SECCOMP_RET_USER_NOTIF);
     }
 
+    /// Regression test for the Landlock V2 + `has_bind_ports=false`
+    /// scenario (issue #685): even with no TCP bind ports configured,
+    /// bind() must route to USER_NOTIF so the supervisor can allow
+    /// pathname AF_UNIX bind. Previously the filter short-circuited to
+    /// ERRNO in this branch, unconditionally failing AF_UNIX bind.
     #[test]
     fn test_build_seccomp_proxy_filter_without_bind() {
         let filter = build_seccomp_proxy_filter(false);
         assert_eq!(filter.len(), 19);
 
-        // Instruction 17 should be ERRNO (bind with has_bind_ports=false)
+        // Instruction 17 (bind) must ALSO route to USER_NOTIF — the
+        // supervisor is the sole gate. This is the fix: previously this
+        // emitted ERRNO, which skipped the supervisor entirely.
         assert_eq!(filter[17].code, BPF_RET | BPF_K);
-        let errno_ret = SECCOMP_RET_ERRNO | (libc::EACCES as u32);
-        assert_eq!(filter[17].k, errno_ret);
+        assert_eq!(
+            filter[17].k,
+            SECCOMP_RET_USER_NOTIF,
+            "bind must route to USER_NOTIF regardless of has_bind_ports so \
+             the supervisor can permit AF_UNIX pathname bind (#685)"
+        );
     }
 
     #[test]
@@ -2709,6 +2789,7 @@ mod tests {
             family: libc::AF_INET as u16,
             port: 8080,
             is_loopback: true,
+            unix_kind: None,
         };
         assert!(info.is_loopback);
         assert_eq!(info.port, 8080);
@@ -2720,6 +2801,7 @@ mod tests {
             family: libc::AF_INET6 as u16,
             port: 443,
             is_loopback: true,
+            unix_kind: None,
         };
         assert!(info.is_loopback);
     }
@@ -2730,6 +2812,7 @@ mod tests {
             family: libc::AF_INET as u16,
             port: 80,
             is_loopback: false,
+            unix_kind: None,
         };
         assert!(!info.is_loopback);
     }
@@ -2740,9 +2823,53 @@ mod tests {
             family: libc::AF_UNIX as u16,
             port: 0,
             is_loopback: true,
+            unix_kind: Some(UnixSocketKind::Pathname),
         };
         assert!(info.is_loopback);
         assert_eq!(info.port, 0);
+    }
+
+    // --- classify_af_unix tests (issue #685) --------------------------------
+
+    #[test]
+    fn test_classify_af_unix_pathname() {
+        // `/tmp/test.sock` — first byte is '/'
+        assert_eq!(
+            classify_af_unix(14, Some(b'/')),
+            UnixSocketKind::Pathname,
+            "non-null first byte => pathname"
+        );
+    }
+
+    #[test]
+    fn test_classify_af_unix_abstract() {
+        // \0foo — first byte is null (Linux abstract namespace)
+        assert_eq!(
+            classify_af_unix(6, Some(0)),
+            UnixSocketKind::Abstract,
+            "null first byte => abstract namespace"
+        );
+    }
+
+    #[test]
+    fn test_classify_af_unix_unnamed() {
+        // addrlen == 2: only sa_family, no sun_path
+        assert_eq!(
+            classify_af_unix(2, None),
+            UnixSocketKind::Unnamed,
+            "addrlen <= 2 => unnamed"
+        );
+    }
+
+    #[test]
+    fn test_classify_af_unix_fails_closed_on_short_read() {
+        // Defensive: if we couldn't read sun_path[0] despite addrlen > 2
+        // (unexpected), treat as unnamed so policy fails closed.
+        assert_eq!(
+            classify_af_unix(10, None),
+            UnixSocketKind::Unnamed,
+            "missing sun_path byte => fail-closed to unnamed"
+        );
     }
 
     /// Integration test: seccomp proxy filter blocks connect to non-proxy ports
@@ -2929,6 +3056,157 @@ mod tests {
         );
     }
 
+    /// End-to-end regression test for issue #685: a pathname `AF_UNIX`
+    /// `bind(2)` must succeed under the proxy-only seccomp filter even
+    /// when `has_bind_ports=false`. Previously the filter short-circuited
+    /// bind() to `EACCES` in that configuration, unconditionally failing
+    /// AF_UNIX bind regardless of what the supervisor would have decided.
+    ///
+    /// Structure mirrors `test_seccomp_proxy_filter_allows_proxy_port_blocks_others`:
+    /// fork, install filter in the child, run a minimal supervisor-mimic
+    /// handler in a child thread, try the bind, report result over a pipe.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_seccomp_proxy_filter_allows_af_unix_bind_without_bind_ports() {
+        use std::io::Read;
+
+        // Unique per-test socket path under /tmp so parallel tests don't
+        // collide.
+        let sock_path = format!(
+            "/tmp/nono-integ-af-unix-bind-{}.sock",
+            std::process::id()
+        );
+        let _ = std::fs::remove_file(&sock_path);
+
+        let mut report_pipe = [0i32; 2];
+        assert_eq!(unsafe { libc::pipe(report_pipe.as_mut_ptr()) }, 0, "pipe()");
+
+        let pid = unsafe { libc::fork() };
+        assert!(pid >= 0, "fork() failed");
+
+        if pid == 0 {
+            // CHILD
+            unsafe { libc::close(report_pipe[0]) };
+
+            // Install filter with `has_bind_ports=false` — this is the
+            // exact configuration the #685 bug manifested under.
+            let notify_fd = match install_seccomp_proxy_filter(false) {
+                Ok(fd) => fd,
+                Err(_) => {
+                    // Seccomp unavailable — skip via sentinel.
+                    let sentinel: [u8; 2] = [2, 2];
+                    unsafe {
+                        libc::write(
+                            report_pipe[1],
+                            sentinel.as_ptr().cast(),
+                            sentinel.len(),
+                        );
+                        libc::close(report_pipe[1]);
+                        libc::_exit(0);
+                    }
+                }
+            };
+
+            let notify_raw = {
+                use std::os::fd::AsRawFd;
+                notify_fd.as_raw_fd()
+            };
+
+            // Minimal supervisor mimic: for each bind notification, allow
+            // pathname AF_UNIX, deny everything else. Matches the policy
+            // baked into `decide_network_notification` at PR A commit 1.
+            let handler = std::thread::spawn(move || {
+                for _ in 0..1 {
+                    let notif = match recv_notif(notify_raw) {
+                        Ok(n) => n,
+                        Err(_) => break,
+                    };
+                    let info = match read_notif_sockaddr(
+                        notif.pid,
+                        notif.data.args[1],
+                        notif.data.args[2],
+                    ) {
+                        Ok(i) => i,
+                        Err(_) => {
+                            let _ = deny_notif(notify_raw, notif.id);
+                            continue;
+                        }
+                    };
+                    let is_pathname_unix = info.family == libc::AF_UNIX as u16
+                        && matches!(info.unix_kind, Some(UnixSocketKind::Pathname));
+                    if is_pathname_unix {
+                        let _ = continue_notif(notify_raw, notif.id);
+                    } else {
+                        let _ = respond_notif_errno(notify_raw, notif.id, libc::EACCES);
+                    }
+                }
+            });
+
+            // Attempt bind(AF_UNIX) at the pathname socket.
+            let sock = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_STREAM, 0) };
+            let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+            addr.sun_family = libc::AF_UNIX as u16;
+            let bytes = sock_path.as_bytes();
+            assert!(bytes.len() < addr.sun_path.len(), "test path too long");
+            for (i, &b) in bytes.iter().enumerate() {
+                addr.sun_path[i] = b as libc::c_char;
+            }
+            let addrlen = (std::mem::size_of::<u16>() + bytes.len() + 1) as libc::socklen_t;
+
+            let rc = unsafe {
+                libc::bind(
+                    sock,
+                    (&addr as *const libc::sockaddr_un).cast(),
+                    addrlen,
+                )
+            };
+            let errno = if rc < 0 {
+                std::io::Error::last_os_error().raw_os_error().unwrap_or(-1)
+            } else {
+                0
+            };
+            unsafe { libc::close(sock) };
+
+            let _ = handler.join();
+            // Clean up the socket file the child just created.
+            let _ = std::fs::remove_file(&sock_path);
+
+            let payload: [u8; 2] = [
+                if rc < 0 { 1 } else { 0 },
+                errno.unsigned_abs().min(255) as u8,
+            ];
+            unsafe {
+                libc::write(report_pipe[1], payload.as_ptr().cast(), payload.len());
+                libc::close(report_pipe[1]);
+                libc::_exit(0);
+            }
+        }
+
+        // PARENT
+        unsafe { libc::close(report_pipe[1]) };
+
+        // Wait for child.
+        let mut status: libc::c_int = 0;
+        unsafe { libc::waitpid(pid, &mut status, 0) };
+
+        use std::os::fd::FromRawFd;
+        let mut pipe_read = unsafe { std::fs::File::from_raw_fd(report_pipe[0]) };
+        let mut buf = [0u8; 2];
+        let n = pipe_read.read(&mut buf).expect("read from pipe");
+
+        if n == 2 && buf[0] == 2 && buf[1] == 2 {
+            // Skip sentinel: seccomp not available.
+            return;
+        }
+        assert_eq!(n, 2, "expected 2 bytes from child, got {n}");
+        assert_eq!(
+            buf[0], 0,
+            "AF_UNIX bind must succeed under proxy filter with \
+             has_bind_ports=false (errno={})",
+            buf[1]
+        );
+    }
+
     /// Integration test: ProxyOnly + Landlock V4+ does NOT install seccomp
     /// proxy filter (Landlock handles networking natively).
     ///
@@ -3022,11 +3300,14 @@ mod tests {
         );
     }
 
-    /// Integration test: seccomp proxy filter blocks bind() when no bind_ports.
-    ///
-    /// Forks a child that installs the proxy filter with has_bind_ports=false,
-    /// then attempts to bind a socket. The bind should fail with EACCES directly
-    /// from the BPF filter (no notification, no handler needed).
+    /// Integration test: under the proxy filter with `has_bind_ports=false`,
+    /// an `AF_INET` `bind(2)` must still be denied — but now the denial
+    /// comes from the supervisor (via `USER_NOTIF`), not from the BPF
+    /// filter directly. Issue #685 required the filter to route bind to
+    /// USER_NOTIF regardless of `has_bind_ports` so pathname `AF_UNIX`
+    /// bind can be allowed (see `test_seccomp_proxy_filter_allows_af_unix_bind_without_bind_ports`);
+    /// this test pins the complementary invariant that `AF_INET` bind is
+    /// still rejected when the supervisor's policy says so.
     #[cfg(target_os = "linux")]
     #[test]
     fn test_seccomp_proxy_filter_blocks_bind_without_bind_ports() {
@@ -3040,40 +3321,13 @@ mod tests {
         if pid == 0 {
             unsafe { libc::close(report_pipe[0]) };
 
-            // Install proxy filter with bind disabled (returns ERRNO, not USER_NOTIF)
-            // No notification handler needed — BPF returns EACCES directly.
-            match install_seccomp_proxy_filter(false) {
-                Ok(_notify_fd) => {
-                    // Attempt bind on an ephemeral port
-                    let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
-
-                    let mut addr: libc::sockaddr_in = unsafe { std::mem::zeroed() };
-                    addr.sin_family = libc::AF_INET as u16;
-                    addr.sin_port = 0; // ephemeral
-                    addr.sin_addr.s_addr = u32::from_be_bytes([127, 0, 0, 1]).to_be();
-
-                    let bind_result = unsafe {
-                        libc::bind(
-                            sock,
-                            (&addr as *const libc::sockaddr_in).cast(),
-                            std::mem::size_of::<libc::sockaddr_in>() as u32,
-                        )
-                    };
-                    let errno = if bind_result < 0 {
-                        std::io::Error::last_os_error().raw_os_error().unwrap_or(-1) as u8
-                    } else {
-                        0
-                    };
-
-                    unsafe {
-                        libc::close(sock);
-                        libc::write(report_pipe[1], &errno as *const u8 as _, 1);
-                        libc::close(report_pipe[1]);
-                        libc::_exit(0);
-                    }
-                }
+            // Install proxy filter with has_bind_ports=false. As of the
+            // #685 fix, bind() now routes to USER_NOTIF — so a handler
+            // IS required even for the "block all bind" policy.
+            let notify_fd = match install_seccomp_proxy_filter(false) {
+                Ok(fd) => fd,
                 Err(_) => {
-                    // Seccomp not available — skip
+                    // Seccomp not available — skip.
                     let skip: u8 = 255;
                     unsafe {
                         libc::write(report_pipe[1], &skip as *const u8 as _, 1);
@@ -3081,6 +3335,50 @@ mod tests {
                         libc::_exit(0);
                     }
                 }
+            };
+            let notify_raw = {
+                use std::os::fd::AsRawFd;
+                notify_fd.as_raw_fd()
+            };
+
+            // Supervisor mimic: deny every bind notification with EACCES.
+            // Models the "no bind ports configured → deny AF_INET bind"
+            // policy that `decide_network_notification` implements in
+            // the real supervisor when `config.proxy_bind_ports` is empty.
+            let handler = std::thread::spawn(move || {
+                for _ in 0..1 {
+                    let notif = match recv_notif(notify_raw) {
+                        Ok(n) => n,
+                        Err(_) => break,
+                    };
+                    let _ = respond_notif_errno(notify_raw, notif.id, libc::EACCES);
+                }
+            });
+
+            let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
+            let mut addr: libc::sockaddr_in = unsafe { std::mem::zeroed() };
+            addr.sin_family = libc::AF_INET as u16;
+            addr.sin_port = 0;
+            addr.sin_addr.s_addr = u32::from_be_bytes([127, 0, 0, 1]).to_be();
+            let bind_result = unsafe {
+                libc::bind(
+                    sock,
+                    (&addr as *const libc::sockaddr_in).cast(),
+                    std::mem::size_of::<libc::sockaddr_in>() as u32,
+                )
+            };
+            let errno = if bind_result < 0 {
+                std::io::Error::last_os_error().raw_os_error().unwrap_or(-1) as u8
+            } else {
+                0
+            };
+            unsafe { libc::close(sock) };
+            let _ = handler.join();
+
+            unsafe {
+                libc::write(report_pipe[1], &errno as *const u8 as _, 1);
+                libc::close(report_pipe[1]);
+                libc::_exit(0);
             }
         }
 
@@ -3106,7 +3404,8 @@ mod tests {
         assert_eq!(
             buf[0],
             libc::EACCES as u8,
-            "bind() should fail with EACCES when has_bind_ports=false, got errno={}",
+            "AF_INET bind() must still receive EACCES (from supervisor, not filter) \
+             when has_bind_ports=false, got errno={}",
             buf[0]
         );
     }

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -306,6 +306,145 @@ fn escape_path(path: &str) -> Result<String> {
     Ok(result)
 }
 
+/// Escape a filesystem path for use inside a Seatbelt `regex` clause.
+///
+/// Used for non-recursive directory socket grants: a directory `/d` is
+/// emitted as `(regex "^<escaped>/[^/]+$")` so only direct-child sockets
+/// are matched.
+///
+/// Escaping strategy, by character:
+///
+/// | Char | Rendered Scheme source | Regex engine sees | Matches |
+/// |------|------------------------|-------------------|---------|
+/// | `.`, `+`, `*`, `?`, `(`, `)`, `{`, `}`, `|`, `^`, `$` | `[.]` etc. | char class | literal `.` etc. |
+/// | `[`  | `\\[`  | `\[`  | literal `[` |
+/// | `]`  | `\\]`  | `\]`  | literal `]` |
+/// | `\`  | `\\\\` | `\\`  | literal `\` |
+/// | `"`  | `\"`   | `"`   | literal `"` |
+/// | other | verbatim | verbatim | as written |
+///
+/// The character-class form (`[.]`) is unambiguous across both raw and
+/// cooked Scheme string readers (the §13 spike verified this for `.`).
+/// For the three chars that can't appear literally inside `[ ]` (`[`,
+/// `]`, `\`), we fall back to Scheme-level backslash escaping: the
+/// Scheme reader collapses `\\` → `\`, and the regex engine then
+/// interprets `\<char>` as a literal. Backslash itself needs a second
+/// layer of escaping (`\\\\` → `\\` → literal `\`).
+///
+/// Control characters are rejected outright, matching `escape_path`'s
+/// policy.
+fn regex_escape_path_for_seatbelt(path: &str) -> Result<String> {
+    for c in path.chars() {
+        if c.is_control() {
+            return Err(NonoError::SandboxInit(format!(
+                "path contains control character 0x{:02X}: {}",
+                c as u32, path
+            )));
+        }
+    }
+    let mut result = String::with_capacity(path.len() * 2);
+    for c in path.chars() {
+        match c {
+            '.' | '+' | '*' | '?' | '(' | ')' | '{' | '}' | '|' | '^' | '$' => {
+                result.push('[');
+                result.push(c);
+                result.push(']');
+            }
+            // `[`, `]`: can't appear in a character class literal. Emit
+            // `\\<char>` (3 source chars); Scheme reduces to `\<char>`
+            // which is a regex-literal match.
+            '[' | ']' => {
+                result.push('\\');
+                result.push('\\');
+                result.push(c);
+            }
+            // `\`: needs double escaping — emit `\\\\` (4 source chars).
+            // Scheme reduces to `\\`, which the regex engine interprets
+            // as a literal backslash.
+            '\\' => result.push_str("\\\\\\\\"),
+            // `"`: Scheme string escape only; regex engine sees the
+            // bare quote as a literal character.
+            '"' => result.push_str("\\\""),
+            _ => result.push(c),
+        }
+    }
+    Ok(result)
+}
+
+/// Emit Seatbelt `(allow network-outbound …)` and `(allow network-bind …)`
+/// rules for each [`UnixSocketCapability`] in `caps`.
+///
+/// On macOS, `connect(2)` and `bind(2)` are classified as **separate**
+/// Seatbelt operations (`network-outbound` and `network-bind`), so each
+/// needs its own allow-rule. Mode enforcement:
+///
+/// - `Connect` mode: emit `network-outbound` only. `bind(2)` stays
+///   denied by the base `(deny network*)` clause.
+/// - `ConnectBind` mode: emit **both** `network-outbound` and
+///   `network-bind`.
+///
+/// Path form:
+///
+/// - File-scoped grants emit `(… (path "…"))`.
+/// - Directory-scoped grants emit `(… (regex "^<dir>/[^/]+$"))` —
+///   non-recursive (direct children only), per §5 / §13 spike.
+///
+/// For both forms, the `original` path is emitted too when it differs
+/// from `resolved` (`/tmp` vs `/private/tmp`), preserving the dual-path
+/// symlink pattern.
+///
+/// `FsCapability` entries intentionally **do not** trigger either rule.
+/// Filesystem grants and unix-socket grants are orthogonal layers per
+/// #696; the CLI-side sugar in `nono-cli` auto-registers the fs grant
+/// that `bind(2)`/`connect(2)` need.
+fn emit_unix_socket_rules(profile: &mut String, caps: &CapabilitySet) -> Result<()> {
+    for cap in caps.unix_socket_capabilities() {
+        let resolved_str = cap.resolved.to_str().ok_or_else(|| {
+            NonoError::SandboxInit(format!(
+                "unix socket path contains non-UTF-8 bytes: {}",
+                cap.resolved.display()
+            ))
+        })?;
+        let original_str = if cap.original != cap.resolved {
+            cap.original.to_str()
+        } else {
+            None
+        };
+
+        // Always emit for connect (network-outbound). Bind (network-bind)
+        // is only emitted for ConnectBind — Connect-only grants intentionally
+        // leave `bind(2)` denied by the base `(deny network*)` clause.
+        let operations: &[&str] = if cap.mode.permits_bind() {
+            &["network-outbound", "network-bind"]
+        } else {
+            &["network-outbound"]
+        };
+
+        if cap.is_directory {
+            let escaped = regex_escape_path_for_seatbelt(resolved_str)?;
+            let escaped_orig = original_str
+                .map(regex_escape_path_for_seatbelt)
+                .transpose()?;
+            for op in operations {
+                profile.push_str(&format!("(allow {} (regex \"^{}/[^/]+$\"))\n", op, escaped));
+                if let Some(ref e) = escaped_orig {
+                    profile.push_str(&format!("(allow {} (regex \"^{}/[^/]+$\"))\n", op, e));
+                }
+            }
+        } else {
+            let escaped = escape_path(resolved_str)?;
+            let escaped_orig = original_str.map(escape_path).transpose()?;
+            for op in operations {
+                profile.push_str(&format!("(allow {} (path \"{}\"))\n", op, escaped));
+                if let Some(ref e) = escaped_orig {
+                    profile.push_str(&format!("(allow {} (path \"{}\"))\n", op, e));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Generate a Seatbelt profile from capabilities
 ///
 /// This is a pure primitive - it generates rules ONLY for paths in the CapabilitySet.
@@ -539,53 +678,12 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
         NetworkMode::Blocked => {
             profile.push_str("(deny network*)\n");
             profile.push_str(MDNS_RULES);
-            // On macOS, connect(2) to a Unix domain socket is classified by Seatbelt
-            // as network-outbound. Emit per-path rules for all explicitly granted
-            // filesystem capabilities so that Unix sockets (IPC, notification daemons,
-            // etc.) remain reachable in restricted modes. See: #687
-            //
-            // Files   -> (allow network-outbound (path "..."))   literal socket path
-            // Dirs    -> (allow network-outbound (subpath "...")) sockets anywhere inside
-            //
-            // Both resolved and original paths are emitted to handle /tmp -> /private/tmp
-            // symlinks, matching the mDNSResponder dual-path pattern above.
-            for cap in caps.fs_capabilities() {
-                let (filter, resolved_str) = if cap.is_file {
-                    (
-                        "path",
-                        cap.resolved.to_str().ok_or_else(|| {
-                            NonoError::SandboxInit(format!(
-                                "path contains non-UTF-8 bytes: {}",
-                                cap.resolved.display()
-                            ))
-                        })?,
-                    )
-                } else {
-                    (
-                        "subpath",
-                        cap.resolved.to_str().ok_or_else(|| {
-                            NonoError::SandboxInit(format!(
-                                "path contains non-UTF-8 bytes: {}",
-                                cap.resolved.display()
-                            ))
-                        })?,
-                    )
-                };
-                let escaped = escape_path(resolved_str)?;
-                profile.push_str(&format!(
-                    "(allow network-outbound ({} \"{}\"))\n",
-                    filter, escaped
-                ));
-                if cap.original != cap.resolved {
-                    if let Some(orig_str) = cap.original.to_str() {
-                        let escaped_orig = escape_path(orig_str)?;
-                        profile.push_str(&format!(
-                            "(allow network-outbound ({} \"{}\"))\n",
-                            filter, escaped_orig
-                        ));
-                    }
-                }
-            }
+            // Unix socket grants (see #685 / #696). Only explicit
+            // UnixSocketCapability entries emit network-outbound rules;
+            // generic FsCapability grants no longer implicitly grant
+            // `connect()`/`bind()` to sockets inside them. Directory
+            // grants use a non-recursive regex.
+            emit_unix_socket_rules(&mut profile, caps)?;
             if !localhost_ports.is_empty() {
                 // Allow system-socket for TCP (required for connect/bind)
                 profile.push_str(
@@ -609,44 +707,8 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
             // Block all network, then allow only localhost TCP to the proxy port.
             profile.push_str("(deny network*)\n");
             profile.push_str(MDNS_RULES);
-            // Same Unix socket logic as Blocked mode above. See: #687
-            for cap in caps.fs_capabilities() {
-                let (filter, resolved_str) = if cap.is_file {
-                    (
-                        "path",
-                        cap.resolved.to_str().ok_or_else(|| {
-                            NonoError::SandboxInit(format!(
-                                "path contains non-UTF-8 bytes: {}",
-                                cap.resolved.display()
-                            ))
-                        })?,
-                    )
-                } else {
-                    (
-                        "subpath",
-                        cap.resolved.to_str().ok_or_else(|| {
-                            NonoError::SandboxInit(format!(
-                                "path contains non-UTF-8 bytes: {}",
-                                cap.resolved.display()
-                            ))
-                        })?,
-                    )
-                };
-                let escaped = escape_path(resolved_str)?;
-                profile.push_str(&format!(
-                    "(allow network-outbound ({} \"{}\"))\n",
-                    filter, escaped
-                ));
-                if cap.original != cap.resolved {
-                    if let Some(orig_str) = cap.original.to_str() {
-                        let escaped_orig = escape_path(orig_str)?;
-                        profile.push_str(&format!(
-                            "(allow network-outbound ({} \"{}\"))\n",
-                            filter, escaped_orig
-                        ));
-                    }
-                }
-            }
+            // Unix socket grants (see Blocked branch above).
+            emit_unix_socket_rules(&mut profile, caps)?;
             profile.push_str(&format!(
                 "(allow network-outbound (remote tcp \"localhost:{}\"))\n",
                 port
@@ -1221,27 +1283,28 @@ mod tests {
         assert!(!profile.contains("(deny network*)"));
     }
 
-    /// Regression test for #687: Unix domain socket paths explicitly granted via
-    /// --allow-file must remain reachable in ProxyOnly and Blocked modes.
-    /// On macOS, connect(2) to a Unix socket is classified as network-outbound by
-    /// Seatbelt, so (deny network*) blocks it unless a per-path rule is emitted.
+    /// Regression test for #687 (+ #696 narrowing): Unix domain socket
+    /// paths explicitly granted via `--allow-unix-socket` must remain
+    /// reachable in ProxyOnly and Blocked modes. On macOS, connect(2) to
+    /// a Unix socket is classified as network-outbound by Seatbelt, so
+    /// `(deny network*)` blocks it unless a per-path rule is emitted.
+    /// Only explicit `UnixSocketCapability` entries trigger the emission
+    /// — generic `FsCapability` grants no longer implicitly do.
     #[test]
     fn test_generate_profile_unix_socket_allowed_in_proxy_only_mode() {
         let mut caps = CapabilitySet::new().proxy_only(54321);
-        caps.add_fs(FsCapability {
+        caps.add_unix_socket(crate::UnixSocketCapability {
             original: PathBuf::from("/tmp/test.sock"),
             resolved: PathBuf::from("/private/tmp/test.sock"),
-            access: AccessMode::ReadWrite,
-            is_file: true,
+            is_directory: false,
+            mode: crate::UnixSocketMode::Connect,
             source: CapabilitySource::User,
         });
 
         let profile = generate_profile(&caps).unwrap();
 
-        // Must deny all network and then allow the proxy port
         assert!(profile.contains("(deny network*)"));
         assert!(profile.contains("(allow network-outbound (remote tcp \"localhost:54321\"))"));
-        // Must allow outbound to the Unix socket path (both original and resolved)
         assert!(
             profile.contains("(allow network-outbound (path \"/private/tmp/test.sock\"))"),
             "must allow network-outbound to resolved socket path"
@@ -1255,38 +1318,109 @@ mod tests {
     #[test]
     fn test_generate_profile_unix_socket_allowed_in_blocked_mode() {
         let mut caps = CapabilitySet::new().block_network();
-        caps.add_fs(FsCapability {
+        caps.add_unix_socket(crate::UnixSocketCapability {
             original: PathBuf::from("/var/run/app.sock"),
             resolved: PathBuf::from("/private/var/run/app.sock"),
-            access: AccessMode::ReadWrite,
-            is_file: true,
+            is_directory: false,
+            mode: crate::UnixSocketMode::ConnectBind,
             source: CapabilitySource::User,
         });
 
         let profile = generate_profile(&caps).unwrap();
 
         assert!(profile.contains("(deny network*)"));
+        // ConnectBind must emit BOTH network-outbound (connect) AND
+        // network-bind (bind) — they're distinct Seatbelt operations.
         assert!(
             profile.contains("(allow network-outbound (path \"/private/var/run/app.sock\"))"),
-            "must allow network-outbound to resolved socket path in blocked mode"
+            "must allow network-outbound to resolved socket path"
         );
         assert!(
             profile.contains("(allow network-outbound (path \"/var/run/app.sock\"))"),
-            "must allow network-outbound to original socket path in blocked mode"
+            "must allow network-outbound to original socket path"
         );
-        // Must NOT open up general TCP outbound
+        assert!(
+            profile.contains("(allow network-bind (path \"/private/var/run/app.sock\"))"),
+            "ConnectBind must also allow network-bind on resolved path"
+        );
+        assert!(
+            profile.contains("(allow network-bind (path \"/var/run/app.sock\"))"),
+            "ConnectBind must also allow network-bind on original path"
+        );
         assert!(!profile.contains("(allow network-outbound)\n"));
     }
 
+    /// Regression: Connect-only mode must emit `network-outbound` but
+    /// NOT `network-bind`. bind(2) stays denied by the base
+    /// `(deny network*)` clause — this is the separate-read-write
+    /// invariant at the socket layer.
     #[test]
-    fn test_generate_profile_unix_socket_subpath_for_directories() {
-        // Directory capabilities should emit (subpath "...") network-outbound rules
-        // so that Unix sockets anywhere inside the directory remain reachable.
-        // e.g. --allow /var/run/ should allow connecting to /var/run/app.sock.
+    fn test_generate_profile_unix_socket_connect_only_does_not_emit_bind() {
+        let mut caps = CapabilitySet::new().block_network();
+        caps.add_unix_socket(crate::UnixSocketCapability {
+            original: PathBuf::from("/var/run/client.sock"),
+            resolved: PathBuf::from("/private/var/run/client.sock"),
+            is_directory: false,
+            mode: crate::UnixSocketMode::Connect,
+            source: CapabilitySource::User,
+        });
+
+        let profile = generate_profile(&caps).unwrap();
+
+        assert!(
+            profile.contains("(allow network-outbound (path \"/private/var/run/client.sock\"))"),
+            "Connect mode must emit network-outbound"
+        );
+        assert!(
+            !profile.contains("(allow network-bind"),
+            "Connect-only mode must NOT emit any network-bind rule: {profile}"
+        );
+    }
+
+    /// Directory-form unix socket grants must emit a NON-RECURSIVE
+    /// regex — `[^/]+$` matches only direct children, not grandchildren.
+    /// #696 scope tightening.
+    #[test]
+    fn test_generate_profile_unix_socket_dir_emits_non_recursive_regex() {
         let mut caps = CapabilitySet::new().proxy_only(54321);
-        caps.add_fs(FsCapability {
+        caps.add_unix_socket(crate::UnixSocketCapability {
             original: PathBuf::from("/tmp/mydir"),
             resolved: PathBuf::from("/private/tmp/mydir"),
+            is_directory: true,
+            mode: crate::UnixSocketMode::ConnectBind,
+            source: CapabilitySource::User,
+        });
+
+        let profile = generate_profile(&caps).unwrap();
+
+        assert!(
+            profile.contains("(allow network-outbound (regex \"^/private/tmp/mydir/[^/]+$\"))"),
+            "directory unix socket grants must emit non-recursive regex: {profile}"
+        );
+        assert!(
+            profile.contains("(allow network-outbound (regex \"^/tmp/mydir/[^/]+$\"))"),
+            "symlinked original must also emit regex form"
+        );
+        // ConnectBind mode also emits network-bind with matching regex.
+        assert!(
+            profile.contains("(allow network-bind (regex \"^/private/tmp/mydir/[^/]+$\"))"),
+            "ConnectBind directory grant must emit network-bind regex"
+        );
+        assert!(
+            !profile.contains("(allow network-outbound (subpath"),
+            "directory unix socket grants must NOT use recursive subpath"
+        );
+    }
+
+    /// #696 core contract: a plain `FsCapability` grant on a socket path
+    /// must NOT trigger any `network-outbound` or `network-bind` rule.
+    /// Only explicit `UnixSocketCapability` grants do.
+    #[test]
+    fn test_generate_profile_fs_capability_does_not_grant_network_outbound() {
+        let mut caps = CapabilitySet::new().block_network();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/var/run"),
+            resolved: PathBuf::from("/private/var/run"),
             access: AccessMode::ReadWrite,
             is_file: false,
             source: CapabilitySource::User,
@@ -1294,31 +1428,65 @@ mod tests {
 
         let profile = generate_profile(&caps).unwrap();
 
+        assert!(profile.contains("(deny network*)"));
         assert!(
-            profile.contains("(allow network-outbound (subpath \"/private/tmp/mydir\"))"),
-            "directory caps must emit subpath network-outbound rules"
+            !profile.contains("(allow network-outbound (subpath \"/private/var/run\"))"),
+            "FsCapability must not implicitly grant network-outbound on its subpath"
         );
         assert!(
-            profile.contains("(allow network-outbound (subpath \"/tmp/mydir\"))"),
-            "directory caps must emit subpath rule for original (symlink) path too"
+            !profile.contains("(allow network-outbound (path \"/var/run\"))"),
+            "FsCapability must not implicitly grant network-outbound on its path"
         );
-        // Must NOT use the literal-path form for directories
         assert!(
-            !profile.contains("(allow network-outbound (path \"/private/tmp/mydir\"))"),
-            "directories must not use (path ...) — that is for literal file sockets"
+            !profile.contains("(allow network-bind"),
+            "FsCapability must not implicitly grant any network-bind rule"
         );
     }
 
     #[test]
+    fn test_regex_escape_metacharacters_wrapped_in_character_class() {
+        // Literal `.` in a directory name must be wrapped as `[.]`.
+        let escaped = regex_escape_path_for_seatbelt("/tmp/foo.bar-1000").unwrap();
+        assert_eq!(escaped, "/tmp/foo[.]bar-1000");
+    }
+
+    #[test]
+    fn test_regex_escape_handles_bracket_and_backslash_via_backslash_escape() {
+        // These chars can't appear literally inside `[ ]` so we fall
+        // back to Scheme-level `\\<c>` → regex-level `\<c>` → literal.
+        assert_eq!(
+            regex_escape_path_for_seatbelt("/tmp/foo[bar").unwrap(),
+            "/tmp/foo\\\\[bar"
+        );
+        assert_eq!(
+            regex_escape_path_for_seatbelt("/tmp/foo]bar").unwrap(),
+            "/tmp/foo\\\\]bar"
+        );
+        // Literal backslash: `\\\\\\\\` in Rust source (4 chars emitted)
+        // → Scheme reads `\\`, regex engine sees `\\` → matches literal `\`.
+        assert_eq!(
+            regex_escape_path_for_seatbelt("/tmp/foo\\bar").unwrap(),
+            "/tmp/foo\\\\\\\\bar"
+        );
+    }
+
+    #[test]
+    fn test_regex_escape_rejects_control_characters() {
+        // Control characters stay rejected — escape_path's policy too.
+        assert!(regex_escape_path_for_seatbelt("/tmp/foo\x00bar").is_err());
+        assert!(regex_escape_path_for_seatbelt("/tmp/foo\nbar").is_err());
+    }
+
+    #[test]
     fn test_generate_profile_unix_socket_rules_not_emitted_in_allow_all() {
-        // AllowAll already permits all network-outbound — no per-path socket rules
-        // should be emitted (they would be redundant noise).
+        // AllowAll already permits all network-outbound — emit_unix_socket_rules
+        // is only called in Blocked/ProxyOnly branches, so there's no per-path noise.
         let mut caps = CapabilitySet::new(); // default = AllowAll
-        caps.add_fs(FsCapability {
+        caps.add_unix_socket(crate::UnixSocketCapability {
             original: PathBuf::from("/tmp/test.sock"),
             resolved: PathBuf::from("/private/tmp/test.sock"),
-            access: AccessMode::ReadWrite,
-            is_file: true,
+            is_directory: false,
+            mode: crate::UnixSocketMode::Connect,
             source: CapabilitySource::User,
         });
 

--- a/crates/nono/src/sandbox/mod.rs
+++ b/crates/nono/src/sandbox/mod.rs
@@ -29,11 +29,12 @@ pub use linux::is_wsl2;
 // Re-export Linux seccomp-notify primitives for supervisor use
 #[cfg(target_os = "linux")]
 pub use linux::{
-    classify_access_from_flags, continue_notif, deny_notif, inject_fd, install_seccomp_notify,
-    install_seccomp_proxy_filter, notif_id_valid, probe_seccomp_block_network_support,
-    read_notif_path, read_notif_sockaddr, read_open_how, recv_notif, resolve_notif_path,
-    respond_notif_errno, validate_openat2_size, OpenHow, SeccompData, SeccompNetFallback,
-    SeccompNotif, SockaddrInfo, SYS_BIND, SYS_CONNECT, SYS_OPENAT, SYS_OPENAT2,
+    classify_access_from_flags, classify_af_unix, continue_notif, deny_notif, inject_fd,
+    install_seccomp_notify, install_seccomp_proxy_filter, notif_id_valid,
+    probe_seccomp_block_network_support, read_notif_path, read_notif_sockaddr, read_open_how,
+    recv_notif, resolve_notif_path, respond_notif_errno, validate_openat2_size, OpenHow,
+    SeccompData, SeccompNetFallback, SeccompNotif, SockaddrInfo, UnixSocketKind, SYS_BIND,
+    SYS_CONNECT, SYS_OPENAT, SYS_OPENAT2,
 };
 
 /// Information about sandbox support on this platform

--- a/crates/nono/src/state.rs
+++ b/crates/nono/src/state.rs
@@ -119,13 +119,31 @@ impl SandboxState {
                 }
             };
 
-            // Re-validate through the standard constructors to ensure
-            // canonicalisation and existence checks are applied.
+            // Reconstruct from the caller-supplied `original` so the
+            // stored alias survives the roundtrip (macOS Seatbelt uses
+            // it for dual-path emission when original != resolved).
+            // Then validate that canonicalisation produced the same
+            // `resolved` as was serialized. The check rejects two
+            // failure modes with one test:
+            //
+            // - Filesystem drift between save and reload (symlink moved,
+            //   ConnectBind pending path now exists, etc.).
+            // - Crafted JSON smuggling: attacker sets an evil `original`
+            //   and legit `resolved`; the reconstructed cap's actual
+            //   resolved won't match the crafted one, so we reject.
             let cap = if sock.is_directory {
                 UnixSocketCapability::new_dir(&sock.original, mode)?
             } else {
                 UnixSocketCapability::new_file(&sock.original, mode)?
             };
+            if cap.resolved != sock.resolved {
+                return Err(crate::error::NonoError::ConfigParse(format!(
+                    "unix socket grant canonical path drifted at state reload: \
+                     serialized resolved={}, actual resolved={}",
+                    sock.resolved.display(),
+                    cap.resolved.display(),
+                )));
+            }
             caps.add_unix_socket(cap);
         }
 
@@ -197,6 +215,48 @@ mod tests {
         assert!(
             state.to_caps().is_err(),
             "to_caps must reject invalid access modes"
+        );
+    }
+
+    #[test]
+    fn test_unix_socket_state_roundtrip_preserves_original_and_resolved() {
+        use tempfile::tempdir;
+        let dir = tempdir().expect("tempdir");
+        let sock = dir.path().join("a.sock");
+        std::fs::write(&sock, b"").expect("stub");
+
+        let caps = CapabilitySet::new()
+            .allow_unix_socket(&sock, UnixSocketMode::Connect)
+            .expect("grant");
+        let state = SandboxState::from_caps(&caps);
+        let restored = state.to_caps().expect("to_caps");
+
+        let round = restored.unix_socket_capabilities();
+        assert_eq!(round.len(), 1);
+        let before = &caps.unix_socket_capabilities()[0];
+        let after = &round[0];
+        assert_eq!(after.resolved, before.resolved);
+        assert_eq!(after.original, before.original);
+        assert_eq!(after.mode, before.mode);
+        assert_eq!(after.is_directory, before.is_directory);
+    }
+
+    #[test]
+    fn test_unix_socket_state_rejects_invalid_mode() {
+        let json = r#"{
+            "fs": [],
+            "unix_sockets": [{
+                "original": "/tmp",
+                "resolved": "/tmp",
+                "is_directory": true,
+                "mode": "bind-only"
+            }],
+            "net_blocked": false
+        }"#;
+        let state = SandboxState::from_json(json).unwrap();
+        assert!(
+            state.to_caps().is_err(),
+            "to_caps must reject unknown unix socket modes"
         );
     }
 }

--- a/crates/nono/src/state.rs
+++ b/crates/nono/src/state.rs
@@ -2,7 +2,9 @@
 //!
 //! This module provides serialization of capability state for diagnostic purposes.
 
-use crate::capability::{AccessMode, CapabilitySet, FsCapability};
+use crate::capability::{
+    AccessMode, CapabilitySet, FsCapability, UnixSocketCapability, UnixSocketMode,
+};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -11,6 +13,10 @@ use std::path::PathBuf;
 pub struct SandboxState {
     /// Filesystem capabilities
     pub fs: Vec<FsCapState>,
+    /// AF_UNIX socket capabilities (may be absent in states persisted
+    /// by older nono builds; `#[serde(default)]` preserves backward compat).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unix_sockets: Vec<UnixSocketCapState>,
     /// Whether network is blocked
     pub net_blocked: bool,
 }
@@ -28,6 +34,19 @@ pub struct FsCapState {
     pub is_file: bool,
 }
 
+/// Serializable representation of a [`UnixSocketCapability`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnixSocketCapState {
+    /// Original path as specified
+    pub original: PathBuf,
+    /// Resolved canonical path
+    pub resolved: PathBuf,
+    /// Whether the grant is directory-scoped (non-recursive)
+    pub is_directory: bool,
+    /// Mode string: "connect" or "connect+bind"
+    pub mode: String,
+}
+
 impl SandboxState {
     /// Create state from a capability set
     #[must_use]
@@ -41,6 +60,16 @@ impl SandboxState {
                     resolved: cap.resolved.clone(),
                     access: cap.access.to_string(),
                     is_file: cap.is_file,
+                })
+                .collect(),
+            unix_sockets: caps
+                .unix_socket_capabilities()
+                .iter()
+                .map(|cap| UnixSocketCapState {
+                    original: cap.original.clone(),
+                    resolved: cap.resolved.clone(),
+                    is_directory: cap.is_directory,
+                    mode: cap.mode.to_string(),
                 })
                 .collect(),
             net_blocked: caps.is_network_blocked(),
@@ -77,6 +106,27 @@ impl SandboxState {
                 FsCapability::new_dir(&fs_cap.original, access)?
             };
             caps.add_fs(cap);
+        }
+
+        for sock in &self.unix_sockets {
+            let mode = match sock.mode.as_str() {
+                "connect" => UnixSocketMode::Connect,
+                "connect+bind" => UnixSocketMode::ConnectBind,
+                other => {
+                    return Err(crate::error::NonoError::ConfigParse(format!(
+                        "invalid unix socket mode in sandbox state: {other}"
+                    )));
+                }
+            };
+
+            // Re-validate through the standard constructors to ensure
+            // canonicalisation and existence checks are applied.
+            let cap = if sock.is_directory {
+                UnixSocketCapability::new_dir(&sock.original, mode)?
+            } else {
+                UnixSocketCapability::new_file(&sock.original, mode)?
+            };
+            caps.add_unix_socket(cap);
         }
 
         caps.set_network_blocked(self.net_blocked);

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -62,7 +62,11 @@ Profiles use JSON format:
     "write": [],
     "allow_file": [],
     "read_file": [],
-    "write_file": []
+    "write_file": [],
+    "unix_socket": [],
+    "unix_socket_bind": [],
+    "unix_socket_dir": [],
+    "unix_socket_dir_bind": []
   },
   "policy": {
     "exclude_groups": [],
@@ -78,6 +82,29 @@ Profiles use JSON format:
   }
 }
 ```
+
+### AF_UNIX Socket Grants
+
+The `unix_socket*` filesystem fields grant `connect(2)` (and optionally
+`bind(2)`) on pathname AF_UNIX sockets. Abstract-namespace and unnamed
+sockets are never grantable — only filesystem-backed socket paths.
+
+| Field | Grants | Implied fs grant |
+|---|---|---|
+| `unix_socket` | `connect` only, single socket file | Read on the file |
+| `unix_socket_bind` | `connect` + `bind`, single socket file | ReadWrite on the file (exists) or on the parent directory (pending — bind will create the file) |
+| `unix_socket_dir` | `connect` only, any direct child of a directory | Read on the directory (recursive) |
+| `unix_socket_dir_bind` | `connect` + `bind`, any direct child of a directory | ReadWrite on the directory (recursive) |
+
+Directory forms are **non-recursive at the socket layer**: only sockets
+directly inside the named directory are covered, not those in
+subdirectories. The implied filesystem grant is recursive (Landlock's
+only expressible granularity), so the non-recursion is enforced
+separately by the supervisor (Linux) or Seatbelt regex emission (macOS).
+
+Under restricted network modes (`--block-net` or `--network-profile`),
+`connect(2)` to a Unix socket requires an explicit `unix_socket*` grant
+— a plain `allow_file`/`allow` grant no longer implicitly permits it.
 
 ### Working Directory
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -255,6 +255,62 @@ Grant write-only access to a single file.
 nono run --write-file ./output.log -- command
 ```
 
+### AF_UNIX Socket Permissions
+
+These flags grant `connect(2)` (and optionally `bind(2)`) on pathname AF_UNIX
+sockets. Abstract-namespace and unnamed sockets are never grantable — only
+filesystem-backed socket paths are supported.
+
+Under restricted network modes (`--block-net` or `--network-profile`),
+explicit socket grants are required. A plain `--allow-file`/`--allow` grant
+no longer implicitly permits socket access.
+
+#### `--allow-unix-socket`
+
+Allow `connect(2)` to an existing AF_UNIX socket file. Implies read access on
+the socket path.
+
+```bash
+# Connect to a running Postgres dev server via Unix socket
+nono run --block-net --allow-unix-socket /tmp/.s.PGSQL.5432 -- psql
+```
+
+#### `--allow-unix-socket-bind`
+
+Allow `connect(2)` and `bind(2)` on an AF_UNIX socket at this path. Use when
+the sandboxed program creates the socket itself. If the path doesn't exist
+yet (the typical `bind(2)` case), the CLI auto-grants write on the parent
+directory so the kernel can create the socket file.
+
+```bash
+# Server that binds its own IPC socket
+nono run --block-net --allow-unix-socket-bind /run/myapp.sock -- myapp
+```
+
+Prefer `--allow-unix-socket-dir-bind` for runtime-generated filenames (e.g.
+PID-suffixed paths) so the implied fs grant stays scoped.
+
+#### `--allow-unix-socket-dir`
+
+Allow `connect(2)` to any AF_UNIX socket **directly** within this directory
+(non-recursive — grandchildren are not covered). Implies read access on the
+directory.
+
+```bash
+# Connect to any Unix socket directly in /run/user/1000
+nono run --block-net --allow-unix-socket-dir /run/user/$UID -- my-client
+```
+
+#### `--allow-unix-socket-dir-bind`
+
+Allow `connect(2)` and `bind(2)` on any AF_UNIX socket directly within this
+directory. Non-recursive. Use for runtime-generated socket filenames.
+
+```bash
+# tsx creates /tmp/tsx-<uid>/<pid>.pipe on every invocation
+nono run --block-net --allow-unix-socket-dir-bind $TMPDIR/tsx-$UID -- tsx app.ts
+```
+
 ### Network Control
 
 #### `--block-net`


### PR DESCRIPTION
## Summary

Adds a new `--allow-unix-socket*` CLI flag family (and matching profile
fields) for granting `connect(2)` and `bind(2)` on pathname AF_UNIX
sockets, and fixes two latent bugs in the existing AF_UNIX handling that
only manifest under restricted network modes:

- **Linux (#685)**: on Landlock V<4 kernels (Debian 12, etc.) where
  nono uses the seccomp-notify supervisor fallback, pathname AF_UNIX
  bind/connect were unconditionally denied even when the path was in a
  granted filesystem region.
- **macOS (#696 / #687 follow-up)**: `--allow-file /some.sock` under
  `--block-net` or `--network-profile` implicitly granted
  `network-outbound` to every file capability, regardless of whether
  operators intended socket access. This PR narrows that so only
  explicit `--allow-unix-socket*` grants emit `network-outbound` (and
  now also `network-bind`) rules.

## Commits

- **`fix(supervisor(linux))`** — Linux V2 pathname AF_UNIX now reaches
  the supervisor. The BPF filter routes `bind(2)` to `USER_NOTIF`
  unconditionally in ProxyOnly mode (previously it short-circuited to
  `EACCES` when no TCP bind ports were configured — the common case),
  and the supervisor's `decide_network_notification` allows pathname
  AF_UNIX while still denying abstract/unnamed. Closes #685.
- **`feat(capability)`** — library foundation: `UnixSocketMode`,
  `UnixSocketOp`, `UnixSocketCapability`, `CapabilitySet` integration,
  `SandboxState` roundtrip with drift detection, dedup with
  user-intent preservation, `summary()` output.
- **`feat(cli)`** — four CLI flags (`--allow-unix-socket[-bind]`,
  `--allow-unix-socket-dir[-bind]`), four matching profile JSON fields,
  CLI-side sugar that auto-grants the implied `FsCapability`, macOS
  Seatbelt narrowing (`network-outbound` and `network-bind` emitted
  only from `UnixSocketCapability`, never from plain `FsCapability`),
  dry-run output section.
- **`docs`** — flag reference + profile field documentation in
  `docs/cli/usage/flags.mdx` and `docs/cli/features/profiles-groups.mdx`.

## Feature shape

| Flag | Socket grant | Implied fs grant |
|---|---|---|
| `--allow-unix-socket <p>` | connect at `p` | `--read-file p` (path must exist) |
| `--allow-unix-socket-bind <p>` | connect + bind at `p` | `--allow-file p` if it exists; `--allow parent(p)` otherwise (the typical `bind(2)` case) |
| `--allow-unix-socket-dir <d>` | connect to any direct child of `d` | `--read d` (recursive) |
| `--allow-unix-socket-dir-bind <d>` | connect + bind on any direct child of `d` | `--allow d` (recursive) |

Directory forms are non-recursive at the socket layer (enforced by
`UnixSocketCapability::covers`); the implied fs grant is recursive
because Landlock has no other expressible granularity.

Abstract-namespace (`sun_path[0] == '\0'`) and unnamed sockets are
never grantable — deny-by-default.

## Per-platform behaviour

| Platform | Before | After |
|---|---|---|
| Linux ABI V2 under ProxyOnly | Pathname AF_UNIX `bind`/`connect` returned `EACCES` at the BPF filter; `--allow /tmp` did not help | Pathname AF_UNIX reaches the supervisor; supervisor allows it, Landlock fs rules govern path reachability |
| Linux ABI V4+ | Native `LANDLOCK_ACCESS_NET_*` handles TCP; AF_UNIX governed by fs rules | Unchanged |
| macOS (ProxyOnly / Blocked) | `--allow-file /foo.sock` implicitly emitted `(allow network-outbound (subpath …))` for every fs grant (#689) | Only explicit `--allow-unix-socket*` grants emit `network-outbound` and `network-bind` rules. Connect-only mode emits `network-outbound` only; bind must be explicitly requested |
| macOS (AllowAll) | — | Unchanged — `emit_unix_socket_rules` is not called when network is blanket-allowed |

## End-to-end verification

### Linux V2 repro (#685's exact reproduction platform)

Debian 12, kernel 6.1, Landlock V2:

```
nono run --network-profile developer --allow /tmp -- \
  node -e 'const net=require("net"); const s=net.createServer();
           s.listen("/tmp/test.sock", () => { s.close(); console.log("ok"); });
           s.on("error", e => { console.error("FAIL:", e.message); process.exit(1); });'
```

- Before: `FAIL: listen EACCES: permission denied /tmp/test.sock`
- After: `ok`

### macOS narrowing verification

Four A/B tests on macOS 15:

| Test | Grant | Expected | Actual |
|---|---|---|---|
| Connect without new flag | `--block-net --allow-file /sock` | FAIL (narrowing) | ✅ FAIL |
| Connect with new flag | `--block-net --allow-unix-socket /sock` | ok | ✅ ok |
| Bind with bind flag | `--block-net --allow-unix-socket-bind /sock` | ok | ✅ ok |
| Bind with connect-only flag | `--block-net --allow-unix-socket /sock` | FAIL (mode enforcement) | ✅ FAIL |

### Seatbelt spike

14 / 14 PASS — `(regex …)` works under `network-outbound` with non-recursive
`[^/]+$` semantics; `network-bind` is a distinct operation from
`network-outbound` (granting only the latter does not permit bind, so the
dual-rule emission for ConnectBind is load-bearing).

## Design notes

- **Library vs CLI split.** `UnixSocketCapability` is pure data — no
  policy in the library (`lib-policy-free`). The implied fs grant and
  the dangling-symlink / non-existent-path handling live in the
  nono-cli `add_cli_unix_socket_caps` helper.
- **Grant-pair coupling.** The implied `FsCapability` is only
  registered inside the `Some(cap)` arm of the socket grant, so
  macOS's `handle_missing_file_capability` can't manufacture a
  phantom fs grant for a non-existent socket path when the socket
  grant itself was skipped.
- **Dangling-symlink guard.** `--allow-unix-socket-bind <link>` where
  `<link>` is a dangling symlink is rejected up front — `bind(2)`
  would otherwise punch through to the symlink target.
- **`SandboxState` roundtrip.** `to_caps()` re-canonicalises from
  `sock.original` and validates that the result equals the serialized
  `sock.resolved`, rejecting both crafted-JSON alias smuggling and
  real filesystem drift between save and reload.
- **Dedup with user-intent preservation.** When a user-supplied
  `Connect` grant collides with a group/default `ConnectBind` grant on
  the same path, the user's literal mode wins — the user narrowing a
  path must not be silently re-widened by dedup.

## Out of scope / follow-up

- **Linux V<4 supervisor allowlist enforcement.** On Linux V2, the
  supervisor currently allows *any* pathname AF_UNIX as long as
  Landlock's fs rules let the path through — it doesn't consult the
  `UnixSocketCapability` allowlist yet. A follow-up PR will extend
  `read_notif_sockaddr` to capture full `sun_path`, add
  `unix_socket_allowlist` to `SupervisorConfig`, and check it in
  `decide_network_notification`.
- **Linux V4+ parity.** On V4+ kernels the supervisor isn't in the
  AF_UNIX path at all (native Landlock handles TCP; AF_UNIX is
  governed by fs rules only), so `--allow-unix-socket` on V4+ is
  advisory — enforcement is whatever Landlock's fs grants allow. A
  separate issue; closing it would require upstream Landlock work
  (e.g. a `LANDLOCK_ACCESS_NET_UNIX_*` access right).
- Built-in policy profile migration: audit found no existing socket
  paths granted via `--allow-file` in `crates/nono-cli/data/policy.json`,
  so no migrations needed. Users with custom profiles relying on
  dev-profile implicit socket access (e.g. Postgres at
  `/tmp/.s.PGSQL.5432` under `--block-net`) must now add an explicit
  `--allow-unix-socket` grant. Documented in `flags.mdx`.

## Test plan

- [x] Full library test suite passes (Linux + macOS).
- [x] `cargo clippy -- -D warnings -D clippy::unwrap_used` clean on
      `nono` + `nono-cli`.
- [x] `cargo fmt --all -- --check` clean.
- [x] Linux V2 end-to-end: Node `bind("/tmp/test.sock")` under
      `--network-profile developer --allow /tmp` succeeds. Repro from
      #685 resolved.
- [x] macOS end-to-end: all four A/B tests above.
- [x] Seatbelt spike verified `(regex …)` predicates work under
      `network-outbound`, `(path …)` under `network-bind`, and that
      the two operations are distinct.

## Invariants relied on

- `lib-policy-free` — library type is pure data; sugar lives in nono-cli.
- `path-canonicalize` — grant-time + enforcement-time canonicalisation.
- `path-component-compare` + `supervisor-path-path-not-string` — socket
  allowlist checks use `Path::parent`/full equality, never string prefix.
- `macos-etc-symlink-aware` — dual `path` + `original` Seatbelt emission.
- `separate-read-write` — `UnixSocketMode::{Connect, ConnectBind}`
  mirror `AccessMode::{Read, ReadWrite}`. `Connect` emits
  `network-outbound` only; `ConnectBind` also emits `network-bind`.
- `least-privilege-scope` — Connect is the default; bind requires
  explicit `-bind` suffix.
- `landlock-strict-allowlist` — supervisor seccomp decision is where
  Linux narrowing happens.
- `fail-secure-config` — dangling symlinks, drifted state, and crafted
  JSON all fail-closed rather than silently degrade.
- `seatbelt-escape-profile-input` — all profile-string interpolation
  routed through `escape_path` / `regex_escape_path_for_seatbelt`.
- `test-new-capability-types` — `UnixSocketCapability`, `UnixSocketMode`,
  `UnixSocketOp`, `classify_af_unix` all have unit coverage.
- `test-on-both-platforms` — Fedora V7 VM + Debian V2 VM + macOS host
  all exercised.

Resolves: #685
Partially addresses: #696 (macOS half)
Supersedes: #703
