### PR TITLE
fix(proxy): stop adding allow_domain hosts to NO_PROXY without direct TCP grants

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -55,7 +55,7 @@ fn try_new_unix_socket_file(
     match UnixSocketCapability::new_file(path, mode) {
         Ok(cap) => Ok(Some(cap)),
         Err(NonoError::PathNotFound(_)) => {
-            warn!("{}: {}", label, path.display());
+            info!("{}: {}", label, path.display());
             Ok(None)
         }
         Err(e) => Err(e),
@@ -71,7 +71,7 @@ fn try_new_unix_socket_dir(
     match UnixSocketCapability::new_dir(path, mode) {
         Ok(cap) => Ok(Some(cap)),
         Err(NonoError::PathNotFound(_)) => {
-            warn!("{}: {}", label, path.display());
+            info!("{}: {}", label, path.display());
             Ok(None)
         }
         Err(e) => Err(e),

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -190,7 +190,8 @@ pub(crate) fn start_proxy_runtime(
         });
     }
 
-    let proxy_config = build_proxy_config_from_flags(proxy)?;
+    let mut proxy_config = build_proxy_config_from_flags(proxy)?;
+    proxy_config.direct_connect_ports = caps.tcp_connect_ports().to_vec();
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(2)
         .enable_all()

--- a/crates/nono-proxy/src/config.rs
+++ b/crates/nono-proxy/src/config.rs
@@ -47,6 +47,12 @@ pub struct ProxyConfig {
     #[serde(default)]
     pub external_proxy: Option<ExternalProxyConfig>,
 
+    /// Outbound TCP ports that the sandbox allows direct connections on
+    /// (via Landlock ConnectTcp). Hosts whose resolved port is NOT in this
+    /// set must go through the proxy and should NOT appear in NO_PROXY.
+    #[serde(default)]
+    pub direct_connect_ports: Vec<u16>,
+
     /// Maximum concurrent connections (0 = unlimited).
     #[serde(default)]
     pub max_connections: usize,
@@ -60,6 +66,7 @@ impl Default for ProxyConfig {
             allowed_hosts: Vec::new(),
             routes: Vec::new(),
             external_proxy: None,
+            direct_connect_ports: Vec::new(),
             max_connections: 256,
         }
     }

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -261,16 +261,17 @@ pub async fn start(config: ProxyConfig) -> Result<ProxyHandle> {
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let audit_log = audit::new_audit_log();
 
-    // Compute NO_PROXY hosts: allowed_hosts minus route upstreams.
-    // Non-route hosts bypass the proxy (direct connection, still
-    // Landlock-enforced). Route upstreams must go through the proxy
-    // for L7 path filtering and/or credential injection.
+    // Compute NO_PROXY hosts: allowed_hosts that can be reached via
+    // direct TCP connections (i.e. their port is in direct_connect_ports).
+    // Hosts without a direct TCP grant MUST go through the proxy —
+    // adding them to NO_PROXY would cause clients to attempt direct
+    // connections that the sandbox (Landlock / Seatbelt) denies.
     //
-    // On macOS this MUST be empty: Seatbelt's ProxyOnly mode generates
-    // `(deny network*) (allow network-outbound (remote tcp "localhost:PORT"))`
-    // which blocks ALL direct outbound. Tools that respect NO_PROXY would
-    // attempt direct connections that the sandbox denies (DNS lookup fails).
-    // All traffic must route through the proxy on macOS. See #580.
+    // Route upstreams are always excluded so their traffic goes through
+    // the proxy for L7 path filtering and/or credential injection.
+    //
+    // On macOS this MUST be empty regardless: Seatbelt's ProxyOnly mode
+    // blocks ALL direct outbound. See #580.
     let no_proxy_hosts: Vec<String> = if cfg!(target_os = "macos") {
         Vec::new()
     } else {
@@ -294,7 +295,16 @@ pub async fn start(config: ProxyConfig) -> Result<ProxyHandle> {
                         format!("{}:443", h)
                     }
                 };
-                !route_hosts.contains(&normalised)
+                if route_hosts.contains(&normalised) {
+                    return false;
+                }
+                // Only bypass the proxy if the sandbox grants direct
+                // TCP on this host's port (via --allow-connect-port).
+                let port = normalised
+                    .rsplit_once(':')
+                    .and_then(|(_, p)| p.parse::<u16>().ok())
+                    .unwrap_or(443);
+                config.direct_connect_ports.contains(&port)
             })
             .cloned()
             .collect()
@@ -1035,5 +1045,53 @@ mod tests {
             no_proxy.1, "localhost,127.0.0.1",
             "NO_PROXY should only contain loopback when no bypass hosts"
         );
+    }
+
+    #[tokio::test]
+    async fn test_no_proxy_empty_without_direct_connect_ports() {
+        // When direct_connect_ports is empty (no --allow-connect-port),
+        // allowed_hosts should NOT appear in NO_PROXY because the sandbox
+        // blocks direct TCP and clients would fail to connect. See #760.
+        let config = ProxyConfig {
+            allowed_hosts: vec!["github.com".to_string()],
+            ..Default::default()
+        };
+        let handle = start(config).await.unwrap();
+
+        let vars = handle.env_vars();
+        let no_proxy = vars.iter().find(|(k, _)| k == "NO_PROXY").unwrap();
+        assert_eq!(
+            no_proxy.1, "localhost,127.0.0.1",
+            "allowed_hosts must not appear in NO_PROXY without direct_connect_ports"
+        );
+
+        handle.shutdown();
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[tokio::test]
+    async fn test_no_proxy_includes_hosts_with_matching_connect_port() {
+        // When direct_connect_ports includes port 443, allowed_hosts on
+        // that port SHOULD appear in NO_PROXY (direct TCP is permitted).
+        // macOS always returns empty NO_PROXY (Seatbelt blocks all direct outbound).
+        let config = ProxyConfig {
+            allowed_hosts: vec!["github.com".to_string(), "server.internal:4222".to_string()],
+            direct_connect_ports: vec![443],
+            ..Default::default()
+        };
+        let handle = start(config).await.unwrap();
+
+        let vars = handle.env_vars();
+        let no_proxy = vars.iter().find(|(k, _)| k == "NO_PROXY").unwrap();
+        assert!(
+            no_proxy.1.contains("github.com"),
+            "host on port 443 should be in NO_PROXY when 443 is in direct_connect_ports"
+        );
+        assert!(
+            !no_proxy.1.contains("server.internal"),
+            "host on port 4222 should NOT be in NO_PROXY when only 443 is allowed"
+        );
+
+        handle.shutdown();
     }
 }


### PR DESCRIPTION
After #720 removed ConnectTcp grants from `--allow-domain`, allowed hosts still appeared in NO_PROXY. HTTP clients that honour NO_PROXY attempted direct connections that the sandbox denied, breaking tools like curl on Linux.

Add direct_connect_ports to ProxyConfig, populated from the capability set's tcp_connect_ports. The NO_PROXY computation now only includes hosts whose port is in this set. With no connect-port grants the list is empty and all allowed-domain traffic routes through the proxy.

Also fix warn! -> info! in try_new_unix_socket_{file,dir} to match the log-level change in 024ca6f that missed these call sites added by 85708ca.

---

Forward-compatible with #744: when `--allow-connect-port` / `connect_port` lands, ports will propagate through `tcp_connect_ports()` into `direct_connect_ports`, and matching hosts will reappear in `NO_PROXY`.

Fixes #760
