### PR TITLE
fix: add macOS warning when --allow targets a deny-group path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - *(packages)* Use native tls root certificates
+- *(ux)* Warn on macOS when `--allow` targets a path blocked by a deny group (e.g. `deny_credentials`), suggesting `--override-deny`
 
 ## [0.44.0] - 2026-04-29
 

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -12,7 +12,7 @@ use nono::{
     UnixSocketCapability, UnixSocketMode,
 };
 use std::path::{Path, PathBuf};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Try to create a directory capability, warning and skipping on PathNotFound.
 /// Propagates all other errors.
@@ -965,7 +965,7 @@ impl CapabilitySetExt for CapabilitySet {
 fn finalize_caps(
     caps: &mut CapabilitySet,
     resolved: &mut policy::ResolvedGroups,
-    _loaded_policy: &policy::Policy,
+    loaded_policy: &policy::Policy,
     args: &SandboxArgs,
     profile_override_deny: &[PathBuf],
 ) -> Result<()> {
@@ -982,6 +982,23 @@ fn finalize_caps(
 
     // Validate deny/allow overlaps (hard-fail on Linux where Landlock cannot enforce denies)
     policy::validate_deny_overlaps(&resolved.deny_paths, caps)?;
+
+    // On macOS, warn when user-granted paths are silently blocked by deny rules.
+    // Seatbelt deny rules override earlier allow rules for content access, so the
+    // user's --allow/--read/--write has no effect without --override-deny.
+    if cfg!(target_os = "macos") {
+        for (path, group) in
+            policy::find_denied_user_grants(&resolved.deny_paths, caps, loaded_policy)
+        {
+            let source = group.as_deref().unwrap_or("a deny rule");
+            warn!(
+                "'{}' is blocked by '{}'; use --override-deny {} to allow access",
+                path.display(),
+                source,
+                path.display(),
+            );
+        }
+    }
 
     // Keep broad keychain deny groups active, but allow explicit
     // keychain DB read grants (profile/CLI) on macOS.

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -1152,6 +1152,70 @@ pub fn validate_deny_overlaps(deny_paths: &[PathBuf], caps: &CapabilitySet) -> R
     )))
 }
 
+/// Find user-granted paths that are blocked by deny rules.
+///
+/// Returns a list of `(deny_path, group_name)` pairs where the deny path overlaps
+/// with an explicit user-intent grant (via `--allow`, `--read`, `--write`, or profile
+/// `filesystem`). On macOS, these grants are silently ineffective because Seatbelt
+/// deny rules override earlier allow rules for content access. The caller should
+/// warn the user to use `--override-deny`.
+///
+/// The group name is `None` when the deny comes from a profile-level
+/// `add_deny_access` rather than a named policy group.
+///
+/// This function is platform-independent (the overlap detection is pure logic),
+/// but the caller should only emit warnings on macOS where the conflict is real.
+pub fn find_denied_user_grants(
+    deny_paths: &[PathBuf],
+    caps: &CapabilitySet,
+    policy: &Policy,
+) -> Vec<(PathBuf, Option<String>)> {
+    let mut conflicts = Vec::new();
+
+    for deny_path in deny_paths {
+        let has_user_grant = caps.fs_capabilities().iter().any(|cap| {
+            if !cap.source.is_user_intent() {
+                return false;
+            }
+            if cap.is_file {
+                cap.resolved == *deny_path
+            } else {
+                deny_path.starts_with(&cap.resolved)
+            }
+        });
+
+        if !has_user_grant {
+            continue;
+        }
+
+        let group_name = find_deny_group_for_path(policy, deny_path);
+        conflicts.push((deny_path.clone(), group_name));
+    }
+
+    conflicts
+}
+
+/// Find which deny group blocks a given path by cross-referencing the policy.
+fn find_deny_group_for_path(policy: &Policy, deny_path: &Path) -> Option<String> {
+    for (name, group) in &policy.groups {
+        if let Some(deny) = &group.deny {
+            for path_str in &deny.access {
+                if let Ok(expanded) = expand_path(path_str) {
+                    if expanded == deny_path {
+                        return Some(name.clone());
+                    }
+                    if let Ok(canonical) = expanded.canonicalize() {
+                        if canonical == *deny_path {
+                            return Some(name.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Get the list of all group names defined in the policy
 #[cfg(test)]
 pub fn list_groups(policy: &Policy) -> Vec<&str> {
@@ -3112,5 +3176,67 @@ mod tests {
             read_paths.contains(&"/nix/store".to_string()),
             "nix_runtime group must include /nix/store for NixOS compatibility"
         );
+    }
+
+    #[test]
+    fn test_find_denied_user_grants_detects_overlap() {
+        let path = PathBuf::from("/nonexistent/test/secret");
+        let policy = load_policy(
+            r#"{"meta":{"version":2,"schema_version":"2.0"},"groups":{
+                "deny_creds":{"description":"creds","deny":{"access":["/nonexistent/test/secret"]}}
+            }}"#,
+        )
+        .expect("parse policy");
+
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: path.clone(),
+            resolved: path.clone(),
+            access: AccessMode::ReadWrite,
+            is_file: false,
+            source: CapabilitySource::User,
+        });
+
+        let conflicts = find_denied_user_grants(&[path], &caps, &policy);
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].1.as_deref(), Some("deny_creds"));
+    }
+
+    #[test]
+    fn test_find_denied_user_grants_ignores_non_user_grants() {
+        let path = PathBuf::from("/nonexistent/test/secret");
+        let policy = load_policy(sample_policy_json()).expect("parse policy");
+
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: path.clone(),
+            resolved: path.clone(),
+            access: AccessMode::ReadWrite,
+            is_file: false,
+            source: CapabilitySource::Group("system".to_string()),
+        });
+
+        let conflicts = find_denied_user_grants(&[path], &caps, &policy);
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn test_find_denied_user_grants_profile_deny_without_group() {
+        let path = PathBuf::from("/nonexistent/test/profile_denied");
+        let policy = load_policy(r#"{"meta":{"version":2,"schema_version":"2.0"},"groups":{}}"#)
+            .expect("parse policy");
+
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: path.clone(),
+            resolved: path.clone(),
+            access: AccessMode::ReadWrite,
+            is_file: false,
+            source: CapabilitySource::User,
+        });
+
+        let conflicts = find_denied_user_grants(&[path], &caps, &policy);
+        assert_eq!(conflicts.len(), 1);
+        assert!(conflicts[0].1.is_none());
     }
 }

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -1178,7 +1178,7 @@ pub fn find_denied_user_grants(
                 return false;
             }
             if cap.is_file {
-                cap.resolved == *deny_path
+                cap.resolved.starts_with(deny_path)
             } else {
                 deny_path.starts_with(&cap.resolved)
             }

--- a/docs/cli/usage/troubleshooting.mdx
+++ b/docs/cli/usage/troubleshooting.mdx
@@ -37,13 +37,13 @@ Command fails with "Permission denied" or "Operation not permitted" errors.
 | Cause | Solution |
 |-------|----------|
 | Path not in allowed list | Add path with `--allow`, `--read`, or `--write` |
-| Sensitive path blocked | These paths cannot be granted (see below) |
+| Sensitive path blocked | Use `--override-deny` with your grant (see below) |
 | Relative path resolved differently | Use absolute paths |
 | Symlink target outside sandbox | Grant access to the symlink target |
 
 ### Sensitive Paths
 
-These paths are always blocked, even if a parent directory is allowed:
+These paths are blocked by default, even if a parent directory is allowed:
 
 - `~/.ssh/` - SSH keys
 - `~/.aws/` - AWS credentials
@@ -54,6 +54,18 @@ These paths are always blocked, even if a parent directory is allowed:
 - Shell configuration files
 
 **Why?** These paths commonly contain secrets that an AI agent should never access.
+
+If you grant one of these paths with `--allow`, nono will warn you on macOS:
+
+```
+WARN '~/.gnupg' is blocked by 'deny_credentials'; use --override-deny ~/.gnupg to allow access
+```
+
+To intentionally access a blocked path, use `--override-deny` alongside your grant:
+
+```bash
+nono run --allow ~/.gnupg --override-deny ~/.gnupg -- gpg --list-keys
+```
 
 ---
 


### PR DESCRIPTION
On macOS, Seatbelt deny rules silently override earlier allow rules, so --allow on a path like ~/.gnupg has no effect when deny_credentials is active. Detect this overlap in finalize_caps and warn the user to use --override-deny.

```
nono run -v --allow-cwd --allow ~/.gnupg gpg --list-keys

2026-04-30T13:49:06.306374Z  WARN '/Users/runner/.gnupg' is blocked by 'deny_credentials'; use --override-deny /Users/runner/.gnupg to allow access
```

Then, if `--override-deny <path>` is included:

```
nono run -v --allow-cwd --allow ~/.gnupg --override-deny ~/.gnupg gpg --list-keys

2026-04-30T13:49:06.403868Z  INFO override_deny relaxing deny rule for '/Users/runner/.gnupg'
```

Closes #799 
@fingon 