### PR TITLE
fix(profile): emit serde-rendered values in show/diff JSON output

### DIFF
--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -1120,16 +1120,34 @@ fn profile_to_json(
         "extends": raw_extends.as_ref().map(|v| serde_json::json!(v)).unwrap_or(serde_json::Value::Null),
     });
 
-    // Security
-    val["security"] = serde_json::json!({
-        "groups": profile.security.groups,
-        "allowed_commands": profile.security.allowed_commands,
-        "signal_mode": format!("{:?}", profile.security.signal_mode),
-        "process_info_mode": format!("{:?}", profile.security.process_info_mode),
-        "ipc_mode": format!("{:?}", profile.security.ipc_mode),
-        "capability_elevation": profile.security.capability_elevation,
-        "wsl2_proxy_policy": format!("{:?}", profile.security.wsl2_proxy_policy),
-    });
+    // Security. Build via Map so that Option<…> mode fields are *omitted* when
+    // None, matching the shape of hand-authored profile files (e.g. those
+    // produced by users) and the input schema accepted by `profile validate`.
+    // The enum types derive Serialize with the right rename_all annotations,
+    // so values render as snake_case (`isolated`, `allow_same_sandbox`, …).
+    let mut security = serde_json::Map::new();
+    security.insert("groups".into(), serde_json::json!(profile.security.groups));
+    security.insert(
+        "allowed_commands".into(),
+        serde_json::json!(profile.security.allowed_commands),
+    );
+    if let Some(v) = profile.security.signal_mode {
+        security.insert("signal_mode".into(), serde_json::json!(v));
+    }
+    if let Some(v) = profile.security.process_info_mode {
+        security.insert("process_info_mode".into(), serde_json::json!(v));
+    }
+    if let Some(v) = profile.security.ipc_mode {
+        security.insert("ipc_mode".into(), serde_json::json!(v));
+    }
+    security.insert(
+        "capability_elevation".into(),
+        serde_json::json!(profile.security.capability_elevation),
+    );
+    if let Some(v) = profile.security.wsl2_proxy_policy {
+        security.insert("wsl2_proxy_policy".into(), serde_json::json!(v));
+    }
+    val["security"] = serde_json::Value::Object(security);
 
     // Filesystem
     val["filesystem"] = serde_json::json!({
@@ -1164,9 +1182,9 @@ fn profile_to_json(
         "upstream_bypass": profile.network.upstream_bypass,
     });
 
-    // Workdir
+    // Workdir. Serde renders WorkdirAccess as lowercase via rename_all.
     val["workdir"] = serde_json::json!({
-        "access": format!("{:?}", profile.workdir.access),
+        "access": profile.workdir.access,
     });
 
     // Rollback
@@ -1886,14 +1904,14 @@ fn diff_to_json(name1: &str, name2: &str, p1: &Profile, p2: &Profile) -> serde_j
             "changed": p1.security.capability_elevation != p2.security.capability_elevation,
         },
         "wsl2_proxy_policy": {
-            "profile1": format!("{:?}", p1.security.wsl2_proxy_policy),
-            "profile2": format!("{:?}", p2.security.wsl2_proxy_policy),
+            "profile1": p1.security.wsl2_proxy_policy,
+            "profile2": p2.security.wsl2_proxy_policy,
             "changed": p1.security.wsl2_proxy_policy != p2.security.wsl2_proxy_policy,
         },
         "filesystem": diff_fs_json(&p1.filesystem, &p2.filesystem),
         "workdir": {
-            "profile1": format!("{:?}", p1.workdir.access),
-            "profile2": format!("{:?}", p2.workdir.access),
+            "profile1": p1.workdir.access,
+            "profile2": p2.workdir.access,
             "changed": p1.workdir.access != p2.workdir.access,
         },
         "network": {

--- a/crates/nono-cli/tests/profile_cli.rs
+++ b/crates/nono-cli/tests/profile_cli.rs
@@ -329,3 +329,160 @@ fn test_show_format_manifest_all_builtins_succeed() {
         );
     }
 }
+
+// ----------------------------------------------------------------------------
+// `profile show --json` / `profile diff --json` — Debug-format leak regression
+//
+// Historically the hand-rolled JSON emitter rendered five enum-valued fields
+// via `format!("{:?}", …)`, leaking Rust Debug syntax (`"Some(Isolated)"`,
+// `"ReadWrite"`, `"None"`-as-string) into output that `profile validate`
+// rejects. These tests guard against any future regression on the same code
+// path. See docs/policy-show-json-serialization-leak.md.
+// ----------------------------------------------------------------------------
+
+const SECURITY_TRI_MODE: &[&str] = &["isolated", "allow_same_sandbox", "allow_all"];
+const IPC_MODES: &[&str] = &["shared_memory_only", "full"];
+const WSL2_POLICIES: &[&str] = &["error", "insecure_proxy"];
+const WORKDIR_ACCESS: &[&str] = &["none", "read", "write", "readwrite"];
+
+/// Asserts a security-mode field is either omitted (None became absent) or a
+/// known snake_case variant. JSON `null` is treated as a failure because the
+/// show emitter omits None rather than nulling.
+fn assert_security_mode(security: &serde_json::Value, field: &str, valid: &[&str], ctx: &str) {
+    let Some(v) = security.get(field) else {
+        return;
+    };
+    assert!(
+        !v.is_null(),
+        "{ctx}: security.{field} is null; expected omitted when absent"
+    );
+    let Some(s) = v.as_str() else {
+        panic!("{ctx}: security.{field} = {v} (expected string)");
+    };
+    assert!(
+        valid.contains(&s),
+        "{ctx}: security.{field} = {s:?} not in {valid:?}"
+    );
+}
+
+/// Catches any leftover Rust Debug syntax in the raw JSON text. Belt and
+/// suspenders to the structural checks above.
+fn assert_no_debug_tokens(stdout: &str, ctx: &str) {
+    for needle in [
+        r#""Some("#,
+        r#""None""#,
+        r#""ReadWrite""#,
+        r#""Read""#,
+        r#""Write""#,
+        r#""Isolated""#,
+        r#""AllowSameSandbox""#,
+        r#""AllowAll""#,
+        r#""SharedMemoryOnly""#,
+        r#""Full""#,
+        r#""Error""#,
+        r#""InsecureProxy""#,
+    ] {
+        assert!(
+            !stdout.contains(needle),
+            "{ctx}: output contains Debug-formatted token {needle}\n--- stdout ---\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn test_show_profile_json_no_debug_leaks() {
+    for profile in ["default", "node-dev"] {
+        let output = nono_bin()
+            .args(["profile", "show", profile, "--json"])
+            .output()
+            .expect("failed to run nono");
+
+        assert!(
+            output.status.success(),
+            "{profile}: expected exit 0, stderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let val: serde_json::Value = serde_json::from_str(&stdout)
+            .unwrap_or_else(|e| panic!("{profile}: invalid JSON: {e}\n{stdout}"));
+
+        let security = val
+            .get("security")
+            .unwrap_or_else(|| panic!("{profile}: missing security block"));
+        assert_security_mode(security, "signal_mode", SECURITY_TRI_MODE, profile);
+        assert_security_mode(security, "process_info_mode", SECURITY_TRI_MODE, profile);
+        assert_security_mode(security, "ipc_mode", IPC_MODES, profile);
+        assert_security_mode(security, "wsl2_proxy_policy", WSL2_POLICIES, profile);
+
+        let workdir = val
+            .get("workdir")
+            .unwrap_or_else(|| panic!("{profile}: missing workdir block"));
+        let access = workdir
+            .get("access")
+            .and_then(|v| v.as_str())
+            .unwrap_or_else(|| panic!("{profile}: workdir.access missing or not a string"));
+        assert!(
+            WORKDIR_ACCESS.contains(&access),
+            "{profile}: workdir.access = {access:?} not in {WORKDIR_ACCESS:?}"
+        );
+
+        assert_no_debug_tokens(&stdout, &format!("show {profile}"));
+    }
+}
+
+#[test]
+fn test_diff_profile_json_no_debug_leaks() {
+    let output = nono_bin()
+        .args(["profile", "diff", "default", "node-dev", "--json"])
+        .output()
+        .expect("failed to run nono");
+
+    assert!(
+        output.status.success(),
+        "expected exit 0, stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let val: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("invalid diff JSON: {e}\n{stdout}"));
+
+    // wsl2_proxy_policy.profileN: null (when None) or a known variant.
+    let wsl2 = val
+        .get("wsl2_proxy_policy")
+        .unwrap_or_else(|| panic!("missing wsl2_proxy_policy block"));
+    for side in ["profile1", "profile2"] {
+        let v = wsl2
+            .get(side)
+            .unwrap_or_else(|| panic!("wsl2_proxy_policy.{side} missing"));
+        if v.is_null() {
+            continue;
+        }
+        let s = v
+            .as_str()
+            .unwrap_or_else(|| panic!("wsl2_proxy_policy.{side} = {v} (expected string)"));
+        assert!(
+            WSL2_POLICIES.contains(&s),
+            "wsl2_proxy_policy.{side} = {s:?} not in {WSL2_POLICIES:?}"
+        );
+    }
+
+    // workdir.profileN: always present, lowercase variant. WorkdirAccess is
+    // not Option-wrapped in the profile struct, so null isn't expected.
+    let workdir = val
+        .get("workdir")
+        .unwrap_or_else(|| panic!("missing workdir block"));
+    for side in ["profile1", "profile2"] {
+        let v = workdir
+            .get(side)
+            .unwrap_or_else(|| panic!("workdir.{side} missing"));
+        let s = v
+            .as_str()
+            .unwrap_or_else(|| panic!("workdir.{side} = {v} (expected string)"));
+        assert!(
+            WORKDIR_ACCESS.contains(&s),
+            "workdir.{side} = {s:?} not in {WORKDIR_ACCESS:?}"
+        );
+    }
+
+    assert_no_debug_tokens(&stdout, "diff default node-dev");
+}


### PR DESCRIPTION
Resolves #810

## Summary

The hand-rolled JSON emitter in `crates/nono-cli/src/profile_cmd.rs` serialized five enum-valued fields via `format!("{:?}", …)`, leaking Rust `Debug` syntax (`"Some(Isolated)"`, `"None"` as a string, `"ReadWrite"`) into output that `nono profile validate` cannot parse. The five enums already derive `Serialize` with the right `rename_all` annotations; this PR routes through serde so values render as the schema-accepted snake_case / lowercase forms.

`profile diff --json` had a parallel leak in two of the same fields (`wsl2_proxy_policy` and `workdir.access`) at sites that did not exist when the underlying enums were originally annotated. Those four sites are fixed in the same PR.

## Approach

1. **`profile_to_json` — security block.** Replaced the `serde_json::json!({…})` literal with a `serde_json::Map` builder so `Option<…>` mode fields are *omitted* when `None`. This matches the shape of hand-authored profile files (e.g. `claude-code-local.json`) and the input schema accepted by `profile validate`.
2. **`profile_to_json` — `workdir.access`.** Dropped the `format!("{:?}", …)` wrapper. Serde renders `WorkdirAccess` as lowercase via its `rename_all` annotation.
3. **`diff_to_json` — four sites.** Dropped the `format!("{:?}", …)` wrappers around `wsl2_proxy_policy` and `workdir.access` for both `profile1` and `profile2`. Serde emits `null` for `None`, preserving the comparison signal (the diff command needs to distinguish "field was set on one side, unset on the other" from "field absent on both").

The `show`/`diff` Option-handling asymmetry (omit on `show`, `null` on `diff`) is intentional. In `show`, the output mirrors the input schema (which omits unset Optional fields); in `diff`, omitting a `None` would discard the comparison signal.

## Files changed

| File | Change |
|---|---|
| `crates/nono-cli/src/profile_cmd.rs` | 9 sites in `profile_to_json` (5) and `diff_to_json` (4); +34 / −16 |
| `crates/nono-cli/tests/profile_cli.rs` | 2 new regression tests + helper functions; +157 |

## Files / sections consulted

- `crates/nono-cli/src/profile_cmd.rs` — `profile_to_json` and `diff_to_json` in particular
- `crates/nono-cli/src/profile/mod.rs` — `ProfileSignalMode` (line 962), `ProfileProcessInfoMode` (986), `ProfileIpcMode` (1010), `Wsl2ProxyPolicy` (1036), `WorkdirAccess` (1051), and the hand-rolled `Profile` Deserialize impl at 1357 (verified the show emitter's intentional shape divergence from the deserialization shape)
- `crates/nono-cli/tests/profile_cli.rs` — followed the existing test conventions (subprocess invocation via `env!("CARGO_BIN_EXE_nono")`, `.expect()` style)
- `CLAUDE.md` — coding standards (no `unwrap`/`expect` in production code), security considerations, agent contribution policy
- `CLAUDE.local.md` (private) — DCO sign-off requirement

## Repro (before this PR)

```sh
$ nono profile show claude-code --json | jq '.security.signal_mode'
"Some(Isolated)"     # bug — schema expects "isolated"

$ nono profile show default --json | jq '.workdir.access'
"None"               # bug — schema expects "none" or omission

$ nono profile diff default node-dev --json | jq '.workdir'
{
  "profile1": "None",         # bug — schema expects "none"
  "profile2": "ReadWrite",    # bug — schema expects "readwrite"
  "changed": true
}
```

## Verification (after this PR)

```sh
$ nono profile show default --json | jq '.security.signal_mode, .workdir.access'
"isolated"
"none"

$ nono profile diff default node-dev --json | jq '.workdir'
{
  "profile1": "none",
  "profile2": "readwrite",
  "changed": true
}
```

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings -D clippy::unwrap_used` clean
- [x] `cargo test -p nono-cli --test profile_cli` — 16/16 (including 2 new regression tests)
- [x] `cargo test -p nono-cli --test profile_cmd --test manifest_roundtrip --test deprecated_policy` — 24/24
- [x] `cargo test -p nono --lib` — 607/607
- [x] Manual smoke test: `nono profile show default --json` and `nono profile diff default node-dev --json` produce schema-conformant output (see "Verification" above)
- [x] `cargo test --workspace` clean