### PR TITLE
fix(cli): shell-quote command args in display output (#660)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,6 +1611,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "shlex",
  "sigstore-sign",
  "similar",
  "tempfile",

--- a/crates/nono-cli/Cargo.toml
+++ b/crates/nono-cli/Cargo.toml
@@ -73,6 +73,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2.5.8"
 tempfile = "3"
 vt100 = "0.16.2"
+shlex = "1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { version = "0.31", features = ["process", "signal", "fs", "user", "term"] }

--- a/crates/nono-cli/src/audit_commands.rs
+++ b/crates/nono-cli/src/audit_commands.rs
@@ -12,6 +12,7 @@ use crate::audit_session::{
 use crate::cli::{
     AuditArgs, AuditCleanupArgs, AuditCommands, AuditListArgs, AuditShowArgs, AuditVerifyArgs,
 };
+use crate::command_display::format_command_line;
 use crate::theme;
 use colored::Colorize;
 use nono::undo::SnapshotManager;
@@ -269,7 +270,7 @@ fn cmd_show(args: AuditShowArgs) -> Result<()> {
     eprintln!(
         "  Command:  {}",
         theme::fg(
-            &session.metadata.command.join(" "),
+            &format_command_line(&session.metadata.command),
             theme::current().subtext
         )
     );
@@ -586,7 +587,7 @@ fn cmd_cleanup(args: AuditCleanupArgs) -> Result<()> {
             eprintln!(
                 "  {} {} ({})",
                 s.metadata.session_id,
-                s.metadata.command.join(" ").truecolor(
+                format_command_line(&s.metadata.command).truecolor(
                     theme::current().subtext.0,
                     theme::current().subtext.1,
                     theme::current().subtext.2
@@ -734,7 +735,7 @@ fn shorten_home(path: &Path) -> String {
 }
 
 fn truncate_command(cmd: &[String], max_len: usize) -> String {
-    let full = cmd.join(" ");
+    let full = format_command_line(cmd);
     if full.len() <= max_len {
         full
     } else {

--- a/crates/nono-cli/src/audit_commands.rs
+++ b/crates/nono-cli/src/audit_commands.rs
@@ -12,7 +12,7 @@ use crate::audit_session::{
 use crate::cli::{
     AuditArgs, AuditCleanupArgs, AuditCommands, AuditListArgs, AuditShowArgs, AuditVerifyArgs,
 };
-use crate::command_display::format_command_line;
+use crate::command_display::{format_command_line, truncate_command};
 use crate::theme;
 use colored::Colorize;
 use nono::undo::SnapshotManager;
@@ -732,15 +732,6 @@ fn shorten_home(path: &Path) -> String {
         }
     }
     s
-}
-
-fn truncate_command(cmd: &[String], max_len: usize) -> String {
-    let full = format_command_line(cmd);
-    if full.len() <= max_len {
-        full
-    } else {
-        format!("{}...", &full[..max_len.saturating_sub(3)])
-    }
 }
 
 fn change_symbol(ct: &nono::undo::ChangeType) -> colored::ColoredString {

--- a/crates/nono-cli/src/command_display.rs
+++ b/crates/nono-cli/src/command_display.rs
@@ -1,0 +1,114 @@
+//! Helpers for rendering user-supplied commands for display.
+//!
+//! Commands passed to `nono` (e.g. after `--`) preserve each argument as a
+//! separate `String`. When we echo those commands back to the user — in the
+//! `nono learn` "Run with:" hint, the dry-run banner, `nono ps` details,
+//! audit/rollback listings — we want the rendered line to round-trip: a user
+//! copy-pasting it into a shell must execute the exact same argv that was
+//! learned or recorded.
+//!
+//! A naive `command.join(" ")` breaks that contract as soon as any argument
+//! contains whitespace, quotes, `$`, backslashes, etc. `echo 'foo bar' baz`
+//! becomes `echo foo bar baz` (three args instead of two). See issue #660.
+//!
+//! This module centralises shell-quoting via [`shlex::try_quote`] so all
+//! display sites stay consistent.
+
+use std::borrow::Cow;
+
+/// Quote a single argument for POSIX shell display.
+///
+/// Returns the input unchanged when it is already safe to display unquoted
+/// (e.g. a simple identifier like `echo`). Falls back to a single-quoted
+/// form when the argument contains a NUL byte, which `shlex::try_quote`
+/// rejects. NUL cannot appear in a real shell argument, so this fallback
+/// is only about keeping display infallible — we still want the user to
+/// see *something* if a recorded command contains corrupt data.
+fn quote_arg(arg: &str) -> Cow<'_, str> {
+    match shlex::try_quote(arg) {
+        Ok(quoted) => quoted,
+        Err(_) => Cow::Owned(format!("'{}'", arg.replace('\'', "'\\''"))),
+    }
+}
+
+/// Render a command (program + args) as a single shell-quoted line suitable
+/// for display or copy-paste back into a terminal.
+///
+/// Each element is quoted independently with [`shlex::try_quote`] and joined
+/// with spaces. Empty `command` returns an empty string.
+pub(crate) fn format_command_line(command: &[String]) -> String {
+    command
+        .iter()
+        .map(|a| quote_arg(a))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_args_unquoted() {
+        assert_eq!(
+            format_command_line(&["echo".to_string(), "hello".to_string()]),
+            "echo hello"
+        );
+    }
+
+    #[test]
+    fn args_with_spaces_are_quoted() {
+        let out =
+            format_command_line(&["echo".to_string(), "foo bar".to_string(), "baz".to_string()]);
+        // Must preserve "foo bar" as a single argument when re-parsed.
+        let reparsed = shlex::split(&out).expect("round-trips through shlex");
+        assert_eq!(reparsed, vec!["echo", "foo bar", "baz"]);
+    }
+
+    #[test]
+    fn args_with_single_quotes_are_quoted() {
+        let out = format_command_line(&["echo".to_string(), "it's".to_string()]);
+        let reparsed = shlex::split(&out).expect("round-trips through shlex");
+        assert_eq!(reparsed, vec!["echo", "it's"]);
+    }
+
+    #[test]
+    fn args_with_double_quotes_are_quoted() {
+        let out = format_command_line(&["echo".to_string(), "a\"b".to_string()]);
+        let reparsed = shlex::split(&out).expect("round-trips through shlex");
+        assert_eq!(reparsed, vec!["echo", "a\"b"]);
+    }
+
+    #[test]
+    fn args_with_dollar_and_backslash_are_quoted() {
+        let out =
+            format_command_line(&["echo".to_string(), "$HOME".to_string(), "a\\b".to_string()]);
+        let reparsed = shlex::split(&out).expect("round-trips through shlex");
+        assert_eq!(reparsed, vec!["echo", "$HOME", "a\\b"]);
+    }
+
+    #[test]
+    fn empty_arg_is_quoted() {
+        let out = format_command_line(&["echo".to_string(), String::new()]);
+        let reparsed = shlex::split(&out).expect("round-trips through shlex");
+        assert_eq!(reparsed, vec!["echo", ""]);
+    }
+
+    #[test]
+    fn empty_command_returns_empty_string() {
+        assert_eq!(format_command_line(&[]), "");
+    }
+
+    #[test]
+    fn issue_660_repro() {
+        // From issue #660: `nono learn -- echo 'foo bar' 'baz'` must not
+        // render as `echo foo bar baz`.
+        let rendered =
+            format_command_line(&["echo".to_string(), "foo bar".to_string(), "baz".to_string()]);
+        let naive = ["echo", "foo bar", "baz"].join(" ");
+        assert_eq!(naive, "echo foo bar baz"); // what the bug produced
+        assert_ne!(rendered, naive);
+        let reparsed = shlex::split(&rendered).expect("round-trips through shlex");
+        assert_eq!(reparsed, vec!["echo", "foo bar", "baz"]);
+    }
+}

--- a/crates/nono-cli/src/command_display.rs
+++ b/crates/nono-cli/src/command_display.rs
@@ -44,6 +44,35 @@ pub(crate) fn format_command_line(command: &[String]) -> String {
         .join(" ")
 }
 
+/// Render a command via [`format_command_line`] and truncate it to at most
+/// `max_len` characters, appending an ellipsis (`...`) when truncated.
+///
+/// Truncation operates on Unicode scalar values (`char`s), not bytes, so it
+/// will never split a multi-byte UTF-8 sequence — byte slicing the result
+/// of `format_command_line` is a panic hazard whenever a recorded command
+/// contains non-ASCII text. Grapheme-cluster width (e.g. emoji ZWJ
+/// sequences, combining marks) is out of scope; callers that render to a
+/// fixed-width terminal column should size `max_len` conservatively.
+///
+/// Edge case: when `max_len < 3` and truncation is needed, the result is
+/// just `"..."` (3 chars), which technically exceeds `max_len`. This
+/// preserves the prior behaviour and matches the only sensible thing to
+/// do — there is no shorter way to signal truncation. Callers should pass
+/// `max_len >= 3`.
+pub(crate) fn truncate_command(command: &[String], max_len: usize) -> String {
+    let full = format_command_line(command);
+    // Fast path: byte length is always >= char count, so when bytes fit, we
+    // know the char count fits too and no truncation (or char counting) is
+    // needed.
+    if full.len() <= max_len {
+        return full;
+    }
+    let keep = max_len.saturating_sub(3);
+    let mut truncated: String = full.chars().take(keep).collect();
+    truncated.push_str("...");
+    truncated
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -110,5 +139,34 @@ mod tests {
         assert_ne!(rendered, naive);
         let reparsed = shlex::split(&rendered).expect("round-trips through shlex");
         assert_eq!(reparsed, vec!["echo", "foo bar", "baz"]);
+    }
+
+    #[test]
+    fn truncate_command_short_passes_through() {
+        let cmd = vec!["echo".to_string(), "hello".to_string()];
+        assert_eq!(truncate_command(&cmd, 40), "echo hello");
+    }
+
+    #[test]
+    fn truncate_command_handles_multibyte_utf8() {
+        // shlex single-quotes non-ASCII args, so the rendered line is
+        // `'éééééé'` — each `é` is 2 bytes in UTF-8. With `max_len = 5`,
+        // byte slicing at index `max_len - 3 = 2` lands inside the first
+        // `é` (between its two bytes, which is *not* a char boundary)
+        // and would panic under the previous implementation.
+        let cmd = vec!["éééééé".to_string()];
+        let result = truncate_command(&cmd, 5);
+        // Char-aware: keep `max_len - 3 = 2` chars (`'é`), append "...".
+        assert_eq!(result, "'é...");
+        assert!(result.chars().count() <= 5);
+    }
+
+    #[test]
+    fn truncate_command_max_len_smaller_than_ellipsis() {
+        // `max_len.saturating_sub(3)` underflows to 0 — we should still
+        // produce a non-panicking result.
+        let cmd = vec!["echo".to_string(), "hello world".to_string()];
+        let result = truncate_command(&cmd, 2);
+        assert_eq!(result, "...");
     }
 }

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -12,6 +12,7 @@ mod capability_ext;
 mod cli;
 mod cli_bootstrap;
 mod command_blocking_deprecation;
+mod command_display;
 mod command_runtime;
 mod config;
 mod credential_runtime;

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -2,6 +2,7 @@
 //!
 //! All colors are drawn from the active theme via `theme::current()`.
 
+use crate::command_display::format_command_line;
 use crate::theme::{self, badge, fg, Rgb};
 use colored::Colorize;
 use nono::{AccessMode, CapabilitySet, NetworkMode, NonoError, Result};
@@ -534,7 +535,7 @@ pub fn print_dry_run(program: &OsStr, cmd_args: &[OsString], silent: bool) {
     eprintln!(
         "  {} {}",
         fg("$", t.subtext),
-        fg(&command.join(" "), t.text)
+        fg(&format_command_line(&command), t.text)
     );
 }
 

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -1,3 +1,4 @@
+use crate::command_display::format_command_line;
 use crate::{profile, query_ext};
 use colored::Colorize;
 use nono::diagnostic::{ErrorObservation, PolicyExplanation};
@@ -321,7 +322,7 @@ pub(crate) fn print_profile_save(prepared: &PreparedProfileSave, command: &[Stri
         "Run with: {} {} -- {}",
         "nono run --profile".bold(),
         prepared.profile_name,
-        command.join(" ")
+        format_command_line(command)
     ));
 }
 

--- a/crates/nono-cli/src/rollback_commands.rs
+++ b/crates/nono-cli/src/rollback_commands.rs
@@ -6,6 +6,7 @@ use crate::cli::{
     RollbackArgs, RollbackCleanupArgs, RollbackCommands, RollbackListArgs, RollbackRestoreArgs,
     RollbackShowArgs, RollbackVerifyArgs,
 };
+use crate::command_display::format_command_line;
 use crate::config::user::load_user_config;
 use crate::rollback_base_exclusions;
 use crate::rollback_session::{
@@ -320,7 +321,7 @@ fn cmd_show(args: RollbackShowArgs) -> Result<()> {
         prefix(),
         session.metadata.session_id.white().bold(),
         theme::fg(
-            &session.metadata.command.join(" "),
+            &format_command_line(&session.metadata.command),
             theme::current().subtext
         )
     );
@@ -889,7 +890,7 @@ fn cmd_cleanup(args: RollbackCleanupArgs) -> Result<()> {
             eprintln!(
                 "  {} {} ({})",
                 s.metadata.session_id,
-                s.metadata.command.join(" ").truecolor(
+                format_command_line(&s.metadata.command).truecolor(
                     theme::current().subtext.0,
                     theme::current().subtext.1,
                     theme::current().subtext.2

--- a/crates/nono-cli/src/session_commands.rs
+++ b/crates/nono-cli/src/session_commands.rs
@@ -4,6 +4,7 @@
 //! `nono inspect`, and `nono prune`.
 
 use crate::cli::{AttachArgs, DetachArgs, InspectArgs, LogsArgs, PruneArgs, PsArgs, StopArgs};
+use crate::command_display::format_command_line;
 use crate::session::{self, SessionAttachment, SessionRecord, SessionStatus};
 use colored::Colorize;
 use nono::{NonoError, Result};
@@ -298,7 +299,7 @@ pub fn run_inspect(args: &InspectArgs) -> Result<()> {
     if let Some(code) = record.exit_code {
         println!("Exit code:  {}", code);
     }
-    println!("Command:    {}", record.command.join(" "));
+    println!("Command:    {}", format_command_line(&record.command));
     if let Some(ref profile) = record.profile {
         println!("Profile:    {}", profile);
     }
@@ -400,7 +401,7 @@ pub fn run_prune(args: &PruneArgs) -> Result<()> {
 
 /// Truncate command display to max_len characters.
 fn truncate_command(command: &[String], max_len: usize) -> String {
-    let full = command.join(" ");
+    let full = format_command_line(command);
     if full.len() <= max_len {
         full
     } else {

--- a/crates/nono-cli/src/session_commands.rs
+++ b/crates/nono-cli/src/session_commands.rs
@@ -4,7 +4,7 @@
 //! `nono inspect`, and `nono prune`.
 
 use crate::cli::{AttachArgs, DetachArgs, InspectArgs, LogsArgs, PruneArgs, PsArgs, StopArgs};
-use crate::command_display::format_command_line;
+use crate::command_display::{format_command_line, truncate_command};
 use crate::session::{self, SessionAttachment, SessionRecord, SessionStatus};
 use colored::Colorize;
 use nono::{NonoError, Result};
@@ -399,16 +399,6 @@ pub fn run_prune(args: &PruneArgs) -> Result<()> {
     Ok(())
 }
 
-/// Truncate command display to max_len characters.
-fn truncate_command(command: &[String], max_len: usize) -> String {
-    let full = format_command_line(command);
-    if full.len() <= max_len {
-        full
-    } else {
-        format!("{}...", &full[..max_len.saturating_sub(3)])
-    }
-}
-
 fn read_event_log_lines(path: &Path, tail: Option<usize>) -> Result<Vec<String>> {
     let file = std::fs::File::open(path).map_err(|e| NonoError::ConfigRead {
         path: path.to_path_buf(),
@@ -500,23 +490,6 @@ fn follow_event_log(path: &Path, tail: Option<usize>, as_json: bool) -> Result<(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_truncate_command_short() {
-        let cmd = vec!["echo".to_string(), "hello".to_string()];
-        assert_eq!(truncate_command(&cmd, 40), "echo hello");
-    }
-
-    #[test]
-    fn test_truncate_command_long() {
-        let cmd = vec![
-            "very-long-command".to_string(),
-            "with-many-arguments-that-exceed-the-limit".to_string(),
-        ];
-        let result = truncate_command(&cmd, 20);
-        assert!(result.len() <= 20);
-        assert!(result.ends_with("..."));
-    }
 
     #[test]
     fn test_format_uptime_seconds() {


### PR DESCRIPTION
## Summary

- `nono learn`'s "Run with:" hint and other command-display sites were calling `command.join(" ")`, which drops argument boundaries whenever an arg contains whitespace, quotes, `$`, or backslashes. `nono learn -- echo 'foo bar' baz` would print `echo foo bar baz` — copy-pasting runs a different command than the one that was learned.
- Added `command_display::format_command_line` (shell-quotes each arg via `shlex::try_quote`, joins with spaces) and routed every `.command.join(" ")` site through it: learn success output (`profile_save_runtime::print_profile_save`), `nono inspect`, dry-run banner, `audit show`/`audit cleanup`, `rollback show`/`rollback cleanup`, and both `truncate_command` helpers.
- 8 unit tests cover plain args, spaces, single/double quotes, `\$`, backslashes, empty args, empty command, and the exact issue #660 repro. Tests assert the quoted output *round-trips* through `shlex::split` rather than pinning an exact quoting style.
- Profile-name escaping intentionally left to #661 per the maintainer's scoping comment — `is_valid_profile_name` already restricts names to `[A-Za-z0-9-]`.

Resolves: #660

## Test plan

- [x] \`make fmt-check\`
- [x] \`make clippy\` (\`-D warnings -D clippy::unwrap_used\`)
- [x] \`cargo test -p nono\` — 578 passed
- [x] \`cargo test -p nono-cli\` unit tests — 815 passed
- [x] \`cargo test -p nono-cli\` non-sandbox integration tests (\`config_flag\`, \`deprecated_policy\`, \`env_vars\`, \`manifest_roundtrip\`, \`profile_cli\`, \`profile_cmd\`) — 68 passed
- [x] \`cargo test -p nono-ffi\` — 39 passed
- [x] \`cargo test --doc --workspace\` — 7 passed
- [x] Manual: \`format_command_line\` output round-trips \`shlex::split\` back to the original argv (see \`issue_660_repro\` test)

Note: the \`audit_attestation\` integration tests failed in my local environment because the harness spawns \`nono\` to apply seatbelt inside an already-sandboxed shell (\`sandbox initialization failed: Operation not permitted\`); failures reproduce on the unmodified rebased branch. They should pass on CI runners.