### PR TITLE
fix(policy): expand browser deny groups with missing Chromium-based browsers

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -66,10 +66,13 @@
       "deny": {
         "access": [
           "~/Library/Application Support/Google/Chrome",
+          "~/Library/Application Support/Chromium",
           "~/Library/Application Support/Firefox",
           "~/Library/Application Support/Microsoft Edge",
           "~/Library/Application Support/Arc",
-          "~/Library/Application Support/Brave Browser",
+          "~/Library/Application Support/BraveSoftware",
+          "~/Library/Application Support/Vivaldi",
+          "~/Library/Application Support/com.operasoftware.Opera",
           "~/Library/Safari"
         ]
       }
@@ -84,7 +87,9 @@
           "~/.config/chromium",
           "~/.mozilla/firefox",
           "~/.config/microsoft-edge",
-          "~/.config/BraveSoftware"
+          "~/.config/BraveSoftware",
+          "~/.config/vivaldi",
+          "~/.config/opera"
         ]
       }
     },


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #868 

## Summary

Add Chromium, Vivaldi, and Opera to both deny_browser_data_macos and deny_browser_data_linux. Fix incorrect Brave macOS path ('Brave Browser' -> 'BraveSoftware/Brave-Browser').

Paths sourced from official documentation:
- Brave: https://community.brave.app/t/bravesoftware-folder-location-on-mac/534255
- Chromium: https://chromium.googlesource.com/chromium/src/+/HEAD/docs/user_data_dir.md
- Vivaldi: https://help.vivaldi.com/desktop/install-update/full-reset-of-vivaldi/
- Opera: https://forums.opera.com/topic/21922/where-does-opera-for-mac-store-its-cookies
<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan
-
<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
