### PR TITLE
feat: fix upstream TLS trust, intercept auth, and multi-route dispatch

### DIFF
--- a/crates/nono-proxy/src/config.rs
+++ b/crates/nono-proxy/src/config.rs
@@ -294,8 +294,13 @@ impl CompiledEndpointRules {
         Ok(Self { rules: compiled })
     }
 
-    /// Check if the given method+path is allowed.
-    /// Returns `true` if no rules were compiled (allow-all, backward compatible).
+    /// `true` if no endpoint rules are defined (allow-all).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    /// `true` if method+path matches a rule, or if no rules are defined.
     #[must_use]
     pub fn is_allowed(&self, method: &str, path: &str) -> bool {
         if self.rules.is_empty() {

--- a/crates/nono-proxy/src/route.rs
+++ b/crates/nono-proxy/src/route.rs
@@ -264,7 +264,8 @@ impl RouteStore {
         })
     }
 
-    /// Return all routes whose upstream matches `host:port`.
+    /// Return all routes whose upstream matches `host:port`, sorted by
+    /// prefix for deterministic iteration.
     #[must_use]
     pub fn lookup_all_by_upstream(&self, host_port: &str) -> Vec<(&str, &LoadedRoute)> {
         let normalised = host_port.to_lowercase();
@@ -362,17 +363,9 @@ fn read_pem_file(path: &std::path::Path, label: &str) -> Result<Zeroizing<Vec<u8
         })
 }
 
-/// Build a `TlsConnector` with optional custom CA and optional client certificate.
+/// Root cert store combining webpki roots with the OS trust store.
 ///
-/// - `ca_path`: PEM-encoded CA certificate file to trust in addition to system roots.
-///   Required for upstreams with self-signed or private CA certificates.
-/// - `client_cert_path`: PEM-encoded client certificate for mTLS. Must be paired with `client_key_path`.
-/// - `client_key_path`: PEM-encoded private key matching `client_cert_path`.
-///
-/// At least one of the three parameters must be `Some`. Returns an error if any
-/// file cannot be read, contains invalid PEM, or the TLS configuration fails.
-/// Build a root cert store with webpki roots + native system CAs.
-/// Called once at startup and shared across per-route connectors.
+/// Loaded once at startup and cloned into each per-route connector.
 fn build_base_root_store() -> rustls::RootCertStore {
     let mut store = rustls::RootCertStore::empty();
     store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
@@ -385,6 +378,8 @@ fn build_base_root_store() -> rustls::RootCertStore {
     store
 }
 
+/// Build a per-route `TlsConnector`, optionally adding a custom CA
+/// and/or mTLS client certificate on top of `base_root_store`.
 fn build_tls_connector(
     base_root_store: &rustls::RootCertStore,
     ca_path: Option<&str>,
@@ -950,6 +945,126 @@ mod tests {
         assert!(store.has_intercept_route("github.com:443"));
         assert!(store.is_route_upstream("github.com:443"));
         assert!(store.lookup_all_by_upstream("other.com:443").is_empty());
+    }
+
+    /// Models a real multi-org GitHub profile. Mirrors the selection
+    /// loop in `tls_intercept::handle`:
+    ///   1 match  → inject that route's credential
+    ///   0 matches → passthrough (no credential injected)
+    ///   2+ matches → ambiguous (hard-deny 403)
+    #[test]
+    fn test_route_selection_multi_org_profile() {
+        // Helper to build a route with the given prefix and endpoint path.
+        fn gh_route(prefix: &str, env: &str, path: &str) -> RouteConfig {
+            RouteConfig {
+                prefix: prefix.to_string(),
+                upstream: "https://github.com".to_string(),
+                credential_key: Some(format!("env://{env}")),
+                inject_mode: Default::default(),
+                inject_header: "Authorization".to_string(),
+                credential_format: "Bearer {}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                proxy: None,
+                env_var: Some(env.to_string()),
+                endpoint_rules: vec![crate::config::EndpointRule {
+                    method: "*".to_string(),
+                    path: path.to_string(),
+                }],
+                tls_ca: None,
+                tls_client_cert: None,
+                tls_client_key: None,
+                oauth2: None,
+            }
+        }
+
+        #[derive(Debug, PartialEq)]
+        enum Selection<'a> {
+            Route(&'a str),
+            Passthrough,
+            Ambiguous(Vec<&'a str>),
+        }
+
+        fn select<'a>(
+            candidates: &'a [(&'a str, &'a LoadedRoute)],
+            method: &str,
+            path: &str,
+        ) -> Selection<'a> {
+            let mut matches: Vec<&str> = Vec::new();
+            let mut catch_all: Option<&str> = None;
+            for (prefix, route) in candidates {
+                if route.endpoint_rules.is_empty() {
+                    if catch_all.is_none() {
+                        catch_all = Some(*prefix);
+                    }
+                } else if route.endpoint_rules.is_allowed(method, path) {
+                    matches.push(prefix);
+                }
+            }
+            if matches.len() > 1 {
+                Selection::Ambiguous(matches)
+            } else if let Some(svc) = matches.into_iter().next().or(catch_all) {
+                Selection::Route(svc)
+            } else {
+                Selection::Passthrough
+            }
+        }
+
+        // --- Profile: two org-scoped routes, no catch-all ---
+        let routes = vec![
+            gh_route("github_https_org_a", "GH_TOKEN_A", "/org-a/**"),
+            gh_route("github_https_org_b", "GH_TOKEN_B", "/org-b/**"),
+        ];
+        let store = RouteStore::load(&routes).unwrap();
+        let candidates = store.lookup_all_by_upstream("github.com:443");
+        assert_eq!(candidates.len(), 2);
+
+        // Private org-a repo → org-a credential
+        assert_eq!(
+            select(&candidates, "GET", "/org-a/repo.git/info/refs"),
+            Selection::Route("github_https_org_a")
+        );
+        // Private org-b repo → org-b credential
+        assert_eq!(
+            select(&candidates, "GET", "/org-b/repo.git/info/refs"),
+            Selection::Route("github_https_org_b")
+        );
+        // Public repo (e.g. always-further/nono) → passthrough, no cred
+        assert_eq!(
+            select(&candidates, "GET", "/always-further/nono.git/info/refs"),
+            Selection::Passthrough
+        );
+        // POST to public repo → also passthrough
+        assert_eq!(
+            select(
+                &candidates,
+                "POST",
+                "/always-further/nono.git/git-upload-pack"
+            ),
+            Selection::Passthrough
+        );
+
+        // --- Adding a /** catch-all would cause ambiguity ---
+        let routes_with_catchall = vec![
+            gh_route("github_https_org_a", "GH_TOKEN_A", "/org-a/**"),
+            gh_route("github_https_org_b", "GH_TOKEN_B", "/org-b/**"),
+            gh_route("github_https_all", "GH_TOKEN_A", "/**"),
+        ];
+        let store2 = RouteStore::load(&routes_with_catchall).unwrap();
+        let candidates2 = store2.lookup_all_by_upstream("github.com:443");
+        assert_eq!(candidates2.len(), 3);
+
+        // org-a request now matches BOTH org_a AND the /** catch-all → ambiguous
+        assert_eq!(
+            select(&candidates2, "GET", "/org-a/repo.git/info/refs"),
+            Selection::Ambiguous(vec!["github_https_all", "github_https_org_a"])
+        );
+        // Public repo matches only the /** catch-all → 1 match, ok
+        assert_eq!(
+            select(&candidates2, "GET", "/always-further/nono.git/info/refs"),
+            Selection::Route("github_https_all")
+        );
     }
 
     /// Self-signed CA for testing. Generated with:

--- a/crates/nono-proxy/src/route.rs
+++ b/crates/nono-proxy/src/route.rs
@@ -142,6 +142,8 @@ impl RouteStore {
     pub fn load(routes: &[RouteConfig]) -> Result<Self> {
         let mut loaded = HashMap::new();
 
+        let base_root_store = build_base_root_store();
+
         for route in routes {
             let normalized_prefix = route.prefix.trim_matches('/').to_string();
 
@@ -164,6 +166,7 @@ impl RouteStore {
                     route.tls_client_cert.is_some(),
                 );
                 Some(build_tls_connector(
+                    &base_root_store,
                     route.tls_ca.as_deref(),
                     route.tls_client_cert.as_deref(),
                     route.tls_client_key.as_deref(),
@@ -265,7 +268,8 @@ impl RouteStore {
     #[must_use]
     pub fn lookup_all_by_upstream(&self, host_port: &str) -> Vec<(&str, &LoadedRoute)> {
         let normalised = host_port.to_lowercase();
-        self.routes
+        let mut matches: Vec<_> = self
+            .routes
             .iter()
             .filter(|(_, route)| {
                 route
@@ -274,15 +278,22 @@ impl RouteStore {
                     .is_some_and(|hp| *hp == normalised)
             })
             .map(|(prefix, route)| (prefix.as_str(), route))
-            .collect()
+            .collect();
+        matches.sort_by_key(|(prefix, _)| *prefix);
+        matches
     }
 
     /// Whether any route for `host:port` requires TLS interception.
     #[must_use]
     pub fn has_intercept_route(&self, host_port: &str) -> bool {
-        self.lookup_all_by_upstream(host_port)
-            .iter()
-            .any(|(_, route)| route.requires_intercept)
+        let normalised = host_port.to_lowercase();
+        self.routes.values().any(|route| {
+            route
+                .upstream_host_port
+                .as_ref()
+                .is_some_and(|hp| *hp == normalised)
+                && route.requires_intercept
+        })
     }
 
     /// All unique upstream `host:port` strings across loaded routes.
@@ -360,19 +371,27 @@ fn read_pem_file(path: &std::path::Path, label: &str) -> Result<Zeroizing<Vec<u8
 ///
 /// At least one of the three parameters must be `Some`. Returns an error if any
 /// file cannot be read, contains invalid PEM, or the TLS configuration fails.
+/// Build a root cert store with webpki roots + native system CAs.
+/// Called once at startup and shared across per-route connectors.
+fn build_base_root_store() -> rustls::RootCertStore {
+    let mut store = rustls::RootCertStore::empty();
+    store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let native = rustls_native_certs::load_native_certs();
+    for cert in native.certs {
+        if let Err(e) = store.add(cert) {
+            debug!("skipping unparseable native cert: {e}");
+        }
+    }
+    store
+}
+
 fn build_tls_connector(
+    base_root_store: &rustls::RootCertStore,
     ca_path: Option<&str>,
     client_cert_path: Option<&str>,
     client_key_path: Option<&str>,
 ) -> Result<tokio_rustls::TlsConnector> {
-    let mut root_store = rustls::RootCertStore::empty();
-    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-    let native = rustls_native_certs::load_native_certs();
-    for cert in native.certs {
-        if let Err(e) = root_store.add(cert) {
-            debug!("skipping unparseable native cert in route connector: {e}");
-        }
-    }
+    let mut root_store = base_root_store.clone();
 
     // Add custom CA if provided
     if let Some(ca_path) = ca_path {
@@ -497,7 +516,8 @@ fn build_tls_connector(
 /// Compatibility shim: build a connector with only a custom CA (no client cert).
 #[cfg(test)]
 fn build_tls_connector_with_ca(ca_path: &str) -> Result<tokio_rustls::TlsConnector> {
-    build_tls_connector(Some(ca_path), None, None)
+    let base = build_base_root_store();
+    build_tls_connector(&base, Some(ca_path), None, None)
 }
 
 #[cfg(test)]
@@ -1032,7 +1052,8 @@ h56ZLEEqHfVWFhJWIKRSabtxYPV/VJyMv+lo3L0QwSKsouHs3dtF1zVQ
         let cert_path = dir.path().join("client.crt");
         std::fs::write(&cert_path, TEST_CLIENT_CERT_PEM).unwrap();
 
-        let result = build_tls_connector(None, Some(cert_path.to_str().unwrap()), None);
+        let base = build_base_root_store();
+        let result = build_tls_connector(&base, None, Some(cert_path.to_str().unwrap()), None);
         let err = result
             .err()
             .expect("should fail with half-pair")
@@ -1050,7 +1071,8 @@ h56ZLEEqHfVWFhJWIKRSabtxYPV/VJyMv+lo3L0QwSKsouHs3dtF1zVQ
         let key_path = dir.path().join("client.key");
         std::fs::write(&key_path, TEST_CLIENT_KEY_PEM).unwrap();
 
-        let result = build_tls_connector(None, None, Some(key_path.to_str().unwrap()));
+        let base = build_base_root_store();
+        let result = build_tls_connector(&base, None, None, Some(key_path.to_str().unwrap()));
         let err = result
             .err()
             .expect("should fail with half-pair")
@@ -1068,7 +1090,9 @@ h56ZLEEqHfVWFhJWIKRSabtxYPV/VJyMv+lo3L0QwSKsouHs3dtF1zVQ
         let key_path = dir.path().join("client.key");
         std::fs::write(&key_path, TEST_CLIENT_KEY_PEM).unwrap();
 
+        let base = build_base_root_store();
         let result = build_tls_connector(
+            &base,
             None,
             Some("/nonexistent/client.crt"),
             Some(key_path.to_str().unwrap()),
@@ -1087,7 +1111,9 @@ h56ZLEEqHfVWFhJWIKRSabtxYPV/VJyMv+lo3L0QwSKsouHs3dtF1zVQ
         let cert_path = dir.path().join("client.crt");
         std::fs::write(&cert_path, TEST_CLIENT_CERT_PEM).unwrap();
 
+        let base = build_base_root_store();
         let result = build_tls_connector(
+            &base,
             None,
             Some(cert_path.to_str().unwrap()),
             Some("/nonexistent/client.key"),
@@ -1115,7 +1141,9 @@ h56ZLEEqHfVWFhJWIKRSabtxYPV/VJyMv+lo3L0QwSKsouHs3dtF1zVQ
             return;
         }
 
+        let base = build_base_root_store();
         let result = build_tls_connector(
+            &base,
             None,
             Some(cert_path.to_str().unwrap()),
             Some("/nonexistent/key"),
@@ -1136,7 +1164,9 @@ h56ZLEEqHfVWFhJWIKRSabtxYPV/VJyMv+lo3L0QwSKsouHs3dtF1zVQ
         std::fs::write(&cert_path, "not a certificate\n").unwrap();
         std::fs::write(&key_path, TEST_CLIENT_KEY_PEM).unwrap();
 
+        let base = build_base_root_store();
         let result = build_tls_connector(
+            &base,
             None,
             Some(cert_path.to_str().unwrap()),
             Some(key_path.to_str().unwrap()),
@@ -1158,7 +1188,9 @@ h56ZLEEqHfVWFhJWIKRSabtxYPV/VJyMv+lo3L0QwSKsouHs3dtF1zVQ
         std::fs::write(&cert_path, TEST_CLIENT_CERT_PEM).unwrap();
         std::fs::write(&key_path, "not a key\n").unwrap();
 
+        let base = build_base_root_store();
         let result = build_tls_connector(
+            &base,
             None,
             Some(cert_path.to_str().unwrap()),
             Some(key_path.to_str().unwrap()),

--- a/crates/nono-proxy/src/route.rs
+++ b/crates/nono-proxy/src/route.rs
@@ -245,12 +245,10 @@ impl RouteStore {
         })
     }
 
-    /// Look up the route prefix and loaded entry for a CONNECT-style
-    /// `host:port`. Returns `Some((prefix, route))` on a match.
+    /// Return the first route matching `host:port`, or `None`.
     ///
-    /// Used by the TLS-intercept CONNECT branch to map the agent's
-    /// `CONNECT api.openai.com:443` target back to a route prefix
-    /// (`"openai"`) so the credential store can be consulted.
+    /// Prefer [`lookup_all_by_upstream`](Self::lookup_all_by_upstream)
+    /// when multiple routes may share the same upstream.
     #[must_use]
     pub fn lookup_by_upstream(&self, host_port: &str) -> Option<(&str, &LoadedRoute)> {
         let normalised = host_port.to_lowercase();
@@ -263,20 +261,31 @@ impl RouteStore {
         })
     }
 
-    /// Returns `true` if the `host:port` matches a route that requires
-    /// TLS interception (has `credential_key`, `oauth2`, or non-empty
-    /// `endpoint_rules`).
-    ///
-    /// Used in the CONNECT dispatch path to choose between transparent
-    /// tunnelling, the existing 403, and the new intercept handler.
+    /// Return all routes whose upstream matches `host:port`.
     #[must_use]
-    pub fn has_intercept_route(&self, host_port: &str) -> bool {
-        self.lookup_by_upstream(host_port)
-            .is_some_and(|(_, route)| route.requires_intercept)
+    pub fn lookup_all_by_upstream(&self, host_port: &str) -> Vec<(&str, &LoadedRoute)> {
+        let normalised = host_port.to_lowercase();
+        self.routes
+            .iter()
+            .filter(|(_, route)| {
+                route
+                    .upstream_host_port
+                    .as_ref()
+                    .is_some_and(|hp| *hp == normalised)
+            })
+            .map(|(prefix, route)| (prefix.as_str(), route))
+            .collect()
     }
 
-    /// Return the set of normalised `host:port` strings for all route
-    /// upstreams. Uses pre-normalised values computed at load time.
+    /// Whether any route for `host:port` requires TLS interception.
+    #[must_use]
+    pub fn has_intercept_route(&self, host_port: &str) -> bool {
+        self.lookup_all_by_upstream(host_port)
+            .iter()
+            .any(|(_, route)| route.requires_intercept)
+    }
+
+    /// All unique upstream `host:port` strings across loaded routes.
     #[must_use]
     pub fn route_upstream_hosts(&self) -> std::collections::HashSet<String> {
         self.routes
@@ -357,8 +366,13 @@ fn build_tls_connector(
     client_key_path: Option<&str>,
 ) -> Result<tokio_rustls::TlsConnector> {
     let mut root_store = rustls::RootCertStore::empty();
-    // Always include system roots
     root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let native = rustls_native_certs::load_native_certs();
+    for cert in native.certs {
+        if let Err(e) = root_store.add(cert) {
+            debug!("skipping unparseable native cert in route connector: {e}");
+        }
+    }
 
     // Add custom CA if provided
     if let Some(ca_path) = ca_path {
@@ -848,6 +862,74 @@ mod tests {
         assert!(hit.1.requires_intercept);
         assert!(hit.1.requires_managed_credential);
         assert!(store.lookup_by_upstream("api.example.com:443").is_none());
+    }
+
+    #[test]
+    fn test_lookup_all_by_upstream_returns_multiple_routes() {
+        let routes = vec![
+            RouteConfig {
+                prefix: "github_org_a".to_string(),
+                upstream: "https://github.com".to_string(),
+                credential_key: Some("env://GH_TOKEN_A".to_string()),
+                inject_mode: Default::default(),
+                inject_header: "Authorization".to_string(),
+                credential_format: "Bearer {}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                proxy: None,
+                env_var: Some("GH_TOKEN_A".to_string()),
+                endpoint_rules: vec![crate::config::EndpointRule {
+                    method: "*".to_string(),
+                    path: "/org-a/**".to_string(),
+                }],
+                tls_ca: None,
+                tls_client_cert: None,
+                tls_client_key: None,
+                oauth2: None,
+            },
+            RouteConfig {
+                prefix: "github_org_b".to_string(),
+                upstream: "https://github.com".to_string(),
+                credential_key: Some("env://GH_TOKEN_B".to_string()),
+                inject_mode: Default::default(),
+                inject_header: "Authorization".to_string(),
+                credential_format: "Bearer {}".to_string(),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                proxy: None,
+                env_var: Some("GH_TOKEN_B".to_string()),
+                endpoint_rules: vec![crate::config::EndpointRule {
+                    method: "*".to_string(),
+                    path: "/org-b/**".to_string(),
+                }],
+                tls_ca: None,
+                tls_client_cert: None,
+                tls_client_key: None,
+                oauth2: None,
+            },
+        ];
+        let store = RouteStore::load(&routes).unwrap();
+
+        let all = store.lookup_all_by_upstream("github.com:443");
+        assert_eq!(all.len(), 2, "both routes share the same upstream");
+
+        let prefixes: Vec<&str> = all.iter().map(|(p, _)| *p).collect();
+        assert!(prefixes.contains(&"github_org_a"));
+        assert!(prefixes.contains(&"github_org_b"));
+
+        let (_, route_a) = all.iter().find(|(p, _)| *p == "github_org_a").unwrap();
+        assert!(route_a.endpoint_rules.is_allowed("GET", "/org-a/repo"));
+        assert!(!route_a.endpoint_rules.is_allowed("GET", "/org-b/repo"));
+
+        let (_, route_b) = all.iter().find(|(p, _)| *p == "github_org_b").unwrap();
+        assert!(route_b.endpoint_rules.is_allowed("GET", "/org-b/repo"));
+        assert!(!route_b.endpoint_rules.is_allowed("GET", "/org-a/repo"));
+
+        assert!(store.has_intercept_route("github.com:443"));
+        assert!(store.is_route_upstream("github.com:443"));
+        assert!(store.lookup_all_by_upstream("other.com:443").is_empty());
     }
 
     /// Self-signed CA for testing. Generated with:

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -368,6 +368,22 @@ pub async fn start(config: ProxyConfig) -> Result<ProxyHandle> {
     // exchange needs TLS.
     let mut root_store = rustls::RootCertStore::empty();
     root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let native = rustls_native_certs::load_native_certs();
+    if !native.errors.is_empty() {
+        debug!(
+            "failed to load {} native cert(s); continuing with webpki roots + any that succeeded",
+            native.errors.len()
+        );
+    }
+    let native_count = native.certs.len();
+    for cert in native.certs {
+        if let Err(e) = root_store.add(cert) {
+            debug!("skipping unparseable native cert: {e}");
+        }
+    }
+    if native_count > 0 {
+        debug!("added {native_count} native system CA(s) to upstream trust store");
+    }
     let tls_config = rustls::ClientConfig::builder_with_provider(Arc::new(
         rustls::crypto::ring::default_provider(),
     ))

--- a/crates/nono-proxy/src/tls_intercept/handle.rs
+++ b/crates/nono-proxy/src/tls_intercept/handle.rs
@@ -1,11 +1,15 @@
 //! CONNECT-intercept entry point.
 //!
-//! Terminates TLS from the agent, reads the inner HTTP request, selects
-//! the matching route (by endpoint rules when multiple routes share an
-//! upstream), and forwards via [`crate::forward::forward_request`].
+//! Terminates TLS from the agent, reads the inner HTTP/1.1 request, and
+//! dispatches it via [`crate::forward::forward_request`].
 //!
-//! Auth relies on the outer CONNECT `Proxy-Authorization`; inner requests
-//! are not required to carry a token. Every failure is hard-fail.
+//! Route selection for each inner request:
+//!   - **1 match** — inject that route's managed credential.
+//!   - **0 matches** — forward without credentials (passthrough).
+//!   - **2+ matches** — reject as ambiguous (403).
+//!
+//! Auth is validated on the outer CONNECT `Proxy-Authorization` only;
+//! inner requests are not required to carry a token.
 
 use crate::audit;
 use crate::config::InjectMode;
@@ -119,7 +123,8 @@ pub async fn handle_intercept_connect(stream: &mut TcpStream, ctx: InterceptCtx<
     Ok(())
 }
 
-/// Parse one inner HTTP/1.1 request, select the route, and forward upstream.
+/// Read one inner HTTP/1.1 request, select the matching route, inject
+/// credentials if matched, and forward upstream.
 async fn forward_inner_request<S>(tls_stream: &mut S, ctx: &InterceptCtx<'_>) -> Result<()>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
@@ -159,9 +164,7 @@ where
     let (method, path, version) = parse_request_line(first_line)?;
     debug!("tls_intercept: inner request {} {}", method, path);
 
-    // Select the route for this request. When multiple routes share
-    // the same upstream, pick the one whose endpoint_rules match;
-    // fall back to a catch-all route (empty rules) if no rules match.
+    // Route selection: 1 match → cred, 0 → passthrough, 2+ → 403.
     let host_port = format!("{}:{}", ctx.host.to_lowercase(), ctx.port);
     let candidates = ctx.route_store.lookup_all_by_upstream(&host_port);
     if candidates.is_empty() {
@@ -173,7 +176,7 @@ where
         return Ok(());
     }
 
-    let mut matched: Option<(&str, &crate::route::LoadedRoute)> = None;
+    let mut matches: Vec<(&str, &crate::route::LoadedRoute)> = Vec::new();
     let mut catch_all: Option<(&str, &crate::route::LoadedRoute)> = None;
     for (prefix, route) in &candidates {
         if route.endpoint_rules.is_empty() {
@@ -181,75 +184,83 @@ where
                 catch_all = Some((prefix, route));
             }
         } else if route.endpoint_rules.is_allowed(&method, &path) {
-            matched = Some((prefix, route));
-            break;
+            matches.push((prefix, route));
         }
     }
-    let (service, route) = match matched.or(catch_all) {
-        Some(hit) => hit,
-        None => {
-            let reason = format!(
-                "endpoint denied: {} {} (no route's endpoint_rules matched)",
-                method, path
-            );
-            warn!("tls_intercept: {}", reason);
-            audit::log_denied(
-                ctx.audit_log,
-                audit::ProxyMode::ConnectIntercept,
-                &audit::EventContext {
-                    denial_category: Some(nono::undo::NetworkAuditDenialCategory::EndpointPolicy),
-                    ..audit::EventContext::default()
-                },
-                ctx.host,
-                ctx.port,
-                &reason,
-            );
-            reverse::send_error_generic(tls_stream, 403, "Forbidden").await?;
-            return Ok(());
-        }
-    };
-    debug!(
-        "tls_intercept: selected route '{}' for {} {}",
-        service, method, path
-    );
 
-    let cred = ctx.credential_store.get(service);
-    let oauth2_route = ctx.credential_store.get_oauth2(service);
-
-    if route.missing_managed_credential(cred.is_some(), oauth2_route.is_some()) {
+    if matches.len() > 1 {
+        let names: Vec<_> = matches.iter().map(|(p, _)| *p).collect();
         let reason = format!(
-            "managed credential unavailable for route '{}': intercepted request requires proxy-supplied auth",
-            service
+            "ambiguous route: {} {} matched {} routes: {:?}. \
+             Narrow endpoint_rules so each request matches exactly one route.",
+            method,
+            path,
+            matches.len(),
+            names
         );
         warn!("tls_intercept: {}", reason);
         audit::log_denied(
             ctx.audit_log,
             audit::ProxyMode::ConnectIntercept,
             &audit::EventContext {
-                route_id: Some(service),
-                auth_mechanism: route.managed_auth_mechanism.clone(),
-                auth_outcome: Some(nono::undo::NetworkAuditAuthOutcome::Failed),
-                managed_credential_active: Some(false),
-                injection_mode: route.managed_injection_mode.clone(),
-                denial_category: Some(
-                    nono::undo::NetworkAuditDenialCategory::ManagedCredentialUnavailable,
-                ),
+                denial_category: Some(nono::undo::NetworkAuditDenialCategory::EndpointPolicy),
+                ..audit::EventContext::default()
             },
             ctx.host,
             ctx.port,
             &reason,
         );
-        reverse::send_error_generic(tls_stream, 503, "Service Unavailable").await?;
+        reverse::send_error_generic(tls_stream, 403, "Forbidden").await?;
         return Ok(());
     }
 
-    // Endpoint filtering already happened during route selection above.
-    // Routes with non-empty endpoint_rules only matched if the inner
-    // request was allowed; catch-all routes (empty rules) allow everything.
+    // Exactly one match → inject credential. No match → passthrough.
+    let selected = matches.into_iter().next().or(catch_all);
+    let service: Option<&str> = selected.map(|(s, _)| s);
+    let route: Option<&crate::route::LoadedRoute> = selected.map(|(_, r)| r);
+    match service {
+        Some(svc) => debug!(
+            "tls_intercept: selected route '{}' for {} {}",
+            svc, method, path
+        ),
+        None => debug!(
+            "tls_intercept: no endpoint_rules matched {} {}, forwarding without credentials",
+            method, path
+        ),
+    }
 
-    // No inner-request auth check — the outer CONNECT Proxy-Authorization
-    // is sufficient. Any client-supplied auth header is stripped below so
-    // it doesn't leak upstream.
+    let cred = service.and_then(|s| ctx.credential_store.get(s));
+    let oauth2_route = service.and_then(|s| ctx.credential_store.get_oauth2(s));
+
+    if let Some(rt) = route {
+        if rt.missing_managed_credential(cred.is_some(), oauth2_route.is_some()) {
+            let svc = service.unwrap_or("unknown");
+            let reason = format!(
+                "managed credential unavailable for route '{}': intercepted request requires proxy-supplied auth",
+                svc
+            );
+            warn!("tls_intercept: {}", reason);
+            audit::log_denied(
+                ctx.audit_log,
+                audit::ProxyMode::ConnectIntercept,
+                &audit::EventContext {
+                    route_id: service,
+                    auth_mechanism: rt.managed_auth_mechanism.clone(),
+                    auth_outcome: Some(nono::undo::NetworkAuditAuthOutcome::Failed),
+                    managed_credential_active: Some(false),
+                    injection_mode: rt.managed_injection_mode.clone(),
+                    denial_category: Some(
+                        nono::undo::NetworkAuditDenialCategory::ManagedCredentialUnavailable,
+                    ),
+                },
+                ctx.host,
+                ctx.port,
+                &reason,
+            );
+            reverse::send_error_generic(tls_stream, 503, "Service Unavailable").await?;
+            return Ok(());
+        }
+    }
 
     // --- Path / credential transformation ---
     let transformed_path = if let Some(cred) = cred {
@@ -281,7 +292,7 @@ where
             ctx.audit_log,
             audit::ProxyMode::ConnectIntercept,
             &audit::EventContext {
-                route_id: Some(service),
+                route_id: service,
                 managed_credential_active: Some(cred.is_some() || oauth2_route.is_some()),
                 injection_mode: cred.map(|c| match c.inject_mode {
                     InjectMode::Header => nono::undo::NetworkAuditInjectionMode::Header,
@@ -337,7 +348,9 @@ where
     request.push_str("\r\n");
 
     // --- Forward via shared pipeline ---
-    let connector = route.tls_connector.as_ref().unwrap_or(ctx.tls_connector);
+    let connector = route
+        .and_then(|r| r.tls_connector.as_ref())
+        .unwrap_or(ctx.tls_connector);
     let upstream_spec = UpstreamSpec {
         scheme: UpstreamScheme::Https,
         host: ctx.host,
@@ -351,7 +364,7 @@ where
         log: ctx.audit_log,
         mode: audit::ProxyMode::ConnectIntercept,
         event_ctx: audit::EventContext {
-            route_id: Some(service),
+            route_id: service,
             auth_mechanism: cred.map(|c| match c.proxy_inject_mode {
                 InjectMode::Header | InjectMode::BasicAuth => {
                     nono::undo::NetworkAuditAuthMechanism::PhantomHeader
@@ -387,7 +400,7 @@ where
             ctx.audit_log,
             audit::ProxyMode::ConnectIntercept,
             &audit::EventContext {
-                route_id: Some(service),
+                route_id: service,
                 auth_mechanism: cred.map(|c| match c.proxy_inject_mode {
                     InjectMode::Header | InjectMode::BasicAuth => {
                         nono::undo::NetworkAuditAuthMechanism::PhantomHeader

--- a/crates/nono-proxy/src/tls_intercept/handle.rs
+++ b/crates/nono-proxy/src/tls_intercept/handle.rs
@@ -1,28 +1,22 @@
 //! CONNECT-intercept entry point.
 //!
-//! Owns:
+//! Terminates TLS from the agent, reads the inner HTTP request, selects
+//! the matching route (by endpoint rules when multiple routes share an
+//! upstream), and forwards via [`crate::forward::forward_request`].
 //!
-//! 1. Sending `200 Connection Established` to the agent.
-//! 2. Driving the inner TLS handshake using the cert resolver from
-//!    [`super::CertCache`].
-//! 3. Reading one HTTP/1.1 request inside the TLS stream.
-//! 4. Endpoint-rule + phantom-token enforcement.
-//! 5. Calling [`crate::forward::forward_request`] with the route's L7
-//!    context so the same upstream pipeline is used as the reverse proxy.
-//!
-//! Every failure mode is hard-fail — a route that asked for L7 visibility
-//! never silently degrades to a transparent tunnel.
+//! Auth relies on the outer CONNECT `Proxy-Authorization`; inner requests
+//! are not required to carry a token. Every failure is hard-fail.
 
 use crate::audit;
 use crate::config::InjectMode;
 use crate::credential::CredentialStore;
 use crate::error::{ProxyError, Result};
+use crate::filter::ProxyFilter;
 use crate::forward::{self, AuditCtx, UpstreamScheme, UpstreamSpec, UpstreamStrategy};
 use crate::reverse;
 use crate::route::RouteStore;
 use crate::tls_intercept::acceptor;
 use crate::tls_intercept::cert_cache::CertCache;
-use crate::{filter::ProxyFilter, token};
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
@@ -125,8 +119,7 @@ pub async fn handle_intercept_connect(stream: &mut TcpStream, ctx: InterceptCtx<
     Ok(())
 }
 
-/// Read one HTTP/1.1 request from the inner TLS stream, enforce endpoint
-/// rules + phantom token, and forward via the shared L7 pipeline.
+/// Parse one inner HTTP/1.1 request, select the route, and forward upstream.
 async fn forward_inner_request<S>(tls_stream: &mut S, ctx: &InterceptCtx<'_>) -> Result<()>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
@@ -166,21 +159,60 @@ where
     let (method, path, version) = parse_request_line(first_line)?;
     debug!("tls_intercept: inner request {} {}", method, path);
 
-    // --- Look up the route by upstream host:port ---
+    // Select the route for this request. When multiple routes share
+    // the same upstream, pick the one whose endpoint_rules match;
+    // fall back to a catch-all route (empty rules) if no rules match.
     let host_port = format!("{}:{}", ctx.host.to_lowercase(), ctx.port);
-    let (service, route) = match ctx.route_store.lookup_by_upstream(&host_port) {
+    let candidates = ctx.route_store.lookup_all_by_upstream(&host_port);
+    if candidates.is_empty() {
+        warn!(
+            "tls_intercept: no route for {} after intercept handshake",
+            host_port
+        );
+        reverse::send_error_generic(tls_stream, 502, "Bad Gateway").await?;
+        return Ok(());
+    }
+
+    let mut matched: Option<(&str, &crate::route::LoadedRoute)> = None;
+    let mut catch_all: Option<(&str, &crate::route::LoadedRoute)> = None;
+    for (prefix, route) in &candidates {
+        if route.endpoint_rules.is_empty() {
+            if catch_all.is_none() {
+                catch_all = Some((prefix, route));
+            }
+        } else if route.endpoint_rules.is_allowed(&method, &path) {
+            matched = Some((prefix, route));
+            break;
+        }
+    }
+    let (service, route) = match matched.or(catch_all) {
         Some(hit) => hit,
         None => {
-            // Shouldn't reach here — the dispatch path already confirmed
-            // a route match before invoking us. Treat as 502 defensively.
-            warn!(
-                "tls_intercept: no route for {} after intercept handshake",
-                host_port
+            let reason = format!(
+                "endpoint denied: {} {} (no route's endpoint_rules matched)",
+                method, path
             );
-            reverse::send_error_generic(tls_stream, 502, "Bad Gateway").await?;
+            warn!("tls_intercept: {}", reason);
+            audit::log_denied(
+                ctx.audit_log,
+                audit::ProxyMode::ConnectIntercept,
+                &audit::EventContext {
+                    denial_category: Some(nono::undo::NetworkAuditDenialCategory::EndpointPolicy),
+                    ..audit::EventContext::default()
+                },
+                ctx.host,
+                ctx.port,
+                &reason,
+            );
+            reverse::send_error_generic(tls_stream, 403, "Forbidden").await?;
             return Ok(());
         }
     };
+    debug!(
+        "tls_intercept: selected route '{}' for {} {}",
+        service, method, path
+    );
+
     let cred = ctx.credential_store.get(service);
     let oauth2_route = ctx.credential_store.get_oauth2(service);
 
@@ -194,7 +226,7 @@ where
             ctx.audit_log,
             audit::ProxyMode::ConnectIntercept,
             &audit::EventContext {
-                route_id: ctx.route_id,
+                route_id: Some(service),
                 auth_mechanism: route.managed_auth_mechanism.clone(),
                 auth_outcome: Some(nono::undo::NetworkAuditAuthOutcome::Failed),
                 managed_credential_active: Some(false),
@@ -211,80 +243,13 @@ where
         return Ok(());
     }
 
-    // --- L7 endpoint filtering ---
-    if !route.endpoint_rules.is_allowed(&method, &path) {
-        let reason = format!("endpoint denied: {} {}", method, path);
-        warn!("tls_intercept: {}", reason);
-        audit::log_denied(
-            ctx.audit_log,
-            audit::ProxyMode::ConnectIntercept,
-            &audit::EventContext {
-                route_id: Some(service),
-                managed_credential_active: Some(cred.is_some() || oauth2_route.is_some()),
-                injection_mode: cred.map(|c| match c.inject_mode {
-                    InjectMode::Header => nono::undo::NetworkAuditInjectionMode::Header,
-                    InjectMode::UrlPath => nono::undo::NetworkAuditInjectionMode::UrlPath,
-                    InjectMode::QueryParam => nono::undo::NetworkAuditInjectionMode::QueryParam,
-                    InjectMode::BasicAuth => nono::undo::NetworkAuditInjectionMode::BasicAuth,
-                }),
-                denial_category: Some(nono::undo::NetworkAuditDenialCategory::EndpointPolicy),
-                ..audit::EventContext::default()
-            },
-            ctx.host,
-            ctx.port,
-            &reason,
-        );
-        reverse::send_error_generic(tls_stream, 403, "Forbidden").await?;
-        return Ok(());
-    }
+    // Endpoint filtering already happened during route selection above.
+    // Routes with non-empty endpoint_rules only matched if the inner
+    // request was allowed; catch-all routes (empty rules) allow everything.
 
-    // --- Phantom-token validation for credentialed routes ---
-    if let Some(cred) = cred {
-        if let Err(e) = reverse::validate_phantom_token_for_mode(
-            &cred.proxy_inject_mode,
-            &header_bytes,
-            &path,
-            &cred.proxy_header_name,
-            cred.proxy_path_pattern.as_deref(),
-            cred.proxy_query_param_name.as_deref(),
-            ctx.session_token,
-        ) {
-            audit::log_denied(
-                ctx.audit_log,
-                audit::ProxyMode::ConnectIntercept,
-                &audit::EventContext {
-                    route_id: Some(service),
-                    auth_mechanism: Some(match cred.proxy_inject_mode {
-                        InjectMode::Header | InjectMode::BasicAuth => {
-                            nono::undo::NetworkAuditAuthMechanism::PhantomHeader
-                        }
-                        InjectMode::UrlPath => nono::undo::NetworkAuditAuthMechanism::PhantomPath,
-                        InjectMode::QueryParam => {
-                            nono::undo::NetworkAuditAuthMechanism::PhantomQuery
-                        }
-                    }),
-                    auth_outcome: Some(nono::undo::NetworkAuditAuthOutcome::Failed),
-                    managed_credential_active: Some(true),
-                    injection_mode: Some(match cred.inject_mode {
-                        InjectMode::Header => nono::undo::NetworkAuditInjectionMode::Header,
-                        InjectMode::UrlPath => nono::undo::NetworkAuditInjectionMode::UrlPath,
-                        InjectMode::QueryParam => nono::undo::NetworkAuditInjectionMode::QueryParam,
-                        InjectMode::BasicAuth => nono::undo::NetworkAuditInjectionMode::BasicAuth,
-                    }),
-                    denial_category: Some(
-                        nono::undo::NetworkAuditDenialCategory::AuthenticationFailed,
-                    ),
-                },
-                ctx.host,
-                ctx.port,
-                &e.to_string(),
-            );
-            reverse::send_error_generic(tls_stream, 401, "Unauthorized").await?;
-            return Ok(());
-        }
-    }
-    // L7-only routes have no inner-token check by design — the outer CONNECT
-    // Proxy-Authorization already proved the caller holds the session token.
+    // No inner-request auth check — the outer CONNECT Proxy-Authorization
+    // is sufficient. Any client-supplied auth header is stripped below so
+    // it doesn't leak upstream.
 
     // --- Path / credential transformation ---
     let transformed_path = if let Some(cred) = cred {
@@ -465,12 +430,6 @@ fn parse_request_line(line: &str) -> Result<(String, String, String)> {
         parts[1].to_string(),
         parts[2].to_string(),
     ))
-}
-
-/// Trim unused-arg warnings: `token` is used implicitly via `validate_phantom_token_for_mode`.
-#[allow(dead_code)]
-fn _suppress_token_dependency() {
-    let _ = token::constant_time_eq;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #889 
Closes #890 
Closes #891 

cc @panga want to test your workflow via this PR? I tested each issue one by one and works on my end, but I am not sure of your workflow so would be good to get your side on it. Thanks

## Summary

- Load native system CAs alongside webpki_roots for upstream TLS connections, fixing UnknownIssuer on corporate networks with TLS inspection.

- Drop phantom-token validation on intercept routes. The outer CONNECT Proxy-Authorization is sufficient; requiring an inner token broke tools like git that expect a WWW-Authenticate challenge first.

- Support multiple credential routes sharing the same upstream host. Route selection now matches the inner request's method+path against each route's endpoint_rules instead of picking the first match.
<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
