### PR TITLE
fix(cli): make 'nono why --host' aware of proxy domain filtering

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -387,6 +387,17 @@ fn validate_requested_dir(
     protected_roots: &ProtectedRoots,
     allow_parent_of_protected: bool,
 ) -> Result<()> {
+    if path.exists() && !path.is_dir() {
+        return Err(NonoError::ConfigParse(format!(
+            "{} path '{}' is not a directory. \
+             Use --allow-file for single files.",
+            source,
+            path.display()
+        )));
+    }
+    if !path.exists() && source == "CLI" {
+        warn!("'{}' does not exist and will be ignored.", path.display());
+    }
     protected_paths::validate_requested_path_against_protected_roots(
         path,
         false,

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -201,7 +201,12 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     if let Some(profile) = recommended_profile {
         output::print_profile_hint(recommended_program_name, profile, flags.silent);
     }
-    let cap_file = write_capability_state_file(&caps, &flags.bypass_protection_paths, flags.silent);
+    let cap_file = write_capability_state_file(
+        &caps,
+        &flags.bypass_protection_paths,
+        &flags.proxy.allow_domain,
+        flags.silent,
+    );
     let cap_file_path = cap_file.unwrap_or_else(|| std::path::PathBuf::from("/dev/null"));
 
     for secret in &loaded_secrets {
@@ -366,9 +371,11 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
 fn write_capability_state_file(
     caps: &CapabilitySet,
     bypass_protection_paths: &[std::path::PathBuf],
+    allowed_domains: &[String],
     silent: bool,
 ) -> Option<std::path::PathBuf> {
-    let state = sandbox_state::SandboxState::from_caps(caps, bypass_protection_paths);
+    let state =
+        sandbox_state::SandboxState::from_caps(caps, bypass_protection_paths, allowed_domains);
 
     for _ in 0..8 {
         let cap_file = next_capability_state_file_path();

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -83,7 +83,6 @@ use command_blocking_deprecation::{
     collect_cli_warnings, print_warnings as print_deprecation_warnings,
 };
 use nono::Result;
-use tracing::error;
 
 const DETACHED_LAUNCH_ENV: &str = "NONO_DETACHED_LAUNCH";
 const DETACHED_CWD_PROMPT_RESPONSE_ENV: &str = "NONO_DETACHED_CWD_PROMPT_RESPONSE";
@@ -121,7 +120,6 @@ fn main() {
         if matches!(e, nono::NonoError::Cancelled(_)) {
             std::process::exit(1);
         }
-        error!("{}", e);
         eprintln!("nono: {}", e);
         std::process::exit(1);
     }

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -170,26 +170,71 @@ pub fn query_path(
     })
 }
 
-/// Query whether network access is permitted
-pub fn query_network(host: &str, port: u16, caps: &CapabilitySet) -> QueryResult {
-    if caps.is_network_blocked() {
-        QueryResult::Denied {
+/// Query whether network access is permitted.
+///
+/// `allowed_domains` contains the resolved proxy allowlist (from profile
+/// `allow_domain`, network profile hosts, and CLI `--allow-domain`).
+/// When the network mode is `ProxyOnly`, delegates to `HostFilter` for
+/// consistent matching with the proxy (including cloud metadata deny list).
+pub fn query_network(
+    host: &str,
+    port: u16,
+    caps: &CapabilitySet,
+    allowed_domains: &[String],
+) -> QueryResult {
+    match caps.network_mode() {
+        nono::NetworkMode::Blocked => QueryResult::Denied {
             reason: "network_blocked".to_string(),
             details: Some(format!(
-                "Network access is blocked. Connection to {}:{} would be denied.",
+                "Network access is fully blocked. Connection to {}:{} would be denied.",
                 host, port
             )),
             policy_source: None,
             matching_capability: None,
-            suggested_flag: None,
+            suggested_flag: Some(format!("--allow-domain {}", host)),
+        },
+        nono::NetworkMode::ProxyOnly { .. } => {
+            let filter = if allowed_domains.is_empty() {
+                nono::net_filter::HostFilter::allow_all()
+            } else {
+                nono::net_filter::HostFilter::new(allowed_domains)
+            };
+            // Pass empty IPs: DNS resolution happens at proxy time, not query time.
+            match filter.check_host(host, &[]) {
+                nono::net_filter::FilterResult::Allow => QueryResult::Allowed {
+                    reason: "proxy_allowed".to_string(),
+                    granted_path: None,
+                    access: Some(format!(
+                        "Connection to {}:{} would be allowed via proxy{}",
+                        host,
+                        port,
+                        if allowed_domains.is_empty() {
+                            " (no domain filter)"
+                        } else {
+                            ""
+                        }
+                    )),
+                    source: Some(if allowed_domains.is_empty() {
+                        "proxy".to_string()
+                    } else {
+                        "domain allowlist".to_string()
+                    }),
+                },
+                deny => QueryResult::Denied {
+                    reason: "proxy_filtered".to_string(),
+                    details: Some(format!("Domain filtering is active. {}", deny.reason())),
+                    policy_source: Some("proxy domain filter".to_string()),
+                    matching_capability: None,
+                    suggested_flag: Some(format!("--allow-domain {}", host)),
+                },
+            }
         }
-    } else {
-        QueryResult::Allowed {
+        nono::NetworkMode::AllowAll => QueryResult::Allowed {
             reason: "network_allowed".to_string(),
             granted_path: None,
             access: Some(format!("Connection to {}:{} would be allowed", host, port)),
             source: None,
-        }
+        },
     }
 }
 
@@ -462,15 +507,89 @@ mod tests {
 
     #[test]
     fn test_query_network_allowed() {
-        let caps = CapabilitySet::new(); // Network allowed by default
-        let result = query_network("example.com", 443, &caps);
+        let caps = CapabilitySet::new();
+        let result = query_network("example.com", 443, &caps, &[]);
         assert!(matches!(result, QueryResult::Allowed { .. }));
     }
 
     #[test]
     fn test_query_network_blocked() {
         let caps = CapabilitySet::new().block_network();
-        let result = query_network("example.com", 443, &caps);
+        let result = query_network("example.com", 443, &caps, &[]);
         assert!(matches!(result, QueryResult::Denied { .. }));
+    }
+
+    #[test]
+    fn test_query_network_proxy_domain_filtering() {
+        let caps = CapabilitySet::new().set_network_mode(nono::NetworkMode::ProxyOnly {
+            port: 0,
+            bind_ports: vec![],
+        });
+        let allowed = vec!["api.example.com".to_string()];
+
+        let result = query_network("api.example.com", 443, &caps, &allowed);
+        assert!(matches!(result, QueryResult::Allowed { .. }));
+
+        match query_network("evil.com", 443, &caps, &allowed) {
+            QueryResult::Denied {
+                reason,
+                suggested_flag,
+                ..
+            } => {
+                assert_eq!(reason, "proxy_filtered");
+                assert_eq!(suggested_flag.as_deref(), Some("--allow-domain evil.com"));
+            }
+            _ => panic!("expected denied result"),
+        }
+    }
+
+    #[test]
+    fn test_query_network_proxy_wildcard_and_bare_domain() {
+        let caps = CapabilitySet::new().set_network_mode(nono::NetworkMode::ProxyOnly {
+            port: 0,
+            bind_ports: vec![],
+        });
+        let allowed = vec!["*.example.com".to_string()];
+
+        assert!(matches!(
+            query_network("sub.example.com", 443, &caps, &allowed),
+            QueryResult::Allowed { .. }
+        ));
+        // *.example.com must NOT match bare example.com (mirrors HostFilter)
+        assert!(matches!(
+            query_network("example.com", 443, &caps, &allowed),
+            QueryResult::Denied { .. }
+        ));
+    }
+
+    #[test]
+    fn test_query_network_proxy_no_domain_filter() {
+        let caps = CapabilitySet::new().set_network_mode(nono::NetworkMode::ProxyOnly {
+            port: 0,
+            bind_ports: vec![],
+        });
+        assert!(matches!(
+            query_network("anything.com", 443, &caps, &[]),
+            QueryResult::Allowed { .. }
+        ));
+    }
+
+    #[test]
+    fn test_query_network_proxy_denies_cloud_metadata() {
+        let caps = CapabilitySet::new().set_network_mode(nono::NetworkMode::ProxyOnly {
+            port: 0,
+            bind_ports: vec![],
+        });
+        // Cloud metadata endpoints are denied even with an empty allowlist
+        assert!(matches!(
+            query_network("169.254.169.254", 80, &caps, &[]),
+            QueryResult::Denied { .. }
+        ));
+        // Also denied even if explicitly in the allowlist
+        let allowed = vec!["169.254.169.254".to_string()];
+        assert!(matches!(
+            query_network("169.254.169.254", 80, &caps, &allowed),
+            QueryResult::Denied { .. }
+        ));
     }
 }

--- a/crates/nono-cli/src/sandbox_state.rs
+++ b/crates/nono-cli/src/sandbox_state.rs
@@ -29,6 +29,9 @@ pub struct SandboxState {
     /// ALIAS(canonical="bypass_protection_paths", introduced="v0.41.0", remove_by="v1.0.0", issue="#594")
     #[serde(default, alias = "override_deny_paths")]
     pub bypass_protection_paths: Vec<String>,
+    /// Proxy domain allowlist at sandbox creation time
+    #[serde(default)]
+    pub allowed_domains: Vec<String>,
 }
 
 /// Serializable filesystem capability state
@@ -45,8 +48,12 @@ pub struct FsCapState {
 }
 
 impl SandboxState {
-    /// Create sandbox state from a CapabilitySet and bypass_protection paths
-    pub fn from_caps(caps: &CapabilitySet, bypass_protection_paths: &[PathBuf]) -> Self {
+    /// Create sandbox state from a CapabilitySet, bypass_protection paths, and domain allowlist
+    pub fn from_caps(
+        caps: &CapabilitySet,
+        bypass_protection_paths: &[PathBuf],
+        allowed_domains: &[String],
+    ) -> Self {
         Self {
             fs: caps
                 .fs_capabilities()
@@ -69,6 +76,7 @@ impl SandboxState {
                 .iter()
                 .map(|p| p.display().to_string())
                 .collect(),
+            allowed_domains: allowed_domains.to_vec(),
         }
     }
 
@@ -110,7 +118,14 @@ impl SandboxState {
             caps.add_fs(cap);
         }
 
-        caps.set_network_blocked(self.net_blocked);
+        if !self.allowed_domains.is_empty() {
+            caps.set_network_mode_mut(nono::NetworkMode::ProxyOnly {
+                port: 0,
+                bind_ports: vec![],
+            });
+        } else {
+            caps.set_network_blocked(self.net_blocked);
+        }
         for cmd in &self.allowed_commands {
             caps.add_allowed_command(cmd.clone());
         }
@@ -362,7 +377,7 @@ mod tests {
         let mut caps = CapabilitySet::new().block_network();
         caps.add_allowed_command("pip".to_string());
 
-        let state = SandboxState::from_caps(&caps, &[]);
+        let state = SandboxState::from_caps(&caps, &[], &[]);
         assert!(state.net_blocked);
         assert_eq!(state.allowed_commands, vec!["pip"]);
 
@@ -380,7 +395,7 @@ mod tests {
 
         let caps = CapabilitySet::new().block_network();
 
-        let state = SandboxState::from_caps(&caps, &[]);
+        let state = SandboxState::from_caps(&caps, &[], &[]);
         state
             .write_to_file(&file_path)
             .expect("Failed to write state");

--- a/crates/nono-cli/src/why_runtime.rs
+++ b/crates/nono-cli/src/why_runtime.rs
@@ -53,7 +53,7 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
                 WhyContext {
                     caps: state.to_caps()?,
                     overridden_paths: paths,
-                    allowed_domains: vec![],
+                    allowed_domains: state.allowed_domains.clone(),
                 }
             }
             None => {

--- a/crates/nono-cli/src/why_runtime.rs
+++ b/crates/nono-cli/src/why_runtime.rs
@@ -1,17 +1,60 @@
 use crate::capability_ext::CapabilitySetExt;
 use crate::cli::{SandboxArgs, WhyArgs, WhyOp};
-use crate::{policy, profile, query_ext, sandbox_state};
+use crate::{network_policy, policy, profile, query_ext, sandbox_state};
 use nono::{AccessMode, CapabilitySet, NonoError, Result};
+
+struct WhyContext {
+    caps: CapabilitySet,
+    overridden_paths: Vec<std::path::PathBuf>,
+    allowed_domains: Vec<String>,
+}
+
+/// Resolve the proxy domain allowlist from a profile's network config.
+fn resolve_allowed_domains(profile: &profile::Profile) -> Vec<String> {
+    let policy_json = crate::config::embedded::embedded_network_policy_json();
+    let net_policy = match network_policy::load_network_policy(policy_json) {
+        Ok(p) => p,
+        Err(_) => return profile.network.allow_domain.clone(),
+    };
+
+    let mut domains = Vec::new();
+
+    if let Some(net_profile_name) = profile.network.resolved_network_profile() {
+        if let Ok(resolved) = network_policy::resolve_network_profile(&net_policy, net_profile_name)
+        {
+            domains.extend(resolved.hosts);
+            for suffix in &resolved.suffixes {
+                let wildcard = if suffix.starts_with('.') {
+                    format!("*{}", suffix)
+                } else {
+                    format!("*.{}", suffix)
+                };
+                domains.push(wildcard);
+            }
+        }
+    }
+
+    domains.extend(network_policy::expand_proxy_allow(
+        &net_policy,
+        &profile.network.allow_domain,
+    ));
+
+    domains
+}
 
 pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
     use query_ext::{print_result, query_network, query_path, QueryResult};
     use sandbox_state::load_sandbox_state;
 
-    let (caps, overridden_paths): (CapabilitySet, Vec<std::path::PathBuf>) = if args.self_query {
+    let ctx: WhyContext = if args.self_query {
         match load_sandbox_state() {
             Some(state) => {
                 let paths = state.bypass_protection_as_paths();
-                (state.to_caps()?, paths)
+                WhyContext {
+                    caps: state.to_caps()?,
+                    overridden_paths: paths,
+                    allowed_domains: vec![],
+                }
             }
             None => {
                 let result = QueryResult::NotSandboxed {
@@ -60,12 +103,18 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
             }
         }
 
+        let allowed_domains = resolve_allowed_domains(&profile);
+
         let prepared = CapabilitySet::from_profile(&profile, &workdir, &sandbox_args)?;
         let mut caps = prepared.caps;
         if prepared.needs_unlink_overrides {
             policy::apply_unlink_overrides(&mut caps);
         }
-        (caps, override_paths)
+        WhyContext {
+            caps,
+            overridden_paths: override_paths,
+            allowed_domains,
+        }
     } else {
         let sandbox_args = SandboxArgs {
             allow: args.allow.clone(),
@@ -84,7 +133,11 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
         if prepared.needs_unlink_overrides {
             policy::apply_unlink_overrides(&mut caps);
         }
-        (caps, vec![])
+        WhyContext {
+            caps,
+            overridden_paths: vec![],
+            allowed_domains: vec![],
+        }
     };
 
     let result = if let Some(ref path) = args.path {
@@ -94,9 +147,9 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
             Some(WhyOp::ReadWrite) => AccessMode::ReadWrite,
             None => AccessMode::Read,
         };
-        query_path(path, op, &caps, &overridden_paths)?
+        query_path(path, op, &ctx.caps, &ctx.overridden_paths)?
     } else if let Some(ref host) = args.host {
-        query_network(host, args.port, &caps)
+        query_network(host, args.port, &ctx.caps, &ctx.allowed_domains)
     } else {
         return Err(NonoError::ConfigParse(
             "--path or --host is required".to_string(),


### PR DESCRIPTION
## Linked Issue

Closes #859 

## Summary

`nono why --host` only checked whether network was globally blocked or allowed, ignoring proxy-based domain filtering entirely. Profiles with `allow_domain` set ProxyOnly mode (which is_network_blocked() treats as blocked), so `nono why` always reported DENIED even for allowed domains.

Rewrites query_network() to match on all three NetworkMode variants and resolves the profile's domain allowlist (from network_profile groups and allow_domain entries) so the query result reflects actual proxy behavior.

Domain matching mirrors HostFilter::check_host from nono::net_filter: case-insensitive exact match, wildcard subdomain matching where `*.example.com` matches subdomains but not the bare domain, and empty allowlist treated as allow-all (proxy active without domain filter).

```

Profile:
{
  "meta": {
    "name": "minimal-network-blocking"
  },
  "network": {
    "allow_domain": [
      "ai-gateway.vercel.sh"
    ]
  }
}

nono why --profile minimal.json --host ai-gateway.vercel.sh
DENIED
  Reason: network_blocked
  Details: Network access is blocked. Connection to ai-gateway.vercel.sh:443 would be denied.
  
./target/debug/nono why --profile minimal.json --host ai-gateway.vercel.sh
ALLOWED
  Reason: proxy_allowed
  Access: Connection to ai-gateway.vercel.sh:443 would be allowed via proxy
  Source: domain allowlist
```

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

Tested manually + 3 tests

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
