### PR TITLE
chore: harden CI workflows and fix stale metadata

### DIFF
--- a/.github/workflows/docs-dispatch.yml
+++ b/.github/workflows/docs-dispatch.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   dispatch:
+    if: github.repository == 'always-further/nono'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger docs repo rebuild

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -33,8 +33,9 @@ jobs:
     name: Resolve build parameters
     runs-on: ubuntu-latest
     if: >-
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      github.repository == 'always-further/nono' &&
+      ((github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'))
     outputs:
       ref: ${{ steps.params.outputs.ref }}
       version: ${{ steps.params.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -20,6 +20,7 @@ env:
 
 jobs:
   build:
+    if: github.repository == 'always-further/nono'
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -121,6 +122,8 @@ jobs:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/sign-instruction-files.yml
+++ b/.github/workflows/sign-instruction-files.yml
@@ -26,6 +26,7 @@ permissions:
 
 jobs:
   sign:
+    if: github.repository == 'always-further/nono'
     runs-on: ubuntu-latest
 
     steps:

--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://nono.dev/schemas/nono-profile.schema.json",
+  "$id": "https://nono.sh/schemas/nono-profile.schema.json",
   "title": "nono Profile",
   "description": "A nono profile definition that configures sandbox capabilities, filesystem access, network policy, and other security settings for running untrusted processes.",
   "type": "object",

--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -596,7 +596,7 @@
         "name": "default",
         "version": "1.0.0",
         "description": "Default conservative base profile",
-        "author": "nono-project"
+        "author": "always-further"
       },
       "groups": {
         "include": [
@@ -634,7 +634,7 @@
         "name": "linux-host-compat",
         "version": "1.0.0",
         "description": "Linux compatibility profile for host runtime, sysfs, and temp access",
-        "author": "nono-project"
+        "author": "always-further"
       },
       "groups": {
         "include": [
@@ -657,7 +657,7 @@
         "name": "openclaw",
         "version": "1.0.0",
         "description": "OpenClaw messaging gateway",
-        "author": "nono-project"
+        "author": "always-further"
       },
       "groups": {
         "include": ["node_runtime"]
@@ -685,7 +685,7 @@
         "name": "opencode",
         "version": "1.0.0",
         "description": "OpenCode AI coding assistant",
-        "author": "nono-project"
+        "author": "always-further"
       },
       "groups": {
         "include": ["user_caches_macos", "user_caches_linux", "node_runtime", "opencode_linux", "linux_sysfs_read", "git_config", "unlink_protection"]
@@ -717,7 +717,7 @@
         "name": "python-dev",
         "version": "1.0.0",
         "description": "Python SDK development profile with pyenv, conda, and pip support",
-        "author": "nono-project"
+        "author": "always-further"
       },
       "groups": {
         "include": ["python_runtime"]
@@ -737,7 +737,7 @@
         "name": "node-dev",
         "version": "1.0.0",
         "description": "Node.js SDK development profile with nvm, fnm, pnpm, and npm support",
-        "author": "nono-project"
+        "author": "always-further"
       },
       "groups": {
         "include": ["node_runtime"]
@@ -756,7 +756,7 @@
         "name": "go-dev",
         "version": "1.0.0",
         "description": "Go SDK development profile with GOPATH and module support",
-        "author": "nono-project"
+        "author": "always-further"
       },
       "groups": {
         "include": ["go_runtime"]
@@ -775,7 +775,7 @@
         "name": "rust-dev",
         "version": "1.0.0",
         "description": "Rust SDK development profile with cargo and rustup support",
-        "author": "nono-project"
+        "author": "always-further"
       },
       "groups": {
         "include": ["rust_runtime"]
@@ -794,7 +794,7 @@
         "name": "swival",
         "version": "1.0.0",
         "description": "Swival CLI coding agent",
-        "author": "nono-project"
+        "author": "always-further"
       },
       "groups": {
         "include": [


### PR DESCRIPTION
- Add 'github.repository' guard to 'release', 'docs-dispatch', 'sign-instruction-files', and 'image-build' workflows to prevent forks from running publish/sign/deploy jobs
- Scope 'release.yml' permissions from workflow-level 'contents: write' to job-level (build jobs only need read)
- Update profile author metadata from 'nono-project' to 'always-further' in policy.json
- Update schema '' from 'nono.dev' to 'nono.sh' to match docs domain