### PR TITLE
fix(schema): add missing 'environment' property to profile JSON schema

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -54,7 +54,10 @@
       "description": "Alias for env_credentials. Maps keystore account names to environment variable names."
     },
     "environment": {
-      "$ref": "#/$defs/EnvironmentConfig",
+      "oneOf": [
+        { "$ref": "#/$defs/EnvironmentConfig" },
+        { "type": "null" }
+      ],
       "description": "Controls which environment variables are passed to the sandboxed process. By default all variables are inherited."
     },
     "workdir": {
@@ -594,12 +597,12 @@
       "properties": {
         "allow_vars": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": { "type": "string", "pattern": "^([^*]+\\*?|\\*)$" },
           "description": "Allow-list of environment variable names passed to the sandboxed process. Supports exact names (\"PATH\") and prefix patterns ending with * (\"AWS_*\"). When empty or absent, all variables are allowed."
         },
         "deny_vars": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": { "type": "string", "pattern": "^([^*]+\\*?|\\*)$" },
           "description": "Deny-list of environment variable names stripped from the sandboxed process. Supports exact names (\"GH_TOKEN\") and prefix patterns ending with * (\"GITHUB_*\"). Denied vars are stripped even if they also appear in allow_vars."
         }
       }

--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -53,6 +53,10 @@
       "$ref": "#/$defs/SecretsConfig",
       "description": "Alias for env_credentials. Maps keystore account names to environment variable names."
     },
+    "environment": {
+      "$ref": "#/$defs/EnvironmentConfig",
+      "description": "Controls which environment variables are passed to the sandboxed process. By default all variables are inherited."
+    },
     "workdir": {
       "$ref": "#/$defs/WorkdirConfig",
       "description": "Working directory access configuration controlling whether and how the current working directory is shared with the sandboxed process."
@@ -581,6 +585,23 @@
       "additionalProperties": {
         "type": "string",
         "description": "Environment variable name to inject the secret value into."
+      }
+    },
+    "EnvironmentConfig": {
+      "type": "object",
+      "description": "Controls which environment variables are passed to the sandboxed process. By default all variables are inherited. Precedence (highest to lowest): 1. Hardcoded dangerous vars (always stripped), 2. deny_vars (stripped even if in allow_vars), 3. allow_vars (if non-empty, only matching vars pass).",
+      "additionalProperties": false,
+      "properties": {
+        "allow_vars": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Allow-list of environment variable names passed to the sandboxed process. Supports exact names (\"PATH\") and prefix patterns ending with * (\"AWS_*\"). When empty or absent, all variables are allowed."
+        },
+        "deny_vars": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Deny-list of environment variable names stripped from the sandboxed process. Supports exact names (\"GH_TOKEN\") and prefix patterns ending with * (\"GITHUB_*\"). Denied vars are stripped even if they also appear in allow_vars."
+        }
       }
     },
     "WorkdirConfig": {


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #882 

## Summary

The 'environment' field (allow_vars, deny_vars) was accepted by the profile parser but missing from nono-profile.schema.json. Since the schema sets additionalProperties to false, editors flagged 'environment' as not allowed.

cc @bodograumann
<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
