### PR TITLE
docs: fix stale references, deprecation wording, and built-in vs pack…

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,7 @@
 > Early alpha -- not yet security audited for production use. Active development may cause breakage.
 
 
-> [!NOTE]
-> Claude Code Logins from within the sandbox -  there has been a regression in v0.36.0 impacting claude code logins - which we hope is now fixed in v0.37.0. If however, you're still seeing the issue, please open an issue outlining with your installation method (npm, curl, brew) along with your OS. Thanks for your patience! 
-
----
-
-Most sandboxes feel like sandboxes. Rigid, sluggish, and designed for a different problem entirely. nono was built from the ground up for AI agents - and the developer workfows they need to thrive - agent multiplexing, snapshots, credential injection, supply chain security out of the box. Develop alongside nono, then deploy anywhere: CI pipelines, Kubernetes, cloud VMs, microVMs. The one stop shop for all your clankers.
+Most sandboxes feel like sandboxes. Rigid, sluggish, and designed for a different problem entirely. nono was built from the ground up for AI agents - and the developer workflows they need to thrive - agent multiplexing, snapshots, credential injection, supply chain security out of the box. Develop alongside nono, then deploy anywhere: CI pipelines, Kubernetes, cloud VMs, microVMs. The one stop shop for all your clankers.
 
 ---
 
@@ -71,7 +66,7 @@ Other options in the [Installation Guide](https://docs.nono.sh/cli/getting_start
 
 ## Quick Start
 
-Built-in profiles for [Claude Code](https://docs.nono.sh/cli/clients/claude-code), [Codex](https://docs.nono.sh/cli/clients/codex), [OpenCode](https://docs.nono.sh/cli/clients/opencode), [OpenClaw](https://docs.nono.sh/cli/clients/openclaw), and [Swival](https://docs.nono.sh/cli/clients/swival) -- or [define your own](https://docs.nono.sh/cli/features/profiles-groups).
+Profiles for [Claude Code](https://docs.nono.sh/cli/clients/claude-code), [Codex](https://docs.nono.sh/cli/clients/codex), [OpenCode](https://docs.nono.sh/cli/clients/opencode), [OpenClaw](https://docs.nono.sh/cli/clients/openclaw), and Swival -- or [define your own](https://docs.nono.sh/cli/features/profiles-groups).
 
 ## Libraries and Bindings
 

--- a/crates/nono-cli/README.md
+++ b/crates/nono-cli/README.md
@@ -39,11 +39,11 @@ nono run --allow ./project-a --allow ./project-b -- command
 # Block network access
 nono run --allow-cwd --block-net -- command
 
-# Use a built-in profile
+# Use a pack profile (requires: nono pull always-further/claude)
 nono run --profile claude-code -- claude
 
-# Use the Codex profile
-nono run --profile codex -- codex
+# Use a built-in profile
+nono run --profile opencode -- opencode
 
 # Keep a profile but temporarily allow unrestricted network
 nono run --profile claude-code --allow-net -- claude
@@ -79,20 +79,26 @@ export NONO_THEME=latte
 
 Precedence is: CLI flag, then `NONO_THEME`, then config file, then the default `mocha`.
 
-## Built-in Profiles
+## Profiles
+
+### Pack profiles (install via `nono pull`)
+
+| Profile | Install | Command |
+|---------|---------|---------|
+| Claude Code | `nono pull always-further/claude` | `nono run --profile claude-code -- claude` |
+| Codex | `nono pull always-further/codex` | `nono run --profile codex -- codex` |
+
+### Built-in profiles
 
 | Profile | Command |
 |---------|---------|
-| Claude Code | `nono run --profile claude-code -- claude` |
-| Claude Code (No Keychain) | `nono run --profile claude-no-kc -- claude` |
-| Codex | `nono run --profile codex -- codex` |
 | OpenCode | `nono run --profile opencode -- opencode` |
 | OpenClaw | `nono run --profile openclaw -- openclaw gateway` |
 | Swival | `nono run --profile swival -- swival` |
 
 ## Profile Inheritance
 
-User profiles can extend built-in or other user profiles with the `extends` field. The child inherits all settings from the base and only declares additions or overrides.
+User profiles can extend built-in, pack, or other user profiles with the `extends` field. The child inherits all settings from the base and only declares additions or overrides.
 
 ```json
 {
@@ -136,7 +142,7 @@ When extending multiple bases, they are merged left-to-right using the same rule
 Profiles can form chains (up to 10 levels deep). Circular dependencies are detected and rejected. Shared transitive bases are deduplicated.
 
 ```
-my-dev.json → team-base.json → claude-code (built-in)
+my-dev.json → team-base.json → claude-code (pack)
 ```
 
 ## Deprecated Command Blocking

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -127,7 +127,7 @@ pub enum Commands {
 {after-help}")]
     #[command(after_help = "\x1b[1mEXAMPLES\x1b[0m
   nono run --allow . claude                    # Read/write current dir, run claude
-  nono run --profile claude-code claude        # Use a built-in profile
+  nono run --profile claude-code claude        # Use a profile
   nono run --profile claude-code --allow-domain api.openai.com claude
                                                # Restrict outbound access to listed domains
   nono run --read ./src --write ./output cargo build
@@ -167,7 +167,7 @@ pub enum Commands {
 {after-help}")]
     #[command(after_help = "\x1b[1mEXAMPLES\x1b[0m
   nono wrap --allow . -- cargo build           # Sandbox and exec into cargo build
-  nono wrap --profile developer -- cargo test  # Use a named profile
+  nono wrap --profile rust-dev -- cargo test    # Use a named profile
 ")]
     Wrap(Box<WrapArgs>),
 
@@ -511,9 +511,9 @@ IN-BAND DETACH:
 {all-args}
 {after-help}")]
     #[command(after_help = "\x1b[1mEXAMPLES\x1b[0m
-  nono pull nono-project/claude-code
-  nono pull nono-project/claude-code@1.2.0 --registry http://localhost:3000
-  nono pull nono-project/claude-code --init
+  nono pull always-further/claude
+  nono pull always-further/claude@1.2.0 --registry http://localhost:3000
+  nono pull always-further/claude --init
 ")]
     Pull(PullArgs),
 
@@ -527,7 +527,7 @@ IN-BAND DETACH:
 {all-args}
 {after-help}")]
     #[command(after_help = "\x1b[1mEXAMPLES\x1b[0m
-  nono remove nono-project/claude-code
+  nono remove always-further/claude
 ")]
     Remove(RemoveArgs),
 
@@ -542,7 +542,7 @@ IN-BAND DETACH:
 {after-help}")]
     #[command(after_help = "\x1b[1mEXAMPLES\x1b[0m
   nono update
-  nono update nono-project/claude-code
+  nono update always-further/claude
 ")]
     Update(UpdateArgs),
 

--- a/crates/nono-cli/src/deprecated_schema.rs
+++ b/crates/nono-cli/src/deprecated_schema.rs
@@ -294,7 +294,7 @@ pub(crate) fn format_deprecation_warning(
     issue: &str,
 ) -> String {
     format!(
-        "warning: deprecated key '{legacy}' — use '{canonical}' instead (removed in {remove_by}, {issue})"
+        "warning: deprecated key '{legacy}' — use '{canonical}' instead (will be removed in {remove_by}, {issue})"
     )
 }
 

--- a/docs/cli/clients/claude-code.mdx
+++ b/docs/cli/clients/claude-code.mdx
@@ -54,8 +54,8 @@ If you need different permissions, create a custom profile at `~/.config/nono/pr
     "version": "1.0.0",
     "description": "Claude Code with additional project access"
   },
-  "security": {
-    "groups": ["git_config"]
+  "groups": {
+    "include": ["git_config"]
   },
   "filesystem": {
     "allow": ["$WORKDIR", "$HOME/.claude"],

--- a/docs/cli/features/profile-authoring.mdx
+++ b/docs/cli/features/profile-authoring.mdx
@@ -43,8 +43,8 @@ A minimal skeleton includes the core sections most profiles need:
     "name": "my-agent",
     "description": "Profile for my agent"
   },
-  "security": {
-    "groups": [
+  "groups": {
+    "include": [
       "deny_credentials"
     ]
   },
@@ -233,7 +233,7 @@ nono profile groups deny_credentials
 Groups are referenced by name in the `groups.include` field. See [Profiles & Groups](/cli/features/profiles-groups#groups) for the full group taxonomy and built-in group list.
 
 <Note>
-  The `groups.include` key was renamed from its former location under `security` in issue #594. The legacy key still deserializes with a deprecation warning; see `nono profile guide` for the full migration table. Legacy keys are removed in v1.0.0.
+  The `groups.include` key was renamed from its former location under `security` in issue #594. The legacy key still deserializes with a deprecation warning; see `nono profile guide` for the full migration table. Legacy keys will be removed in v1.0.0.
 </Note>
 
 ## Common Patterns

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -139,7 +139,7 @@ This is the primary mechanism for surgically customizing inherited profiles with
 | `bypass_protection` | `filesystem` | Paths exempted from deny groups. **Does not grant access** — each path must also appear in `filesystem.allow`, `filesystem.read`, or `filesystem.write`. |
 
 <Note>
-  **Renamed in issue #594.** The old top-level `policy` section was dissolved into `filesystem`, `groups`, and `commands` in the canonical schema. Legacy names still deserialize with a deprecation warning; see the migration table in `nono profile guide` for the full mapping. The legacy keys are removed in v1.0.0.
+  **Renamed in issue #594.** The old top-level `policy` section was dissolved into `filesystem`, `groups`, and `commands` in the canonical schema. Legacy names still deserialize with a deprecation warning; see the migration table in `nono profile guide` for the full mapping. The legacy keys will be removed in v1.0.0.
 </Note>
 
 #### Adding a Deny Rule to an Inherited Profile

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -621,7 +621,7 @@ Can be specified multiple times.
 </Note>
 
 <Note>
-  **Renamed in issue #594.** This flag was renamed from its former deny-override name. The legacy name is still accepted as a deprecated alias and emits a warning on use; it is removed in v1.0.0.
+  **Renamed in issue #594.** This flag was renamed from its former deny-override name. The legacy name is still accepted as a deprecated alias and emits a warning on use; it will be removed in v1.0.0.
 </Note>
 
 ### Credential Options


### PR DESCRIPTION
… distinction

- Remove stale v0.36/v0.37 Claude login advisory from README
- Fix 'workfows' typo in README
- Remove broken Swival docs link (no page exists)
- Remove non-existent 'claude-no-kc' profile from nono-cli README
- Split profile table into pack-delivered ('claude-code', 'codex') and built-in
- Fix 'nono wrap' example to use 'rust-dev' instead of non-existent 'developer' profile
- Fix 'nono run' example comment from 'built-in profile' to 'profile'
- Update deprecated 'security.groups' to 'groups.include' in doc examples
- Change deprecation wording from 'removed in v1.0.0' to 'will be removed in v1.0.0'

Noticed some issues in the wording/missing links/incorrect help commands etc.

Closes #833 