### PR TITLE
feat(cli): add --allow-connect-port for outbound TCP port allowlisting

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -2360,8 +2360,8 @@ mod tests {
         let workdir = tempdir().expect("workdir");
         let args = sandbox_args();
 
-        let err = from_profile_locked(&profile, workdir.path(), &args)
-            .expect_err("should fail on macOS");
+        let err =
+            from_profile_locked(&profile, workdir.path(), &args).expect_err("should fail on macOS");
         assert!(
             err.to_string().contains("not supported on macOS"),
             "unexpected error: {err}"

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -537,15 +537,17 @@ impl CapabilitySetExt for CapabilitySet {
         }
 
         // Outbound TCP connect port allowlist (Linux Landlock V4+ only)
-        for port in &args.allow_connect_port {
-            caps.add_tcp_connect_port(*port);
-        }
         #[cfg(target_os = "macos")]
         if !args.allow_connect_port.is_empty() {
-            warn!(
-                "--allow-connect-port has no effect on macOS: Seatbelt cannot filter by TCP port. \
-                 Use --allow-domain for host-level filtering instead."
-            );
+            return Err(NonoError::UnsupportedPlatform(
+                "--allow-connect-port is not supported on macOS: Seatbelt cannot filter by TCP port. \
+                 Use --allow-domain for host-level filtering, or ProxyOnly mode."
+                    .to_string(),
+            ));
+        }
+        #[cfg(not(target_os = "macos"))]
+        for port in &args.allow_connect_port {
+            caps.add_tcp_connect_port(*port);
         }
 
         // Command allow/block lists
@@ -885,15 +887,17 @@ impl CapabilitySetExt for CapabilitySet {
         }
 
         // Outbound TCP connect port allowlist from profile (Linux Landlock V4+ only)
-        for port in &profile.network.connect_port {
-            caps.add_tcp_connect_port(*port);
-        }
         #[cfg(target_os = "macos")]
         if !profile.network.connect_port.is_empty() {
-            warn!(
-                "profile `connect_port` has no effect on macOS: Seatbelt cannot filter by TCP \
-                 port. Use `allow_domain` for host-level filtering instead."
-            );
+            return Err(NonoError::UnsupportedPlatform(
+                "profile `connect_port` is not supported on macOS: Seatbelt cannot filter by TCP \
+                 port. Use `allow_domain` for host-level filtering, or ProxyOnly mode."
+                    .to_string(),
+            ));
+        }
+        #[cfg(not(target_os = "macos"))]
+        for port in &profile.network.connect_port {
+            caps.add_tcp_connect_port(*port);
         }
 
         // Apply allowed commands from profile
@@ -1074,15 +1078,17 @@ fn add_cli_overrides(
     }
 
     // Outbound TCP connect port allowlist from CLI (Linux Landlock V4+ only)
-    for port in &args.allow_connect_port {
-        caps.add_tcp_connect_port(*port);
-    }
     #[cfg(target_os = "macos")]
     if !args.allow_connect_port.is_empty() {
-        warn!(
-            "--allow-connect-port has no effect on macOS: Seatbelt cannot filter by TCP port. \
-             Use --allow-domain for host-level filtering instead."
-        );
+        return Err(NonoError::UnsupportedPlatform(
+            "--allow-connect-port is not supported on macOS: Seatbelt cannot filter by TCP port. \
+             Use --allow-domain for host-level filtering, or ProxyOnly mode."
+                .to_string(),
+        ));
+    }
+    #[cfg(not(target_os = "macos"))]
+    for port in &args.allow_connect_port {
+        caps.add_tcp_connect_port(*port);
     }
 
     // Command allow/block from CLI
@@ -2288,6 +2294,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(target_os = "macos"))]
     #[test]
     fn test_from_args_allow_connect_port_populates_tcp_connect_ports() {
         let args = SandboxArgs {
@@ -2299,6 +2306,21 @@ mod tests {
         assert_eq!(caps.tcp_connect_ports(), &[443, 80, 5432]);
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_from_args_allow_connect_port_errors_on_macos() {
+        let args = SandboxArgs {
+            allow_connect_port: vec![443],
+            ..sandbox_args()
+        };
+        let err = from_args_locked(&args).expect_err("should fail on macOS");
+        assert!(
+            err.to_string().contains("not supported on macOS"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(not(target_os = "macos"))]
     #[test]
     fn test_from_profile_connect_port_populates_tcp_connect_ports() {
         let dir = tempdir().expect("tmpdir");
@@ -2320,6 +2342,33 @@ mod tests {
         assert_eq!(caps.tcp_connect_ports(), &[443, 5432]);
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_from_profile_connect_port_errors_on_macos() {
+        let dir = tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("connect-port-profile.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "connect-port-profile" },
+                "network": { "connect_port": [443] }
+            }"#,
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+
+        let workdir = tempdir().expect("workdir");
+        let args = sandbox_args();
+
+        let err = from_profile_locked(&profile, workdir.path(), &args)
+            .expect_err("should fail on macOS");
+        assert!(
+            err.to_string().contains("not supported on macOS"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(not(target_os = "macos"))]
     #[test]
     fn test_cli_allow_connect_port_overrides_profile_connect_port() {
         let dir = tempdir().expect("tmpdir");

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -536,6 +536,18 @@ impl CapabilitySetExt for CapabilitySet {
             caps.add_localhost_port(*port);
         }
 
+        // Outbound TCP connect port allowlist (Linux Landlock V4+ only)
+        for port in &args.allow_connect_port {
+            caps.add_tcp_connect_port(*port);
+        }
+        #[cfg(target_os = "macos")]
+        if !args.allow_connect_port.is_empty() {
+            warn!(
+                "--allow-connect-port has no effect on macOS: Seatbelt cannot filter by TCP port. \
+                 Use --allow-domain for host-level filtering instead."
+            );
+        }
+
         // Command allow/block lists
         for cmd in &args.allow_command {
             caps.add_allowed_command(cmd.clone());
@@ -872,6 +884,18 @@ impl CapabilitySetExt for CapabilitySet {
             caps.add_localhost_port(*port);
         }
 
+        // Outbound TCP connect port allowlist from profile (Linux Landlock V4+ only)
+        for port in &profile.network.connect_port {
+            caps.add_tcp_connect_port(*port);
+        }
+        #[cfg(target_os = "macos")]
+        if !profile.network.connect_port.is_empty() {
+            warn!(
+                "profile `connect_port` has no effect on macOS: Seatbelt cannot filter by TCP \
+                 port. Use `allow_domain` for host-level filtering instead."
+            );
+        }
+
         // Apply allowed commands from profile
         for cmd in &profile.security.allowed_commands {
             caps.add_allowed_command(cmd.as_str());
@@ -1047,6 +1071,18 @@ fn add_cli_overrides(
     // Localhost IPC ports from CLI
     for port in &args.allow_port {
         caps.add_localhost_port(*port);
+    }
+
+    // Outbound TCP connect port allowlist from CLI (Linux Landlock V4+ only)
+    for port in &args.allow_connect_port {
+        caps.add_tcp_connect_port(*port);
+    }
+    #[cfg(target_os = "macos")]
+    if !args.allow_connect_port.is_empty() {
+        warn!(
+            "--allow-connect-port has no effect on macOS: Seatbelt cannot filter by TCP port. \
+             Use --allow-domain for host-level filtering instead."
+        );
     }
 
     // Command allow/block from CLI
@@ -2250,6 +2286,65 @@ mod tests {
             regex_escape_path("/Users/me/.claude.json"),
             "/Users/me/\\.claude\\.json"
         );
+    }
+
+    #[test]
+    fn test_from_args_allow_connect_port_populates_tcp_connect_ports() {
+        let args = SandboxArgs {
+            allow_connect_port: vec![443, 80, 5432],
+            ..sandbox_args()
+        };
+
+        let (caps, _) = from_args_locked(&args).expect("build caps");
+        assert_eq!(caps.tcp_connect_ports(), &[443, 80, 5432]);
+    }
+
+    #[test]
+    fn test_from_profile_connect_port_populates_tcp_connect_ports() {
+        let dir = tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("connect-port-profile.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "connect-port-profile" },
+                "network": { "connect_port": [443, 5432] }
+            }"#,
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+
+        let workdir = tempdir().expect("workdir");
+        let args = sandbox_args();
+
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
+        assert_eq!(caps.tcp_connect_ports(), &[443, 5432]);
+    }
+
+    #[test]
+    fn test_cli_allow_connect_port_overrides_profile_connect_port() {
+        let dir = tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("connect-port-override.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "connect-port-override" },
+                "network": { "connect_port": [443] }
+            }"#,
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+
+        let workdir = tempdir().expect("workdir");
+        let args = SandboxArgs {
+            allow_connect_port: vec![5432],
+            ..sandbox_args()
+        };
+
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
+        // Both profile and CLI ports should be present
+        let ports = caps.tcp_connect_ports();
+        assert!(ports.contains(&443), "profile port 443 should be present");
+        assert!(ports.contains(&5432), "CLI port 5432 should be present");
     }
 
     #[test]

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -969,6 +969,14 @@ pub struct SandboxArgs {
     )]
     pub allow_port: Vec<u16>,
 
+    /// Allow outbound TCP connect to a specific port (repeatable; Linux Landlock V4+ only)
+    #[arg(
+        long = "allow-connect-port",
+        value_name = "PORT",
+        help_heading = "NETWORK"
+    )]
+    pub allow_connect_port: Vec<u16>,
+
     /// Chain outbound traffic through an upstream proxy (host:port)
     #[arg(
         long = "upstream-proxy",
@@ -1075,7 +1083,7 @@ pub struct SandboxArgs {
             "allow_unix_socket_dir", "allow_unix_socket_dir_bind",
             "profile", "override_deny", "allow_cwd",
             "block_net", "allow_net", "network_profile", "allow_proxy",
-            "allow_bind", "allow_port", "external_proxy", "proxy_port",
+            "allow_bind", "allow_port", "allow_connect_port", "external_proxy", "proxy_port",
             "proxy_credential", "allow_endpoint", "env_credential", "env_credential_map",
             "allow_command", "block_command", "allow_launch_services", "allow_gpu",
         ],
@@ -1202,6 +1210,14 @@ pub struct WrapSandboxArgs {
     )]
     pub allow_port: Vec<u16>,
 
+    /// Allow outbound TCP connect to a specific port (repeatable; Linux Landlock V4+ only)
+    #[arg(
+        long = "allow-connect-port",
+        value_name = "PORT",
+        help_heading = "NETWORK"
+    )]
+    pub allow_connect_port: Vec<u16>,
+
     // ── Credentials ──────────────────────────────────────────────────────
     /// Load credentials as env vars
     #[arg(
@@ -1261,7 +1277,7 @@ pub struct WrapSandboxArgs {
             "allow_unix_socket", "allow_unix_socket_bind",
             "allow_unix_socket_dir", "allow_unix_socket_dir_bind",
             "profile", "override_deny", "allow_cwd",
-            "block_net", "allow_bind", "allow_port",
+            "block_net", "allow_bind", "allow_port", "allow_connect_port",
             "env_credential", "env_credential_map",
             "allow_command", "block_command", "allow_launch_services", "allow_gpu",
         ],
@@ -1300,6 +1316,7 @@ impl From<WrapSandboxArgs> for SandboxArgs {
             allow_proxy: Vec::new(),
             allow_bind: args.allow_bind,
             allow_port: args.allow_port,
+            allow_connect_port: args.allow_connect_port,
             external_proxy: None,
             external_proxy_bypass: Vec::new(),
             proxy_port: None,

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -870,6 +870,10 @@ pub struct NetworkConfig {
     /// Equivalent to `--listen-port` CLI flag.
     #[serde(default)]
     pub listen_port: Vec<u16>,
+    /// Outbound TCP connect ports (allowlist). Linux Landlock V4+ only.
+    /// Equivalent to `--allow-connect-port` CLI flag.
+    #[serde(default)]
+    pub connect_port: Vec<u16>,
     /// Custom credential definitions for services not in network-policy.json.
     /// Keys are service names (used with `--credential`), values define
     /// how to route and inject credentials for that service.
@@ -1838,6 +1842,7 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
             allow_domain: dedup_append(&base.network.allow_domain, &child.network.allow_domain),
             open_port: dedup_append(&base.network.open_port, &child.network.open_port),
             listen_port: dedup_append(&base.network.listen_port, &child.network.listen_port),
+            connect_port: dedup_append(&base.network.connect_port, &child.network.connect_port),
             // Child `Some([])` overrides parent credentials to empty (disables proxy).
             // Child `None` inherits parent credentials. Child `Some([...])` merges with parent.
             credentials: match child.network.credentials {
@@ -3449,6 +3454,7 @@ mod tests {
                 allow_domain: vec!["base.example.com".to_string()],
                 open_port: vec![3000],
                 listen_port: vec![4000],
+                connect_port: vec![],
                 credentials: Some(vec!["base_cred".to_string()]),
                 custom_credentials: HashMap::new(),
                 upstream_proxy: None,
@@ -3527,6 +3533,7 @@ mod tests {
                 allow_domain: vec!["child.example.com".to_string()],
                 open_port: vec![3000, 5000],
                 listen_port: vec![4000, 6000],
+                connect_port: vec![],
                 credentials: None,
                 custom_credentials: HashMap::new(),
                 upstream_proxy: None,


### PR DESCRIPTION
Adds --allow-connect-port PORT (repeatable) to SandboxArgs and WrapSandboxArgs, wiring caps.add_tcp_connect_port() through from_args, from_profile, and add_cli_overrides.

Also adds connect_port: Vec<u16> to NetworkConfig for profile-based configuration, merged via dedup_append consistent with open_port and listen_port.

On macOS, the flag emits a warning (Seatbelt cannot filter by TCP port). OS-level enforcement requires Linux Landlock V4+ (kernel >= 6.7).

Closes #743