### PR TITLE
feat(policy): add group-level deny_override to eliminate platform-spe…

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -431,6 +431,7 @@
     "claude_code_macos": {
       "description": "Claude Code macOS-specific state and credential paths",
       "platform": "macos",
+      "deny_override": ["~/Library/Keychains"],
       "allow": {
         "read": [
           "$HOME/.local/share/claude",
@@ -446,6 +447,7 @@
     "codex_macos": {
       "description": "Codex macOS-specific state and credential paths",
       "platform": "macos",
+      "deny_override": ["~/Library/Keychains"],
       "allow": {
         "readwrite": [
           "$HOME/Library/Keychains/login.keychain-db",

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -55,6 +55,13 @@ pub struct Group {
     /// macOS symlink path pairs (symlink -> real target)
     #[serde(default)]
     pub symlink_pairs: Option<HashMap<String, String>>,
+    /// Paths whose deny entries should be removed when this group is active.
+    /// Allows a group that grants access (e.g. `claude_code_macos`) to
+    /// override a deny from another group (e.g. `deny_keychains_macos`)
+    /// without requiring the external pack profile to carry a
+    /// platform-specific `bypass_protection` entry.
+    #[serde(default)]
+    pub deny_override: Option<Vec<String>>,
 }
 
 /// Allow operations nested under `allow`
@@ -352,6 +359,7 @@ pub fn resolve_groups(
     let mut resolved_groups = Vec::new();
     let mut needs_unlink_overrides = false;
     let mut deny_paths = Vec::new();
+    let mut deny_override_entries: Vec<(String, PathBuf)> = Vec::new();
 
     for name in group_names {
         let group = policy
@@ -372,7 +380,43 @@ pub fn resolve_groups(
         if resolve_single_group(name, group, caps, &mut deny_paths)? {
             needs_unlink_overrides = true;
         }
+
+        if let Some(overrides) = &group.deny_override {
+            for path_str in overrides {
+                let path = expand_path(path_str)?;
+                if !path.exists() {
+                    debug!(
+                        "Group '{}' deny_override path '{}' (expanded to '{}') \
+                         does not exist, skipping",
+                        name,
+                        path_str,
+                        path.display()
+                    );
+                    continue;
+                }
+                deny_override_entries.push((name.clone(), path));
+            }
+        }
+
         resolved_groups.push(name.clone());
+    }
+
+    for (group_name, path) in &deny_override_entries {
+        let canonical = canonicalize_for_comparison(path);
+        let before = deny_paths.len();
+        deny_paths.retain(|dp| !dp.starts_with(&canonical));
+        if canonical != *path {
+            deny_paths.retain(|dp| !dp.starts_with(path));
+        }
+        let removed = before.saturating_sub(deny_paths.len());
+        if removed > 0 {
+            info!(
+                "Group '{}' deny_override removed {} deny entry/entries via '{}'",
+                group_name,
+                removed,
+                path.display()
+            );
+        }
     }
 
     Ok(ResolvedGroups {
@@ -1554,6 +1598,14 @@ mod tests {
             .contains(&"$HOME/Library/Keychains/login.keychain-db".to_string()));
         assert!(claude_code_macos_paths
             .contains(&"$HOME/Library/Keychains/metadata.keychain-db".to_string()));
+        let deny_overrides = claude_code_macos
+            .deny_override
+            .as_ref()
+            .expect("claude_code_macos deny_override missing");
+        assert!(
+            deny_overrides.contains(&"~/Library/Keychains".to_string()),
+            "claude_code_macos must override the keychain deny"
+        );
 
         let claude_code_linux = policy
             .groups
@@ -2406,6 +2458,93 @@ mod tests {
                 .contains("nonexistent/test/path"),
             "Expected deny path to contain 'nonexistent/test/path', got: {}",
             resolved.deny_paths[0].display()
+        );
+    }
+
+    #[test]
+    fn test_deny_override_strips_matching_deny_paths() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let deny_dir = dir.path().join("secret");
+        std::fs::create_dir(&deny_dir).expect("mkdir");
+        let deny_str = deny_dir.to_string_lossy().to_string();
+
+        let json = format!(
+            r#"{{
+                "meta": {{ "version": 2, "schema_version": "2.0" }},
+                "groups": {{
+                    "g_deny": {{
+                        "description": "deny group",
+                        "deny": {{ "access": ["{}"] }}
+                    }},
+                    "g_override": {{
+                        "description": "override group",
+                        "deny_override": ["{}"]
+                    }}
+                }}
+            }}"#,
+            deny_str, deny_str,
+        );
+        let policy = load_policy(&json).expect("parse failed");
+
+        // Override AFTER deny -- normal case
+        let mut caps = CapabilitySet::new();
+        let resolved = resolve_groups(
+            &policy,
+            &["g_deny".to_string(), "g_override".to_string()],
+            &mut caps,
+        )
+        .expect("resolve failed");
+        assert!(
+            resolved.deny_paths.is_empty(),
+            "deny_override should have removed the matching deny path, but got: {:?}",
+            resolved.deny_paths
+        );
+
+        // Override BEFORE deny -- must also work (order-independent)
+        let mut caps2 = CapabilitySet::new();
+        let resolved2 = resolve_groups(
+            &policy,
+            &["g_override".to_string(), "g_deny".to_string()],
+            &mut caps2,
+        )
+        .expect("resolve failed");
+        assert!(
+            resolved2.deny_paths.is_empty(),
+            "deny_override must be order-independent, but got: {:?}",
+            resolved2.deny_paths
+        );
+    }
+
+    #[test]
+    fn test_deny_override_absent_path_is_skipped() {
+        let json = r#"{
+            "meta": { "version": 2, "schema_version": "2.0" },
+            "groups": {
+                "g_deny": {
+                    "description": "deny group",
+                    "deny": { "access": ["/nonexistent/test/path"] }
+                },
+                "g_override_absent": {
+                    "description": "override with non-existent path",
+                    "deny_override": ["/nonexistent/deny_override_target_9999"]
+                }
+            }
+        }"#;
+        let policy = load_policy(json).expect("parse failed");
+        let mut caps = CapabilitySet::new();
+
+        let resolved = resolve_groups(
+            &policy,
+            &["g_deny".to_string(), "g_override_absent".to_string()],
+            &mut caps,
+        )
+        .expect("resolve failed");
+
+        assert_eq!(
+            resolved.deny_paths.len(),
+            1,
+            "Non-existent deny_override path should be skipped (deny stays), got: {:?}",
+            resolved.deny_paths
         );
     }
 


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->
This must be merged first, then https://github.com/always-further/nono-packs/pull/14 and claude pack rereleased.
Linux won't have the macos warning anymore.

Closes https://github.com/always-further/nono-packs/issues/13

## Summary

Pack profiles like 'always-further/claude' carried 'bypass_protection: [/home/<>/Library/Keychains]' to override the deny_keychains_macos group, producing spurious warnings on Linux where the path does not exist. The new 'deny_override' field on policy groups lets nono's own groups (claude_code_macos, codex_macos) declare which deny entries they override, keeping platform-specific logic inside the core policy instead of leaking it into external packs.

```
❯ ~/WORK/nono/target/debug/nono run --profile claude/policy.json -- echo ok

  nono v0.50.1
  Share /home/<>/WORK/nono-packs with read+write access?
  use --allow-cwd to skip this prompt
  [y/N] y
  Applying sandbox...

ok
```

No more warning of the below kind, using nono binary built from this PR and the updated profile in nono-packs:

```
2026-05-09T12:39:08.022780Z  WARN filesystem.bypass_protection entry "$HOME/Library/Keychains" expanded to /home/<>/Library/Keychains which does not exist on this system; skipping. The deny rule remains in force. If you meant to bypass a deny on this path, check for typos or platform-specific path differences.
```

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan
Added tests in PR
<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
