### PR TITLE
fix(policy): make nix_runtime group cross-platform and add XDG_STATE_HOME profiles path

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -484,7 +484,6 @@
     },
     "nix_runtime": {
       "description": "Nix package manager runtime paths",
-      "platform": "linux",
       "allow": {
         "read": [
           "~/.nix-profile",

--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -491,6 +491,7 @@
           "/run/current-system/sw",
           "/etc/profiles/per-user",
           "/nix/var/nix/profiles",
+          "$HOME/.local/state/nix/profiles",
           "/nix/store"
         ]
       }


### PR DESCRIPTION
Two fixes to the `nix_runtime` policy group in `policy.json`:

1. **Remove `"platform": "linux"` restriction** — the `nix_runtime` group was previously limited to Linux only, but Nix is also widely used on macOS. Removing the platform guard makes the group available on both platforms.

2. **Add `$HOME/.local/state/nix/profiles`** — some Nix installations and macOS multi-user installs store per-user profiles under the XDG state home path (`~/.local/state/nix/profiles`) with `~/.nix-profile` being a symlink. Without this path, sandboxed processes using `nix_runtime` would fail to resolve Nix-managed binaries and libraries on affected systems.

Verified that a sandboxed process granted `nix_runtime` can correctly resolve Nix-managed binaries on macOS with a Nix install using XDG directories.