### PR TITLE
fix: resolve extends against sibling profiles in the same directory

### DIFF
--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1784,7 +1784,7 @@ pub(crate) fn finalize_profile(mut profile: Profile) -> Result<Profile> {
 
 /// Resolve inheritance and apply implicit default-group merging for a raw profile.
 pub(crate) fn resolve_and_finalize_profile(profile: Profile) -> Result<Profile> {
-    finalize_profile(resolve_extends(profile, &mut Vec::new(), 0)?)
+    finalize_profile(resolve_extends(profile, &mut Vec::new(), 0, None)?)
 }
 
 /// Get the implicit default groups for a finalized profile.
@@ -1855,10 +1855,12 @@ fn parse_profile_file(path: &Path) -> Result<Profile> {
     Ok(profile)
 }
 
-/// Load a profile from a JSON file, resolving inheritance.
+/// Load a profile from a JSON file, resolving inheritance. The parent
+/// directory is passed as context so `extends` can resolve sibling profiles.
 fn load_from_file(path: &Path) -> Result<Profile> {
     let profile = parse_profile_file(path)?;
-    resolve_extends(profile, &mut Vec::new(), 0)
+    let context_dir = path.parent();
+    resolve_extends(profile, &mut Vec::new(), 0, context_dir)
 }
 
 // ============================================================================
@@ -1872,15 +1874,22 @@ const MAX_INHERITANCE_DEPTH: usize = 10;
 ///
 /// If the profile declares `extends` (one or more base names), each base is
 /// loaded and resolved recursively, then they are fold-merged left-to-right.
-/// The accumulated base is finally merged with the child. The `visited` vec
-/// tracks profile names already in the chain to detect circular dependencies.
+/// The accumulated base is finally merged with the child. When `context_dir`
+/// is set, sibling `<name>.json` files are checked first so project-local
+/// profiles can reference each other by name. The `visited` vec tracks
+/// profile names already in the chain to detect circular dependencies.
 ///
 /// Shared transitive bases are handled naturally: `visited` tracks only the
 /// current ancestor chain (push before recurse, pop after). When two siblings
 /// share a transitive base, it is resolved once per sibling; because
 /// `merge_profiles` is idempotent, the result is correct. Only true cycles
 /// (a profile extending one of its own ancestors) are rejected.
-fn resolve_extends(child: Profile, visited: &mut Vec<String>, depth: usize) -> Result<Profile> {
+fn resolve_extends(
+    child: Profile,
+    visited: &mut Vec<String>,
+    depth: usize,
+    context_dir: Option<&Path>,
+) -> Result<Profile> {
     let base_names = match child.extends {
         Some(ref names) => names.clone(),
         None => return Ok(child),
@@ -1907,8 +1916,12 @@ fn resolve_extends(child: Profile, visited: &mut Vec<String>, depth: usize) -> R
 
         visited.push(base_name.clone());
 
-        let base = load_base_profile_raw(base_name)?;
-        let resolved_base = resolve_extends(base, visited, depth + 1)?;
+        let resolved = load_base_profile_raw(base_name, context_dir)?;
+        let (base, next_context) = match resolved {
+            ResolvedBase::Sibling(p) => (p, context_dir),
+            ResolvedBase::Global(p) => (p, None),
+        };
+        let resolved_base = resolve_extends(base, visited, depth + 1, next_context)?;
         // Pop to restore the stack to the pre-base state. On the error path
         // above (? propagation), visited is abandoned so the missing pop is harmless.
         visited.pop();
@@ -1925,16 +1938,26 @@ fn resolve_extends(child: Profile, visited: &mut Vec<String>, depth: usize) -> R
     }
 }
 
+/// Distinguishes where a base profile was resolved from so `resolve_extends`
+/// can propagate `context_dir` only for sibling-resolved profiles. Global
+/// sources (user dir, pack-store, built-in) clear the context to prevent
+/// project-local files from hijacking built-in inheritance chains.
+enum ResolvedBase {
+    Sibling(Profile),
+    Global(Profile),
+}
+
 /// Load a base profile by name WITHOUT applying implicit default-group merging.
 ///
-/// Checks user profiles, then installed packs, then built-in profiles.
-/// Built-in profiles are loaded as raw profile definitions so inheritance
-/// can resolve before implicit default groups are merged. The pack-store
-/// branch lets a user profile do `"extends": "claude-code"` and pick up
-/// the pack-shipped profile transparently — same precedence as
-/// `load_profile`.
+/// Checks sibling profiles in `context_dir` first (so project-local profiles
+/// can reference each other by name), then user profiles, installed packs,
+/// and built-in profiles. Built-in profiles are loaded as raw profile
+/// definitions so inheritance can resolve before implicit default groups are
+/// merged. The pack-store branch lets a user profile do
+/// `"extends": "claude-code"` and pick up the pack-shipped profile
+/// transparently — same precedence as `load_profile`.
 ///
-/// If all three resolvers miss AND the requested name is in
+/// If all resolvers miss AND the requested name is in
 /// `migration::PACK_PROVIDED_PROFILES` AND we were entered via
 /// `load_profile` (not `load_profile_no_migrate`), prompt the user to
 /// install the providing pack, then retry the pack-store lookup once.
@@ -1943,7 +1966,7 @@ fn resolve_extends(child: Profile, visited: &mut Vec<String>, depth: usize) -> R
 /// instead of an inscrutable "base profile not found" error, the user
 /// sees the same install prompt that `--profile claude-code` would
 /// produce, with the chain still resolving cleanly on accept.
-fn load_base_profile_raw(name: &str) -> Result<Profile> {
+fn load_base_profile_raw(name: &str, context_dir: Option<&Path>) -> Result<ResolvedBase> {
     if !is_valid_profile_name(name) {
         return Err(NonoError::ProfileInheritance(format!(
             "invalid base profile name '{}'",
@@ -1951,21 +1974,34 @@ fn load_base_profile_raw(name: &str) -> Result<Profile> {
         )));
     }
 
+    // 0. Sibling in the same directory as the child profile.
+    if let Some(dir) = context_dir {
+        let sibling_path = dir.join(format!("{name}.json"));
+        if sibling_path.is_file() {
+            tracing::debug!(
+                "Resolved '{}' from sibling: {}",
+                name,
+                sibling_path.display()
+            );
+            return Ok(ResolvedBase::Sibling(parse_profile_file(&sibling_path)?));
+        }
+    }
+
     // 1. User profiles take precedence.
     let profile_path = get_user_profile_path(name)?;
     if profile_path.exists() {
-        return parse_profile_file(&profile_path);
+        return Ok(ResolvedBase::Global(parse_profile_file(&profile_path)?));
     }
 
     // 2. Pack-store: any installed pack with a matching `install_as`.
     if let Some(profile_path) = find_pack_store_profile(name) {
-        return parse_profile_file(&profile_path);
+        return Ok(ResolvedBase::Global(parse_profile_file(&profile_path)?));
     }
 
     // 3. Built-in profile from embedded policy.
     let policy = crate::policy::load_embedded_policy()?;
     if let Some(def) = policy.profiles.get(name) {
-        return Ok(def.to_raw_profile());
+        return Ok(ResolvedBase::Global(def.to_raw_profile()));
     }
 
     // 4. Pack-provided rescue: when we were entered through
@@ -1983,7 +2019,7 @@ fn load_base_profile_raw(name: &str) -> Result<Profile> {
         match outcome {
             crate::migration::MigrationOutcome::Migrated => {
                 if let Some(profile_path) = find_pack_store_profile(name) {
-                    return parse_profile_file(&profile_path);
+                    return Ok(ResolvedBase::Global(parse_profile_file(&profile_path)?));
                 }
             }
             crate::migration::MigrationOutcome::Skipped => {
@@ -4311,7 +4347,7 @@ mod tests {
         };
 
         // Resolve B first
-        let resolved_b = resolve_extends(b_profile, &mut Vec::new(), 0).expect("resolve b");
+        let resolved_b = resolve_extends(b_profile, &mut Vec::new(), 0, None).expect("resolve b");
         // Then merge A on top
         let merged = merge_profiles(resolved_b, a_profile);
 
@@ -4327,7 +4363,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = resolve_extends(profile, &mut Vec::new(), 0);
+        let result = resolve_extends(profile, &mut Vec::new(), 0, None);
         assert!(result.is_err());
         let err = result.expect_err("missing base should error");
         assert!(
@@ -4346,7 +4382,7 @@ mod tests {
         };
 
         let mut visited = vec!["a".to_string(), "b".to_string()];
-        let result = resolve_extends(profile, &mut visited, 2);
+        let result = resolve_extends(profile, &mut visited, 2, None);
         assert!(result.is_err());
         let err = result.expect_err("circular dep should error");
         assert!(
@@ -4364,7 +4400,7 @@ mod tests {
         };
 
         let mut visited = vec!["self-ref".to_string()];
-        let result = resolve_extends(profile, &mut visited, 1);
+        let result = resolve_extends(profile, &mut visited, 1, None);
         assert!(result.is_err());
         let err = result.expect_err("self-reference should error");
         assert!(
@@ -4384,7 +4420,7 @@ mod tests {
         let visited: Vec<String> = (0..MAX_INHERITANCE_DEPTH)
             .map(|i| format!("level-{}", i))
             .collect();
-        let result = resolve_extends(profile, &mut visited.clone(), MAX_INHERITANCE_DEPTH);
+        let result = resolve_extends(profile, &mut visited.clone(), MAX_INHERITANCE_DEPTH, None);
         assert!(result.is_err());
         let err = result.expect_err("depth limit should error");
         assert!(
@@ -4744,7 +4780,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = resolve_extends(profile, &mut Vec::new(), 0);
+        let result = resolve_extends(profile, &mut Vec::new(), 0, None);
         assert!(result.is_err());
         let err = result.expect_err("empty string base should error");
         assert!(
@@ -4873,7 +4909,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = resolve_extends(profile, &mut Vec::new(), 0);
+        let result = resolve_extends(profile, &mut Vec::new(), 0, None);
         assert!(
             result.is_ok(),
             "duplicate base should be deduplicated, not error: {:?}",
@@ -4927,6 +4963,29 @@ mod tests {
         );
         let profile = result.expect("shared base profile");
         assert_eq!(profile.meta.name, "shared-base-test");
+    }
+
+    #[test]
+    fn test_extends_resolves_sibling_in_same_directory() {
+        let dir = tempdir().expect("tmpdir");
+        std::fs::write(
+            dir.path().join("shared.json"),
+            r#"{ "meta": { "name": "shared" }, "filesystem": { "allow": ["/tmp/shared"] } }"#,
+        )
+        .expect("write");
+        let child_path = dir.path().join("child.json");
+        std::fs::write(
+            &child_path,
+            r#"{ "extends": "shared", "meta": { "name": "child" } }"#,
+        )
+        .expect("write");
+
+        let profile = load_from_file(&child_path).expect("resolve");
+        assert_eq!(profile.meta.name, "child");
+        assert!(profile
+            .filesystem
+            .allow
+            .contains(&"/tmp/shared".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
Profile extends resolution only searched ~/.config/nono/profiles/, pack-store, and built-ins. Project-local profiles (e.g. in .nono/) that extended each other by name failed with 'base profile not found'. Thread the parent directory as context through the inheritance chain so sibling <name>.json files are checked first before falling back to global locations.

```
nono profile show .nono/my-profile.json 2>&1

nono profile: profile '.nono/my-profile.json'
  Extends:      default, filesystem
  
2026-04-30T15:20:30.955473Z DEBUG Resolved 'filesystem' from sibling: .nono/filesystem.json
```

Closes #750 

@skoch13 please let me know if this works for you :)