### PR TITLE
feat(policy): remove openclaw built-in profile

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -645,32 +645,6 @@
       "workdir": { "access": "none" },
       "interactive": false
     },
-    "openclaw": {
-      "extends": "default",
-      "meta": {
-        "name": "openclaw",
-        "version": "1.0.0",
-        "description": "OpenClaw messaging gateway",
-        "author": "nono-project"
-      },
-      "security": {
-        "groups": ["node_runtime"],
-        "signal_mode": "isolated"
-      },
-      "filesystem": {
-        "allow": [
-          "$HOME/.openclaw",
-          "$HOME/.config/openclaw",
-          "$TMPDIR/openclaw-$UID"
-        ]
-      },
-      "network": { "block": false },
-      "workdir": { "access": "read" },
-      "undo": {
-        "exclude_patterns": ["node_modules", ".next"]
-      },
-      "interactive": false
-    },
     "opencode": {
       "extends": "default",
       "meta": {

--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -143,6 +143,7 @@ pub(crate) fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
             wsl2_proxy_policy: prepared.wsl2_proxy_policy,
             override_deny_paths: prepared.override_deny_paths,
             allowed_env_vars: prepared.allowed_env_vars,
+            denied_env_vars: prepared.denied_env_vars,
             proxy,
             session: SessionLaunchOptions {
                 session_name: args.name,
@@ -212,6 +213,7 @@ pub(crate) fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
             no_diagnostics,
             override_deny_paths: prepared.override_deny_paths,
             allowed_env_vars: prepared.allowed_env_vars,
+            denied_env_vars: prepared.denied_env_vars,
             ..ExecutionFlags::defaults(silent)?
         },
     })

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -39,7 +39,7 @@ use tracing::{debug, info, warn};
 
 pub(crate) use env_sanitization::is_dangerous_env_var;
 use env_sanitization::should_skip_env_var;
-pub(crate) use env_sanitization::validate_allow_vars_pattern;
+pub(crate) use env_sanitization::validate_env_var_patterns;
 
 /// Resolve a program name to its absolute path.
 ///
@@ -221,6 +221,10 @@ pub struct ExecConfig<'a> {
     /// matching an exact name or prefix pattern (e.g. `"AWS_*"`) are
     /// passed to the child. Nono-injected credentials always bypass this.
     pub allowed_env_vars: Option<Vec<String>>,
+    /// Deny-list of environment variable names. Variables matching an exact
+    /// name or prefix pattern (e.g. `"GITHUB_*"`) are stripped even if they
+    /// also appear in `allowed_env_vars`. Nono-injected credentials bypass this.
+    pub denied_env_vars: Option<Vec<String>>,
 }
 
 #[derive(Clone, Copy)]
@@ -308,6 +312,11 @@ pub fn execute_direct(config: &ExecConfig<'_>) -> Result<()> {
             ],
         ) {
             continue;
+        }
+        if let Some(ref denied) = config.denied_env_vars {
+            if env_sanitization::is_env_var_denied(&key, denied) {
+                continue;
+            }
         }
         if let Some(ref allowed) = config.allowed_env_vars {
             if !env_sanitization::is_env_var_allowed(&key, allowed) {
@@ -436,6 +445,11 @@ pub fn execute_supervised(
                 ],
             ) {
                 continue;
+            }
+            if let Some(ref denied) = config.denied_env_vars {
+                if env_sanitization::is_env_var_denied(k, denied) {
+                    continue;
+                }
             }
             if let Some(ref allowed) = config.allowed_env_vars {
                 if !env_sanitization::is_env_var_allowed(k, allowed) {

--- a/crates/nono-cli/src/exec_strategy/env_sanitization.rs
+++ b/crates/nono-cli/src/exec_strategy/env_sanitization.rs
@@ -74,24 +74,33 @@ pub(crate) fn is_env_var_allowed(key: &str, allowed_env_vars: &[String]) -> bool
     false
 }
 
-/// Validates that all allow-list patterns use `*` only as a trailing suffix.
+/// Validates that all env var patterns use `*` only as a trailing suffix.
+/// `field_name` is used in the error message (e.g. `"allow_vars"` or `"deny_vars"`).
 /// Returns an error message describing the first invalid pattern, or None if valid.
-pub(crate) fn validate_allow_vars_pattern(allow_vars: &[String]) -> Option<String> {
-    for pattern in allow_vars {
+pub(crate) fn validate_env_var_patterns(patterns: &[String], field_name: &str) -> Option<String> {
+    for pattern in patterns {
         if pattern.contains('*') && !pattern.ends_with('*') {
             return Some(format!(
-                "Invalid allow_vars pattern '{}': '*' is only valid as a trailing suffix",
-                pattern
+                "Invalid {} pattern '{}': '*' is only valid as a trailing suffix",
+                field_name, pattern
             ));
         }
         if pattern.starts_with('*') && pattern.len() > 1 {
             return Some(format!(
-                "Invalid allow_vars pattern '{}': use a bare '*' to match all variables, or a specific prefix like 'AWS_*'",
-                pattern
+                "Invalid {} pattern '{}': use a bare '*' to match all variables, or a specific prefix like 'AWS_*'",
+                field_name, pattern
             ));
         }
     }
     None
+}
+
+/// Returns true if an environment variable matches the deny-list.
+///
+/// Uses the same pattern syntax as `is_env_var_allowed`: exact names and
+/// trailing-`*` prefix patterns.
+pub(crate) fn is_env_var_denied(key: &str, denied_env_vars: &[String]) -> bool {
+    is_env_var_allowed(key, denied_env_vars)
 }
 
 /// Decide whether an inherited env var should be dropped for sandbox execution.
@@ -238,19 +247,19 @@ mod tests {
     }
 
     // ============================================================================
-    // Pattern validation — validate_allow_vars_pattern
+    // Pattern validation — validate_env_var_patterns
     // ============================================================================
 
     #[test]
     fn test_validate_valid_patterns() {
         let patterns: Vec<String> = vec!["PATH".into(), "AWS_*".into(), "*".into()];
-        assert!(validate_allow_vars_pattern(&patterns).is_none());
+        assert!(validate_env_var_patterns(&patterns, "allow_vars").is_none());
     }
 
     #[test]
     fn test_validate_rejects_mid_star() {
         let patterns: Vec<String> = vec!["A*B".into()];
-        let err = validate_allow_vars_pattern(&patterns);
+        let err = validate_env_var_patterns(&patterns, "allow_vars");
         assert!(err.is_some());
         assert!(err.as_ref().is_some_and(|e| e.contains("A*B")));
     }
@@ -258,7 +267,7 @@ mod tests {
     #[test]
     fn test_validate_rejects_leading_star_with_suffix() {
         let patterns: Vec<String> = vec!["*X".into()];
-        let err = validate_allow_vars_pattern(&patterns);
+        let err = validate_env_var_patterns(&patterns, "allow_vars");
         assert!(err.is_some());
         assert!(err.as_ref().is_some_and(|e| e.contains("*X")));
     }
@@ -266,12 +275,65 @@ mod tests {
     #[test]
     fn test_validate_accepts_bare_star() {
         let patterns: Vec<String> = vec!["*".into()];
-        assert!(validate_allow_vars_pattern(&patterns).is_none());
+        assert!(validate_env_var_patterns(&patterns, "allow_vars").is_none());
     }
 
     #[test]
     fn test_validate_exact_name_no_star() {
         let patterns: Vec<String> = vec!["PATH".into()];
-        assert!(validate_allow_vars_pattern(&patterns).is_none());
+        assert!(validate_env_var_patterns(&patterns, "allow_vars").is_none());
+    }
+
+    #[test]
+    fn test_validate_deny_vars_field_name_in_error() {
+        let patterns: Vec<String> = vec!["A*B".into()];
+        let err = validate_env_var_patterns(&patterns, "deny_vars");
+        assert!(err.is_some());
+        let msg = err.unwrap();
+        assert!(msg.contains("deny_vars"));
+        assert!(msg.contains("A*B"));
+    }
+
+    // ============================================================================
+    // is_env_var_denied
+    // ============================================================================
+
+    #[test]
+    fn test_env_var_denied_exact_match() {
+        let denied: Vec<String> = vec!["GH_TOKEN".into(), "ANTHROPIC_API_KEY".into()];
+        assert!(is_env_var_denied("GH_TOKEN", &denied));
+        assert!(is_env_var_denied("ANTHROPIC_API_KEY", &denied));
+    }
+
+    #[test]
+    fn test_env_var_denied_prefix_match() {
+        let denied: Vec<String> = vec!["GITHUB_*".into()];
+        assert!(is_env_var_denied("GITHUB_TOKEN", &denied));
+        assert!(is_env_var_denied("GITHUB_ACTIONS", &denied));
+        assert!(!is_env_var_denied("GH_TOKEN", &denied));
+    }
+
+    #[test]
+    fn test_env_var_denied_no_match() {
+        let denied: Vec<String> = vec!["GH_TOKEN".into()];
+        assert!(!is_env_var_denied("PATH", &denied));
+        assert!(!is_env_var_denied("HOME", &denied));
+    }
+
+    #[test]
+    fn test_env_var_denied_empty_list() {
+        let denied: Vec<String> = vec![];
+        assert!(!is_env_var_denied("GH_TOKEN", &denied));
+    }
+
+    #[test]
+    fn test_env_var_denied_overrides_allowed() {
+        // Simulates: deny_vars has GH_TOKEN, allow_vars has GH_TOKEN
+        // deny wins: denied should return true regardless of allowed
+        let denied: Vec<String> = vec!["GH_TOKEN".into()];
+        let allowed: Vec<String> = vec!["GH_TOKEN".into()];
+        assert!(is_env_var_denied("GH_TOKEN", &denied));
+        assert!(is_env_var_allowed("GH_TOKEN", &allowed));
+        // In exec path, deny is checked before allow, so GH_TOKEN is stripped
     }
 }

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -312,6 +312,7 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
         #[cfg(target_os = "linux")]
         seccomp_proxy_fallback,
         allowed_env_vars: flags.allowed_env_vars,
+        denied_env_vars: flags.denied_env_vars,
     };
 
     match strategy {

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -125,7 +125,6 @@ fn recommended_builtin_profile(program: &Path) -> Option<&'static str> {
         "claude" => Some("claude-code"),
         "codex" => Some("codex"),
         "opencode" => Some("opencode"),
-        "openclaw" => Some("openclaw"),
         "swival" => Some("swival"),
         _ => None,
     }

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -101,6 +101,7 @@ pub(crate) struct ExecutionFlags {
     pub(crate) trust: TrustLaunchOptions,
     pub(crate) proxy: ProxyLaunchOptions,
     pub(crate) allowed_env_vars: Option<Vec<String>>,
+    pub(crate) denied_env_vars: Option<Vec<String>>,
 }
 
 impl ExecutionFlags {
@@ -124,6 +125,7 @@ impl ExecutionFlags {
             },
             proxy: ProxyLaunchOptions::default(),
             allowed_env_vars: None,
+            denied_env_vars: None,
         })
     }
 }
@@ -251,6 +253,7 @@ pub(crate) fn prepare_run_launch_plan(
             trust,
             proxy,
             allowed_env_vars: prepared.allowed_env_vars,
+            denied_env_vars: prepared.denied_env_vars,
         },
     })
 }

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -240,6 +240,7 @@ mod tests {
             open_url_allow_localhost: false,
             override_deny_paths: Vec::new(),
             allowed_env_vars: None,
+            denied_env_vars: None,
         };
 
         let effective = resolve_effective_proxy_settings(&args, &prepared);
@@ -283,6 +284,7 @@ mod tests {
             open_url_allow_localhost: false,
             override_deny_paths: Vec::new(),
             allowed_env_vars: None,
+            denied_env_vars: None,
         };
 
         let effective = resolve_effective_proxy_settings(&args, &prepared);

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -39,14 +39,11 @@ mod tests {
     }
 
     #[test]
-    fn test_get_builtin_openclaw() {
-        let profile = get_builtin("openclaw").expect("Profile not found");
-        assert_eq!(profile.meta.name, "openclaw");
-        assert!(!profile.network.block); // network allowed
-        assert!(profile
-            .filesystem
-            .allow
-            .contains(&"$HOME/.openclaw".to_string()));
+    fn test_openclaw_no_longer_inbuilt() {
+        // Removed in v0.44.0: openclaw ships via the registry pack
+        // `always-further/openclaw` and is resolved through the user-profile
+        // symlink, not the embedded policy.json.
+        assert!(get_builtin("openclaw").is_none());
     }
 
     #[test]
@@ -96,15 +93,16 @@ mod tests {
         let profiles = list_builtin();
         assert!(profiles.contains(&"default".to_string()));
         assert!(profiles.contains(&"linux-host-compat".to_string()));
-        assert!(profiles.contains(&"openclaw".to_string()));
         assert!(profiles.contains(&"opencode".to_string()));
         assert!(profiles.contains(&"swival".to_string()));
         // Profiles that ship via registry packs instead of as built-ins:
-        //   claude-code → always-further/claude (removed v0.43.0)
-        //   codex       → always-further/codex  (removed v0.43.0)
+        //   claude-code → always-further/claude   (removed v0.43.0)
+        //   codex       → always-further/codex    (removed v0.43.0)
+        //   openclaw    → always-further/openclaw (removed v0.44.0)
         assert!(!profiles.contains(&"claude-code".to_string()));
         assert!(!profiles.contains(&"claude-no-kc".to_string()));
         assert!(!profiles.contains(&"codex".to_string()));
+        assert!(!profiles.contains(&"openclaw".to_string()));
     }
 
     #[test]
@@ -133,13 +131,13 @@ mod tests {
     fn test_profile_exclusion_mechanism() {
         // Verify that built-in profiles resolve exclusions through the shared
         // group-exclusion path. Current embedded profiles do not exclude any.
-        let profile = get_builtin("openclaw").expect("Profile not found");
+        let profile = get_builtin("opencode").expect("Profile not found");
         let default = get_builtin("default").expect("default profile");
         // All default groups should be present since embedded exclusions are empty.
         for group in &default.security.groups {
             assert!(
                 profile.security.groups.contains(group),
-                "openclaw should contain default profile group '{}'",
+                "opencode should contain default profile group '{}'",
                 group
             );
         }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1134,6 +1134,11 @@ pub struct RollbackConfig {
 /// When `allow_vars` is set, only the listed variables (and nono-injected
 /// credentials) are passed through. Supports exact names (`"PATH"`) and
 /// prefix patterns (`"AWS_*"`).
+///
+/// Precedence (highest to lowest):
+/// 1. Hardcoded `is_dangerous_env_var` — always stripped, cannot be re-allowed.
+/// 2. `deny_vars` — stripped even if matched by `allow_vars`.
+/// 3. `allow_vars` — if non-empty, only matching vars pass; if empty, all (except 1+2) pass.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct EnvironmentConfig {
@@ -1145,6 +1150,15 @@ pub struct EnvironmentConfig {
     /// Nono-injected credentials always bypass this list.
     #[serde(default)]
     pub allow_vars: Vec<String>,
+
+    /// Deny-list of environment variable names stripped from the sandboxed process.
+    ///
+    /// Supports exact names (`"GH_TOKEN"`) and prefix patterns ending with `*`
+    /// (`"GITHUB_*"` strips all vars starting with `GITHUB_`).
+    /// Denied vars are stripped even if they also appear in `allow_vars`.
+    /// Use this to strip specific secrets while keeping everything else inherited.
+    #[serde(default)]
+    pub deny_vars: Vec<String>,
 }
 
 /// Configuration for supervisor-delegated URL opening.
@@ -2127,6 +2141,7 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
             (None, Some(child_env)) => Some(child_env.clone()),
             (Some(base_env), Some(child_env)) => Some(EnvironmentConfig {
                 allow_vars: dedup_append(&base_env.allow_vars, &child_env.allow_vars),
+                deny_vars: dedup_append(&base_env.deny_vars, &child_env.deny_vars),
             }),
         },
         // NOTE: WorkdirAccess::None serves as both "not specified" and "explicitly no access".
@@ -2768,6 +2783,95 @@ mod tests {
             .as_ref()
             .expect("environment should be Some");
         assert!(env_config.allow_vars.is_empty());
+    }
+
+    #[test]
+    fn test_environment_config_with_deny_vars() {
+        let json_str = r#"{
+            "meta": { "name": "test-profile" },
+            "environment": {
+                "deny_vars": ["GH_TOKEN", "GITHUB_*", "ANTHROPIC_API_KEY"]
+            }
+        }"#;
+
+        let profile: Profile = serde_json::from_str(json_str).expect("Failed to parse profile");
+        let env_config = profile
+            .environment
+            .as_ref()
+            .expect("environment should be Some");
+        assert_eq!(
+            env_config.deny_vars,
+            vec!["GH_TOKEN", "GITHUB_*", "ANTHROPIC_API_KEY"]
+        );
+        assert!(env_config.allow_vars.is_empty());
+    }
+
+    #[test]
+    fn test_environment_config_allow_and_deny_vars_together() {
+        let json_str = r#"{
+            "meta": { "name": "test-profile" },
+            "environment": {
+                "allow_vars": ["PATH", "HOME", "AWS_*"],
+                "deny_vars": ["AWS_SECRET_ACCESS_KEY"]
+            }
+        }"#;
+
+        let profile: Profile = serde_json::from_str(json_str).expect("Failed to parse profile");
+        let env_config = profile
+            .environment
+            .as_ref()
+            .expect("environment should be Some");
+        assert_eq!(env_config.allow_vars, vec!["PATH", "HOME", "AWS_*"]);
+        assert_eq!(env_config.deny_vars, vec!["AWS_SECRET_ACCESS_KEY"]);
+    }
+
+    #[test]
+    fn test_environment_config_deny_vars_merge() {
+        // Merging two profiles with deny_vars concatenates them
+        let base = Profile {
+            environment: Some(EnvironmentConfig {
+                allow_vars: vec![],
+                deny_vars: vec!["GH_TOKEN".into()],
+            }),
+            ..Default::default()
+        };
+        let child = Profile {
+            environment: Some(EnvironmentConfig {
+                allow_vars: vec![],
+                deny_vars: vec!["ANTHROPIC_API_KEY".into()],
+            }),
+            ..Default::default()
+        };
+        let merged = merge_profiles(base, child);
+        let env_config = merged.environment.expect("merged environment should be Some");
+        assert_eq!(
+            env_config.deny_vars,
+            vec!["GH_TOKEN", "ANTHROPIC_API_KEY"]
+        );
+    }
+
+    #[test]
+    fn test_environment_config_deny_vars_merge_deduplicates() {
+        let base = Profile {
+            environment: Some(EnvironmentConfig {
+                allow_vars: vec![],
+                deny_vars: vec!["GH_TOKEN".into(), "ANTHROPIC_API_KEY".into()],
+            }),
+            ..Default::default()
+        };
+        let child = Profile {
+            environment: Some(EnvironmentConfig {
+                allow_vars: vec![],
+                deny_vars: vec!["ANTHROPIC_API_KEY".into()],
+            }),
+            ..Default::default()
+        };
+        let merged = merge_profiles(base, child);
+        let env_config = merged.environment.expect("merged environment should be Some");
+        assert_eq!(
+            env_config.deny_vars,
+            vec!["GH_TOKEN", "ANTHROPIC_API_KEY"]
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1,8 +1,8 @@
 //! Profile system for pre-configured capability sets
 //!
 //! Profiles provide named configurations for common applications like
-//! claude-code, openclaw, and opencode. They can be built-in (compiled
-//! into the binary) or user-defined (in ~/.config/nono/profiles/).
+//! opencode and swival. They can be built-in (compiled into the binary),
+//! installed via registry packs, or user-defined (in ~/.config/nono/profiles/).
 
 pub(crate) mod builtin;
 
@@ -2694,12 +2694,14 @@ mod tests {
     #[test]
     fn test_list_profiles() {
         let profiles = list_profiles();
-        assert!(profiles.contains(&"openclaw".to_string()));
         assert!(profiles.contains(&"opencode".to_string()));
-        // claude-code and codex were removed from the inbuilt profiles in
-        // v0.43.0; they ship via registry packs.
+        // Profiles removed from built-ins; now ship via registry packs:
+        //   claude-code → always-further/claude   (removed v0.43.0)
+        //   codex       → always-further/codex    (removed v0.43.0)
+        //   openclaw    → always-further/openclaw (removed v0.44.0)
         assert!(!profiles.contains(&"claude-code".to_string()));
         assert!(!profiles.contains(&"codex".to_string()));
+        assert!(!profiles.contains(&"openclaw".to_string()));
     }
 
     #[test]

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -26,6 +26,7 @@ pub(crate) struct PreparedProfile {
     pub(crate) allow_parent_of_protected: bool,
     pub(crate) override_deny_paths: Vec<PathBuf>,
     pub(crate) allowed_env_vars: Option<Vec<String>>,
+    pub(crate) denied_env_vars: Option<Vec<String>>,
 }
 
 #[derive(Clone, Copy)]
@@ -378,13 +379,29 @@ fn prepare_profile_with_options(
             workdir,
         ),
         allowed_env_vars: loaded_profile.as_ref().and_then(|profile| {
-            profile.environment.as_ref().map(|env_config| {
+            profile.environment.as_ref().and_then(|env_config| {
+                if env_config.allow_vars.is_empty() {
+                    return None;
+                }
                 if let Some(err) =
-                    crate::exec_strategy::validate_allow_vars_pattern(&env_config.allow_vars)
+                    crate::exec_strategy::validate_env_var_patterns(&env_config.allow_vars, "allow_vars")
                 {
                     eprintln!("Warning: {}", err);
                 }
-                env_config.allow_vars.clone()
+                Some(env_config.allow_vars.clone())
+            })
+        }),
+        denied_env_vars: loaded_profile.as_ref().and_then(|profile| {
+            profile.environment.as_ref().and_then(|env_config| {
+                if env_config.deny_vars.is_empty() {
+                    return None;
+                }
+                if let Some(err) =
+                    crate::exec_strategy::validate_env_var_patterns(&env_config.deny_vars, "deny_vars")
+                {
+                    eprintln!("Warning: {}", err);
+                }
+                Some(env_config.deny_vars.clone())
             })
         }),
         loaded_profile,
@@ -503,6 +520,8 @@ mod tests {
         );
         assert_eq!(runtime.allow_gpu, preflight.allow_gpu);
         assert_eq!(runtime.override_deny_paths, preflight.override_deny_paths);
+        assert_eq!(runtime.allowed_env_vars, preflight.allowed_env_vars);
+        assert_eq!(runtime.denied_env_vars, preflight.denied_env_vars);
         assert_eq!(
             runtime.loaded_profile.as_ref().map(|profile| {
                 (

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -435,6 +435,7 @@ pub(crate) struct PreparedSandbox {
     pub(crate) open_url_allow_localhost: bool,
     pub(crate) override_deny_paths: Vec<PathBuf>,
     pub(crate) allowed_env_vars: Option<Vec<String>>,
+    pub(crate) denied_env_vars: Option<Vec<String>>,
 }
 
 fn resolved_workdir(args: &SandboxArgs) -> PathBuf {
@@ -1010,6 +1011,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
                 open_url_allow_localhost: false,
                 override_deny_paths: Vec::new(),
                 allowed_env_vars: None,
+                denied_env_vars: None,
             },
             args,
             silent,
@@ -1039,6 +1041,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         allow_parent_of_protected: profile_allow_parent_of_protected,
         override_deny_paths,
         allowed_env_vars: profile_allowed_env_vars,
+        denied_env_vars: profile_denied_env_vars,
     } = prepared_profile;
 
     if let Some(profile) = loaded_profile.as_ref() {
@@ -1279,6 +1282,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
             open_url_allow_localhost,
             override_deny_paths,
             allowed_env_vars: profile_allowed_env_vars,
+            denied_env_vars: profile_denied_env_vars,
         },
         args,
         silent,

--- a/docs/cli/features/environment.mdx
+++ b/docs/cli/features/environment.mdx
@@ -15,7 +15,7 @@ When `environment.allow_vars` is set in a profile, nono:
 2. Passes through only variables matching the allow-list
 3. Adds back nono-injected credentials (from `env_credentials`) on top
 
-If the `environment` section is omitted entirely, all variables are passed through (backward compatible). Setting `allow_vars` to an empty array `[]` restricts the environment to only nono-injected credentials — no inherited variables are passed.
+If the `environment` section is omitted entirely, or if `allow_vars` is absent or empty, all variables are passed through (backward compatible). To restrict to only nono-injected credentials, either set an explicit allow-list (`allow_vars: ["PATH", "HOME", ...]`) or use `deny_vars: ["*"]` to block all inherited variables.
 
 ## Configuration
 
@@ -88,7 +88,46 @@ In this case, `OPENAI_API_KEY` is passed through even though it's not in `allow_
   If you inject a secret via `env_credentials` and also list it in `allow_vars`, it will be present once (deduplicated). There is no conflict.
 </Warning>
 
-## Interaction with the Deny-List
+## Operator-configured deny-list
+
+Use `deny_vars` to strip specific variables while keeping everything else inherited — without having to enumerate an explicit allow-list:
+
+```json
+{
+  "environment": {
+    "deny_vars": ["GH_TOKEN", "GITHUB_TOKEN", "ANTHROPIC_API_KEY"]
+  }
+}
+```
+
+Prefix patterns work the same as in `allow_vars` — only trailing `*` is supported:
+
+```json
+{
+  "environment": {
+    "deny_vars": ["GITHUB_*", "ANTHROPIC_", "OPENAI_"]
+  }
+}
+```
+
+This strips `GITHUB_TOKEN`, `GITHUB_ACTIONS`, any var starting with `ANTHROPIC_` or `OPENAI_`, etc. Patterns like `*_TOKEN` (leading wildcard) are **not** supported and are silently ignored.
+
+**Precedence:** `deny_vars` wins over `allow_vars`. If a variable appears in both, it is stripped:
+
+```json
+{
+  "environment": {
+    "allow_vars": ["AWS_*"],
+    "deny_vars": ["AWS_SECRET_ACCESS_KEY"]
+  }
+}
+```
+
+`AWS_REGION` passes through; `AWS_SECRET_ACCESS_KEY` is stripped.
+
+**Inheritance:** like `allow_vars`, `deny_vars` is additive across profile inheritance — a child profile appends to the base's list, and duplicates are removed.
+
+## Interaction with the Built-in Deny-List
 
 nono maintains a built-in deny-list of dangerous environment variables (e.g., `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `PYTHONPATH`, `NODE_OPTIONS`). These variables are **always blocked**, even if they appear in `allow_vars`. This prevents a compromised profile from disabling sandbox protections.
 
@@ -105,10 +144,12 @@ nono maintains a built-in deny-list of dangerous environment variables (e.g., `L
 ## Security Properties
 
 - **Default-allow**: Without the `environment` section, all variables are passed through (no regression)
-- **Empty allow-list restricts all**: `"allow_vars": []` passes zero inherited variables — only nono-injected credentials reach the child
-- **Explicit allow-list**: When configured with entries, only listed variables reach the child process
-- **Injected credentials bypass the allow-list**: `env_credentials` variables always pass through
-- **Deny-list is non-overridable**: Dangerous variables like `LD_PRELOAD` are always blocked
+- **Empty or absent allow-list is a no-op**: `"allow_vars": []` (or omitting the field) passes all variables through — only a non-empty `allow_vars` activates filtering
+- **Explicit allow-list**: When `allow_vars` has entries, only matching variables reach the child process
+- **Operator deny-list**: `deny_vars` strips named variables even when `allow_vars` would otherwise pass them through
+- **Injected credentials bypass both lists**: `env_credentials` variables always pass through, regardless of `allow_vars` or `deny_vars`
+- **Built-in deny-list is non-overridable**: Dangerous variables like `LD_PRELOAD` are always blocked and cannot be re-allowed
+- **Precedence**: built-in blocklist > `deny_vars` > `allow_vars`
 - **Prefix patterns reduce misconfiguration**: Only `*` suffix is supported (no regex), reducing risk of accidental over-permission
 - **Bare `*` matches everything**: Use as an escape hatch, but prefer explicit lists
 


### PR DESCRIPTION
## Summary

- Removes the `openclaw` profile from the embedded `policy.json` — it now ships via the `always-further/openclaw` registry pack (nono-packs#2)
- Removes `"openclaw"` from the `recommended_builtin_profile` auto-detection table in `execution_runtime.rs`
- Updates tests in `builtin.rs` and `profile/mod.rs` to assert openclaw is no longer a built-in, following the same pattern as the claude-code/codex removals

Closes #791

## Test plan

- [x] `cargo build` passes
- [x] `cargo test -p nono-cli` — all tests pass