### PR TITLE
feat(trust): prefer CI_CONFIG_REF_URI for GitLab keyless workflow identity

### DIFF
--- a/crates/nono-cli/src/trust_cmd.rs
+++ b/crates/nono-cli/src/trust_cmd.rs
@@ -592,15 +592,30 @@ fn gitlab_keyless_predicate() -> Option<serde_json::Map<String, serde_json::Valu
         ),
     };
 
-    let workflow = format!("{host_authority}/{project_path}//.gitlab-ci.yml@{git_ref}");
+    // Prefer GitLab's authoritative pipeline config reference (GitLab 18.11+,
+    // via merge request https://gitlab.com/gitlab-org/gitlab/-/merge_requests/226857).
+    // CI_CONFIG_REF_URI is the fully qualified reference to the pipeline
+    // definition, so it covers includes, component refs, and non-default
+    // pipeline files. Fall back to the hardcoded `.gitlab-ci.yml` shape for
+    // older GitLab versions that don't expose the variable.
+    let workflow = std::env::var("CI_CONFIG_REF_URI")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| format!("{host_authority}/{project_path}//.gitlab-ci.yml@{git_ref}"));
+
     let server_url =
         std::env::var("CI_SERVER_URL").unwrap_or_else(|_| "https://gitlab.com".to_string());
 
+    // Mirror the workflow reference into `build_signer_uri` so publishers
+    // pinning on that field (see SignerIdentity matching in
+    // crates/nono/src/trust/types.rs) can match and so format_identity renders
+    // the full URI instead of `repository (workflow)`.
     serde_json::json!({
         "oidc_issuer": server_url,
         "server_url": server_url,
         "repository": project_path,
         "workflow": workflow,
+        "build_signer_uri": workflow,
         "ref": git_ref
     })
     .as_object()
@@ -1772,5 +1787,77 @@ mod tests {
 
         std::env::set_current_dir(original).unwrap();
         result.unwrap();
+    }
+
+    #[test]
+    fn gitlab_keyless_predicate_prefers_ci_config_ref_uri() {
+        let _lock = match crate::test_env::ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let _env = crate::test_env::EnvVarGuard::set_all(&[
+            ("GITLAB_CI", "true"),
+            ("CI_SERVER_HOST", "gitlab.com"),
+            ("CI_SERVER_PORT", "443"),
+            ("CI_SERVER_URL", "https://gitlab.com"),
+            ("CI_PROJECT_PATH", "my-group/my-project"),
+            ("CI_COMMIT_REF_NAME", "main"),
+            ("CI_COMMIT_TAG", ""),
+            (
+                "CI_CONFIG_REF_URI",
+                "gitlab.com/my-group/my-project//pipelines/release.yml@refs/tags/v1.0.0",
+            ),
+        ]);
+
+        let pred = gitlab_keyless_predicate().expect("predicate should be Some in GitLab CI");
+        assert_eq!(
+            pred.get("workflow").and_then(|v| v.as_str()),
+            Some("gitlab.com/my-group/my-project//pipelines/release.yml@refs/tags/v1.0.0"),
+            "workflow must mirror CI_CONFIG_REF_URI verbatim when set"
+        );
+        assert_eq!(
+            pred.get("repository").and_then(|v| v.as_str()),
+            Some("my-group/my-project")
+        );
+        assert_eq!(
+            pred.get("oidc_issuer").and_then(|v| v.as_str()),
+            Some("https://gitlab.com")
+        );
+        assert_eq!(
+            pred.get("build_signer_uri").and_then(|v| v.as_str()),
+            pred.get("workflow").and_then(|v| v.as_str()),
+            "build_signer_uri must mirror workflow so format_identity and build_signer_uri-pinned publishers work"
+        );
+    }
+
+    #[test]
+    fn gitlab_keyless_predicate_falls_back_to_hardcoded_workflow() {
+        let _lock = match crate::test_env::ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let _env = crate::test_env::EnvVarGuard::set_all(&[
+            ("GITLAB_CI", "true"),
+            ("CI_SERVER_HOST", "gitlab.com"),
+            ("CI_SERVER_PORT", "443"),
+            ("CI_SERVER_URL", "https://gitlab.com"),
+            ("CI_PROJECT_PATH", "my-group/my-project"),
+            ("CI_COMMIT_REF_NAME", "main"),
+            ("CI_COMMIT_TAG", ""),
+            ("CI_CONFIG_REF_URI", ""),
+        ]);
+
+        let pred =
+            gitlab_keyless_predicate().expect("predicate should be Some when GITLAB_CI=true");
+        assert_eq!(
+            pred.get("workflow").and_then(|v| v.as_str()),
+            Some("gitlab.com/my-group/my-project//.gitlab-ci.yml@refs/heads/main"),
+            "fallback workflow must reconstruct the legacy .gitlab-ci.yml@ref shape"
+        );
+        assert_eq!(
+            pred.get("build_signer_uri").and_then(|v| v.as_str()),
+            pred.get("workflow").and_then(|v| v.as_str()),
+            "build_signer_uri must mirror workflow in the legacy fallback too"
+        );
     }
 }

--- a/crates/nono/src/trust/types.rs
+++ b/crates/nono/src/trust/types.rs
@@ -718,6 +718,37 @@ mod tests {
     }
 
     #[test]
+    fn publisher_matches_gitlab_ci_config_ref_uri() {
+        // Regression test for the GitLab 18.11 `CI_CONFIG_REF_URI` variable
+        // (see https://gitlab.com/gitlab-org/gitlab/-/merge_requests/226857).
+        // When Nono consumes that variable verbatim as the `workflow` field,
+        // publishers pinned to a non-default pipeline config path must match
+        // without rewriting or stripping the value.
+        let publisher = Publisher {
+            name: "gitlab-ci-release".to_string(),
+            issuer: Some("https://gitlab.com".to_string()),
+            repository: Some("my-group/my-project".to_string()),
+            workflow: Some(
+                "gitlab.com/my-group/my-project//pipelines/release.yml@refs/tags/*".to_string(),
+            ),
+            ref_pattern: Some("refs/tags/*".to_string()),
+            key_id: None,
+            public_key: None,
+            build_signer_uri: None,
+        };
+        let identity = SignerIdentity::Keyless {
+            issuer: "https://gitlab.com".to_string(),
+            repository: "my-group/my-project".to_string(),
+            workflow: "gitlab.com/my-group/my-project//pipelines/release.yml@refs/tags/v1.0.0"
+                .to_string(),
+            git_ref: "refs/tags/v1.0.0".to_string(),
+            build_signer_uri: "gitlab.com/my-group/my-project//pipelines/release.yml@refs/tags/v1.0.0"
+                .to_string(),
+        };
+        assert!(publisher.matches(&identity));
+    }
+
+    #[test]
     fn publisher_matches_gitlab_self_managed_keyless() {
         let publisher = Publisher {
             name: "gitlab-self-managed".to_string(),

--- a/crates/nono/src/trust/types.rs
+++ b/crates/nono/src/trust/types.rs
@@ -742,8 +742,8 @@ mod tests {
             workflow: "gitlab.com/my-group/my-project//pipelines/release.yml@refs/tags/v1.0.0"
                 .to_string(),
             git_ref: "refs/tags/v1.0.0".to_string(),
-            build_signer_uri: "gitlab.com/my-group/my-project//pipelines/release.yml@refs/tags/v1.0.0"
-                .to_string(),
+            build_signer_uri:
+                "gitlab.com/my-group/my-project//pipelines/release.yml@refs/tags/v1.0.0".to_string(),
         };
         assert!(publisher.matches(&identity));
     }


### PR DESCRIPTION
## Summary

Consume GitLab's new [`CI_CONFIG_REF_URI`](https://docs.gitlab.com/ci/variables/predefined_variables/#predefined-variables-for-all-pipelines) predefined variable (shipped in GitLab 18.11 via [`!226857`](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/226857)) as the `workflow` identity for GitLab keyless signing. Falls back to the existing hardcoded `.gitlab-ci.yml@<ref>` reconstruction when the variable isn't set (GitLab 18.10 and earlier, or when the variable is empty).

This mirrors how `github_keyless_predicate` consumes `GITHUB_WORKFLOW_REF`.

## Why

`gitlab_keyless_predicate` currently hardcodes `.gitlab-ci.yml` in the workflow URI:

```rust
let workflow = format!(\"{host_authority}/{project_path}//.gitlab-ci.yml@{git_ref}\");
```

That's wrong for any repo that:
- Uses a non-default pipeline file (`pipelines/release.yml`)
- Uses [CI/CD components](https://docs.gitlab.com/ci/components/)
- Triggers pipelines from a `.gitlab/ci/*.yml` include

The reconstructed string doesn't match the actual config that authored the pipeline, which breaks trust pinning for anyone doing anything more complex than a root `.gitlab-ci.yml`.

## What changed

- `crates/nono-cli/src/trust_cmd.rs` — `gitlab_keyless_predicate()` now reads `CI_CONFIG_REF_URI` first, falls back to the prior behavior when empty/unset
- `crates/nono-cli/src/trust_cmd.rs` — two new unit tests (`gitlab_keyless_predicate_prefers_ci_config_ref_uri`, `gitlab_keyless_predicate_falls_back_to_hardcoded_workflow`)
- `crates/nono/src/trust/types.rs` — regression test `publisher_matches_gitlab_ci_config_ref_uri` showing a publisher pinned to a non-default pipeline path + tag ref matches correctly

All six tests (4 publisher-match in the types module + 2 predicate in trust_cmd) pass locally with `cargo test`. `cargo clippy` is clean.

## Verified end-to-end

Built this branch and ran it in GitLab CI against [mmishaev/nono-gitlab-demo](https://gitlab.com/mmishaev/nono-gitlab-demo):

- Pre-patch run (Nono 0.37.1 release): [pipeline #2463524028](https://gitlab.com/mmishaev/nono-gitlab-demo/-/pipelines/2463524028) / [Rekor 1340558956](https://search.sigstore.dev/?logIndex=1340558956)
- Post-patch run (this branch): [pipeline #2463546687](https://gitlab.com/mmishaev/nono-gitlab-demo/-/pipelines/2463546687) / [Rekor 1340571393](https://search.sigstore.dev/?logIndex=1340571393)

The post-patch bundle's in-toto predicate reports `workflow == ci_config_ref_uri` verbatim:

```json
{
  \"workflow\": \"gitlab.com/mmishaev/nono-gitlab-demo//.gitlab-ci.yml@refs/heads/ci-config-ref-uri-patched\",
  \"ci_config_ref_uri\": \"gitlab.com/mmishaev/nono-gitlab-demo//.gitlab-ci.yml@refs/heads/ci-config-ref-uri-patched\",
  \"match\": true
}
```

## Related

- GitLab MR: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/226857
- GitLab issue: https://gitlab.com/gitlab-org/gitlab/-/work_items/593105
- Demo repo: https://gitlab.com/mmishaev/nono-gitlab-demo

## Checklist

- [x] Code compiles
- [x] New tests added, existing tests pass
- [x] Backward-compatible (fallback preserves pre-18.11 behavior)
- [x] End-to-end verified against real GitLab CI