### PR TITLE
feat(profile): support env:// URI in custom_credentials credential_key

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -396,7 +396,7 @@
         },
         "credential_key": {
           "type": "string",
-          "description": "Keystore account name for the credential (e.g., \"telegram_bot_token\"), or a 1Password op:// URI, or an apple-password:// URI. Mutually exclusive with auth."
+          "description": "Keystore account name for the credential (e.g., \"telegram_bot_token\"), or a 1Password op:// URI, apple-password:// URI, file:// URI, or env:// URI (e.g., \"env://MY_TOKEN\"). Mutually exclusive with auth."
         },
         "auth": {
           "$ref": "#/$defs/OAuth2Config",
@@ -450,7 +450,7 @@
             { "type": "string" },
             { "type": "null" }
           ],
-          "description": "Explicit environment variable name for the phantom token (e.g., \"OPENAI_API_KEY\"). Required when credential_key is a URI manager reference (op:// or apple-password://)."
+          "description": "Explicit environment variable name for the phantom token (e.g., \"OPENAI_API_KEY\"). Required when credential_key is a URI manager reference (op://, apple-password://, or file://). Optional for env:// (derived from the URI)."
         },
         "endpoint_rules": {
           "type": "array",

--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -139,7 +139,7 @@ Define a custom reverse proxy credential route for services not in `network-poli
 | Field               | Type            | Required    | Description |
 |---------------------|-----------------|-------------|-------------|
 | `upstream`          | string          | yes         | Upstream URL. Must be HTTPS (HTTP only for loopback). |
-| `credential_key`    | string          | yes         | Keystore account name, `op://` URI, `apple-password://` URI, or `file://` URI. |
+| `credential_key`    | string          | yes         | Keystore account name, `op://` URI, `apple-password://` URI, `file://` URI, or `env://` URI. |
 | `inject_mode`       | string          | no          | One of: `"header"` (default), `"url_path"`, `"query_param"`, `"basic_auth"`. |
 | `inject_header`     | string          | header mode | HTTP header name. Default: `"Authorization"`. |
 | `credential_format` | string          | header mode | Format string with `{}` placeholder. Default: `"Bearer {}"`. |
@@ -147,7 +147,7 @@ Define a custom reverse proxy credential route for services not in `network-poli
 | `path_replacement`  | string          | url_path    | Replacement pattern. Defaults to `path_pattern`. |
 | `query_param_name`  | string          | query_param | Query parameter name for credential injection. |
 | `proxy`             | object          | no          | Optional proxy-side overrides for phantom token parsing. Omitted fields inherit from top-level values. |
-| `env_var`           | string          | URI keys    | Environment variable name for SDK API key. Required when `credential_key` is a URI. |
+| `env_var`           | string          | URI keys    | Environment variable name for SDK API key. Required when `credential_key` is `op://`, `apple-password://`, or `file://`. Optional for `env://`. |
 | `endpoint_rules`    | array           | no          | L7 allow-list of `{"method": "GET", "path": "/**"}` rules. When non-empty, only matching requests are forwarded (default-deny). |
 | `tls_ca`            | string (path)   | no          | Path to a PEM-encoded CA certificate. Use for upstreams with self-signed or private CA certs (e.g. a Kubernetes API server). |
 | `tls_client_cert`   | string (path)   | no          | Path to a PEM-encoded client certificate for mutual TLS (mTLS). Must be set together with `tls_client_key`. |

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -253,6 +253,7 @@ fn is_http_token_char(c: char) -> bool {
 /// - A 1Password `op://` URI (validated by `nono::keystore::validate_op_uri`)
 /// - An Apple Passwords `apple-password://` URI
 /// - A `file://` URI pointing to an absolute path (validated by `nono::keystore::validate_file_uri`)
+/// - An `env://` URI referencing a host environment variable (validated by `nono::keystore::validate_env_uri`)
 fn validate_credential_key(context_name: &str, key: &str) -> Result<()> {
     if key.is_empty() {
         return Err(NonoError::ProfileParse(format!(
@@ -262,7 +263,6 @@ fn validate_credential_key(context_name: &str, key: &str) -> Result<()> {
     }
 
     if nono::keystore::is_op_uri(key) {
-        // Validate as 1Password URI
         nono::keystore::validate_op_uri(key).map_err(|e| {
             NonoError::ProfileParse(format!(
                 "invalid 1Password URI for custom credential '{}': {}",
@@ -283,12 +283,18 @@ fn validate_credential_key(context_name: &str, key: &str) -> Result<()> {
                 context_name, e
             ))
         })
+    } else if nono::keystore::is_env_uri(key) {
+        nono::keystore::validate_env_uri(key).map_err(|e| {
+            NonoError::ProfileParse(format!(
+                "invalid env:// URI for custom credential '{}': {}",
+                context_name, e
+            ))
+        })
     } else {
-        // Validate as keyring account name (alphanumeric + underscore)
         if !key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
             return Err(NonoError::ProfileParse(format!(
                 "credential_key '{}' for custom credential '{}' must contain only \
-                 alphanumeric characters and underscores (or use op:// / apple-password:// / file:// URI)",
+                 alphanumeric characters and underscores (or use op:// / apple-password:// / file:// / env:// URI)",
                 key, context_name
             )));
         }
@@ -300,7 +306,7 @@ fn validate_credential_key(context_name: &str, key: &str) -> Result<()> {
 ///
 /// Checks:
 /// - `credential_key` must be alphanumeric + underscores only, or a valid
-///   `op://` / `apple-password://` / `file://` URI
+///   `op://` / `apple-password://` / `file://` / `env://` URI
 /// - `upstream` must be HTTPS (or HTTP for loopback only)
 /// - Mode-specific validation:
 ///   - `header`: inject_header must be valid HTTP token, credential_format no CRLF
@@ -334,9 +340,9 @@ fn validate_custom_credential(name: &str, cred: &CustomCredentialDef) -> Result<
     if let Some(ref key) = cred.credential_key {
         validate_credential_key(name, key)?;
 
-        // When credential_key is a URI manager reference, env_var is required because the URI
-        // cannot be meaningfully uppercased into an env var name (e.g.,
-        // "op://vault/item/field" -> "OP://VAULT/ITEM/FIELD" is nonsensical).
+        // URI manager references (except env://) cannot be meaningfully
+        // uppercased into an env var name, so env_var is required for them.
+        // env:// is exempt: the var name is derived from the URI itself.
         if (nono::keystore::is_op_uri(key)
             || nono::keystore::is_apple_password_uri(key)
             || nono::keystore::is_file_uri(key))
@@ -5522,8 +5528,52 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_custom_credential_env_uri_accepted() {
+        let cred = CustomCredentialDef {
+            upstream: "https://api.example.com".to_string(),
+            credential_key: Some("env://MY_API_TOKEN".to_string()),
+            auth: None,
+            inject_mode: InjectMode::Header,
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
+            proxy: None,
+            endpoint_rules: vec![],
+            env_var: None,
+            tls_ca: None,
+            tls_client_cert: None,
+            tls_client_key: None,
+        };
+        assert!(validate_custom_credential("example", &cred).is_ok());
+    }
+
+    #[test]
+    fn test_validate_custom_credential_env_uri_dangerous_var_rejected() {
+        let cred = CustomCredentialDef {
+            upstream: "https://api.example.com".to_string(),
+            credential_key: Some("env://LD_PRELOAD".to_string()),
+            auth: None,
+            inject_mode: InjectMode::Header,
+            inject_header: "Authorization".to_string(),
+            credential_format: "Bearer {}".to_string(),
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
+            proxy: None,
+            endpoint_rules: vec![],
+            env_var: None,
+            tls_ca: None,
+            tls_client_cert: None,
+            tls_client_key: None,
+        };
+        let result = validate_custom_credential("example", &cred);
+        assert!(result.is_err(), "env://LD_PRELOAD should be rejected");
+    }
+
+    #[test]
     fn test_profile_json_with_file_uri_custom_credential_parses() {
-        // End-to-end: parse a profile JSON with a file:// custom credential
         let dir = tempdir().expect("tmpdir");
         let profile_path = dir.path().join("file-cred.json");
         std::fs::write(

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -263,6 +263,7 @@ fn validate_credential_key(context_name: &str, key: &str) -> Result<()> {
     }
 
     if nono::keystore::is_op_uri(key) {
+        // Validate as 1Password URI
         nono::keystore::validate_op_uri(key).map_err(|e| {
             NonoError::ProfileParse(format!(
                 "invalid 1Password URI for custom credential '{}': {}",
@@ -291,6 +292,7 @@ fn validate_credential_key(context_name: &str, key: &str) -> Result<()> {
             ))
         })
     } else {
+        // Validate as keyring account name (alphanumeric + underscore)
         if !key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
             return Err(NonoError::ProfileParse(format!(
                 "credential_key '{}' for custom credential '{}' must contain only \
@@ -5572,6 +5574,7 @@ mod tests {
         assert!(result.is_err(), "env://LD_PRELOAD should be rejected");
     }
 
+    // End-to-end: parse a profile JSON with a file:// custom credential
     #[test]
     fn test_profile_json_with_file_uri_custom_credential_parses() {
         let dir = tempdir().expect("tmpdir");

--- a/crates/nono/src/manifest.rs
+++ b/crates/nono/src/manifest.rs
@@ -74,7 +74,8 @@ impl CapabilityManifest {
         for cred in &self.credentials {
             // URI manager sources (op://, apple-password://, file://) need an
             // explicit env_var because uppercasing the URI produces a nonsensical
-            // environment variable name.
+            // environment variable name. env:// is exempt: the var name is derived
+            // from the URI itself.
             let source = cred.source.as_str();
             if (crate::keystore::is_op_uri(source)
                 || crate::keystore::is_apple_password_uri(source)

--- a/docs/cli/features/credential-injection.mdx
+++ b/docs/cli/features/credential-injection.mdx
@@ -338,7 +338,7 @@ For APIs not covered by the built-in services, you can define custom credentials
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `upstream` | Yes | - | Upstream URL to proxy requests to (must be HTTPS, or HTTP for localhost only) |
-| `credential_key` | Yes | - | Keystore account name (alphanumeric and underscores only), `op://` URI for [1Password](#1password-integration), or `apple-password://` URI for [Apple Passwords](#apple-passwords-integration-macos) |
+| `credential_key` | Yes | - | Keystore account name (alphanumeric and underscores only), `op://` URI for [1Password](#1password-integration), `apple-password://` URI for [Apple Passwords](#apple-passwords-integration-macos), `file://` URI for file-backed secrets, or `env://` URI for host environment variables (e.g., `env://MY_TOKEN`) |
 | `inject_mode` | No | `header` | Credential injection mode: `header`, `url_path`, `query_param`, or `basic_auth` |
 | `inject_header` | No | `Authorization` | HTTP header to inject the credential into (used with `header` and `basic_auth` modes) |
 | `credential_format` | No | `Bearer {}` | Format string for the credential value (`{}` is replaced with the credential) |
@@ -346,7 +346,7 @@ For APIs not covered by the built-in services, you can define custom credentials
 | `path_replacement` | No | - | Optional replacement pattern for `url_path` mode (e.g., `/v2/bot{}/`) |
 | `query_param_name` | Conditional | - | Required for `query_param` mode. Query parameter name for credential injection (e.g., `key` or `api_key`) |
 | `proxy` | No | - | Optional proxy overrides for phantom token parsing. Omitted fields inherit from top-level values. See [Proxy-Side Overrides](#proxy-side-overrides). |
-| `env_var` | Conditional | - | Explicit environment variable name for the phantom token. Required when `credential_key` is a URI manager ref (`op://...` or `apple-password://...`) |
+| `env_var` | Conditional | - | Explicit environment variable name for the phantom token. Required when `credential_key` is `op://`, `apple-password://`, or `file://`. Optional for `env://` (derived from the URI) |
 
 **Important:** Use underscores, not hyphens, in credential names (the keys in `custom_credentials`). The credential name is used to generate environment variables like `TELEGRAM_BASE_URL`. Shell variable names cannot contain hyphens, so `my-api` would create `MY-API_BASE_URL` which cannot be referenced as `$MY-API_BASE_URL` in shell scripts. Use `my_api` instead.
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -359,7 +359,7 @@ nono run --allow-cwd --network-profile minimal --allow-domain custom-api.example
 
 #### `--credential`
 
-Enable credential injection for a named service via the reverse proxy. The service must be either a built-in service (`openai`, `anthropic`, `gemini`, `google-ai`) or defined as a custom credential in your profile. Credentials are loaded from the system keyring under the `nono` service name, from 1Password when `credential_key` is an `op://` URI, or from Apple Passwords on macOS when `credential_key` is an `apple-password://` URI.
+Enable credential injection for a named service via the reverse proxy. The service must be either a built-in service (`openai`, `anthropic`, `gemini`, `google-ai`) or defined as a custom credential in your profile. Credentials are loaded from the system keyring under the `nono` service name, from 1Password when `credential_key` is an `op://` URI, from Apple Passwords on macOS when `credential_key` is an `apple-password://` URI, from a file when `credential_key` is a `file://` URI, or from the host environment when `credential_key` is an `env://` URI.
 
 ```bash
 # Inject OpenAI credentials (loads from keyring account "openai_api_key")


### PR DESCRIPTION
- Accept env:// in credential_key for custom credentials, matching existing support in env_credentials and load_secret_by_ref()
- env_var is optional for env:// (derived from the URI), required for op://, apple-password://, and file://
- Dangerous variables (LD_PRELOAD, PATH, etc.) rejected via existing validate_env_uri blocklist
- Update schema, profile authoring guide, and credential injection docs

Closes #820 

cc @panga please let me know if this works for you now :)