### PR TITLE
fix(trust): reject path traversal in multi-subject bundle subject names

### DIFF
--- a/crates/nono-cli/src/trust_cmd.rs
+++ b/crates/nono-cli/src/trust_cmd.rs
@@ -810,8 +810,7 @@ fn run_verify(args: TrustVerifyArgs) -> Result<()> {
                     // defense-in-depth so that the canonicalize-then-insert
                     // step cannot be reached with a traversal name even if
                     // the inner guard is somehow bypassed in the future.
-                    if let Ok(subject_path) =
-                        crate::trust_scan::safe_subject_path(scan_root, name)
+                    if let Ok(subject_path) = crate::trust_scan::safe_subject_path(scan_root, name)
                     {
                         if let Ok(canon) = std::fs::canonicalize(&subject_path) {
                             multi_verified_paths.insert(canon);

--- a/crates/nono-cli/src/trust_cmd.rs
+++ b/crates/nono-cli/src/trust_cmd.rs
@@ -804,10 +804,18 @@ fn run_verify(args: TrustVerifyArgs) -> Result<()> {
                 for (name, signer) in &subjects {
                     eprintln!("  {} {} (signer: {})", "VERIFIED".green(), name, signer);
                     verified = verified.saturating_add(1);
-                    // Track the canonical path so per-file check can skip it
-                    let subject_path = scan_root.join(name);
-                    if let Ok(canon) = std::fs::canonicalize(&subject_path) {
-                        multi_verified_paths.insert(canon);
+                    // Track the canonical path so per-file check can skip it.
+                    // safe_subject_path was already enforced inside
+                    // verify_multi_subject_file; this second call is
+                    // defense-in-depth so that the canonicalize-then-insert
+                    // step cannot be reached with a traversal name even if
+                    // the inner guard is somehow bypassed in the future.
+                    if let Ok(subject_path) =
+                        crate::trust_scan::safe_subject_path(scan_root, name)
+                    {
+                        if let Ok(canon) = std::fs::canonicalize(&subject_path) {
+                            multi_verified_paths.insert(canon);
+                        }
                     }
                 }
             }
@@ -940,7 +948,8 @@ fn verify_multi_subject_file(
     let mut results = Vec::with_capacity(subjects.len());
 
     for (name, expected_digest) in &subjects {
-        let file_path = scan_root.join(name);
+        let file_path = crate::trust_scan::safe_subject_path(scan_root, name)
+            .map_err(|reason| format!("rejected subject '{name}': {reason}"))?;
         let actual_digest = trust::file_digest(&file_path)
             .map_err(|e| format!("failed to read subject '{}': {e}", name))?;
         if actual_digest != *expected_digest {

--- a/crates/nono-cli/src/trust_cmd.rs
+++ b/crates/nono-cli/src/trust_cmd.rs
@@ -798,7 +798,13 @@ fn run_verify(args: TrustVerifyArgs) -> Result<()> {
         std::collections::HashSet::new();
 
     for bundle_path in &multi_bundles {
-        let scan_root = bundle_path.parent().unwrap_or_else(|| Path::new("."));
+        // Path::parent() returns Some("") for a bare filename (e.g.
+        // ".nono-trust.bundle" with no directory component).  An empty path
+        // cannot be canonicalized; treat it as the current directory.
+        let scan_root = bundle_path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
         match verify_multi_subject_file(bundle_path, scan_root, &policy) {
             Ok(subjects) => {
                 for (name, signer) in &subjects {

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -766,14 +766,22 @@ fn verify_keyless_crypto(
 
 /// Resolve a bundle subject `name` to a path within `scan_root`.
 ///
-/// Rejects names that would escape the scan root before any filesystem I/O:
+/// Rejects names that would escape the scan root before any filesystem I/O,
+/// covering three distinct vectors:
+///
 /// - **Absolute paths** (`/etc/passwd`): `Path::join` discards `scan_root`
 ///   entirely for absolute inputs, so the join itself escapes the root.
 /// - **`..` traversal** (`../../etc/shadow`): parent-directory components
-///   climb above `scan_root` after resolution by the OS.
+///   climb above `scan_root` after OS resolution.
+/// - **Symlink escape** (`link/passwd` where `scan_root/link → /etc`):
+///   passes the component checks above but resolves outside the root when
+///   the OS follows the symlink at I/O time.  Caught by canonicalizing both
+///   `scan_root` and the joined path and asserting containment.
 ///
-/// Both cases are rejected at the component level — before `join` — so no
-/// path is constructed or opened for traversal inputs.
+/// If the target file does not yet exist (`canonicalize` on the joined path
+/// returns `Err`), the symlink check is skipped and the caller's own file I/O
+/// will produce the appropriate error.  `scan_root` itself must be resolvable;
+/// an error is returned immediately if it cannot be canonicalized.
 ///
 /// # Errors
 ///
@@ -802,7 +810,30 @@ pub(crate) fn safe_subject_path(
         }
     }
 
-    Ok(scan_root.join(name_path))
+    let joined = scan_root.join(name_path);
+
+    // Symlink-escape check: canonicalize scan_root and the joined subject
+    // path, then require the resolved subject to remain within the resolved
+    // root.  A subject like "link/passwd" passes the component checks above
+    // when scan_root/link is a symlink pointing outside scan_root; the OS
+    // follows it and the digest computation reads the target.
+    //
+    // scan_root is canonicalized unconditionally — if it cannot be resolved
+    // we return an error immediately.  The joined path is canonicalized only
+    // when the file exists; a missing file is not an escape, and the
+    // caller's I/O will produce the appropriate not-found error.
+    let canon_root = std::fs::canonicalize(scan_root)
+        .map_err(|e| format!("failed to canonicalize scan root: {e}"))?;
+
+    if let Ok(canon_path) = std::fs::canonicalize(&joined) {
+        if !canon_path.starts_with(&canon_root) {
+            return Err(format!(
+                "subject '{name}' resolves outside scan root via symlink"
+            ));
+        }
+    }
+
+    Ok(joined)
 }
 
 // ---------------------------------------------------------------------------
@@ -1694,16 +1725,20 @@ mod tests {
 
     #[test]
     fn safe_subject_path_accepts_plain_filename() {
-        let root = std::path::Path::new("/tmp/scan");
-        let result = safe_subject_path(root, "SKILLS.md").unwrap();
-        assert_eq!(result, root.join("SKILLS.md"));
+        // scan_root must exist on disk because safe_subject_path now calls
+        // canonicalize(scan_root).  The file itself need not exist — when
+        // canonicalize(joined) fails the symlink check is skipped and the
+        // caller's I/O will handle the missing-file error.
+        let dir = tempfile::tempdir().unwrap();
+        let result = safe_subject_path(dir.path(), "SKILLS.md").unwrap();
+        assert_eq!(result, dir.path().join("SKILLS.md"));
     }
 
     #[test]
     fn safe_subject_path_accepts_subdirectory() {
-        let root = std::path::Path::new("/tmp/scan");
-        let result = safe_subject_path(root, ".claude/commands/deploy.md").unwrap();
-        assert_eq!(result, root.join(".claude/commands/deploy.md"));
+        let dir = tempfile::tempdir().unwrap();
+        let result = safe_subject_path(dir.path(), ".claude/commands/deploy.md").unwrap();
+        assert_eq!(result, dir.path().join(".claude/commands/deploy.md"));
     }
 
     #[test]
@@ -1736,6 +1771,98 @@ mod tests {
         let root = std::path::Path::new("/tmp/scan");
         let err = safe_subject_path(root, "subdir/..").unwrap_err();
         assert!(err.contains(".."), "error should mention '..': {err}");
+    }
+
+    /// A subject name that is syntactically clean but resolves outside
+    /// scan_root via a symlink must be rejected.
+    #[cfg(unix)]
+    #[test]
+    fn safe_subject_path_rejects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let outer = tempfile::tempdir().unwrap();
+        let scan_root = outer.path().join("scan");
+        std::fs::create_dir_all(&scan_root).unwrap();
+
+        // Target file lives outside scan_root.
+        let outside = outer.path().join("secret.txt");
+        std::fs::write(&outside, "SECRET").unwrap();
+
+        // Symlink inside scan_root points to the outside file.
+        let link = scan_root.join("link.txt");
+        symlink(&outside, &link).unwrap();
+
+        let err = safe_subject_path(&scan_root, "link.txt").unwrap_err();
+        assert!(
+            err.contains("symlink") || err.contains("outside"),
+            "error must describe the escape: {err}"
+        );
+    }
+
+    /// Regression test: a bundle whose subject name escapes scan_root through a
+    /// symlink must be blocked end-to-end by verify_multi_subject_bundle.
+    #[cfg(unix)]
+    #[test]
+    fn multi_subject_bundle_rejects_symlink_escape() {
+        use nono::trust;
+        use std::os::unix::fs::symlink;
+
+        let outer = tempfile::tempdir().unwrap();
+        let scan_root = outer.path().join("scan");
+        std::fs::create_dir_all(&scan_root).unwrap();
+
+        // Real file outside scan_root; attacker knows its digest.
+        let content = b"SYMLINK_SECRET";
+        let outside = outer.path().join("secret.txt");
+        std::fs::write(&outside, content).unwrap();
+        let secret_digest = trust::bytes_digest(content);
+
+        // Symlink inside scan_root → outside file.
+        let link_name = "link.txt";
+        symlink(&outside, scan_root.join(link_name)).unwrap();
+
+        // Craft a valid, correctly-signed bundle whose subject is the symlink.
+        let key_pair = trust::generate_signing_key().unwrap();
+        let key_id = trust::key_id_hex(&key_pair).unwrap();
+        let pub_key_bytes = trust::export_public_key(&key_pair).unwrap();
+        let pub_key_b64 = nono::trust::base64::base64_encode(pub_key_bytes.as_bytes());
+
+        let files = vec![(std::path::PathBuf::from(link_name), secret_digest)];
+        let bundle_json = trust::sign_files(&files, &key_pair, &key_id).unwrap();
+        let bundle_path = trust::multi_subject_bundle_path(&scan_root);
+        std::fs::write(&bundle_path, &bundle_json).unwrap();
+
+        let policy = TrustPolicy {
+            includes: Vec::new(),
+            enforcement: Enforcement::Deny,
+            publishers: vec![trust::Publisher {
+                name: "attacker".to_string(),
+                issuer: None,
+                repository: None,
+                workflow: None,
+                ref_pattern: None,
+                key_id: Some(key_id),
+                public_key: Some(pub_key_b64),
+                build_signer_uri: None,
+            }],
+            ..TrustPolicy::default()
+        };
+
+        let results = verify_multi_subject_bundle(&bundle_path, &scan_root, &policy);
+        assert_eq!(
+            results.len(),
+            1,
+            "expected one result for the symlink subject"
+        );
+        let outcome = &results[0].outcome;
+        assert!(
+            matches!(outcome, VerificationOutcome::InvalidSignature { .. }),
+            "symlink escape must yield InvalidSignature, got: {outcome:?}"
+        );
+        assert!(
+            !outcome.is_verified(),
+            "symlink escape must not pass as verified"
+        );
     }
 
     /// Regression test: a bundle with a path-traversal subject name must be

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -934,9 +934,7 @@ fn verify_multi_subject_bundle(
                 results.push(VerificationResult {
                     path: scan_root.to_path_buf(),
                     digest: String::new(),
-                    outcome: VerificationOutcome::InvalidSignature {
-                        detail: reason,
-                    },
+                    outcome: VerificationOutcome::InvalidSignature { detail: reason },
                 });
                 continue;
             }
@@ -1722,10 +1720,7 @@ mod tests {
     fn safe_subject_path_rejects_relative_dotdot_traversal() {
         let root = std::path::Path::new("/tmp/scan");
         let err = safe_subject_path(root, "../../../etc/shadow").unwrap_err();
-        assert!(
-            err.contains(".."),
-            "error should mention '..': {err}"
-        );
+        assert!(err.contains(".."), "error should mention '..': {err}");
     }
 
     #[test]
@@ -1733,20 +1728,14 @@ mod tests {
         let root = std::path::Path::new("/tmp/scan");
         // Embedded traversal: starts inside root then climbs out.
         let err = safe_subject_path(root, "subdir/../../etc/passwd").unwrap_err();
-        assert!(
-            err.contains(".."),
-            "error should mention '..': {err}"
-        );
+        assert!(err.contains(".."), "error should mention '..': {err}");
     }
 
     #[test]
     fn safe_subject_path_rejects_trailing_dotdot() {
         let root = std::path::Path::new("/tmp/scan");
         let err = safe_subject_path(root, "subdir/..").unwrap_err();
-        assert!(
-            err.contains(".."),
-            "error should mention '..': {err}"
-        );
+        assert!(err.contains(".."), "error should mention '..': {err}");
     }
 
     /// Regression test: a bundle with a path-traversal subject name must be
@@ -1793,7 +1782,11 @@ mod tests {
         };
 
         let results = verify_multi_subject_bundle(&bundle_path, &scan_root, &policy);
-        assert_eq!(results.len(), 1, "expected one result for the traversal subject");
+        assert_eq!(
+            results.len(),
+            1,
+            "expected one result for the traversal subject"
+        );
         let outcome = &results[0].outcome;
         // Must be rejected as InvalidSignature (traversal is a policy violation).
         assert!(
@@ -1801,6 +1794,9 @@ mod tests {
             "traversal subject must yield InvalidSignature, got: {outcome:?}"
         );
         // Must NOT be Verified.
-        assert!(!outcome.is_verified(), "traversal must not pass as verified");
+        assert!(
+            !outcome.is_verified(),
+            "traversal must not pass as verified"
+        );
     }
 }

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -761,6 +761,51 @@ fn verify_keyless_crypto(
 }
 
 // ---------------------------------------------------------------------------
+// Path safety for multi-subject bundle subject names
+// ---------------------------------------------------------------------------
+
+/// Resolve a bundle subject `name` to a path within `scan_root`.
+///
+/// Rejects names that would escape the scan root before any filesystem I/O:
+/// - **Absolute paths** (`/etc/passwd`): `Path::join` discards `scan_root`
+///   entirely for absolute inputs, so the join itself escapes the root.
+/// - **`..` traversal** (`../../etc/shadow`): parent-directory components
+///   climb above `scan_root` after resolution by the OS.
+///
+/// Both cases are rejected at the component level — before `join` — so no
+/// path is constructed or opened for traversal inputs.
+///
+/// # Errors
+///
+/// Returns a descriptive `String` error when the name is rejected.
+pub(crate) fn safe_subject_path(
+    scan_root: &Path,
+    name: &str,
+) -> std::result::Result<PathBuf, String> {
+    let name_path = std::path::Path::new(name);
+
+    // Reject absolute paths: Path::join replaces the base entirely for
+    // absolute inputs, e.g. scan_root.join("/etc/passwd") == "/etc/passwd".
+    if name_path.is_absolute() {
+        return Err(format!(
+            "subject name '{name}' rejected: absolute paths are not permitted in bundle subjects"
+        ));
+    }
+
+    // Reject any `..` component so relative traversal cannot climb above
+    // scan_root regardless of nesting depth.
+    for component in name_path.components() {
+        if component == std::path::Component::ParentDir {
+            return Err(format!(
+                "subject name '{name}' rejected: '..' components are not permitted in bundle subjects"
+            ));
+        }
+    }
+
+    Ok(scan_root.join(name_path))
+}
+
+// ---------------------------------------------------------------------------
 // Multi-subject bundle verification
 // ---------------------------------------------------------------------------
 
@@ -883,7 +928,19 @@ fn verify_multi_subject_bundle(
     let mut results = Vec::with_capacity(subjects.len());
 
     for (name, expected_digest) in &subjects {
-        let file_path = scan_root.join(name);
+        let file_path = match safe_subject_path(scan_root, name) {
+            Ok(p) => p,
+            Err(reason) => {
+                results.push(VerificationResult {
+                    path: scan_root.to_path_buf(),
+                    digest: String::new(),
+                    outcome: VerificationOutcome::InvalidSignature {
+                        detail: reason,
+                    },
+                });
+                continue;
+            }
+        };
 
         let actual_digest = match trust::file_digest(&file_path) {
             Ok(d) => d,
@@ -1631,5 +1688,119 @@ mod tests {
         assert!(is_glob_pattern(".claude/**/*.md"));
         assert!(is_glob_pattern("test[0-9].md"));
         assert!(is_glob_pattern("{a,b}.md"));
+    }
+
+    // -----------------------------------------------------------------------
+    // safe_subject_path — path traversal prevention
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn safe_subject_path_accepts_plain_filename() {
+        let root = std::path::Path::new("/tmp/scan");
+        let result = safe_subject_path(root, "SKILLS.md").unwrap();
+        assert_eq!(result, root.join("SKILLS.md"));
+    }
+
+    #[test]
+    fn safe_subject_path_accepts_subdirectory() {
+        let root = std::path::Path::new("/tmp/scan");
+        let result = safe_subject_path(root, ".claude/commands/deploy.md").unwrap();
+        assert_eq!(result, root.join(".claude/commands/deploy.md"));
+    }
+
+    #[test]
+    fn safe_subject_path_rejects_absolute_path() {
+        let root = std::path::Path::new("/tmp/scan");
+        let err = safe_subject_path(root, "/etc/passwd").unwrap_err();
+        assert!(
+            err.contains("absolute"),
+            "error should mention 'absolute': {err}"
+        );
+    }
+
+    #[test]
+    fn safe_subject_path_rejects_relative_dotdot_traversal() {
+        let root = std::path::Path::new("/tmp/scan");
+        let err = safe_subject_path(root, "../../../etc/shadow").unwrap_err();
+        assert!(
+            err.contains(".."),
+            "error should mention '..': {err}"
+        );
+    }
+
+    #[test]
+    fn safe_subject_path_rejects_embedded_dotdot() {
+        let root = std::path::Path::new("/tmp/scan");
+        // Embedded traversal: starts inside root then climbs out.
+        let err = safe_subject_path(root, "subdir/../../etc/passwd").unwrap_err();
+        assert!(
+            err.contains(".."),
+            "error should mention '..': {err}"
+        );
+    }
+
+    #[test]
+    fn safe_subject_path_rejects_trailing_dotdot() {
+        let root = std::path::Path::new("/tmp/scan");
+        let err = safe_subject_path(root, "subdir/..").unwrap_err();
+        assert!(
+            err.contains(".."),
+            "error should mention '..': {err}"
+        );
+    }
+
+    /// Regression test: a bundle with a path-traversal subject name must be
+    /// rejected by verify_multi_subject_bundle before any file I/O.
+    #[test]
+    fn multi_subject_bundle_rejects_traversal_subject_name() {
+        use nono::trust;
+
+        let outer = tempfile::tempdir().unwrap();
+        let scan_root = outer.path().join("scan");
+        std::fs::create_dir_all(&scan_root).unwrap();
+
+        // A real file outside scan_root that the attacker wants to read.
+        let secret = outer.path().join("secret.txt");
+        std::fs::write(&secret, "SECRET").unwrap();
+        let secret_digest = trust::bytes_digest(b"SECRET");
+
+        // Craft a bundle whose subject name traverses out of scan_root.
+        let traversal_name = "../secret.txt";
+        let key_pair = trust::generate_signing_key().unwrap();
+        let key_id = trust::key_id_hex(&key_pair).unwrap();
+        let pub_key_bytes = trust::export_public_key(&key_pair).unwrap();
+        let pub_key_b64 = nono::trust::base64::base64_encode(pub_key_bytes.as_bytes());
+
+        let files = vec![(std::path::PathBuf::from(traversal_name), secret_digest)];
+        let bundle_json = trust::sign_files(&files, &key_pair, &key_id).unwrap();
+        let bundle_path = trust::multi_subject_bundle_path(&scan_root);
+        std::fs::write(&bundle_path, &bundle_json).unwrap();
+
+        let policy = TrustPolicy {
+            includes: Vec::new(),
+            enforcement: Enforcement::Deny,
+            publishers: vec![trust::Publisher {
+                name: "attacker".to_string(),
+                issuer: None,
+                repository: None,
+                workflow: None,
+                ref_pattern: None,
+                key_id: Some(key_id),
+                public_key: Some(pub_key_b64),
+                build_signer_uri: None,
+            }],
+            ..TrustPolicy::default()
+        };
+
+        let results = verify_multi_subject_bundle(&bundle_path, &scan_root, &policy);
+        assert_eq!(results.len(), 1, "expected one result for the traversal subject");
+        let outcome = &results[0].outcome;
+        // Must be rejected as InvalidSignature (traversal is a policy violation).
+        assert!(
+            matches!(outcome, VerificationOutcome::InvalidSignature { .. }),
+            "traversal subject must yield InvalidSignature, got: {outcome:?}"
+        );
+        // Must NOT be Verified.
+        assert!(!outcome.is_verified(), "traversal must not pass as verified");
     }
 }


### PR DESCRIPTION
Subject names extracted from Sigstore bundle DSSE envelopes were joined with scan_root via Path::join without validation. An attacker who controls a signing key could embed (when much worse things could happen), could embed:

    - `../../../etc/passwd` (relative traversal) – OS resolves the join to a path outside scan_root.
    - `/etc/passwd` (absolute path) – Path::join discards scan_root entirely for absolute inputs


Fixed care of: add `safe_subject_path(scan_root, name)` which rejects names before any path construction:

1. Absolute paths – detected via `Path::is_absolute()`.
2. ParentDir (`..`) components – detected by iterating
   `Path::components()`; covers both leading and embedded traversal.

  Apply the guard at all three call sites:
- `trust_scan::verify_multi_subject_bundle` (pre-exec scan path)
- `trust_cmd::verify_multi_subject_file` (trust verify command)
- `trust_cmd` caller loop (defense-in-depth after subject names
    already pass the inner guard)
    
Kudos to @hackerman70000 for raising this to us. 