### PR TITLE
fix(sandbox): cache Landlock ABI detection with OnceLock

### DIFF
--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -119,16 +119,15 @@ const ABI_PROBE_ORDER: [ABI; 6] = [ABI::V6, ABI::V5, ABI::V4, ABI::V3, ABI::V2, 
 ///
 /// Returns an error if no ABI version is supported (Landlock not available).
 pub fn detect_abi() -> Result<DetectedAbi> {
-    static CACHED: OnceLock<Option<DetectedAbi>> = OnceLock::new();
+    static CACHED: OnceLock<DetectedAbi> = OnceLock::new();
 
-    let cached = CACHED.get_or_init(|| detect_abi_uncached().ok());
-
-    match cached {
-        Some(abi) => Ok(*abi),
-        None => Err(NonoError::SandboxInit(
-            "No supported Landlock ABI detected".to_string(),
-        )),
+    if let Some(abi) = CACHED.get() {
+        return Ok(*abi);
     }
+
+    let abi = detect_abi_uncached()?;
+    let _ = CACHED.set(abi);
+    Ok(abi)
 }
 
 fn detect_abi_uncached() -> Result<DetectedAbi> {

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -8,6 +8,7 @@ use landlock::{
     Ruleset, RulesetAttr, RulesetCreatedAttr, Scope, ABI,
 };
 use std::path::Path;
+use std::sync::OnceLock;
 use tracing::{debug, info, warn};
 
 /// Detected Landlock ABI version with feature query methods.
@@ -111,10 +112,26 @@ const ABI_PROBE_ORDER: [ABI; 6] = [ABI::V6, ABI::V5, ABI::V4, ABI::V3, ABI::V2, 
 /// Probes from V6 down to V1 using `HardRequirement` compatibility mode.
 /// Returns the highest ABI for which a full ruleset can be created.
 ///
+/// The result is cached after the first call since the kernel ABI does not
+/// change at runtime.
+///
 /// # Errors
 ///
 /// Returns an error if no ABI version is supported (Landlock not available).
 pub fn detect_abi() -> Result<DetectedAbi> {
+    static CACHED: OnceLock<Option<DetectedAbi>> = OnceLock::new();
+
+    let cached = CACHED.get_or_init(|| detect_abi_uncached().ok());
+
+    match cached {
+        Some(abi) => Ok(*abi),
+        None => Err(NonoError::SandboxInit(
+            "No supported Landlock ABI detected".to_string(),
+        )),
+    }
+}
+
+fn detect_abi_uncached() -> Result<DetectedAbi> {
     let mut last_error = None;
 
     for &abi in &ABI_PROBE_ORDER {


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #871 

## Summary

detect_abi() probes the kernel via landlock_create_ruleset syscalls and is called up to 5 times during a single nono run. Since the kernel ABI does not change at runtime, cache the result in a process-global OnceLock. First call probes as before; subsequent calls return the cached value via a lock-free pointer read.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
