### PR TITLE
fix: update example in Quickstart examples after `nono setup` is run

### DIFF
--- a/crates/nono-cli/src/setup.rs
+++ b/crates/nono-cli/src/setup.rs
@@ -383,7 +383,7 @@ impl SetupRunner {
             println!("  nono run --allow-cwd -- <command>");
             println!();
             println!("  # Check why a sensitive path is blocked");
-            println!("  nono why ~/.ssh/id_rsa");
+            println!("  nono why --path ~/.ssh/id_rsa");
             println!();
 
             if self.generate_profiles {


### PR DESCRIPTION
When `nono setup` is run some examples are given. The last one is not accurate.