### PR TITLE
fix(policy): normalize nix profile paths to tilde-style and add defexpr

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -487,11 +487,13 @@
       "allow": {
         "read": [
           "~/.nix-profile",
+          "~/.local/state/nix/profile",
+          "~/.local/state/nix/profiles",
           "~/.nix-defexpr",
+          "~/.local/state/nix/defexpr",
           "/run/current-system/sw",
           "/etc/profiles/per-user",
           "/nix/var/nix/profiles",
-          "$HOME/.local/state/nix/profiles",
           "/nix/store"
         ]
       }


### PR DESCRIPTION
Replace $HOME/.local/state/nix/profiles with ~/.local/state/nix/profiles for consistency with the other tilde-style paths in the nix group, and add ~/.local/state/nix/defexpr alongside ~/.nix-defexpr to cover the modern XDG directory profile layout.