### PR TITLE
feat(network): support GitLab domains in developer network policy

### DIFF
--- a/crates/nono-cli/data/network-policy.json
+++ b/crates/nono-cli/data/network-policy.json
@@ -58,6 +58,14 @@
         "pkg-containers.githubusercontent.com"
       ]
     },
+    "gitlab": {
+      "description": "GitLab API, AI Gateway, Packages, and Registries",
+      "hosts": [
+        "gitlab.com",
+        "cloud.gitlab.com",
+        "registry.gitlab.com"
+      ]
+    },
     "sigstore": {
       "description": "Sigstore transparency and signing infrastructure",
       "hosts": [
@@ -107,40 +115,44 @@
         "llm_apis",
         "package_registries",
         "github",
+        "gitlab",
         "sigstore",
         "documentation"
       ],
-      "credentials": ["google-ai", "github"]
+      "credentials": ["google-ai", "github", "gitlab"]
     },
     "developer": {
       "groups": [
         "llm_apis",
         "package_registries",
         "github",
+        "gitlab",
         "sigstore",
         "documentation"
       ],
-      "credentials": ["github"]
+      "credentials": ["github", "gitlab"]
     },
     "codex": {
       "groups": [
         "llm_apis",
         "package_registries",
         "github",
+        "gitlab",
         "sigstore",
         "documentation"
       ],
-      "credentials": ["openai", "github"]
+      "credentials": ["openai", "github", "gitlab"]
     },
     "claude-code": {
       "groups": [
         "llm_apis",
         "package_registries",
         "github",
+        "gitlab",
         "sigstore",
         "documentation"
       ],
-      "credentials": ["anthropic", "github"]
+      "credentials": ["anthropic", "github", "gitlab"]
     },
     "minimal": {
       "groups": [
@@ -152,6 +164,7 @@
         "llm_apis",
         "package_registries",
         "github",
+        "gitlab",
         "sigstore",
         "documentation",
         "google_cloud",
@@ -189,6 +202,13 @@
       "inject_header": "Authorization",
       "credential_format": "token {}",
       "env_var": "GITHUB_TOKEN"
+    },
+    "gitlab": {
+      "upstream": "https://gitlab.com/api",
+      "credential_key": "env://GITLAB_TOKEN",
+      "inject_header": "Authorization",
+      "credential_format": "Bearer {}",
+      "env_var": "GITLAB_TOKEN"
     }
   }
 }

--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -861,7 +861,32 @@ mod tests {
     }
 
     #[test]
-    fn test_claude_code_profile_includes_github_credential() {
+    fn test_resolve_gitlab_credential() {
+        let json = embedded_network_policy_json();
+        let policy = load_network_policy(json).expect("policy should load");
+
+        let custom = HashMap::new();
+        let routes =
+            resolve_credentials(&policy, &["gitlab".to_string()], &custom).expect("should resolve");
+        assert_eq!(routes.len(), 1);
+
+        let gitlab = &routes[0];
+        assert_eq!(gitlab.prefix, "gitlab");
+        assert_eq!(gitlab.upstream, "https://gitlab.com/api");
+        assert_eq!(
+            gitlab.credential_key,
+            Some("env://GITLAB_TOKEN".to_string())
+        );
+        assert_eq!(gitlab.credential_format, "Bearer {}");
+        assert_eq!(
+            gitlab.env_var,
+            Some("GITLAB_TOKEN".to_string()),
+            "gitlab credential must have explicit env_var for phantom token"
+        );
+    }
+
+    #[test]
+    fn test_claude_code_profile_includes_git_provider_credential() {
         let json = embedded_network_policy_json();
         let policy = load_network_policy(json).expect("policy should load");
 
@@ -871,10 +896,15 @@ mod tests {
             "claude-code profile should include github credential, got: {:?}",
             resolved.profile_credentials
         );
+        assert!(
+            resolved.profile_credentials.contains(&"gitlab".to_string()),
+            "claude-code profile should include gitlab credential, got: {:?}",
+            resolved.profile_credentials
+        );
     }
 
     #[test]
-    fn test_codex_profile_includes_openai_and_github_credentials() {
+    fn test_codex_profile_includes_openai_and_git_provider_credentials() {
         let json = embedded_network_policy_json();
         let policy = load_network_policy(json).expect("policy should load");
 
@@ -887,6 +917,11 @@ mod tests {
         assert!(
             resolved.profile_credentials.contains(&"github".to_string()),
             "codex profile should include github credential, got: {:?}",
+            resolved.profile_credentials
+        );
+        assert!(
+            resolved.profile_credentials.contains(&"gitlab".to_string()),
+            "codex profile should include gitlab credential, got: {:?}",
             resolved.profile_credentials
         );
     }
@@ -939,6 +974,19 @@ mod tests {
         assert!(
             resolved.profile_credentials.contains(&"github".to_string()),
             "developer profile should include github credential, got: {:?}",
+            resolved.profile_credentials
+        );
+    }
+
+    #[test]
+    fn test_developer_profile_includes_gitlab_credential() {
+        let json = embedded_network_policy_json();
+        let policy = load_network_policy(json).expect("policy should load");
+
+        let resolved = resolve_network_profile(&policy, "developer").expect("should resolve");
+        assert!(
+            resolved.profile_credentials.contains(&"gitlab".to_string()),
+            "developer profile should include gitlab credential, got: {:?}",
             resolved.profile_credentials
         );
     }


### PR DESCRIPTION
Add network policy and credential injection support for GitLab domains. 🎉 

I’m intentionally omitting JWT auth for cloud.gitlab.com as they’re scoped shortlived access tokens which can’t refresh themselves so would lead to workarounds.