### PR TITLE
feat(cli): add shell completion generation via `nono completion <shell>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,6 +1663,7 @@ dependencies = [
  "aws-lc-rs",
  "chrono",
  "clap",
+ "clap_complete",
  "colored",
  "dirs",
  "dns-lookup",

--- a/crates/nono-cli/Cargo.toml
+++ b/crates/nono-cli/Cargo.toml
@@ -43,6 +43,7 @@ test-trust-overrides = []
 nono = { version = "0.47.0", path = "../nono", default-features = false }
 nono-proxy = { version = "0.47.0", path = "../nono-proxy", default-features = false }
 clap = { version = "4", features = ["derive", "env"] }
+clap_complete = "4"
 colored = "3"
 similar = "3"
 rand = "0.10"

--- a/crates/nono-cli/src/app_runtime.rs
+++ b/crates/nono-cli/src/app_runtime.rs
@@ -1,6 +1,7 @@
 use crate::audit_commands;
 use crate::cli::{Cli, Commands, RunArgs, SetupArgs};
 use crate::command_runtime::{run_sandbox, run_shell, run_wrap};
+use crate::completions::run_completions;
 use crate::deprecated_policy;
 use crate::learn_runtime::run_learn;
 use crate::open_url_runtime::run_open_url_helper;
@@ -108,6 +109,7 @@ fn dispatch_command(
             run_command_with_update(update_handle, silent, || package_cmd::run_list(args))
         }
         Commands::OpenUrlHelper(args) => run_open_url_helper(args),
+        Commands::Completions(args) => run_completions(args),
     }
 }
 

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -58,6 +58,9 @@ const STYLES: Styles = Styles::plain().header(Style::new().bold());
   policy     [deprecated] Use 'nono profile' instead
   profile    Create, inspect, and compare nono profiles
 
+\x1b[1mSHELL\x1b[0m
+  completion   Generate shell completion scripts
+
 \x1b[1mOPTIONS\x1b[0m
 {options}
 
@@ -576,6 +579,24 @@ IN-BAND DETACH:
 ")]
     List(ListArgs),
 
+    /// Generate shell completion scripts
+    #[command(name = "completion")]
+    #[command(help_template = "\
+{about}
+
+\x1b[1mUSAGE\x1b[0m
+  nono completion <shell>
+
+{all-args}
+{after-help}")]
+    #[command(after_help = "\x1b[1mEXAMPLES\x1b[0m
+  nono completion bash >> ~/.bashrc
+  nono completion zsh > ~/.zfunc/_nono
+  nono completion fish > ~/.config/fish/completions/nono.fish
+  nono completion powershell >> $PROFILE
+")]
+    Completions(CompletionsArgs),
+
     /// Internal: open a URL via supervisor IPC
     #[command(hide = true)]
     OpenUrlHelper(OpenUrlHelperArgs),
@@ -703,6 +724,34 @@ pub struct ListArgs {
 pub struct OpenUrlHelperArgs {
     /// The URL to open
     pub url: String,
+}
+
+/// Shell variant for completion generation.
+///
+/// Mirrors `clap_complete::Shell` but is defined here so it implements
+/// `clap::ValueEnum` and appears correctly in `--help` output.
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub enum CompletionShell {
+    /// Bourne Again SHell (bash)
+    Bash,
+    /// Z Shell (zsh)
+    Zsh,
+    /// Friendly Interactive Shell (fish)
+    Fish,
+    /// PowerShell
+    #[value(name = "powershell")]
+    PowerShell,
+}
+
+#[derive(Parser, Debug)]
+#[command(disable_help_flag = true)]
+pub struct CompletionsArgs {
+    /// Shell to generate completions for
+    pub shell: CompletionShell,
+
+    /// Print help
+    #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
+    pub help: Option<bool>,
 }
 
 // NOTE: `PolicyArgs`, `PolicyCommands`, and `Policy*Args` types that
@@ -3364,9 +3413,30 @@ mod tests {
     /// All subcommand names that must appear in the root help template.
     /// If you add a new command to the `Commands` enum, add it here too.
     const ALL_SUBCOMMANDS: &[&str] = &[
-        "setup", "run", "shell", "wrap", "learn", "why", "ps", "stop", "detach", "attach", "logs",
-        "inspect", "session", "rollback", "audit", "trust", "policy", "profile", "pull", "remove",
-        "update", "search", "list",
+        "setup",
+        "run",
+        "shell",
+        "wrap",
+        "learn",
+        "why",
+        "ps",
+        "stop",
+        "detach",
+        "attach",
+        "logs",
+        "inspect",
+        "session",
+        "rollback",
+        "audit",
+        "trust",
+        "policy",
+        "profile",
+        "pull",
+        "remove",
+        "update",
+        "search",
+        "list",
+        "completion",
     ];
 
     #[test]

--- a/crates/nono-cli/src/cli_bootstrap.rs
+++ b/crates/nono-cli/src/cli_bootstrap.rs
@@ -174,7 +174,8 @@ fn cli_verbosity(cli: &Cli) -> u8 {
         | Commands::Prune(_)
         | Commands::Policy(_)
         | Commands::Profile(_)
-        | Commands::OpenUrlHelper(_) => 0,
+        | Commands::OpenUrlHelper(_)
+        | Commands::Completions(_) => 0,
     }
 }
 

--- a/crates/nono-cli/src/completions.rs
+++ b/crates/nono-cli/src/completions.rs
@@ -1,0 +1,166 @@
+//! Shell completion script generation.
+//!
+//! Implements `nono completion <shell>`, which writes a completion script for
+//! the requested shell to stdout.  Users pipe or redirect the output into their
+//! shell's completion directory:
+//!
+//! ```text
+//! nono completion bash   >> ~/.bashrc
+//! nono completion zsh    > ~/.zfunc/_nono
+//! nono completion fish   > ~/.config/fish/completions/nono.fish
+//! nono completion powershell >> $PROFILE
+//! ```
+
+use clap::CommandFactory;
+use clap_complete::{Generator, Shell};
+use nono::{NonoError, Result};
+use std::io::Write;
+
+use crate::cli::{Cli, CompletionShell, CompletionsArgs};
+
+/// Run `nono completion <shell>`.
+///
+/// Writes the completion script for `shell` to stdout and returns `Ok(())`.
+/// On I/O failure (e.g. the pipe is closed) the error is propagated as a
+/// [`nono::NonoError::Io`] variant.
+pub(crate) fn run_completions(args: CompletionsArgs) -> Result<()> {
+    let shell = to_clap_shell(&args.shell);
+    let mut cmd = Cli::command();
+    let mut stdout = std::io::stdout();
+
+    try_generate(shell, &mut cmd, "nono", &mut stdout).map_err(NonoError::Io)?;
+    stdout.flush().map_err(NonoError::Io)
+}
+
+/// Generate completions while preserving write errors instead of panicking.
+fn try_generate<G, S>(
+    generator: G,
+    cmd: &mut clap::Command,
+    bin_name: S,
+    buf: &mut dyn Write,
+) -> std::io::Result<()>
+where
+    G: Generator,
+    S: Into<String>,
+{
+    cmd.set_bin_name(bin_name);
+    cmd.build();
+    generator.try_generate(cmd, buf)
+}
+
+/// Convert our `CompletionShell` value-enum to the `clap_complete::Shell` type.
+fn to_clap_shell(shell: &CompletionShell) -> Shell {
+    match shell {
+        CompletionShell::Bash => Shell::Bash,
+        CompletionShell::Zsh => Shell::Zsh,
+        CompletionShell::Fish => Shell::Fish,
+        CompletionShell::PowerShell => Shell::PowerShell,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::CompletionShell;
+
+    type TestResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+    fn generate_to_string(shell: CompletionShell) -> TestResult<String> {
+        let clap_shell = to_clap_shell(&shell);
+        let mut cmd = Cli::command();
+        let mut buf = Vec::new();
+        try_generate(clap_shell, &mut cmd, "nono", &mut buf)?;
+        Ok(String::from_utf8(buf)?)
+    }
+
+    #[test]
+    fn test_bash_completions_contain_binary_name() -> TestResult<()> {
+        let output = generate_to_string(CompletionShell::Bash)?;
+        assert!(
+            output.contains("nono"),
+            "bash completions should reference the binary name"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_zsh_completions_contain_binary_name() -> TestResult<()> {
+        let output = generate_to_string(CompletionShell::Zsh)?;
+        assert!(
+            output.contains("nono"),
+            "zsh completions should reference the binary name"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_fish_completions_contain_binary_name() -> TestResult<()> {
+        let output = generate_to_string(CompletionShell::Fish)?;
+        assert!(
+            output.contains("nono"),
+            "fish completions should reference the binary name"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_powershell_completions_non_empty() -> TestResult<()> {
+        let output = generate_to_string(CompletionShell::PowerShell)?;
+        assert!(
+            !output.is_empty(),
+            "powershell completions must not be empty"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_bash_completions_contain_subcommands() -> TestResult<()> {
+        let output = generate_to_string(CompletionShell::Bash)?;
+        // Core subcommands must appear in bash completions
+        for sub in &["run", "shell", "wrap", "learn", "why", "setup"] {
+            assert!(
+                output.contains(sub),
+                "bash completions missing subcommand: {sub}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_completions_args_parse_all_shells() {
+        use crate::cli::Cli;
+        use clap::Parser;
+
+        for shell in &["bash", "zsh", "fish", "powershell"] {
+            let cli = Cli::parse_from(["nono", "completion", shell]);
+            assert!(
+                matches!(cli.command, crate::cli::Commands::Completions(_)),
+                "completions command should parse for shell: {shell}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_completion_write_errors_are_returned() {
+        struct FailingWriter;
+
+        impl Write for FailingWriter {
+            fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "closed",
+                ))
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut cmd = Cli::command();
+        let mut writer = FailingWriter;
+        let result = try_generate(Shell::Bash, &mut cmd, "nono", &mut writer);
+
+        assert!(result.is_err(), "write errors must be returned");
+    }
+}

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -14,6 +14,7 @@ mod cli_bootstrap;
 mod command_blocking_deprecation;
 mod command_display;
 mod command_runtime;
+mod completions;
 mod config;
 mod credential_runtime;
 mod deprecated_policy;
@@ -379,6 +380,17 @@ mod tests {
 
         let wrap = Cli::parse_from(["nono", "wrap", "--allow", "/tmp", "--", "/bin/sh"]);
         assert!(!allows_pre_exec_update_check(&wrap.command));
+    }
+
+    #[test]
+    fn test_pre_exec_update_check_disabled_for_completions() {
+        // `nono completions` is used in shell init scripts such as
+        // `eval "$(nono completions zsh)"`.  It never shows an update
+        // notification (it is dispatched directly without
+        // run_command_with_update), so spawning the background update-check
+        // thread would incur network I/O with no benefit.
+        let completions = Cli::parse_from(["nono", "completion", "zsh"]);
+        assert!(!allows_pre_exec_update_check(&completions.command));
     }
 
     #[test]

--- a/crates/nono-cli/src/startup_runtime.rs
+++ b/crates/nono-cli/src/startup_runtime.rs
@@ -15,7 +15,7 @@ use std::process::{Child, Command, Stdio};
 pub(crate) fn allows_pre_exec_update_check(command: &Commands) -> bool {
     !matches!(
         command,
-        Commands::Run(_) | Commands::Shell(_) | Commands::Wrap(_)
+        Commands::Run(_) | Commands::Shell(_) | Commands::Wrap(_) | Commands::Completions(_)
     )
 }
 


### PR DESCRIPTION
Adds a new `completion` subcommand that writes a shell completion script for bash, zsh, fish, or powershell to stdout.

Usage:
  nono completion bash   >> ~/.bashrc
  nono completion zsh    > ~/.zfunc/_nono
  nono completion fish   > ~/.config/fish/completions/nono.fish
  nono completion powershell >> $PROFILE