### PR TITLE
fix(ci): poll crates.io index instead of fixed sleep before publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,16 +174,32 @@ jobs:
 
       - name: Publish nono-proxy
         run: |
-          # Wait for crates.io to index the core library
-          sleep 30
+          VERSION="${RELEASE_TAG#v}"
+          echo "Waiting for nono $VERSION to appear on crates.io..."
+          for i in $(seq 1 30); do
+            if cargo search nono --limit 1 2>/dev/null | grep -q "\"$VERSION\""; then
+              echo "Found nono $VERSION on crates.io"
+              break
+            fi
+            echo "Attempt $i: not yet indexed, retrying in 10s..."
+            sleep 10
+          done
           cargo publish -p nono-proxy --allow-dirty --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Publish nono-cli
         run: |
-          # Wait for crates.io to index nono-proxy
-          sleep 30
+          VERSION="${RELEASE_TAG#v}"
+          echo "Waiting for nono-proxy $VERSION to appear on crates.io..."
+          for i in $(seq 1 30); do
+            if cargo search nono-proxy --limit 1 2>/dev/null | grep -q "\"$VERSION\""; then
+              echo "Found nono-proxy $VERSION on crates.io"
+              break
+            fi
+            echo "Attempt $i: not yet indexed, retrying in 10s..."
+            sleep 10
+          done
           cargo publish -p nono-cli --allow-dirty --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Replace 30-second sleep with a polling loop that checks for the
dependency version on crates.io before publishing the next crate.

Prevents publish failures when indexing takes longer than expected. This happened with 0.46.0 release, the nono-proxy and nono-cli crates failed as nono was not yet indexed properly and it timed out

https://github.com/always-further/nono/actions/runs/25209600413/job/73917807545