### PR TITLE
feat: upgrade to Rust edition 2024, centralize workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ members = [
 ]
 
 [workspace.package]
-edition = "2021"
-rust-version = "1.74"
+edition = "2024"
+rust-version = "1.95"
 authors = ["Luke Hinds"]
 license = "Apache-2.0"
 repository = "https://github.com/always-further/nono"
@@ -21,7 +21,7 @@ thiserror = "2"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1.0.149", features = ["preserve_order"] }
+serde_json = { version = "1", features = ["preserve_order"] }
 toml = "1.0"
 
 # Logging
@@ -38,6 +38,12 @@ walkdir = "2"
 ignore = "0.4"
 globset = "0.4"
 
+# Shared system dependencies
+nix = "0.31.3"
+landlock = "0.4"
+url = "2"
+getrandom = "0.4"
+
 # Async runtime and HTTP
 tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "macros", "signal", "sync", "time"] }
 hyper = { version = "1", features = ["http1", "server", "client"] }
@@ -49,6 +55,9 @@ tempfile = "3"
 
 # C FFI bindings
 cbindgen = "0.29"
+
+[workspace.lints.clippy]
+unwrap_used = "deny"
 
 [profile.release]
 opt-level = 3

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -19,3 +19,6 @@ nono = { version = "0.53.0", path = "../../crates/nono", default-features = fals
 
 [build-dependencies]
 cbindgen.workspace = true
+
+[lints]
+workspace = true

--- a/bindings/c/src/capability_set.rs
+++ b/bindings/c/src/capability_set.rs
@@ -2,7 +2,7 @@
 
 use std::os::raw::c_char;
 
-use crate::types::{validate_access_mode, NonoErrorCode};
+use crate::types::{NonoErrorCode, validate_access_mode};
 use crate::{c_str_to_str, map_error, rust_string_to_c, set_last_error};
 
 /// Opaque handle to a capability set.
@@ -25,7 +25,7 @@ impl Default for NonoCapabilitySet {
 ///
 /// The returned pointer is never NULL. Caller must free with
 /// `nono_capability_set_free()`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn nono_capability_set_new() -> *mut NonoCapabilitySet {
     Box::into_raw(Box::new(NonoCapabilitySet::default()))
 }
@@ -38,7 +38,7 @@ pub extern "C" fn nono_capability_set_new() -> *mut NonoCapabilitySet {
 ///
 /// `caps` must be NULL or a pointer previously returned by
 /// `nono_capability_set_new()` or a factory function.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_free(caps: *mut NonoCapabilitySet) {
     if !caps.is_null() {
         // SAFETY: The pointer was created by Box::into_raw() in
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn nono_capability_set_free(caps: *mut NonoCapabilitySet) 
 ///
 /// - `caps` must be a valid pointer from `nono_capability_set_new()`.
 /// - `path` must be a valid null-terminated UTF-8 string.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_allow_path(
     caps: *mut NonoCapabilitySet,
     path: *const c_char,
@@ -106,7 +106,7 @@ pub unsafe extern "C" fn nono_capability_set_allow_path(
 ///
 /// - `caps` must be a valid pointer from `nono_capability_set_new()`.
 /// - `path` must be a valid null-terminated UTF-8 string.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_allow_file(
     caps: *mut NonoCapabilitySet,
     path: *const c_char,
@@ -151,7 +151,7 @@ pub unsafe extern "C" fn nono_capability_set_allow_file(
 /// # Safety
 ///
 /// `caps` must be a valid pointer from `nono_capability_set_new()`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_set_network_blocked(
     caps: *mut NonoCapabilitySet,
     blocked: bool,
@@ -174,7 +174,7 @@ pub unsafe extern "C" fn nono_capability_set_set_network_blocked(
 /// # Safety
 ///
 /// `caps` must be a valid pointer from `nono_capability_set_new()`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_set_network_mode(
     caps: *mut NonoCapabilitySet,
     mode: u32,
@@ -203,7 +203,7 @@ pub unsafe extern "C" fn nono_capability_set_set_network_mode(
 /// # Safety
 ///
 /// `caps` must be a valid pointer or NULL.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_network_mode(caps: *const NonoCapabilitySet) -> u32 {
     if caps.is_null() {
         return crate::types::NONO_NETWORK_MODE_ALLOW_ALL;
@@ -219,7 +219,7 @@ pub unsafe extern "C" fn nono_capability_set_network_mode(caps: *const NonoCapab
 /// # Safety
 ///
 /// `caps` must be a valid pointer from `nono_capability_set_new()`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_set_proxy_port(
     caps: *mut NonoCapabilitySet,
     port: u16,
@@ -244,7 +244,7 @@ pub unsafe extern "C" fn nono_capability_set_set_proxy_port(
 /// # Safety
 ///
 /// `caps` must be a valid pointer or NULL.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_proxy_port(caps: *const NonoCapabilitySet) -> u16 {
     if caps.is_null() {
         return 0;
@@ -262,7 +262,7 @@ pub unsafe extern "C" fn nono_capability_set_proxy_port(caps: *const NonoCapabil
 ///
 /// - `caps` must be a valid pointer.
 /// - `cmd` must be a valid null-terminated UTF-8 string.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_allow_command(
     caps: *mut NonoCapabilitySet,
     cmd: *const c_char,
@@ -291,7 +291,7 @@ pub unsafe extern "C" fn nono_capability_set_allow_command(
 ///
 /// - `caps` must be a valid pointer.
 /// - `cmd` must be a valid null-terminated UTF-8 string.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_block_command(
     caps: *mut NonoCapabilitySet,
     cmd: *const c_char,
@@ -324,7 +324,7 @@ pub unsafe extern "C" fn nono_capability_set_block_command(
 ///
 /// - `caps` must be a valid pointer.
 /// - `rule` must be a valid null-terminated UTF-8 string.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_add_platform_rule(
     caps: *mut NonoCapabilitySet,
     rule: *const c_char,
@@ -354,7 +354,7 @@ pub unsafe extern "C" fn nono_capability_set_add_platform_rule(
 /// # Safety
 ///
 /// `caps` must be a valid pointer.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_deduplicate(caps: *mut NonoCapabilitySet) {
     if caps.is_null() {
         return;
@@ -371,7 +371,7 @@ pub unsafe extern "C" fn nono_capability_set_deduplicate(caps: *mut NonoCapabili
 ///
 /// - `caps` must be a valid pointer or NULL.
 /// - `path` must be a valid null-terminated UTF-8 string or NULL.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_path_covered(
     caps: *const NonoCapabilitySet,
     path: *const c_char,
@@ -396,7 +396,7 @@ pub unsafe extern "C" fn nono_capability_set_path_covered(
 /// # Safety
 ///
 /// `caps` must be a valid pointer or NULL.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_is_network_blocked(
     caps: *const NonoCapabilitySet,
 ) -> bool {
@@ -415,7 +415,7 @@ pub unsafe extern "C" fn nono_capability_set_is_network_blocked(
 /// # Safety
 ///
 /// `caps` must be a valid pointer or NULL.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_summary(
     caps: *const NonoCapabilitySet,
 ) -> *mut c_char {

--- a/bindings/c/src/fs_capability.rs
+++ b/bindings/c/src/fs_capability.rs
@@ -4,7 +4,7 @@ use std::os::raw::c_char;
 
 use crate::capability_set::NonoCapabilitySet;
 use crate::rust_string_to_c;
-use crate::types::{access_mode_to_raw, NonoCapabilitySourceTag, NONO_ACCESS_MODE_INVALID};
+use crate::types::{NONO_ACCESS_MODE_INVALID, NonoCapabilitySourceTag, access_mode_to_raw};
 
 /// Get the number of filesystem capabilities in the set.
 ///
@@ -13,7 +13,7 @@ use crate::types::{access_mode_to_raw, NonoCapabilitySourceTag, NONO_ACCESS_MODE
 /// # Safety
 ///
 /// `caps` must be a valid pointer or NULL.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_fs_count(caps: *const NonoCapabilitySet) -> usize {
     if caps.is_null() {
         return 0;
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn nono_capability_set_fs_count(caps: *const NonoCapabilit
 /// # Safety
 ///
 /// `caps` must be a valid pointer or NULL.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_fs_original(
     caps: *const NonoCapabilitySet,
     index: usize,
@@ -53,7 +53,7 @@ pub unsafe extern "C" fn nono_capability_set_fs_original(
 /// # Safety
 ///
 /// `caps` must be a valid pointer or NULL.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_fs_resolved(
     caps: *const NonoCapabilitySet,
     index: usize,
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn nono_capability_set_fs_resolved(
 /// # Safety
 ///
 /// `caps` must be a valid pointer or NULL.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_fs_access(
     caps: *const NonoCapabilitySet,
     index: usize,
@@ -103,7 +103,7 @@ pub unsafe extern "C" fn nono_capability_set_fs_access(
 /// # Safety
 ///
 /// `caps` must be a valid pointer or NULL.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_fs_is_file(
     caps: *const NonoCapabilitySet,
     index: usize,
@@ -127,7 +127,7 @@ pub unsafe extern "C" fn nono_capability_set_fs_is_file(
 /// # Safety
 ///
 /// `caps` must be a valid pointer or NULL.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_fs_source_tag(
     caps: *const NonoCapabilitySet,
     index: usize,
@@ -161,7 +161,7 @@ pub unsafe extern "C" fn nono_capability_set_fs_source_tag(
 /// # Safety
 ///
 /// `caps` must be a valid pointer or NULL.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_capability_set_fs_source_group_name(
     caps: *const NonoCapabilitySet,
     index: usize,

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -178,7 +178,7 @@ pub(crate) unsafe fn c_str_to_str<'a>(ptr: *const c_char) -> Option<&'a str> {
 /// null-terminated UTF-8 string, or NULL if no error has occurred.
 ///
 /// Caller must free the returned string with `nono_string_free()`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn nono_last_error() -> *mut c_char {
     LAST_ERROR.with(|cell| {
         let borrow = cell.borrow();
@@ -198,7 +198,7 @@ pub extern "C" fn nono_last_error() -> *mut c_char {
 }
 
 /// Clear the last error for the current thread.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn nono_clear_error() {
     LAST_ERROR.with(|cell| {
         *cell.borrow_mut() = None;
@@ -214,7 +214,7 @@ pub extern "C" fn nono_clear_error() {
 /// # Safety
 ///
 /// `s` must be NULL or a pointer previously returned by a nono FFI function.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_string_free(s: *mut c_char) {
     if !s.is_null() {
         // SAFETY: The pointer was created by CString::into_raw() in this
@@ -229,7 +229,7 @@ pub unsafe extern "C" fn nono_string_free(s: *mut c_char) {
 /// Get the nono library version string.
 ///
 /// Caller must free the returned string with `nono_string_free()`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn nono_version() -> *mut c_char {
     rust_string_to_c(env!("CARGO_PKG_VERSION").to_string())
 }

--- a/bindings/c/src/query.rs
+++ b/bindings/c/src/query.rs
@@ -4,7 +4,7 @@ use std::os::raw::c_char;
 
 use crate::capability_set::NonoCapabilitySet;
 use crate::types::{
-    validate_access_mode, NonoErrorCode, NonoQueryReason, NonoQueryResult, NonoQueryStatus,
+    NonoErrorCode, NonoQueryReason, NonoQueryResult, NonoQueryStatus, validate_access_mode,
 };
 use crate::{c_str_to_str, rust_string_to_c, set_last_error};
 
@@ -78,7 +78,7 @@ fn query_result_to_c(result: &nono::query::QueryResult) -> NonoQueryResult {
 ///
 /// `caps` must be a valid pointer from `nono_capability_set_new()`.
 /// Returns NULL if `caps` is NULL.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_query_context_new(
     caps: *const NonoCapabilitySet,
 ) -> *mut NonoQueryContext {
@@ -100,7 +100,7 @@ pub unsafe extern "C" fn nono_query_context_new(
 ///
 /// `ctx` must be NULL or a pointer previously returned by
 /// `nono_query_context_new()`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_query_context_free(ctx: *mut NonoQueryContext) {
     if !ctx.is_null() {
         // SAFETY: The pointer was created by Box::into_raw() in
@@ -123,7 +123,7 @@ pub unsafe extern "C" fn nono_query_context_free(ctx: *mut NonoQueryContext) {
 /// - `ctx` must be a valid pointer from `nono_query_context_new()`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - `out_result` must be a valid writable pointer.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_query_context_query_path(
     ctx: *const NonoQueryContext,
     path: *const c_char,
@@ -167,7 +167,7 @@ pub unsafe extern "C" fn nono_query_context_query_path(
 ///
 /// - `ctx` must be a valid pointer from `nono_query_context_new()`.
 /// - `out_result` must be a valid writable pointer.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_query_context_query_network(
     ctx: *const NonoQueryContext,
     out_result: *mut NonoQueryResult,

--- a/bindings/c/src/sandbox.rs
+++ b/bindings/c/src/sandbox.rs
@@ -14,7 +14,7 @@ use crate::{map_error, rust_string_to_c, set_last_error};
 /// # Safety
 ///
 /// `caps` must be a valid pointer from `nono_capability_set_new()`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_sandbox_apply(caps: *const NonoCapabilitySet) -> NonoErrorCode {
     if caps.is_null() {
         set_last_error("caps pointer is NULL");
@@ -28,7 +28,7 @@ pub unsafe extern "C" fn nono_sandbox_apply(caps: *const NonoCapabilitySet) -> N
 }
 
 /// Check if sandboxing is supported on this platform.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn nono_sandbox_is_supported() -> bool {
     nono::Sandbox::is_supported()
 }
@@ -37,7 +37,7 @@ pub extern "C" fn nono_sandbox_is_supported() -> bool {
 ///
 /// Caller must free `platform` and `details` fields with
 /// `nono_string_free()`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn nono_sandbox_support_info() -> NonoSupportInfo {
     let info = nono::Sandbox::support_info();
     NonoSupportInfo {

--- a/bindings/c/src/state.rs
+++ b/bindings/c/src/state.rs
@@ -22,7 +22,7 @@ pub struct NonoSandboxState {
 /// # Safety
 ///
 /// `caps` must be a valid pointer or NULL.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_sandbox_state_from_caps(
     caps: *const NonoCapabilitySet,
 ) -> *mut NonoSandboxState {
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn nono_sandbox_state_from_caps(
 ///
 /// `state` must be NULL or a pointer previously returned by
 /// `nono_sandbox_state_from_caps()` or `nono_sandbox_state_from_json()`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_sandbox_state_free(state: *mut NonoSandboxState) {
     if !state.is_null() {
         // SAFETY: The pointer was created by Box::into_raw() in a factory
@@ -64,7 +64,7 @@ pub unsafe extern "C" fn nono_sandbox_state_free(state: *mut NonoSandboxState) {
 /// # Safety
 ///
 /// `state` must be a valid pointer or NULL.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_sandbox_state_to_json(state: *const NonoSandboxState) -> *mut c_char {
     if state.is_null() {
         return std::ptr::null_mut();
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn nono_sandbox_state_to_json(state: *const NonoSandboxSta
 /// # Safety
 ///
 /// `json` must be a valid null-terminated UTF-8 string.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_sandbox_state_from_json(
     json: *const c_char,
 ) -> *mut NonoSandboxState {
@@ -117,7 +117,7 @@ pub unsafe extern "C" fn nono_sandbox_state_from_json(
 /// # Safety
 ///
 /// `state` must be a valid pointer or NULL.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nono_sandbox_state_to_caps(
     state: *const NonoSandboxState,
 ) -> *mut NonoCapabilitySet {

--- a/crates/nono-cli/Cargo.toml
+++ b/crates/nono-cli/Cargo.toml
@@ -48,10 +48,10 @@ colored = "3"
 similar = "3"
 rand = "0.10"
 which = "8"
-toml = "1.0"
+toml.workspace = true
 xdg-home = "1.3.0"
 dirs = "6"
-walkdir = "2"
+walkdir.workspace = true
 ignore.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 
@@ -76,26 +76,29 @@ serde_json.workspace = true
 serde_yaml_ng = "0.10.0"
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-url = "2.5.8"
-tempfile = "3"
+url.workspace = true
+tempfile.workspace = true
 vt100 = "0.16.2"
 shlex = "1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-nix = { version = "0.31", features = ["process", "signal", "fs", "user", "term"] }
-landlock = "0.4"
+nix = { workspace = true, features = ["process", "signal", "fs", "user", "term"] }
+landlock.workspace = true
 dns-lookup = "2"
 keyring = { version = "3", features = ["sync-secret-service"], optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-nix = { version = "0.31", features = ["process", "signal", "fs", "user", "term"] }
+nix = { workspace = true, features = ["process", "signal", "fs", "user", "term"] }
 dns-lookup = "2"
 keyring = { version = "3", features = ["apple-native"], optional = true }
 
 [build-dependencies]
-toml = "1.0"
-serde = { version = "1", features = ["derive"] }
+toml.workspace = true
+serde.workspace = true
 
 [dev-dependencies]
 jsonschema = "0.46"
 proptest = "1"
+
+[lints]
+workspace = true

--- a/crates/nono-cli/src/app_runtime.rs
+++ b/crates/nono-cli/src/app_runtime.rs
@@ -17,7 +17,7 @@ use crate::startup_runtime::{
 use crate::trust_cmd;
 use crate::update_check;
 use crate::why_runtime::run_why;
-use crate::{Result, DETACHED_LAUNCH_ENV};
+use crate::{DETACHED_LAUNCH_ENV, Result};
 
 pub(crate) fn run(cli: Cli) -> Result<()> {
     let mut update_handle = start_update_check_handle(&cli);

--- a/crates/nono-cli/src/audit_attestation.rs
+++ b/crates/nono-cli/src/audit_attestation.rs
@@ -193,7 +193,7 @@ pub(crate) fn verify_audit_attestation(
                 summary,
                 expected_public_key_file.map(|_| true),
                 err.to_string(),
-            ))
+            ));
         }
     };
     let predicate_type = match trust::extract_predicate_type(&bundle, &bundle_path) {
@@ -203,7 +203,7 @@ pub(crate) fn verify_audit_attestation(
                 summary,
                 expected_public_key_file.map(|_| true),
                 err.to_string(),
-            ))
+            ));
         }
     };
     if predicate_type != AUDIT_ATTESTATION_PREDICATE_TYPE_ALPHA {
@@ -224,7 +224,7 @@ pub(crate) fn verify_audit_attestation(
                 summary,
                 expected_public_key_file.map(|_| true),
                 err.to_string(),
-            ))
+            ));
         }
     };
     let signer_key_id = match signer_identity {
@@ -234,7 +234,7 @@ pub(crate) fn verify_audit_attestation(
                 summary,
                 expected_public_key_file.map(|_| true),
                 "audit attestation must be keyed".to_string(),
-            ))
+            ));
         }
     };
     let public_key_der = match trust::base64::base64_decode(&summary.public_key) {
@@ -244,7 +244,7 @@ pub(crate) fn verify_audit_attestation(
                 summary,
                 expected_public_key_file.map(|_| true),
                 format!("invalid attested public key encoding: {err}"),
-            ))
+            ));
         }
     };
     let recomputed_key_id = trust::public_key_id_hex(&public_key_der);
@@ -293,7 +293,7 @@ pub(crate) fn verify_audit_attestation(
                 summary,
                 expected_public_key_file.map(|_| true),
                 err.to_string(),
-            ))
+            ));
         }
     };
     if attested_root != integrity.merkle_root.to_string() {
@@ -311,7 +311,7 @@ pub(crate) fn verify_audit_attestation(
                 summary,
                 expected_public_key_file.map(|_| true),
                 err.to_string(),
-            ))
+            ));
         }
     };
     let Some(statement_session_id) = statement

--- a/crates/nono-cli/src/audit_commands.rs
+++ b/crates/nono-cli/src/audit_commands.rs
@@ -6,8 +6,8 @@ use crate::audit_attestation::verify_audit_attestation;
 use crate::audit_integrity::verify_audit_log;
 use crate::audit_ledger::verify_session_in_ledger;
 use crate::audit_session::{
-    discover_sessions, format_bytes, is_legacy_audit_only_session, is_primary_audit_session,
-    load_session, remove_session, SessionInfo,
+    SessionInfo, discover_sessions, format_bytes, is_legacy_audit_only_session,
+    is_primary_audit_session, load_session, remove_session,
 };
 use crate::cli::{
     AuditArgs, AuditCleanupArgs, AuditCommands, AuditListArgs, AuditShowArgs, AuditVerifyArgs,

--- a/crates/nono-cli/src/audit_integrity.rs
+++ b/crates/nono-cli/src/audit_integrity.rs
@@ -365,20 +365,20 @@ pub(crate) fn verify_audit_log(
         .map(|count| count == event_count)
         .unwrap_or(true);
 
-    if let Some(stored_head) = stored_chain_head {
-        if Some(stored_head) != computed_chain_head {
-            return Err(NonoError::Snapshot(
-                "Alpha audit log chain head mismatch".to_string(),
-            ));
-        }
+    if let Some(stored_head) = stored_chain_head
+        && Some(stored_head) != computed_chain_head
+    {
+        return Err(NonoError::Snapshot(
+            "Alpha audit log chain head mismatch".to_string(),
+        ));
     }
 
-    if let Some(stored_root) = stored_merkle_root {
-        if Some(stored_root) != computed_merkle_root {
-            return Err(NonoError::Snapshot(
-                "Alpha audit log Merkle root mismatch".to_string(),
-            ));
-        }
+    if let Some(stored_root) = stored_merkle_root
+        && Some(stored_root) != computed_merkle_root
+    {
+        return Err(NonoError::Snapshot(
+            "Alpha audit log Merkle root mismatch".to_string(),
+        ));
     }
 
     Ok(AuditVerificationResult {
@@ -399,9 +399,9 @@ pub(crate) fn verify_audit_log(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use nono::AccessMode;
     use nono::supervisor::{ApprovalDecision, AuditEntry, CapabilityRequest, UrlOpenRequest};
     use nono::undo::{NetworkAuditDecision, NetworkAuditEvent, NetworkAuditMode};
-    use nono::AccessMode;
     use std::path::PathBuf;
     use std::time::{Duration, UNIX_EPOCH};
 
@@ -587,8 +587,9 @@ mod tests {
             Ok(_) => panic!("alpha verification should reject records missing event_json"),
             Err(err) => err,
         };
-        assert!(err
-            .to_string()
-            .contains("missing canonical event_json bytes"));
+        assert!(
+            err.to_string()
+                .contains("missing canonical event_json bytes")
+        );
     }
 }

--- a/crates/nono-cli/src/audit_ledger.rs
+++ b/crates/nono-cli/src/audit_ledger.rs
@@ -370,7 +370,7 @@ fn hash_ledger_link(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::test_env::{EnvVarGuard, ENV_LOCK};
+    use crate::test_env::{ENV_LOCK, EnvVarGuard};
     use nono::undo::{
         AuditAttestationSummary, ExecutableIdentity, NetworkAuditDecision, NetworkAuditMode,
     };

--- a/crates/nono-cli/src/audit_session.rs
+++ b/crates/nono-cli/src/audit_session.rs
@@ -235,7 +235,7 @@ fn calculate_dir_size(dir: &Path) -> u64 {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::test_env::{EnvVarGuard, ENV_LOCK};
+    use crate::test_env::{ENV_LOCK, EnvVarGuard};
     use nono::undo::SessionMetadata;
 
     #[test]

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -5,7 +5,7 @@
 
 use crate::cli::SandboxArgs;
 use crate::policy;
-use crate::profile::{expand_vars, Profile};
+use crate::profile::{Profile, expand_vars};
 use crate::protected_paths::{self, ProtectedRoots};
 use nono::{
     AccessMode, CapabilitySet, CapabilitySource, FsCapability, NonoError, Result,
@@ -155,14 +155,14 @@ fn add_cli_unix_socket_caps(
                 if let Some(cap) = try_new_file(path, AccessMode::ReadWrite, LBL_FS_FILE_IMPLIED)? {
                     caps.add_fs(cap);
                 }
-            } else if let Some(parent) = path.parent() {
-                if let Some(cap) = try_new_dir(
+            } else if let Some(parent) = path.parent()
+                && let Some(cap) = try_new_dir(
                     parent,
                     AccessMode::ReadWrite,
                     LBL_FS_DIR_IMPLIED_BIND_PARENT,
-                )? {
-                    caps.add_fs(cap);
-                }
+                )?
+            {
+                caps.add_fs(cap);
             }
         }
     }
@@ -762,11 +762,11 @@ impl CapabilitySetExt for CapabilitySet {
                         cap.source = CapabilitySource::Profile;
                         caps.add_fs(cap);
                     }
-                } else if let Some(parent) = path.parent() {
-                    if let Some(mut cap) = try_new_dir(parent, AccessMode::ReadWrite, &label)? {
-                        cap.source = CapabilitySource::Profile;
-                        caps.add_fs(cap);
-                    }
+                } else if let Some(parent) = path.parent()
+                    && let Some(mut cap) = try_new_dir(parent, AccessMode::ReadWrite, &label)?
+                {
+                    cap.source = CapabilitySource::Profile;
+                    caps.add_fs(cap);
                 }
             }
         }

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -3442,12 +3442,12 @@ mod tests {
         let cli =
             Cli::try_parse_from(["nono", "profile", "show", "default", "--format", "manifest"])
                 .expect("profile show --format manifest must parse");
-        if let Commands::Profile(args) = cli.command {
-            if let ProfileCommands::Show(a) = args.command {
-                assert_eq!(a.profile, "default");
-                assert!(matches!(a.format, Some(ProfileShowFormat::Manifest)));
-                return;
-            }
+        if let Commands::Profile(args) = cli.command
+            && let ProfileCommands::Show(a) = args.command
+        {
+            assert_eq!(a.profile, "default");
+            assert!(matches!(a.format, Some(ProfileShowFormat::Manifest)));
+            return;
         }
         panic!("expected Commands::Profile(Show(..))");
     }
@@ -3456,12 +3456,12 @@ mod tests {
     fn test_profile_show_parses_with_json_and_raw() {
         let cli = Cli::try_parse_from(["nono", "profile", "show", "default", "--json", "--raw"])
             .expect("profile show --json --raw must parse");
-        if let Commands::Profile(args) = cli.command {
-            if let ProfileCommands::Show(a) = args.command {
-                assert!(a.json);
-                assert!(a.raw);
-                return;
-            }
+        if let Commands::Profile(args) = cli.command
+            && let ProfileCommands::Show(a) = args.command
+        {
+            assert!(a.json);
+            assert!(a.raw);
+            return;
         }
         panic!("expected Commands::Profile(Show(..))");
     }
@@ -3470,12 +3470,12 @@ mod tests {
     fn test_profile_groups_parses() {
         let cli = Cli::try_parse_from(["nono", "profile", "groups", "--json", "--all-platforms"])
             .expect("profile groups --json --all-platforms must parse");
-        if let Commands::Profile(args) = cli.command {
-            if let ProfileCommands::Groups(a) = args.command {
-                assert!(a.json);
-                assert!(a.all_platforms);
-                return;
-            }
+        if let Commands::Profile(args) = cli.command
+            && let ProfileCommands::Groups(a) = args.command
+        {
+            assert!(a.json);
+            assert!(a.all_platforms);
+            return;
         }
         panic!("expected Commands::Profile(Groups(..))");
     }
@@ -3484,11 +3484,11 @@ mod tests {
     fn test_profile_groups_with_name() {
         let cli = Cli::try_parse_from(["nono", "profile", "groups", "deny_credentials"])
             .expect("profile groups <name> must parse");
-        if let Commands::Profile(args) = cli.command {
-            if let ProfileCommands::Groups(a) = args.command {
-                assert_eq!(a.name.as_deref(), Some("deny_credentials"));
-                return;
-            }
+        if let Commands::Profile(args) = cli.command
+            && let ProfileCommands::Groups(a) = args.command
+        {
+            assert_eq!(a.name.as_deref(), Some("deny_credentials"));
+            return;
         }
         panic!("expected Commands::Profile(Groups(..))");
     }
@@ -3497,12 +3497,12 @@ mod tests {
     fn test_profile_diff_parses() {
         let cli = Cli::try_parse_from(["nono", "profile", "diff", "a", "b"])
             .expect("profile diff must parse");
-        if let Commands::Profile(args) = cli.command {
-            if let ProfileCommands::Diff(a) = args.command {
-                assert_eq!(a.profile1, "a");
-                assert_eq!(a.profile2, "b");
-                return;
-            }
+        if let Commands::Profile(args) = cli.command
+            && let ProfileCommands::Diff(a) = args.command
+        {
+            assert_eq!(a.profile1, "a");
+            assert_eq!(a.profile2, "b");
+            return;
         }
         panic!("expected Commands::Profile(Diff(..))");
     }
@@ -3511,11 +3511,11 @@ mod tests {
     fn test_profile_validate_parses() {
         let cli = Cli::try_parse_from(["nono", "profile", "validate", "/tmp/p.json"])
             .expect("profile validate must parse");
-        if let Commands::Profile(args) = cli.command {
-            if let ProfileCommands::Validate(a) = args.command {
-                assert_eq!(a.file.to_string_lossy(), "/tmp/p.json");
-                return;
-            }
+        if let Commands::Profile(args) = cli.command
+            && let ProfileCommands::Validate(a) = args.command
+        {
+            assert_eq!(a.file.to_string_lossy(), "/tmp/p.json");
+            return;
         }
         panic!("expected Commands::Profile(Validate(..))");
     }

--- a/crates/nono-cli/src/cli_bootstrap.rs
+++ b/crates/nono-cli/src/cli_bootstrap.rs
@@ -4,8 +4,8 @@ use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use tracing_subscriber::fmt::writer::MakeWriter;
 use tracing_subscriber::EnvFilter;
+use tracing_subscriber::fmt::writer::MakeWriter;
 
 pub(crate) fn normalize_legacy_flag_env_vars() {
     copy_legacy_env_var("NONO_NET_BLOCK", "NONO_BLOCK_NET");
@@ -123,7 +123,9 @@ fn copy_legacy_env_var(old: &str, new: &str) {
     }
 
     if let Some(value) = std::env::var_os(old) {
-        std::env::set_var(new, value);
+        // SAFETY: called during single-threaded CLI bootstrap, before any
+        // threads are spawned.
+        unsafe { std::env::set_var(new, value) };
     }
 }
 

--- a/crates/nono-cli/src/command_blocking_deprecation.rs
+++ b/crates/nono-cli/src/command_blocking_deprecation.rs
@@ -8,12 +8,10 @@ use crate::profile::Profile;
 use nono::manifest::CapabilityManifest;
 use std::path::Path;
 
-const DEPRECATION_SUMMARY: &str =
-    "deprecated in v0.33.0: startup-only command gating, not kernel-enforced. \
+const DEPRECATION_SUMMARY: &str = "deprecated in v0.33.0: startup-only command gating, not kernel-enforced. \
      Child processes can bypass it. Prefer resource-based controls such as \
      add_deny_access, narrower filesystem grants, unlink_protection, and network policy.";
-pub(crate) const BLOCKED_COMMAND_REASON: &str =
-    "Command blocking is deprecated in v0.33.0 and only checks the directly-invoked \
+pub(crate) const BLOCKED_COMMAND_REASON: &str = "Command blocking is deprecated in v0.33.0 and only checks the directly-invoked \
      startup command. Child processes can bypass it. Prefer resource-based controls \
      such as add_deny_access, narrower filesystem grants, unlink_protection, and \
      network policy.";

--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -2,9 +2,9 @@ use crate::cli::{RunArgs, SandboxArgs, ShellArgs, WrapArgs};
 use crate::exec_strategy;
 use crate::execution_runtime::execute_sandboxed;
 use crate::launch_runtime::{
-    load_configured_detach_sequence, load_configured_redaction_policy, prepare_run_launch_plan,
-    resolve_requested_workdir, select_exec_strategy, ExecutionFlags, LaunchPlan,
-    SessionLaunchOptions,
+    ExecutionFlags, LaunchPlan, SessionLaunchOptions, load_configured_detach_sequence,
+    load_configured_redaction_policy, prepare_run_launch_plan, resolve_requested_workdir,
+    select_exec_strategy,
 };
 use crate::output;
 use crate::profile;

--- a/crates/nono-cli/src/config/mod.rs
+++ b/crates/nono-cli/src/config/mod.rs
@@ -140,74 +140,102 @@ mod tests {
 
     #[test]
     fn test_check_blocked_command_basic() {
-        assert!(check_blocked_command("echo", &[], &[])
-            .expect("should not fail")
-            .is_none());
-        assert!(check_blocked_command("ls", &[], &[])
-            .expect("should not fail")
-            .is_none());
+        assert!(
+            check_blocked_command("echo", &[], &[])
+                .expect("should not fail")
+                .is_none()
+        );
+        assert!(
+            check_blocked_command("ls", &[], &[])
+                .expect("should not fail")
+                .is_none()
+        );
     }
 
     #[test]
     fn test_check_blocked_command_with_path() {
         let blocked = vec!["rm".to_string(), "dd".to_string()];
-        assert!(check_blocked_command("/bin/rm", &[], &blocked)
-            .expect("should not fail")
-            .is_some());
-        assert!(check_blocked_command("/usr/bin/dd", &[], &blocked)
-            .expect("should not fail")
-            .is_some());
+        assert!(
+            check_blocked_command("/bin/rm", &[], &blocked)
+                .expect("should not fail")
+                .is_some()
+        );
+        assert!(
+            check_blocked_command("/usr/bin/dd", &[], &blocked)
+                .expect("should not fail")
+                .is_some()
+        );
     }
 
     #[test]
     fn test_check_blocked_command_with_override() {
         let allowed = vec!["rm".to_string()];
         let blocked = vec!["rm".to_string(), "dd".to_string()];
-        assert!(check_blocked_command("rm", &allowed, &blocked)
-            .expect("should not fail")
-            .is_none());
-        assert!(check_blocked_command("dd", &allowed, &blocked)
-            .expect("should not fail")
-            .is_some());
+        assert!(
+            check_blocked_command("rm", &allowed, &blocked)
+                .expect("should not fail")
+                .is_none()
+        );
+        assert!(
+            check_blocked_command("dd", &allowed, &blocked)
+                .expect("should not fail")
+                .is_some()
+        );
     }
 
     #[test]
     fn test_check_blocked_command_extra_blocked() {
         let extra = vec!["custom-dangerous".to_string()];
-        assert!(check_blocked_command("custom-dangerous", &[], &extra)
-            .expect("should not fail")
-            .is_some());
-        assert!(check_blocked_command("rm", &[], &extra)
-            .expect("should not fail")
-            .is_none());
+        assert!(
+            check_blocked_command("custom-dangerous", &[], &extra)
+                .expect("should not fail")
+                .is_some()
+        );
+        assert!(
+            check_blocked_command("rm", &[], &extra)
+                .expect("should not fail")
+                .is_none()
+        );
     }
 
     #[test]
     fn test_check_blocked_command_only_uses_resolved_policy() {
-        assert!(check_blocked_command("rm", &[], &[])
-            .expect("should not fail")
-            .is_none());
+        assert!(
+            check_blocked_command("rm", &[], &[])
+                .expect("should not fail")
+                .is_none()
+        );
     }
 
     #[test]
     fn test_check_sensitive_path() {
-        assert!(check_sensitive_path("~/.ssh")
-            .expect("should not fail")
-            .is_some());
-        assert!(check_sensitive_path("~/.aws")
-            .expect("should not fail")
-            .is_some());
-        assert!(check_sensitive_path("~/.bashrc")
-            .expect("should not fail")
-            .is_some());
+        assert!(
+            check_sensitive_path("~/.ssh")
+                .expect("should not fail")
+                .is_some()
+        );
+        assert!(
+            check_sensitive_path("~/.aws")
+                .expect("should not fail")
+                .is_some()
+        );
+        assert!(
+            check_sensitive_path("~/.bashrc")
+                .expect("should not fail")
+                .is_some()
+        );
         // /tmp is a system path, not sensitive
-        assert!(check_sensitive_path("/tmp")
-            .expect("should not fail")
-            .is_none());
+        assert!(
+            check_sensitive_path("/tmp")
+                .expect("should not fail")
+                .is_none()
+        );
         // ~/Documents is not sensitive
-        assert!(check_sensitive_path("~/Documents")
-            .expect("should not fail")
-            .is_none());
+        assert!(
+            check_sensitive_path("~/Documents")
+                .expect("should not fail")
+                .is_none()
+        );
     }
 
     #[test]
@@ -215,13 +243,17 @@ mod tests {
         // ~/.sshevil must NOT match ~/.ssh (component-wise comparison)
         let home = validated_home().expect("HOME must be set");
         let evil_path = format!("{}/.sshevil", home);
-        assert!(check_sensitive_path(&evil_path)
-            .expect("should not fail")
-            .is_none());
+        assert!(
+            check_sensitive_path(&evil_path)
+                .expect("should not fail")
+                .is_none()
+        );
 
         // But ~/.ssh/id_rsa should match ~/.ssh
-        assert!(check_sensitive_path("~/.ssh/id_rsa")
-            .expect("should not fail")
-            .is_some());
+        assert!(
+            check_sensitive_path("~/.ssh/id_rsa")
+                .expect("should not fail")
+                .is_some()
+        );
     }
 }

--- a/crates/nono-cli/src/config/user.rs
+++ b/crates/nono-cli/src/config/user.rs
@@ -388,10 +388,12 @@ alice = { name = "Alice", fingerprint = "abc123" }
         assert_eq!(config.meta.version, 1);
 
         // Check overrides
-        assert!(config
-            .overrides
-            .sensitive_paths
-            .contains_key("~/.ssh/id_rsa.pub"));
+        assert!(
+            config
+                .overrides
+                .sensitive_paths
+                .contains_key("~/.ssh/id_rsa.pub")
+        );
         let ssh_override = &config.overrides.sensitive_paths["~/.ssh/id_rsa.pub"];
         assert_eq!(ssh_override.reason, "Public key for git");
         assert_eq!(ssh_override.access.as_deref(), Some("read"));

--- a/crates/nono-cli/src/config/version.rs
+++ b/crates/nono-cli/src/config/version.rs
@@ -77,14 +77,14 @@ impl VersionTracker {
     ///
     /// Returns Ok(()) if version is acceptable, Err if it's a downgrade attack.
     pub fn check_version(&self, name: &str, version: u64) -> Result<()> {
-        if let Some(state) = self.configs.get(name) {
-            if version < state.version {
-                return Err(NonoError::VersionDowngrade {
-                    config: name.to_string(),
-                    current: state.version,
-                    attempted: version,
-                });
-            }
+        if let Some(state) = self.configs.get(name)
+            && version < state.version
+        {
+            return Err(NonoError::VersionDowngrade {
+                config: name.to_string(),
+                current: state.version,
+                attempted: version,
+            });
         }
         Ok(())
     }

--- a/crates/nono-cli/src/credential_runtime.rs
+++ b/crates/nono-cli/src/credential_runtime.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use tracing::info;
 
 fn parse_env_credential_map_args(values: &[String]) -> Result<Vec<(String, String)>> {
-    if values.len() % 2 != 0 {
+    if !values.len().is_multiple_of(2) {
         return Err(NonoError::ConfigParse(
             "--env-credential-map expects pairs: <CREDENTIAL_REF> <ENV_VAR>".to_string(),
         ));

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -530,23 +530,20 @@ pub fn execute_supervised(
                 // Create a shim `open` script that delegates to nono open-url-helper.
                 // The npm `open` package spawns `open <url>` on macOS; by placing our
                 // shim earlier in PATH, we intercept the call.
-                if let Some(fd) = child_sock_fd {
-                    if let Some(shim) = create_open_shim(&nono_exe, fd) {
-                        // Prepend shim dir to PATH and also set BROWSER for any tool
-                        // that does respect it.
-                        let current_path = std::env::var("PATH").unwrap_or_default();
-                        let new_path = format!("PATH={}:{current_path}", shim.dir.path().display());
-                        if let Ok(cstr) = CString::new(new_path) {
-                            // Remove existing PATH from env_c, then add our modified one
-                            env_c.retain(|c| !c.as_bytes().starts_with(b"PATH="));
-                            env_c.push(cstr);
-                        }
-                        let browser_cmd = format!("BROWSER={}", shim.launcher.display());
-                        if let Ok(cstr) = CString::new(browser_cmd) {
-                            env_c.push(cstr);
-                        }
-                        browser_shim = Some(shim);
+                if let Some(fd) = child_sock_fd
+                    && let Some(shim) = create_open_shim(&nono_exe, fd)
+                {
+                    let current_path = std::env::var("PATH").unwrap_or_default();
+                    let new_path = format!("PATH={}:{current_path}", shim.dir.path().display());
+                    if let Ok(cstr) = CString::new(new_path) {
+                        env_c.retain(|c| !c.as_bytes().starts_with(b"PATH="));
+                        env_c.push(cstr);
                     }
+                    let browser_cmd = format!("BROWSER={}", shim.launcher.display());
+                    if let Ok(cstr) = CString::new(browser_cmd) {
+                        env_c.push(cstr);
+                    }
+                    browser_shim = Some(shim);
                 }
             }
         }
@@ -1975,17 +1972,17 @@ fn run_supervisor_loop(
                 }
             }
 
-            if let Some(ref mut p) = pty {
-                if !handle_pty_poll_events(
+            if let Some(ref mut p) = pty
+                && !handle_pty_poll_events(
                     p,
                     pfds[1].revents,
                     pfds[2].revents,
                     pfds[3].revents,
                     pfds[4].revents,
                     "supervisor loop",
-                ) {
-                    break;
-                }
+                )
+            {
+                break;
             }
         } else if ret < 0 {
             let err = std::io::Error::last_os_error();
@@ -1996,10 +1993,10 @@ fn run_supervisor_loop(
         }
 
         let pause_requested = drain_pause_pipe();
-        if let Some(ref mut p) = pty {
-            if pause_requested {
-                p.sync_current_terminal_winsize();
-            }
+        if let Some(ref mut p) = pty
+            && pause_requested
+        {
+            p.sync_current_terminal_winsize();
         }
         let in_band_detach_requested = pty.as_mut().is_some_and(|p| p.take_detach_request());
         handle_pty_detach_request(

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -18,8 +18,8 @@ use crate::startup_prompt::{print_terminal_safe_stderr, prompt_startup_terminati
 use crate::{DETACHED_CWD_PROMPT_RESPONSE_ENV, DETACHED_LAUNCH_ENV, DETACHED_SESSION_ID_ENV};
 use nix::libc;
 use nix::sys::signal::{self, Signal};
-use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
-use nix::unistd::{fork, ForkResult, Pid};
+use nix::sys::wait::{WaitPidFlag, WaitStatus, waitpid};
+use nix::unistd::{ForkResult, Pid, fork};
 use nono::supervisor::{ApprovalDecision, AuditEntry, SupervisorMessage, SupervisorResponse};
 use nono::{
     ApprovalBackend, CapabilitySet, DenialReason, DenialRecord, DiagnosticFormatter,
@@ -330,15 +330,15 @@ pub fn execute_direct(config: &ExecConfig<'_>) -> Result<()> {
         ) {
             continue;
         }
-        if let Some(ref denied) = config.denied_env_vars {
-            if env_sanitization::is_env_var_denied(&key, denied) {
-                continue;
-            }
+        if let Some(ref denied) = config.denied_env_vars
+            && env_sanitization::is_env_var_denied(&key, denied)
+        {
+            continue;
         }
-        if let Some(ref allowed) = config.allowed_env_vars {
-            if !env_sanitization::is_env_var_allowed(&key, allowed) {
-                continue;
-            }
+        if let Some(ref allowed) = config.allowed_env_vars
+            && !env_sanitization::is_env_var_allowed(&key, allowed)
+        {
+            continue;
         }
         cmd.env(&key, &value);
     }
@@ -464,15 +464,15 @@ pub fn execute_supervised(
             ) {
                 continue;
             }
-            if let Some(ref denied) = config.denied_env_vars {
-                if env_sanitization::is_env_var_denied(k, denied) {
-                    continue;
-                }
+            if let Some(ref denied) = config.denied_env_vars
+                && env_sanitization::is_env_var_denied(k, denied)
+            {
+                continue;
             }
-            if let Some(ref allowed) = config.allowed_env_vars {
-                if !env_sanitization::is_env_var_allowed(k, allowed) {
-                    continue;
-                }
+            if let Some(ref allowed) = config.allowed_env_vars
+                && !env_sanitization::is_env_var_allowed(k, allowed)
+            {
+                continue;
             }
             if let Ok(cstr) = CString::new(format!("{}={}", k, v)) {
                 env_c.push(cstr);
@@ -481,10 +481,10 @@ pub fn execute_supervised(
     }
 
     // Add NONO_CAP_FILE
-    if let Some(cap_file_str) = config.cap_file.to_str() {
-        if let Ok(cstr) = CString::new(format!("NONO_CAP_FILE={}", cap_file_str)) {
-            env_c.push(cstr);
-        }
+    if let Some(cap_file_str) = config.cap_file.to_str()
+        && let Ok(cstr) = CString::new(format!("NONO_CAP_FILE={}", cap_file_str))
+    {
+        env_c.push(cstr);
     }
 
     // Add user-specified environment variables (secrets, etc.)
@@ -508,45 +508,44 @@ pub fn execute_supervised(
     // `/usr/bin/open`. Seatbelt blocks that from launching URLs. Instead, we
     // create a shim script named `open` in a temp directory and prepend it to
     // PATH so the npm `open` package hits our shim first.
-    if supervisor.is_some() {
-        if let Ok(nono_exe) = std::env::current_exe() {
-            #[cfg(target_os = "linux")]
+    if supervisor.is_some()
+        && let Ok(nono_exe) = std::env::current_exe()
+    {
+        #[cfg(target_os = "linux")]
+        {
+            if let Some(fd) = child_sock_fd
+                && let Some(shim) = create_linux_browser_shim(&nono_exe, fd)
             {
+                let browser_cmd = format!("BROWSER={}", shim.launcher.display());
+                if let Ok(cstr) = CString::new(browser_cmd) {
+                    env_c.push(cstr);
+                }
+                browser_shim = Some(shim);
+            }
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            if should_install_macos_open_shim(supervisor) {
+                // Create a shim `open` script that delegates to nono open-url-helper.
+                // The npm `open` package spawns `open <url>` on macOS; by placing our
+                // shim earlier in PATH, we intercept the call.
                 if let Some(fd) = child_sock_fd {
-                    if let Some(shim) = create_linux_browser_shim(&nono_exe, fd) {
+                    if let Some(shim) = create_open_shim(&nono_exe, fd) {
+                        // Prepend shim dir to PATH and also set BROWSER for any tool
+                        // that does respect it.
+                        let current_path = std::env::var("PATH").unwrap_or_default();
+                        let new_path = format!("PATH={}:{current_path}", shim.dir.path().display());
+                        if let Ok(cstr) = CString::new(new_path) {
+                            // Remove existing PATH from env_c, then add our modified one
+                            env_c.retain(|c| !c.as_bytes().starts_with(b"PATH="));
+                            env_c.push(cstr);
+                        }
                         let browser_cmd = format!("BROWSER={}", shim.launcher.display());
                         if let Ok(cstr) = CString::new(browser_cmd) {
                             env_c.push(cstr);
                         }
                         browser_shim = Some(shim);
-                    }
-                }
-            }
-
-            #[cfg(target_os = "macos")]
-            {
-                if should_install_macos_open_shim(supervisor) {
-                    // Create a shim `open` script that delegates to nono open-url-helper.
-                    // The npm `open` package spawns `open <url>` on macOS; by placing our
-                    // shim earlier in PATH, we intercept the call.
-                    if let Some(fd) = child_sock_fd {
-                        if let Some(shim) = create_open_shim(&nono_exe, fd) {
-                            // Prepend shim dir to PATH and also set BROWSER for any tool
-                            // that does respect it.
-                            let current_path = std::env::var("PATH").unwrap_or_default();
-                            let new_path =
-                                format!("PATH={}:{current_path}", shim.dir.path().display());
-                            if let Ok(cstr) = CString::new(new_path) {
-                                // Remove existing PATH from env_c, then add our modified one
-                                env_c.retain(|c| !c.as_bytes().starts_with(b"PATH="));
-                                env_c.push(cstr);
-                            }
-                            let browser_cmd = format!("BROWSER={}", shim.launcher.display());
-                            if let Ok(cstr) = CString::new(browser_cmd) {
-                                env_c.push(cstr);
-                            }
-                            browser_shim = Some(shim);
-                        }
                     }
                 }
             }
@@ -678,21 +677,21 @@ pub fn execute_supervised(
             // and later into any helper (`open-url-helper`) that needs to speak
             // IPC back to the unsandboxed parent. `UnixStream::pair()` creates
             // fds with close-on-exec set, so clear it on the child end here.
-            if let Some(fd) = child_sock_fd {
-                if let Err(e) = clear_close_on_exec(fd) {
-                    let detail = format!(
-                        "nono: failed to clear close-on-exec on supervisor socket: {}\n",
-                        e
+            if let Some(fd) = child_sock_fd
+                && let Err(e) = clear_close_on_exec(fd)
+            {
+                let detail = format!(
+                    "nono: failed to clear close-on-exec on supervisor socket: {}\n",
+                    e
+                );
+                let msg = detail.as_bytes();
+                unsafe {
+                    libc::write(
+                        libc::STDERR_FILENO,
+                        msg.as_ptr().cast::<libc::c_void>(),
+                        msg.len(),
                     );
-                    let msg = detail.as_bytes();
-                    unsafe {
-                        libc::write(
-                            libc::STDERR_FILENO,
-                            msg.as_ptr().cast::<libc::c_void>(),
-                            msg.len(),
-                        );
-                        libc::_exit(126);
-                    }
+                    libc::_exit(126);
                 }
             }
 
@@ -767,33 +766,17 @@ pub fn execute_supervised(
                             msg.len(),
                         );
                     }
-                } else if config.capability_elevation {
-                    if let Some(fd) = child_sock_fd {
-                        match nono::sandbox::install_seccomp_notify() {
-                            Ok(notify_fd) => {
-                                if let Err(e) = nono::supervisor::socket::send_fd_via_socket(
-                                    fd,
-                                    notify_fd.as_raw_fd(),
-                                ) {
-                                    let detail = format!(
-                                        "nono: failed to send seccomp notify fd to supervisor: {}\n",
-                                        e
-                                    );
-                                    let msg = detail.as_bytes();
-                                    unsafe {
-                                        libc::write(
-                                            libc::STDERR_FILENO,
-                                            msg.as_ptr().cast::<libc::c_void>(),
-                                            msg.len(),
-                                        );
-                                        libc::_exit(126);
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                // seccomp not available -- proceed without transparent expansion
+                } else if config.capability_elevation
+                    && let Some(fd) = child_sock_fd
+                {
+                    match nono::sandbox::install_seccomp_notify() {
+                        Ok(notify_fd) => {
+                            if let Err(e) = nono::supervisor::socket::send_fd_via_socket(
+                                fd,
+                                notify_fd.as_raw_fd(),
+                            ) {
                                 let detail = format!(
-                                    "nono: seccomp-notify not available, expansion disabled: {}\n",
+                                    "nono: failed to send seccomp notify fd to supervisor: {}\n",
                                     e
                                 );
                                 let msg = detail.as_bytes();
@@ -803,7 +786,23 @@ pub fn execute_supervised(
                                         msg.as_ptr().cast::<libc::c_void>(),
                                         msg.len(),
                                     );
+                                    libc::_exit(126);
                                 }
+                            }
+                        }
+                        Err(e) => {
+                            // seccomp not available -- proceed without transparent expansion
+                            let detail = format!(
+                                "nono: seccomp-notify not available, expansion disabled: {}\n",
+                                e
+                            );
+                            let msg = detail.as_bytes();
+                            unsafe {
+                                libc::write(
+                                    libc::STDERR_FILENO,
+                                    msg.as_ptr().cast::<libc::c_void>(),
+                                    msg.len(),
+                                );
                             }
                         }
                     }
@@ -1293,8 +1292,8 @@ fn build_policy_explanations(
     sandbox_violations: &[nono::SandboxViolation],
     caps: &nono::CapabilitySet,
 ) -> Vec<nono::diagnostic::PolicyExplanation> {
-    use nono::diagnostic::PolicyExplanation;
     use nono::AccessMode;
+    use nono::diagnostic::PolicyExplanation;
     use std::collections::BTreeMap;
 
     // Merge access modes per path so a path denied for both Read and Write
@@ -1332,13 +1331,13 @@ fn build_policy_explanations(
             .or_insert(access);
     }
 
-    if has_keychain_service_violation(sandbox_violations) {
-        if let Some(path) = login_keychain_db_path() {
-            paths
-                .entry(path)
-                .and_modify(|a| *a = merge(*a, AccessMode::Read))
-                .or_insert(AccessMode::Read);
-        }
+    if has_keychain_service_violation(sandbox_violations)
+        && let Some(path) = login_keychain_db_path()
+    {
+        paths
+            .entry(path)
+            .and_modify(|a| *a = merge(*a, AccessMode::Read))
+            .or_insert(AccessMode::Read);
     }
 
     let mut explanations = Vec::new();
@@ -1575,13 +1574,14 @@ fn wait_for_child_with_startup_timeout(
     loop {
         match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
             Ok(WaitStatus::StillAlive) => {
-                if let Some((deadline, timeout_cfg)) = startup_deadline {
-                    if Instant::now() >= deadline && !startup_prompted {
-                        startup_prompted = true;
-                        if prompt_startup_termination_for_child(child, timeout_cfg, true, None) {
-                            let _ = signal::kill(child, Signal::SIGKILL);
-                            return wait_for_child(child);
-                        }
+                if let Some((deadline, timeout_cfg)) = startup_deadline
+                    && Instant::now() >= deadline
+                    && !startup_prompted
+                {
+                    startup_prompted = true;
+                    if prompt_startup_termination_for_child(child, timeout_cfg, true, None) {
+                        let _ = signal::kill(child, Signal::SIGKILL);
+                        return wait_for_child(child);
                     }
                 }
                 std::thread::sleep(Duration::from_millis(200));
@@ -1670,13 +1670,13 @@ fn setup_signal_forwarding(child: Pid, pty_master_fd: Option<i32>) {
             }
         }
 
-        if pty_master_fd.is_some() {
-            if let Err(e) = signal::signal(
+        if pty_master_fd.is_some()
+            && let Err(e) = signal::signal(
                 Signal::SIGWINCH,
                 signal::SigHandler::Handler(forward_signal),
-            ) {
-                debug!("Failed to install SIGWINCH handler: {:?}", e);
-            }
+            )
+        {
+            debug!("Failed to install SIGWINCH handler: {:?}", e);
         }
     }
 }
@@ -1819,12 +1819,12 @@ fn handle_pty_detach_request(
     if in_band_detach_requested {
         info!("PTY detach requested via in-band key sequence");
     }
-    if let Some(p) = pty {
-        if pause_requested || in_band_detach_requested {
-            let in_alt_screen = p.in_alt_screen();
-            if detach_client_for_session(p) {
-                restore_terminal_after_detach(in_alt_screen);
-            }
+    if let Some(p) = pty
+        && (pause_requested || in_band_detach_requested)
+    {
+        let in_alt_screen = p.in_alt_screen();
+        if detach_client_for_session(p) {
+            restore_terminal_after_detach(in_alt_screen);
         }
     }
 }
@@ -2184,49 +2184,45 @@ fn run_supervisor_loop(
                     }
                 }
 
-                if let Some(notify_idx) = notify_idx {
-                    if pfds[notify_idx].revents & libc::POLLIN != 0 {
-                        if let Some(nfd) = notify_raw_fd {
-                            if let Err(e) = supervisor_linux::handle_seccomp_notification(
-                                nfd,
-                                child,
-                                config,
-                                initial_caps,
-                                &mut rate_limiter,
-                                &mut denials,
-                                trust_interceptor.as_mut(),
-                            ) {
-                                debug!("Error handling seccomp notification: {}", e);
-                            }
-                        }
-                    }
+                if let Some(notify_idx) = notify_idx
+                    && pfds[notify_idx].revents & libc::POLLIN != 0
+                    && let Some(nfd) = notify_raw_fd
+                    && let Err(e) = supervisor_linux::handle_seccomp_notification(
+                        nfd,
+                        child,
+                        config,
+                        initial_caps,
+                        &mut rate_limiter,
+                        &mut denials,
+                        trust_interceptor.as_mut(),
+                    )
+                {
+                    debug!("Error handling seccomp notification: {}", e);
                 }
 
-                if let Some(proxy_notify_idx) = proxy_notify_idx {
-                    if pfds[proxy_notify_idx].revents & libc::POLLIN != 0 {
-                        if let Some(pfd) = proxy_notify_raw_fd {
-                            if let Err(e) = supervisor_linux::handle_network_notification(
-                                pfd,
-                                config,
-                                &mut rate_limiter,
-                            ) {
-                                debug!("Error handling proxy seccomp notification: {}", e);
-                            }
-                        }
-                    }
+                if let Some(proxy_notify_idx) = proxy_notify_idx
+                    && pfds[proxy_notify_idx].revents & libc::POLLIN != 0
+                    && let Some(pfd) = proxy_notify_raw_fd
+                    && let Err(e) = supervisor_linux::handle_network_notification(
+                        pfd,
+                        config,
+                        &mut rate_limiter,
+                    )
+                {
+                    debug!("Error handling proxy seccomp notification: {}", e);
                 }
 
-                if let Some(ref mut p) = pty {
-                    if !handle_pty_poll_events(
+                if let Some(ref mut p) = pty
+                    && !handle_pty_poll_events(
                         p,
                         pfds[pty_base_idx].revents,
                         pfds[pty_base_idx + 1].revents,
                         pfds[pty_base_idx + 2].revents,
                         pfds[pty_base_idx + 3].revents,
                         "supervisor loop",
-                    ) {
-                        break;
-                    }
+                    )
+                {
+                    break;
                 }
             }
             std::cmp::Ordering::Less => {
@@ -2240,10 +2236,10 @@ fn run_supervisor_loop(
         }
 
         let pause_requested = drain_pause_pipe();
-        if let Some(ref mut p) = pty {
-            if pause_requested {
-                p.sync_current_terminal_winsize();
-            }
+        if let Some(ref mut p) = pty
+            && pause_requested
+        {
+            p.sync_current_terminal_winsize();
         }
         let in_band_detach_requested = pty.as_mut().is_some_and(|p| p.take_detach_request());
         handle_pty_detach_request(
@@ -2999,13 +2995,13 @@ fn validate_procfs_access(
         )));
     }
 
-    if let Some(component) = sensitive_component {
-        if SELF_BLOCKED_PROC_NAMES.contains(&component) {
-            return Err(OpenPathError::policy_blocked(format!(
-                "Access to {} is blocked by policy",
-                resolved_path.display(),
-            )));
-        }
+    if let Some(component) = sensitive_component
+        && SELF_BLOCKED_PROC_NAMES.contains(&component)
+    {
+        return Err(OpenPathError::policy_blocked(format!(
+            "Access to {} is blocked by policy",
+            resolved_path.display(),
+        )));
     }
 
     Ok(())
@@ -3299,12 +3295,16 @@ mod tests {
 
         crate::profile_save_runtime::configure_prompt_termios(&mut termios);
 
-        assert!(termios
-            .input_flags
-            .contains(InputFlags::ICRNL | InputFlags::IXON));
-        assert!(!termios
-            .input_flags
-            .intersects(InputFlags::IGNBRK | InputFlags::INLCR | InputFlags::IGNCR));
+        assert!(
+            termios
+                .input_flags
+                .contains(InputFlags::ICRNL | InputFlags::IXON)
+        );
+        assert!(
+            !termios
+                .input_flags
+                .intersects(InputFlags::IGNBRK | InputFlags::INLCR | InputFlags::IGNCR)
+        );
         assert!(termios.output_flags.contains(OutputFlags::OPOST));
         assert!(termios.local_flags.contains(
             LocalFlags::ECHO
@@ -3891,11 +3891,13 @@ mod tests {
         // Disallowed origin: must fail validation
         let result = validate_url("https://evil.example.com/phishing", &config);
         assert!(result.is_err());
-        assert!(result
-            .as_ref()
-            .err()
-            .map(|e| e.contains("not in the profile"))
-            .unwrap_or(false));
+        assert!(
+            result
+                .as_ref()
+                .err()
+                .map(|e| e.contains("not in the profile"))
+                .unwrap_or(false)
+        );
     }
 
     #[test]
@@ -3920,11 +3922,13 @@ mod tests {
 
         let result = validate_url("file:///etc/passwd", &config);
         assert!(result.is_err());
-        assert!(result
-            .as_ref()
-            .err()
-            .map(|e| e.contains("Only https://"))
-            .unwrap_or(false));
+        assert!(
+            result
+                .as_ref()
+                .err()
+                .map(|e| e.contains("Only https://"))
+                .unwrap_or(false)
+        );
 
         let result = validate_url("javascript:alert(1)", &config);
         assert!(result.is_err());
@@ -3969,11 +3973,13 @@ mod tests {
         // Localhost denied when not allowed
         let result = validate_url("http://localhost:8080/callback", &config_deny);
         assert!(result.is_err());
-        assert!(result
-            .as_ref()
-            .err()
-            .map(|e| e.contains("not allowed"))
-            .unwrap_or(false));
+        assert!(
+            result
+                .as_ref()
+                .err()
+                .map(|e| e.contains("not allowed"))
+                .unwrap_or(false)
+        );
 
         // Localhost allowed when configured
         let result = validate_url("http://localhost:8080/callback", &config_allow);
@@ -4006,11 +4012,13 @@ mod tests {
         let long_url = format!("https://example.com/{}", "a".repeat(MAX_URL_LENGTH));
         let result = validate_url(&long_url, &config);
         assert!(result.is_err());
-        assert!(result
-            .as_ref()
-            .err()
-            .map(|e| e.contains("maximum length"))
-            .unwrap_or(false));
+        assert!(
+            result
+                .as_ref()
+                .err()
+                .map(|e| e.contains("maximum length"))
+                .unwrap_or(false)
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -11,7 +11,7 @@
 
 use super::*;
 use crate::trust_intercept::TrustInterceptor;
-use nono::{try_canonicalize, AccessMode};
+use nono::{AccessMode, try_canonicalize};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct InitialCapability {
@@ -135,9 +135,9 @@ pub(super) fn handle_seccomp_notification(
     mut trust_interceptor: Option<&mut TrustInterceptor>,
 ) -> Result<()> {
     use nono::sandbox::{
-        classify_access_from_flags, continue_notif, deny_notif, inject_fd, notif_id_valid,
-        read_notif_path, read_open_how, recv_notif, resolve_notif_path, respond_notif_errno,
-        validate_openat2_size, SYS_OPENAT, SYS_OPENAT2,
+        SYS_OPENAT, SYS_OPENAT2, classify_access_from_flags, continue_notif, deny_notif, inject_fd,
+        notif_id_valid, read_notif_path, read_open_how, recv_notif, resolve_notif_path,
+        respond_notif_errno, validate_openat2_size,
     };
 
     // 1. Receive the notification
@@ -319,15 +319,15 @@ pub(super) fn handle_seccomp_notification(
                     Some(procfs_context),
                 ) {
                     Ok(file) => {
-                        if notif_id_valid(notify_fd, notif.id)? {
-                            if let Err(e) = inject_fd(notify_fd, notif.id, file.as_raw_fd()) {
-                                debug!(
-                                    "inject_fd failed for initial-set proc path {}: {}",
-                                    path.display(),
-                                    e
-                                );
-                                let _ = deny_notif(notify_fd, notif.id);
-                            }
+                        if notif_id_valid(notify_fd, notif.id)?
+                            && let Err(e) = inject_fd(notify_fd, notif.id, file.as_raw_fd())
+                        {
+                            debug!(
+                                "inject_fd failed for initial-set proc path {}: {}",
+                                path.display(),
+                                e
+                            );
+                            let _ = deny_notif(notify_fd, notif.id);
                         }
                     }
                     Err(e) => {
@@ -351,15 +351,15 @@ pub(super) fn handle_seccomp_notification(
                         }
                     }
                 }
-            } else if notif_id_valid(notify_fd, notif.id)? {
-                if let Err(e) = continue_notif(notify_fd, notif.id) {
-                    debug!(
-                        "continue_notif failed for initial-set path {}: {}",
-                        path.display(),
-                        e
-                    );
-                    let _ = deny_notif(notify_fd, notif.id);
-                }
+            } else if notif_id_valid(notify_fd, notif.id)?
+                && let Err(e) = continue_notif(notify_fd, notif.id)
+            {
+                debug!(
+                    "continue_notif failed for initial-set path {}: {}",
+                    path.display(),
+                    e
+                );
+                let _ = deny_notif(notify_fd, notif.id);
             }
             return Ok(());
         }
@@ -377,15 +377,15 @@ pub(super) fn handle_seccomp_notification(
             if e.kind() == std::io::ErrorKind::NotFound
                 || e.raw_os_error() == Some(libc::ENOTDIR) =>
         {
-            if notif_id_valid(notify_fd, notif.id)? {
-                if let Err(send_err) = continue_notif(notify_fd, notif.id) {
-                    debug!(
-                        "continue_notif failed for missing path {}: {}",
-                        path.display(),
-                        send_err
-                    );
-                    let _ = deny_notif(notify_fd, notif.id);
-                }
+            if notif_id_valid(notify_fd, notif.id)?
+                && let Err(send_err) = continue_notif(notify_fd, notif.id)
+            {
+                debug!(
+                    "continue_notif failed for missing path {}: {}",
+                    path.display(),
+                    send_err
+                );
+                let _ = deny_notif(notify_fd, notif.id);
             }
             return Ok(());
         }
@@ -576,7 +576,7 @@ pub(super) fn decide_network_notification(
     sockaddr: &nono::sandbox::SockaddrInfo,
     config: &SupervisorConfig<'_>,
 ) -> NetworkDecision {
-    use nono::sandbox::{UnixSocketKind, SYS_BIND, SYS_CONNECT};
+    use nono::sandbox::{SYS_BIND, SYS_CONNECT, UnixSocketKind};
 
     // AF_UNIX: allow only filesystem-backed (pathname) sockets — Landlock's
     // filesystem rules will then decide whether the specific path is
@@ -946,11 +946,11 @@ mod tests {
     // behavior where `LANDLOCK_ACCESS_NET_*` only scopes TCP.
 
     mod network_decision {
-        use super::super::{decide_network_notification, NetworkDecision, SupervisorConfig};
+        use super::super::{NetworkDecision, SupervisorConfig, decide_network_notification};
         use nix::libc;
-        use nono::sandbox::{SockaddrInfo, UnixSocketKind, SYS_BIND, SYS_CONNECT};
-        use nono::supervisor::{ApprovalDecision, CapabilityRequest};
         use nono::ApprovalBackend;
+        use nono::sandbox::{SYS_BIND, SYS_CONNECT, SockaddrInfo, UnixSocketKind};
+        use nono::supervisor::{ApprovalDecision, CapabilityRequest};
 
         struct DenyAllBackend;
         impl ApprovalBackend for DenyAllBackend {

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -1,7 +1,7 @@
 use crate::audit_attestation::prepare_audit_signer;
-use crate::launch_runtime::{select_threading_context, LaunchPlan};
+use crate::launch_runtime::{LaunchPlan, select_threading_context};
 use crate::proxy_runtime::start_proxy_runtime;
-use crate::supervised_runtime::{execute_supervised_runtime, SupervisedRuntimeContext};
+use crate::supervised_runtime::{SupervisedRuntimeContext, execute_supervised_runtime};
 use crate::{command_blocking_deprecation, config, exec_strategy, output, sandbox_state};
 use nono::undo::{ContentHash, ExecutableIdentity};
 use nono::{CapabilitySet, NonoError, Result, Sandbox};
@@ -141,10 +141,10 @@ fn startup_timeout_profile<'a>(
     explicit_profile: Option<&str>,
 ) -> Option<&'a str> {
     let recommended = recommended_profile?;
-    if let Some(explicit) = explicit_profile {
-        if explicit == recommended || explicit == format!("{recommended}-local") {
-            return None;
-        }
+    if let Some(explicit) = explicit_profile
+        && (explicit == recommended || explicit == format!("{recommended}-local"))
+    {
+        return None;
     }
     Some(recommended)
 }

--- a/crates/nono-cli/src/instruction_deny.rs
+++ b/crates/nono-cli/src/instruction_deny.rs
@@ -76,13 +76,13 @@ fn add_literal_write_deny(caps: &mut CapabilitySet, path: &Path) -> Result<()> {
     caps.add_platform_rule(deny_rule)?;
 
     // Handle macOS symlinks: emit rule for canonical path too
-    if let Ok(canonical) = std::fs::canonicalize(path) {
-        if canonical != path {
-            let canonical_str = canonical.display().to_string();
-            validate_seatbelt_path(&canonical_str)?;
-            let canonical_rule = format!("(deny file-write-data (literal \"{canonical_str}\"))");
-            caps.add_platform_rule(canonical_rule)?;
-        }
+    if let Ok(canonical) = std::fs::canonicalize(path)
+        && canonical != path
+    {
+        let canonical_str = canonical.display().to_string();
+        validate_seatbelt_path(&canonical_str)?;
+        let canonical_rule = format!("(deny file-write-data (literal \"{canonical_str}\"))");
+        caps.add_platform_rule(canonical_rule)?;
     }
 
     Ok(())

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -2,7 +2,7 @@ use crate::cli::RunArgs;
 use crate::config;
 use crate::proxy_runtime::prepare_proxy_launch_options;
 use crate::sandbox_prepare::{
-    prepare_sandbox, print_allow_gpu_warning, print_allow_launch_services_warning, PreparedSandbox,
+    PreparedSandbox, prepare_sandbox, print_allow_gpu_warning, print_allow_launch_services_warning,
 };
 use crate::{exec_strategy, instruction_deny, profile, trust_scan};
 use colored::Colorize;

--- a/crates/nono-cli/src/learn.rs
+++ b/crates/nono-cli/src/learn.rs
@@ -812,10 +812,10 @@ fn parse_nettop_line(line: &str, listening_ports: &HashSet<u16>) -> Option<Netwo
         // than an outbound connection. If the local port matches a known
         // listening port, this is an accepted client connection — the remote
         // address is the client, not a server we're connecting to.
-        if let Some((_, local_port)) = parse_nettop_endpoint(local_part, is_ipv6) {
-            if listening_ports.contains(&local_port) {
-                return None;
-            }
+        if let Some((_, local_port)) = parse_nettop_endpoint(local_part, is_ipv6)
+            && listening_ports.contains(&local_port)
+        {
+            return None;
         }
 
         // Outbound connection — extract remote address and port

--- a/crates/nono-cli/src/learn.rs
+++ b/crates/nono-cli/src/learn.rs
@@ -5,7 +5,7 @@
 //! to be allowed in a nono profile.
 
 use crate::cli::LearnArgs;
-use nono::{try_canonicalize, AccessMode, NonoError, Result};
+use nono::{AccessMode, NonoError, Result, try_canonicalize};
 use std::collections::BTreeSet;
 use std::net::IpAddr;
 use std::path::PathBuf;
@@ -1222,12 +1222,12 @@ fn run_strace(
 
     for line in reader.lines() {
         // Check timeout
-        if let Some(timeout) = timeout_duration {
-            if start.elapsed() > timeout {
-                warn!("Timeout reached, killing child process");
-                let _ = child.kill();
-                break;
-            }
+        if let Some(timeout) = timeout_duration
+            && start.elapsed() > timeout
+        {
+            warn!("Timeout reached, killing child process");
+            let _ = child.kill();
+            break;
         }
 
         let line = match line {
@@ -1442,7 +1442,7 @@ fn unescape_strace_string(s: &str) -> String {
                 }
                 Some('x') => {
                     chars.next(); // consume 'x'
-                                  // Hex escape \xNN - must have exactly 2 hex digits
+                    // Hex escape \xNN - must have exactly 2 hex digits
                     let mut hex = String::new();
                     for _ in 0..2 {
                         if chars.peek().is_some_and(|c| c.is_ascii_hexdigit()) {
@@ -1666,10 +1666,10 @@ fn minimize_learned_entries(learned_entries: &mut BTreeMap<PathBuf, LearnedPathE
 fn is_covered_by_set(path: &Path, allowed: &HashSet<&str>) -> Result<bool> {
     for allowed_path in allowed {
         let allowed_expanded = expand_home(allowed_path)?;
-        if let Ok(allowed_canonical) = std::fs::canonicalize(&allowed_expanded) {
-            if path.starts_with(&allowed_canonical) {
-                return Ok(true);
-            }
+        if let Ok(allowed_canonical) = std::fs::canonicalize(&allowed_expanded)
+            && path.starts_with(&allowed_canonical)
+        {
+            return Ok(true);
         }
         // Also check without canonicalization for paths that may not exist
         let allowed_path_buf = PathBuf::from(&allowed_expanded);
@@ -1685,10 +1685,10 @@ fn is_covered_by_set(path: &Path, allowed: &HashSet<&str>) -> Result<bool> {
 fn is_covered_by_profile(path: &Path, profile_paths: &HashSet<String>) -> Result<bool> {
     for profile_path in profile_paths {
         let expanded = expand_home(profile_path)?;
-        if let Ok(canonical) = std::fs::canonicalize(&expanded) {
-            if path.starts_with(&canonical) {
-                return Ok(true);
-            }
+        if let Ok(canonical) = std::fs::canonicalize(&expanded)
+            && path.starts_with(&canonical)
+        {
+            return Ok(true);
         }
         let path_buf = PathBuf::from(&expanded);
         if path.starts_with(&path_buf) {
@@ -2855,8 +2855,7 @@ mod macos_tests {
 
     #[test]
     fn test_parse_fs_usage_getattrlist() {
-        let line =
-            "14:23:45.123456  getattrlist       /Applications/Safari.app    0.000004   Finder.12345";
+        let line = "14:23:45.123456  getattrlist       /Applications/Safari.app    0.000004   Finder.12345";
         let access = parse_fs_usage_line(line).expect("should parse getattrlist");
         assert_eq!(access.path, PathBuf::from("/Applications/Safari.app"));
         assert!(!access.is_write);

--- a/crates/nono-cli/src/learn_runtime.rs
+++ b/crates/nono-cli/src/learn_runtime.rs
@@ -2,8 +2,8 @@ use crate::cli::LearnArgs;
 #[cfg(target_os = "macos")]
 use crate::command_display::format_command_line;
 use crate::profile_save_runtime::{
-    command_name, confirm, patch_has_policy_overrides, print_patch_preview, print_profile_save,
-    suggested_profile_name, write_profile, PreparedProfileSave, SaveAction,
+    PreparedProfileSave, SaveAction, command_name, confirm, patch_has_policy_overrides,
+    print_patch_preview, print_profile_save, suggested_profile_name, write_profile,
 };
 use crate::{learn, profile};
 use colored::Colorize;
@@ -145,7 +145,9 @@ fn print_macos_run_guidance(args: &LearnArgs, silent: bool) -> Result<()> {
     }
 
     eprintln!();
-    eprintln!("When a path is denied, `nono run` will show diagnostics and offer to save a user profile patch.");
+    eprintln!(
+        "When a path is denied, `nono run` will show diagnostics and offer to save a user profile patch."
+    );
     eprintln!("Legacy unsandboxed tracing remains available with:");
     eprintln!("  nono learn --trace -- {}", command);
 

--- a/crates/nono-cli/src/legacy_cleanup.rs
+++ b/crates/nono-cli/src/legacy_cleanup.rs
@@ -101,11 +101,11 @@ fn scan(home: &Path) -> LegacyArtifacts {
     }
 
     let settings_path = home.join(".claude").join("settings.json");
-    if let Some(entries) = scan_settings(&settings_path, home) {
-        if !entries.is_empty() {
-            artifacts.settings_entries = entries;
-            artifacts.settings_path = Some(settings_path);
-        }
+    if let Some(entries) = scan_settings(&settings_path, home)
+        && !entries.is_empty()
+    {
+        artifacts.settings_entries = entries;
+        artifacts.settings_path = Some(settings_path);
     }
 
     artifacts

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -135,13 +135,13 @@ mod tests {
         resolve_requested_workdir, select_exec_strategy, select_threading_context,
         trust_interception_active,
     };
-    use crate::proxy_runtime::{resolve_effective_proxy_settings, EffectiveProxySettings};
+    use crate::proxy_runtime::{EffectiveProxySettings, resolve_effective_proxy_settings};
+    use crate::sandbox_prepare::PreparedSandbox;
     #[cfg(target_os = "linux")]
     use crate::sandbox_prepare::maybe_enable_gpu;
     use crate::sandbox_prepare::maybe_enable_macos_gpu;
     #[cfg(target_os = "macos")]
     use crate::sandbox_prepare::maybe_enable_macos_launch_services;
-    use crate::sandbox_prepare::PreparedSandbox;
     use crate::startup_runtime::allows_pre_exec_update_check;
     use nono::{AccessMode, CapabilitySet, FsCapability};
 
@@ -168,41 +168,57 @@ mod tests {
 
     #[test]
     fn test_check_blocked_command_basic() {
-        assert!(config::check_blocked_command("echo", &[], &[])
-            .expect("policy must load")
-            .is_none());
-        assert!(config::check_blocked_command("ls", &[], &[])
-            .expect("policy must load")
-            .is_none());
-        assert!(config::check_blocked_command("cat", &[], &[])
-            .expect("policy must load")
-            .is_none());
+        assert!(
+            config::check_blocked_command("echo", &[], &[])
+                .expect("policy must load")
+                .is_none()
+        );
+        assert!(
+            config::check_blocked_command("ls", &[], &[])
+                .expect("policy must load")
+                .is_none()
+        );
+        assert!(
+            config::check_blocked_command("cat", &[], &[])
+                .expect("policy must load")
+                .is_none()
+        );
     }
 
     #[test]
     fn test_check_blocked_command_with_path() {
         let blocked = vec!["rm".to_string(), "dd".to_string()];
-        assert!(config::check_blocked_command("/bin/rm", &[], &blocked)
-            .expect("policy must load")
-            .is_some());
-        assert!(config::check_blocked_command("/usr/bin/dd", &[], &blocked)
-            .expect("policy must load")
-            .is_some());
-        assert!(config::check_blocked_command("./rm", &[], &blocked)
-            .expect("policy must load")
-            .is_some());
+        assert!(
+            config::check_blocked_command("/bin/rm", &[], &blocked)
+                .expect("policy must load")
+                .is_some()
+        );
+        assert!(
+            config::check_blocked_command("/usr/bin/dd", &[], &blocked)
+                .expect("policy must load")
+                .is_some()
+        );
+        assert!(
+            config::check_blocked_command("./rm", &[], &blocked)
+                .expect("policy must load")
+                .is_some()
+        );
     }
 
     #[test]
     fn test_check_blocked_command_allow_override() {
         let allowed = vec!["rm".to_string()];
         let blocked = vec!["rm".to_string(), "dd".to_string()];
-        assert!(config::check_blocked_command("rm", &allowed, &blocked)
-            .expect("policy must load")
-            .is_none());
-        assert!(config::check_blocked_command("dd", &allowed, &blocked)
-            .expect("policy must load")
-            .is_some());
+        assert!(
+            config::check_blocked_command("rm", &allowed, &blocked)
+                .expect("policy must load")
+                .is_none()
+        );
+        assert!(
+            config::check_blocked_command("dd", &allowed, &blocked)
+                .expect("policy must load")
+                .is_some()
+        );
     }
 
     #[test]
@@ -213,16 +229,20 @@ mod tests {
                 .expect("policy must load")
                 .is_some()
         );
-        assert!(config::check_blocked_command("rm", &[], &extra)
-            .expect("policy must load")
-            .is_none());
+        assert!(
+            config::check_blocked_command("rm", &[], &extra)
+                .expect("policy must load")
+                .is_none()
+        );
     }
 
     #[test]
     fn test_check_blocked_command_uses_resolved_policy_only() {
-        assert!(config::check_blocked_command("rm", &[], &[])
-            .expect("policy must load")
-            .is_none());
+        assert!(
+            config::check_blocked_command("rm", &[], &[])
+                .expect("policy must load")
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/migration.rs
+++ b/crates/nono-cli/src/migration.rs
@@ -16,7 +16,7 @@
 use crate::cli::PullArgs;
 use crate::package::ProfileProvider;
 use crate::package_cmd;
-use crate::registry_client::{resolve_registry_url, RegistryClient};
+use crate::registry_client::{RegistryClient, resolve_registry_url};
 use colored::Colorize;
 use nono::Result;
 use std::io::{self, BufRead, IsTerminal, Write};
@@ -301,7 +301,7 @@ fn run_pull(pack_ref: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_env::{EnvVarGuard, ENV_LOCK};
+    use crate::test_env::{ENV_LOCK, EnvVarGuard};
 
     #[test]
     fn registry_ref_skips_migration() {

--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -641,12 +641,16 @@ mod tests {
         };
         let config = build_proxy_config(&resolved, &["extra.example.com".to_string()]);
         assert!(config.allowed_hosts.contains(&"api.openai.com".to_string()));
-        assert!(config
-            .allowed_hosts
-            .contains(&"*.googleapis.com".to_string()));
-        assert!(config
-            .allowed_hosts
-            .contains(&"extra.example.com".to_string()));
+        assert!(
+            config
+                .allowed_hosts
+                .contains(&"*.googleapis.com".to_string())
+        );
+        assert!(
+            config
+                .allowed_hosts
+                .contains(&"extra.example.com".to_string())
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -3,7 +3,7 @@
 //! All colors are drawn from the active theme via `theme::current()`.
 
 use crate::command_display::format_command_line;
-use crate::theme::{self, badge, fg, Rgb};
+use crate::theme::{self, Rgb, badge, fg};
 use colored::Colorize;
 use nono::{AccessMode, CapabilitySet, NetworkMode, NonoError, Result};
 use std::ffi::{OsStr, OsString};
@@ -661,17 +661,17 @@ fn sanitize_terminal_output(s: &str) -> String {
     while let Some(c) = chars.next() {
         if c == '\x1b' {
             // Skip ESC and the entire escape sequence
-            if let Some(next) = chars.next() {
-                if next == '[' {
-                    // CSI sequence: skip until a letter is found
-                    for seq_char in chars.by_ref() {
-                        if seq_char.is_ascii_alphabetic() {
-                            break;
-                        }
+            if let Some(next) = chars.next()
+                && next == '['
+            {
+                // CSI sequence: skip until a letter is found
+                for seq_char in chars.by_ref() {
+                    if seq_char.is_ascii_alphabetic() {
+                        break;
                     }
                 }
-                // OSC, other sequences: already consumed the next char, continue
             }
+            // OSC, other sequences: already consumed the next char, continue
         } else if c.is_control() && c != '\n' {
             // Strip control characters (except newline)
         } else {

--- a/crates/nono-cli/src/package_cmd.rs
+++ b/crates/nono-cli/src/package_cmd.rs
@@ -5,7 +5,7 @@ use crate::package::{
     self, ArtifactEntry, ArtifactType, LockedArtifact, LockedPackage, PackageManifest,
     PackageProvenance, PackageRef, PullResponse,
 };
-use crate::registry_client::{resolve_registry_url, RegistryClient};
+use crate::registry_client::{RegistryClient, resolve_registry_url};
 use chrono::{DateTime, Local, Utc};
 use nono::{NonoError, Result, SignerIdentity};
 use semver::Version;
@@ -25,15 +25,16 @@ pub fn run_pull(args: PullArgs) -> Result<()> {
     validate_pull_response(&package_ref, &pull)?;
 
     let lockfile = package::read_lockfile()?;
-    if let Some(existing) = lockfile.packages.get(&package_ref.key()) {
-        if existing.version == pull.version && !args.force {
-            eprintln!(
-                "  {} is already at {} (use --force to reinstall)",
-                package_ref.key(),
-                pull.version
-            );
-            return Ok(());
-        }
+    if let Some(existing) = lockfile.packages.get(&package_ref.key())
+        && existing.version == pull.version
+        && !args.force
+    {
+        eprintln!(
+            "  {} is already at {} (use --force to reinstall)",
+            package_ref.key(),
+            pull.version
+        );
+        return Ok(());
     }
 
     let printer = crate::pull_ui::ProgressPrinter::new(&pull);
@@ -61,20 +62,20 @@ pub fn run_pull(args: PullArgs) -> Result<()> {
     // If reversal fails for any record, abort the re-pull (do not
     // proceed to apply the new directives). The lockfile entry stays
     // intact so the user can investigate.
-    if let Some(prior_pkg) = lockfile.packages.get(&package_ref.key()) {
-        if !prior_pkg.wiring_record.is_empty() {
-            let failures = crate::wiring::reverse(&prior_pkg.wiring_record);
-            if !failures.is_empty() {
-                for f in &failures {
-                    eprintln!("    failed: {} — {}", f.record_summary, f.error);
-                }
-                return Err(NonoError::PackageInstall(format!(
-                    "re-pull of {} aborted — {} prior wiring directive(s) failed to reverse. \
-                     Resolve the failures above (or `nono remove --force` first) before retrying.",
-                    package_ref.key(),
-                    failures.len()
-                )));
+    if let Some(prior_pkg) = lockfile.packages.get(&package_ref.key())
+        && !prior_pkg.wiring_record.is_empty()
+    {
+        let failures = crate::wiring::reverse(&prior_pkg.wiring_record);
+        if !failures.is_empty() {
+            for f in &failures {
+                eprintln!("    failed: {} — {}", f.record_summary, f.error);
             }
+            return Err(NonoError::PackageInstall(format!(
+                "re-pull of {} aborted — {} prior wiring directive(s) failed to reverse. \
+                     Resolve the failures above (or `nono remove --force` first) before retrying.",
+                package_ref.key(),
+                failures.len()
+            )));
         }
     }
 
@@ -151,32 +152,32 @@ pub fn run_remove(args: RemoveArgs) -> Result<()> {
     // the failures and proceed — the lockfile entry is still
     // dropped, leaving any orphaned wiring as the user's problem
     // (typically because the user already cleaned it up by hand).
-    if let Some(pkg) = locked_pkg {
-        if !pkg.wiring_record.is_empty() {
-            let failures = crate::wiring::reverse(&pkg.wiring_record);
-            let total = pkg.wiring_record.len();
-            let succeeded = total.saturating_sub(failures.len());
-            eprintln!("  reversed {succeeded}/{total} wiring directive(s)",);
-            if !failures.is_empty() {
-                for f in &failures {
-                    eprintln!("    failed: {} — {}", f.record_summary, f.error);
-                }
-                if !args.force {
-                    return Err(NonoError::PackageInstall(format!(
-                        "remove of {} aborted — {} wiring directive(s) failed to reverse. \
+    if let Some(pkg) = locked_pkg
+        && !pkg.wiring_record.is_empty()
+    {
+        let failures = crate::wiring::reverse(&pkg.wiring_record);
+        let total = pkg.wiring_record.len();
+        let succeeded = total.saturating_sub(failures.len());
+        eprintln!("  reversed {succeeded}/{total} wiring directive(s)",);
+        if !failures.is_empty() {
+            for f in &failures {
+                eprintln!("    failed: {} — {}", f.record_summary, f.error);
+            }
+            if !args.force {
+                return Err(NonoError::PackageInstall(format!(
+                    "remove of {} aborted — {} wiring directive(s) failed to reverse. \
                          The lockfile entry has been preserved so you can retry. \
                          Inspect the failures above and either resolve them and re-run, \
                          or pass --force to drop the lockfile entry and accept any \
                          orphaned wiring.",
-                        package_ref.key(),
-                        failures.len()
-                    )));
-                }
-                eprintln!(
-                    "  --force: dropping lockfile entry despite {} failed reversal(s)",
+                    package_ref.key(),
                     failures.len()
-                );
+                )));
             }
+            eprintln!(
+                "  --force: dropping lockfile entry despite {} failed reversal(s)",
+                failures.len()
+            );
         }
     }
 
@@ -186,10 +187,11 @@ pub fn run_remove(args: RemoveArgs) -> Result<()> {
     }
 
     // Clean up empty namespace directory.
-    if let Some(ns_dir) = install_dir.parent() {
-        if ns_dir.exists() && is_dir_empty(ns_dir) {
-            let _ = fs::remove_dir(ns_dir);
-        }
+    if let Some(ns_dir) = install_dir.parent()
+        && ns_dir.exists()
+        && is_dir_empty(ns_dir)
+    {
+        let _ = fs::remove_dir(ns_dir);
     }
 
     package::remove_package_from_lockfile(&package_ref)?;
@@ -471,14 +473,14 @@ fn validate_manifest(manifest: &PackageManifest) -> Result<()> {
         )));
     }
 
-    if let Some(min_version) = &manifest.min_nono_version {
-        if compare_versions(env!("CARGO_PKG_VERSION"), min_version)?.is_lt() {
-            return Err(NonoError::PackageInstall(format!(
-                "package requires nono >= {}, current version is {}",
-                min_version,
-                env!("CARGO_PKG_VERSION")
-            )));
-        }
+    if let Some(min_version) = &manifest.min_nono_version
+        && compare_versions(env!("CARGO_PKG_VERSION"), min_version)?.is_lt()
+    {
+        return Err(NonoError::PackageInstall(format!(
+            "package requires nono >= {}, current version is {}",
+            min_version,
+            env!("CARGO_PKG_VERSION")
+        )));
     }
 
     Ok(())
@@ -778,20 +780,18 @@ fn enforce_signer_pinning(
         return Ok(());
     }
 
-    if let Some(existing) = existing {
-        if let Some(provenance) = &existing.provenance {
-            if canonical_signer_identity(&provenance.signer_identity)
-                != canonical_signer_identity(signer_identity)
-            {
-                return Err(NonoError::PackageVerification {
-                    package: provenance.repository.clone(),
-                    reason: format!(
-                        "signer identity changed from '{}' to '{}'",
-                        provenance.signer_identity, signer_identity
-                    ),
-                });
-            }
-        }
+    if let Some(existing) = existing
+        && let Some(provenance) = &existing.provenance
+        && canonical_signer_identity(&provenance.signer_identity)
+            != canonical_signer_identity(signer_identity)
+    {
+        return Err(NonoError::PackageVerification {
+            package: provenance.repository.clone(),
+            reason: format!(
+                "signer identity changed from '{}' to '{}'",
+                provenance.signer_identity, signer_identity
+            ),
+        });
     }
 
     Ok(())

--- a/crates/nono-cli/src/package_status.rs
+++ b/crates/nono-cli/src/package_status.rs
@@ -2,7 +2,7 @@
 
 use crate::package::{self, PackageRef, PackageStatusResponse};
 use crate::profile;
-use crate::registry_client::{resolve_registry_url, RegistryClient};
+use crate::registry_client::{RegistryClient, resolve_registry_url};
 use nono::{NonoError, Result};
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/nono-cli/src/platform.rs
+++ b/crates/nono-cli/src/platform.rs
@@ -152,15 +152,13 @@ fn parse_windows_registry_value(output: &str, name: &str) -> Option<String> {
         let kind = parts.next()?;
         let value = parts.collect::<Vec<_>>().join(" ");
         if !value.is_empty() {
-            if kind == "REG_DWORD" {
-                if let Some(hex) = value
+            if kind == "REG_DWORD"
+                && let Some(hex) = value
                     .strip_prefix("0x")
                     .or_else(|| value.strip_prefix("0X"))
-                {
-                    if let Ok(number) = u64::from_str_radix(hex, 16) {
-                        return Some(number.to_string());
-                    }
-                }
+                && let Ok(number) = u64::from_str_radix(hex, 16)
+            {
+                return Some(number.to_string());
             }
             return Some(value);
         }
@@ -291,7 +289,7 @@ impl<'de> Deserialize<'de> for When {
 }
 
 pub fn when_matches_current(when: Option<&When>) -> Result<bool> {
-    Ok(when.map_or(true, |predicate| predicate.matches(current())))
+    Ok(when.is_none_or(|predicate| predicate.matches(current())))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -413,11 +411,7 @@ impl Predicate {
             PredicateOs::Windows => self.matches_windows(platform),
             PredicateOs::Unknown(_) => false,
         };
-        if self.negated {
-            !matched
-        } else {
-            matched
-        }
+        if self.negated { !matched } else { matched }
     }
 
     fn matches_linux(&self, platform: &PlatformInfo) -> bool {
@@ -446,10 +440,10 @@ impl Predicate {
                 return false;
             }
         }
-        if let Some(variant) = &self.variant {
-            if info.variant_id.as_deref() != Some(variant.as_str()) {
-                return false;
-            }
+        if let Some(variant) = &self.variant
+            && info.variant_id.as_deref() != Some(variant.as_str())
+        {
+            return false;
         }
         true
     }
@@ -474,10 +468,10 @@ impl Predicate {
         let Some(info) = &platform.windows else {
             return false;
         };
-        if let Some(version) = &self.version {
-            if !version.matches(&info.version) {
-                return false;
-            }
+        if let Some(version) = &self.version
+            && !version.matches(&info.version)
+        {
+            return false;
         }
         if let Some(build) = &self.build {
             let build_version = info.version.rsplit('.').next().map_or("", |part| part);
@@ -646,21 +640,31 @@ VARIANT_ID=workstation
     fn linux_predicates_match_distro_like_version_and_variant() {
         let platform = fedora();
         assert!(When::parse("linux").expect("parse").matches(&platform));
-        assert!(When::parse("linux:fedora")
-            .expect("parse")
-            .matches(&platform));
-        assert!(When::parse("linux:rhel-like")
-            .expect("parse")
-            .matches(&platform));
-        assert!(When::parse("linux:fedora:>=42")
-            .expect("parse")
-            .matches(&platform));
-        assert!(When::parse("linux:fedora:43:workstation")
-            .expect("parse")
-            .matches(&platform));
-        assert!(!When::parse("linux:ubuntu")
-            .expect("parse")
-            .matches(&platform));
+        assert!(
+            When::parse("linux:fedora")
+                .expect("parse")
+                .matches(&platform)
+        );
+        assert!(
+            When::parse("linux:rhel-like")
+                .expect("parse")
+                .matches(&platform)
+        );
+        assert!(
+            When::parse("linux:fedora:>=42")
+                .expect("parse")
+                .matches(&platform)
+        );
+        assert!(
+            When::parse("linux:fedora:43:workstation")
+                .expect("parse")
+                .matches(&platform)
+        );
+        assert!(
+            !When::parse("linux:ubuntu")
+                .expect("parse")
+                .matches(&platform)
+        );
     }
 
     #[test]
@@ -683,15 +687,21 @@ VARIANT_ID=workstation
                 edition: Some("Professional".to_string()),
             }),
         };
-        assert!(When::parse("windows:>=10:>=22000")
-            .expect("parse")
-            .matches(&platform));
-        assert!(When::parse("windows:>=10:22631")
-            .expect("parse")
-            .matches(&platform));
-        assert!(!When::parse("windows:>=10:>30000")
-            .expect("parse")
-            .matches(&platform));
+        assert!(
+            When::parse("windows:>=10:>=22000")
+                .expect("parse")
+                .matches(&platform)
+        );
+        assert!(
+            When::parse("windows:>=10:22631")
+                .expect("parse")
+                .matches(&platform)
+        );
+        assert!(
+            !When::parse("windows:>=10:>30000")
+                .expect("parse")
+                .matches(&platform)
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -436,13 +436,13 @@ fn resolve_single_group(
     }
 
     // Process symlink pairs (Seatbelt-only: macOS symlink → target path handling)
-    if cfg!(target_os = "macos") {
-        if let Some(pairs) = &group.symlink_pairs {
-            for symlink in pairs.keys() {
-                let expanded = expand_path(symlink)?;
-                let escaped = escape_seatbelt_path(path_to_utf8(&expanded)?)?;
-                caps.add_platform_rule(format!("(allow file-read* (subpath \"{}\"))", escaped))?;
-            }
+    if cfg!(target_os = "macos")
+        && let Some(pairs) = &group.symlink_pairs
+    {
+        for symlink in pairs.keys() {
+            let expanded = expand_path(symlink)?;
+            let escaped = escape_seatbelt_path(path_to_utf8(&expanded)?)?;
+            caps.add_platform_rule(format!("(allow file-read* (subpath \"{}\"))", escaped))?;
         }
     }
 
@@ -617,17 +617,17 @@ pub(crate) fn add_deny_access_rules(
     // Seatbelt operates on kernel-resolved paths, so deny rules must use
     // the canonical form. We also keep the original to cover both forms.
     let canonical = path.canonicalize().ok();
-    if let Some(ref canonical) = canonical {
-        if *canonical != path {
-            if should_skip_resolved_deny_target(canonical) {
-                debug!(
-                    "Skipping deny canonical path '{}' (Nix store immutable symlink target of '{}')",
-                    canonical.display(),
-                    path.display(),
-                );
-            } else {
-                deny_paths.push(canonical.clone());
-            }
+    if let Some(ref canonical) = canonical
+        && *canonical != path
+    {
+        if should_skip_resolved_deny_target(canonical) {
+            debug!(
+                "Skipping deny canonical path '{}' (Nix store immutable symlink target of '{}')",
+                canonical.display(),
+                path.display(),
+            );
+        } else {
+            deny_paths.push(canonical.clone());
         }
     }
 
@@ -684,28 +684,27 @@ pub(crate) fn add_deny_access_rules(
         emit_deny_rules(&path, caps)?;
 
         // Emit deny rules for the canonical path too (covers parent symlinks on existing paths)
-        if let Some(ref canonical) = canonical {
-            if *canonical != path {
-                if let Err(e) = emit_deny_rules(canonical, caps) {
-                    warn!(
-                        "Skipping canonical deny rules for {}: {}",
-                        canonical.display(),
-                        e
-                    );
-                }
-            }
+        if let Some(ref canonical) = canonical
+            && *canonical != path
+            && let Err(e) = emit_deny_rules(canonical, caps)
+        {
+            warn!(
+                "Skipping canonical deny rules for {}: {}",
+                canonical.display(),
+                e
+            );
         }
 
         // Emit deny rules for the parent-resolved path (covers non-existent paths
         // whose parents contain symlinks, e.g. /var/run/future.sock -> /private/var/run/future.sock)
-        if let Some(ref resolved) = parent_resolved {
-            if let Err(e) = emit_deny_rules(resolved, caps) {
-                warn!(
-                    "Skipping parent-resolved deny rules for {}: {}",
-                    resolved.display(),
-                    e
-                );
-            }
+        if let Some(ref resolved) = parent_resolved
+            && let Err(e) = emit_deny_rules(resolved, caps)
+        {
+            warn!(
+                "Skipping parent-resolved deny rules for {}: {}",
+                resolved.display(),
+                e
+            );
         }
     }
 
@@ -741,10 +740,10 @@ pub fn apply_macos_keychain_db_exception(caps: &mut CapabilitySet) {
         {
             return true;
         }
-        if let Some(ref user_keychain_dbs) = user_keychain_dbs {
-            if user_keychain_dbs.iter().any(|candidate| path == candidate) {
-                return true;
-            }
+        if let Some(ref user_keychain_dbs) = user_keychain_dbs
+            && user_keychain_dbs.iter().any(|candidate| path == candidate)
+        {
+            return true;
         }
         false
     };
@@ -1207,10 +1206,10 @@ fn find_deny_group_for_path(policy: &Policy, deny_path: &Path) -> Option<String>
                     if expanded == deny_path {
                         return Some(name.clone());
                     }
-                    if let Ok(canonical) = expanded.canonicalize() {
-                        if canonical == *deny_path {
-                            return Some(name.clone());
-                        }
+                    if let Ok(canonical) = expanded.canonicalize()
+                        && canonical == *deny_path
+                    {
+                        return Some(name.clone());
                     }
                 }
             }
@@ -1274,16 +1273,16 @@ pub fn get_sensitive_paths(policy: &Policy) -> Result<Vec<SensitivePathRule>> {
                 // those paths (see add_deny_access_rules). Marking the Nix store
                 // target as sensitive would cause `nono why` to report a false
                 // denial for paths the sandbox actually permits.
-                if expanded.is_symlink() {
-                    if let Ok(resolved) = expanded.canonicalize() {
-                        if resolved != expanded && !should_skip_resolved_deny_target(&resolved) {
-                            result.push(SensitivePathRule {
-                                expanded_path: resolved.to_string_lossy().into_owned(),
-                                group_name: group_name.clone(),
-                                description: group.description.clone(),
-                            });
-                        }
-                    }
+                if expanded.is_symlink()
+                    && let Ok(resolved) = expanded.canonicalize()
+                    && resolved != expanded
+                    && !should_skip_resolved_deny_target(&resolved)
+                {
+                    result.push(SensitivePathRule {
+                        expanded_path: resolved.to_string_lossy().into_owned(),
+                        group_name: group_name.clone(),
+                        description: group.description.clone(),
+                    });
                 }
             }
         }
@@ -1543,35 +1542,45 @@ mod tests {
             .as_ref()
             .expect("claude_code_macos allow missing")
             .readwrite;
-        assert!(claude_code_macos
-            .allow
-            .as_ref()
-            .expect("claude_code_macos allow missing")
-            .read
-            .contains(&"$HOME/.local/share/claude".to_string()));
-        assert!(claude_code_macos
-            .allow
-            .as_ref()
-            .expect("claude_code_macos allow missing")
-            .read
-            .contains(&"$HOME/Applications/Claude Code URL Handler.app".to_string()));
+        assert!(
+            claude_code_macos
+                .allow
+                .as_ref()
+                .expect("claude_code_macos allow missing")
+                .read
+                .contains(&"$HOME/.local/share/claude".to_string())
+        );
+        assert!(
+            claude_code_macos
+                .allow
+                .as_ref()
+                .expect("claude_code_macos allow missing")
+                .read
+                .contains(&"$HOME/Applications/Claude Code URL Handler.app".to_string())
+        );
         assert!(claude_code_macos_paths.contains(&"$HOME/Library/Keychains".to_string()));
-        assert!(claude_code_macos_paths
-            .contains(&"$HOME/Library/Keychains/login.keychain-db".to_string()));
-        assert!(claude_code_macos_paths
-            .contains(&"$HOME/Library/Keychains/metadata.keychain-db".to_string()));
+        assert!(
+            claude_code_macos_paths
+                .contains(&"$HOME/Library/Keychains/login.keychain-db".to_string())
+        );
+        assert!(
+            claude_code_macos_paths
+                .contains(&"$HOME/Library/Keychains/metadata.keychain-db".to_string())
+        );
 
         let claude_code_linux = policy
             .groups
             .get("claude_code_linux")
             .expect("claude_code_linux group missing");
         assert_eq!(claude_code_linux.platform.as_deref(), Some("linux"));
-        assert!(claude_code_linux
-            .allow
-            .as_ref()
-            .expect("claude_code_linux allow missing")
-            .read
-            .contains(&"$HOME/.local/share/claude".to_string()));
+        assert!(
+            claude_code_linux
+                .allow
+                .as_ref()
+                .expect("claude_code_linux allow missing")
+                .read
+                .contains(&"$HOME/.local/share/claude".to_string())
+        );
 
         let vscode_macos = policy
             .groups
@@ -1709,16 +1718,19 @@ mod tests {
         assert!(resolved.is_ok());
 
         if cfg!(target_os = "macos") {
-            assert!(caps
-                .platform_rules()
-                .iter()
-                .any(|r| r.contains("deny file-write-unlink")));
+            assert!(
+                caps.platform_rules()
+                    .iter()
+                    .any(|r| r.contains("deny file-write-unlink"))
+            );
         } else {
             // On Linux, unlink protection is Seatbelt-only
-            assert!(!caps
-                .platform_rules()
-                .iter()
-                .any(|r| r.contains("deny file-write-unlink")));
+            assert!(
+                !caps
+                    .platform_rules()
+                    .iter()
+                    .any(|r| r.contains("deny file-write-unlink"))
+            );
         }
     }
 

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -43,10 +43,12 @@ mod tests {
         let profile = get_builtin("openclaw").expect("Profile not found");
         assert_eq!(profile.meta.name, "openclaw");
         assert!(!profile.network.block); // network allowed
-        assert!(profile
-            .filesystem
-            .allow
-            .contains(&"$HOME/.openclaw".to_string()));
+        assert!(
+            profile
+                .filesystem
+                .allow
+                .contains(&"$HOME/.openclaw".to_string())
+        );
     }
 
     #[test]
@@ -55,14 +57,18 @@ mod tests {
         assert_eq!(profile.meta.name, "opencode");
         assert_eq!(profile.workdir.access, WorkdirAccess::ReadWrite);
         assert!(profile.interactive);
-        assert!(profile
-            .filesystem
-            .allow
-            .contains(&"$HOME/.opencode".to_string()));
-        assert!(profile
-            .filesystem
-            .allow
-            .contains(&"$HOME/.local/share/opentui".to_string()));
+        assert!(
+            profile
+                .filesystem
+                .allow
+                .contains(&"$HOME/.opencode".to_string())
+        );
+        assert!(
+            profile
+                .filesystem
+                .allow
+                .contains(&"$HOME/.local/share/opentui".to_string())
+        );
     }
 
     #[test]
@@ -72,18 +78,24 @@ mod tests {
         assert_eq!(profile.workdir.access, WorkdirAccess::ReadWrite);
         assert!(profile.interactive);
         assert!(!profile.network.block);
-        assert!(profile
-            .filesystem
-            .allow
-            .contains(&"$HOME/.config/swival".to_string()));
-        assert!(profile
-            .groups
-            .include
-            .contains(&"python_runtime".to_string()));
-        assert!(profile
-            .groups
-            .include
-            .contains(&"unlink_protection".to_string()));
+        assert!(
+            profile
+                .filesystem
+                .allow
+                .contains(&"$HOME/.config/swival".to_string())
+        );
+        assert!(
+            profile
+                .groups
+                .include
+                .contains(&"python_runtime".to_string())
+        );
+        assert!(
+            profile
+                .groups
+                .include
+                .contains(&"unlink_protection".to_string())
+        );
     }
 
     #[test]
@@ -131,16 +143,20 @@ mod tests {
         // in v0.43.0 alongside claude-code).
         let profile = get_builtin("opencode").expect("Profile not found");
         // Should have default profile groups (inherited via extends).
-        assert!(profile
-            .groups
-            .include
-            .contains(&"deny_credentials".to_string()));
+        assert!(
+            profile
+                .groups
+                .include
+                .contains(&"deny_credentials".to_string())
+        );
         // Should have profile-specific groups
         assert!(profile.groups.include.contains(&"node_runtime".to_string()));
-        assert!(profile
-            .groups
-            .include
-            .contains(&"unlink_protection".to_string()));
+        assert!(
+            profile
+                .groups
+                .include
+                .contains(&"unlink_protection".to_string())
+        );
     }
 
     #[test]
@@ -207,18 +223,24 @@ mod tests {
     #[test]
     fn test_linux_host_compat_profile_groups() {
         let profile = get_builtin("linux-host-compat").expect("Profile not found");
-        assert!(profile
-            .groups
-            .include
-            .contains(&"linux_runtime_state".to_string()));
-        assert!(profile
-            .groups
-            .include
-            .contains(&"linux_sysfs_read".to_string()));
-        assert!(profile
-            .groups
-            .include
-            .contains(&"linux_temp_read".to_string()));
+        assert!(
+            profile
+                .groups
+                .include
+                .contains(&"linux_runtime_state".to_string())
+        );
+        assert!(
+            profile
+                .groups
+                .include
+                .contains(&"linux_sysfs_read".to_string())
+        );
+        assert!(
+            profile
+                .groups
+                .include
+                .contains(&"linux_temp_read".to_string())
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1622,12 +1622,12 @@ pub fn load_profile_extends(name_or_path: &str) -> Option<Vec<String>> {
     }
 
     // User profile
-    if let Ok(profile_path) = get_user_profile_path(name_or_path) {
-        if profile_path.exists() {
-            return parse_profile_file(&profile_path)
-                .ok()
-                .and_then(|p| p.extends);
-        }
+    if let Ok(profile_path) = get_user_profile_path(name_or_path)
+        && profile_path.exists()
+    {
+        return parse_profile_file(&profile_path)
+            .ok()
+            .and_then(|p| p.extends);
     }
 
     // Pack-store: any installed pack that declares a profile artifact with
@@ -1639,10 +1639,10 @@ pub fn load_profile_extends(name_or_path: &str) -> Option<Vec<String>> {
     }
 
     // Built-in profile
-    if let Ok(policy) = crate::policy::load_embedded_policy() {
-        if let Some(def) = policy.profiles.get(name_or_path) {
-            return def.extends.as_ref().map(|s| vec![s.clone()]);
-        }
+    if let Ok(policy) = crate::policy::load_embedded_policy()
+        && let Some(def) = policy.profiles.get(name_or_path)
+    {
+        return def.extends.as_ref().map(|s| vec![s.clone()]);
     }
 
     None
@@ -2652,18 +2652,16 @@ pub fn list_profiles() -> Vec<String> {
     let mut profiles = builtin::list_builtin();
 
     // Add user profiles (if home directory is available)
-    if let Ok(profile_path) = get_user_profile_path("") {
-        if let Some(dir) = profile_path.parent() {
-            if dir.exists() {
-                if let Ok(entries) = fs::read_dir(dir) {
-                    for entry in entries.flatten() {
-                        if let Some(name) = entry.path().file_stem() {
-                            let name_str = name.to_string_lossy().to_string();
-                            if !profiles.contains(&name_str) {
-                                profiles.push(name_str);
-                            }
-                        }
-                    }
+    if let Ok(profile_path) = get_user_profile_path("")
+        && let Some(dir) = profile_path.parent()
+        && dir.exists()
+        && let Ok(entries) = fs::read_dir(dir)
+    {
+        for entry in entries.flatten() {
+            if let Some(name) = entry.path().file_stem() {
+                let name_str = name.to_string_lossy().to_string();
+                if !profiles.contains(&name_str) {
+                    profiles.push(name_str);
                 }
             }
         }
@@ -3017,10 +3015,12 @@ mod tests {
         assert_eq!(profile.meta.name, "custom-test");
         assert!(profile.network.block);
         // implicit default profile groups should be merged in
-        assert!(profile
-            .groups
-            .include
-            .contains(&"deny_credentials".to_string()));
+        assert!(
+            profile
+                .groups
+                .include
+                .contains(&"deny_credentials".to_string())
+        );
         assert!(profile.groups.include.contains(&"node_runtime".to_string()));
     }
 
@@ -3880,9 +3880,10 @@ mod tests {
 
         let result = validate_custom_credential("test", &cred);
         let err = result.expect_err("proxy query_param_name should be required");
-        assert!(err
-            .to_string()
-            .contains("proxy.query_param_name is required"));
+        assert!(
+            err.to_string()
+                .contains("proxy.query_param_name is required")
+        );
     }
 
     #[test]
@@ -4355,10 +4356,12 @@ mod tests {
         assert!(merged.filesystem.allow.contains(&"/base/rw".to_string()));
         assert!(merged.filesystem.allow.contains(&"/child/rw".to_string()));
         assert!(merged.filesystem.read.contains(&"/base/read".to_string()));
-        assert!(merged
-            .filesystem
-            .read_file
-            .contains(&"/base/file.txt".to_string()));
+        assert!(
+            merged
+                .filesystem
+                .read_file
+                .contains(&"/base/file.txt".to_string())
+        );
     }
 
     #[test]
@@ -4642,10 +4645,12 @@ mod tests {
             "Expected inherited paths from codex, got: {:?}",
             profile.filesystem.allow
         );
-        assert!(profile
-            .filesystem
-            .allow
-            .contains(&"/tmp/ext-test".to_string()));
+        assert!(
+            profile
+                .filesystem
+                .allow
+                .contains(&"/tmp/ext-test".to_string())
+        );
         // extends should be consumed
         assert!(profile.extends.is_none());
     }
@@ -4933,9 +4938,11 @@ mod tests {
         let merged = merge_profiles(base_profile(), child_profile());
         let urls = merged.open_urls.expect("should have open_urls");
         assert_eq!(urls.allow_origins, vec!["https://child.example.com"]);
-        assert!(!urls
-            .allow_origins
-            .contains(&"https://base.example.com".to_string()));
+        assert!(
+            !urls
+                .allow_origins
+                .contains(&"https://base.example.com".to_string())
+        );
         assert!(urls.allow_localhost);
     }
 
@@ -5022,46 +5029,66 @@ mod tests {
         let merged = merge_profiles(base_profile(), child_profile());
         // Canonical equivalents of the old `policy.*` patch fields.
         assert!(merged.groups.exclude.contains(&"base_excluded".to_string()));
-        assert!(merged
-            .groups
-            .exclude
-            .contains(&"child_excluded".to_string()));
-        assert!(merged
-            .filesystem
-            .read
-            .contains(&"/base/policy-read".to_string()));
-        assert!(merged
-            .filesystem
-            .write
-            .contains(&"/child/policy-write".to_string()));
-        assert!(merged
-            .filesystem
-            .allow
-            .contains(&"/child/policy-rw".to_string()));
-        assert!(merged
-            .filesystem
-            .deny
-            .contains(&"/base/policy-deny".to_string()));
-        assert!(merged
-            .filesystem
-            .deny
-            .contains(&"/child/policy-deny".to_string()));
-        assert!(merged
-            .filesystem
-            .bypass_protection
-            .contains(&"/base/override-deny".to_string()));
-        assert!(merged
-            .filesystem
-            .bypass_protection
-            .contains(&"/child/override-deny".to_string()));
-        assert!(merged
-            .filesystem
-            .suppress_save_prompt
-            .contains(&"/base/no-prompt".to_string()));
-        assert!(merged
-            .filesystem
-            .suppress_save_prompt
-            .contains(&"/child/no-prompt".to_string()));
+        assert!(
+            merged
+                .groups
+                .exclude
+                .contains(&"child_excluded".to_string())
+        );
+        assert!(
+            merged
+                .filesystem
+                .read
+                .contains(&"/base/policy-read".to_string())
+        );
+        assert!(
+            merged
+                .filesystem
+                .write
+                .contains(&"/child/policy-write".to_string())
+        );
+        assert!(
+            merged
+                .filesystem
+                .allow
+                .contains(&"/child/policy-rw".to_string())
+        );
+        assert!(
+            merged
+                .filesystem
+                .deny
+                .contains(&"/base/policy-deny".to_string())
+        );
+        assert!(
+            merged
+                .filesystem
+                .deny
+                .contains(&"/child/policy-deny".to_string())
+        );
+        assert!(
+            merged
+                .filesystem
+                .bypass_protection
+                .contains(&"/base/override-deny".to_string())
+        );
+        assert!(
+            merged
+                .filesystem
+                .bypass_protection
+                .contains(&"/child/override-deny".to_string())
+        );
+        assert!(
+            merged
+                .filesystem
+                .suppress_save_prompt
+                .contains(&"/base/no-prompt".to_string())
+        );
+        assert!(
+            merged
+                .filesystem
+                .suppress_save_prompt
+                .contains(&"/child/no-prompt".to_string())
+        );
     }
 
     #[test]
@@ -5328,10 +5355,12 @@ mod tests {
 
         let profile = load_from_file(&profile_path).expect("load extended profile");
         assert_eq!(profile.meta.name, "multi-ext-test");
-        assert!(profile
-            .filesystem
-            .allow
-            .contains(&"/tmp/multi-ext".to_string()));
+        assert!(
+            profile
+                .filesystem
+                .allow
+                .contains(&"/tmp/multi-ext".to_string())
+        );
         assert!(profile.extends.is_none());
     }
 
@@ -5376,10 +5405,12 @@ mod tests {
 
         let profile = load_from_file(&child_path).expect("resolve");
         assert_eq!(profile.meta.name, "child");
-        assert!(profile
-            .filesystem
-            .allow
-            .contains(&"/tmp/shared".to_string()));
+        assert!(
+            profile
+                .filesystem
+                .allow
+                .contains(&"/tmp/shared".to_string())
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -79,12 +79,12 @@ fn cmd_init(args: ProfileInitArgs) -> Result<()> {
 
     // Validate --extends target exists in any of the three sources the
     // resolver knows about (user dir, pack store, built-in).
-    if let Some(ref base) = args.extends {
-        if !profile_exists(base) {
-            return Err(NonoError::ProfileParse(extends_target_not_found_message(
-                base,
-            )));
-        }
+    if let Some(ref base) = args.extends
+        && !profile_exists(base)
+    {
+        return Err(NonoError::ProfileParse(extends_target_not_found_message(
+            base,
+        )));
     }
 
     // Validate --groups against embedded policy
@@ -295,10 +295,10 @@ fn profile_exists(name: &str) -> bool {
     if profile::builtin::get_builtin(name).is_some() {
         return true;
     }
-    if let Ok(path) = profile::get_user_profile_path(name) {
-        if path.exists() {
-            return true;
-        }
+    if let Ok(path) = profile::get_user_profile_path(name)
+        && path.exists()
+    {
+        return true;
     }
     profile::find_pack_store_profile(name).is_some()
 }
@@ -485,19 +485,19 @@ fn cmd_groups_detail(pol: &policy::Policy, name: &str, json: bool) -> Result<()>
         }
     }
 
-    if let Some(ref pairs) = group.symlink_pairs {
-        if !pairs.is_empty() {
-            println!();
-            println!("  {}", theme::fg("symlink_pairs:", t.subtext).bold());
-            let mut sorted: Vec<(&String, &String)> = pairs.iter().collect();
-            sorted.sort_by_key(|(k, _)| k.as_str());
-            for (from, to) in sorted {
-                println!(
-                    "    {} -> {}",
-                    theme::fg(from, t.text),
-                    theme::fg(to, t.subtext)
-                );
-            }
+    if let Some(ref pairs) = group.symlink_pairs
+        && !pairs.is_empty()
+    {
+        println!();
+        println!("  {}", theme::fg("symlink_pairs:", t.subtext).bold());
+        let mut sorted: Vec<(&String, &String)> = pairs.iter().collect();
+        sorted.sort_by_key(|(k, _)| k.as_str());
+        for (from, to) in sorted {
+            println!(
+                "    {} -> {}",
+                theme::fg(from, t.text),
+                theme::fg(to, t.subtext)
+            );
         }
     }
 
@@ -598,10 +598,10 @@ fn group_to_json(name: &str, group: &Group) -> serde_json::Value {
         val["deny"] = serde_json::Value::Object(deny_val);
     }
 
-    if let Some(ref pairs) = group.symlink_pairs {
-        if !pairs.is_empty() {
-            val["symlink_pairs"] = serde_json::json!(pairs);
-        }
+    if let Some(ref pairs) = group.symlink_pairs
+        && !pairs.is_empty()
+    {
+        val["symlink_pairs"] = serde_json::json!(pairs);
     }
 
     val
@@ -1834,10 +1834,10 @@ fn diff_scalar_option(
     }
     println!();
     println!("  {}:", theme::fg(label, t.subtext).bold());
-    if let Some(ref old) = v1 {
+    if let Some(old) = v1 {
         println!("    {}", theme::fg(&format!("- {old}"), t.red));
     }
-    if let Some(ref new) = v2 {
+    if let Some(new) = v2 {
         println!("    {}", theme::fg(&format!("+ {new}"), t.green));
     }
     true
@@ -2173,10 +2173,10 @@ fn resolve_validate_target(input: &std::path::Path) -> std::path::PathBuf {
     if name.contains('/') || name.ends_with(".json") {
         return input.to_path_buf();
     }
-    if let Ok(p) = profile::get_user_profile_path(name) {
-        if p.exists() {
-            return p;
-        }
+    if let Ok(p) = profile::get_user_profile_path(name)
+        && p.exists()
+    {
+        return p;
     }
     if let Some(p) = profile::find_pack_store_profile(name) {
         return p;
@@ -2404,14 +2404,14 @@ pub(crate) fn cmd_promote(args: ProfilePromoteArgs) -> Result<()> {
         None
     };
 
-    if current_bytes.is_none() {
-        if let Some(source) = reserved_profile_source(&args.name)? {
-            return Err(NonoError::ProfileParse(format!(
-                "refusing to promote '{}' because it would shadow a {source} profile. \
+    if current_bytes.is_none()
+        && let Some(source) = reserved_profile_source(&args.name)?
+    {
+        return Err(NonoError::ProfileParse(format!(
+            "refusing to promote '{}' because it would shadow a {source} profile. \
                  Draft a derived profile such as '{}-local' with \"extends\": \"{}\" instead.",
-                args.name, args.name, args.name
-            )));
-        }
+            args.name, args.name, args.name
+        )));
     }
 
     if let Some(current) = current_bytes.as_deref() {

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -575,14 +575,18 @@ mod tests {
             preflight.bypass_protection_paths
         );
         assert_eq!(runtime.ignored_denial_paths, preflight.ignored_denial_paths);
-        assert!(runtime
-            .ignored_denial_paths
-            .contains(&nono::try_canonicalize(
-                &workdir.path().join(".copilot/settings.json")
-            )));
-        assert!(runtime
-            .ignored_denial_paths
-            .contains(&nono::try_canonicalize(&workdir.path().join("cli-ignore"))));
+        assert!(
+            runtime
+                .ignored_denial_paths
+                .contains(&nono::try_canonicalize(
+                    &workdir.path().join(".copilot/settings.json")
+                ))
+        );
+        assert!(
+            runtime
+                .ignored_denial_paths
+                .contains(&nono::try_canonicalize(&workdir.path().join("cli-ignore")))
+        );
         assert_eq!(runtime.allowed_env_vars, preflight.allowed_env_vars);
         assert_eq!(runtime.denied_env_vars, preflight.denied_env_vars);
         assert_eq!(

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -1,8 +1,8 @@
 use crate::command_display::format_command_line;
 use crate::{profile, query_ext};
 use colored::Colorize;
-use nono::diagnostic::{ErrorObservation, PolicyExplanation};
 use nono::SandboxViolation;
+use nono::diagnostic::{ErrorObservation, PolicyExplanation};
 use nono::{AccessMode, CapabilitySet, NonoError, Result};
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::{BufRead, IsTerminal, Write};
@@ -1085,7 +1085,7 @@ pub(crate) fn shorten_path_for_profile(path: &Path, home_path: &Path) -> String 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_env::{EnvVarGuard, ENV_LOCK};
+    use crate::test_env::{ENV_LOCK, EnvVarGuard};
     use tempfile::TempDir;
 
     #[test]

--- a/crates/nono-cli/src/protected_paths.rs
+++ b/crates/nono-cli/src/protected_paths.rs
@@ -3,7 +3,7 @@
 //! These checks enforce a hard fail if initial sandbox capabilities overlap
 //! with internal CLI state roots (currently `~/.nono`).
 
-use nono::{try_canonicalize, CapabilitySet, NonoError, Result};
+use nono::{CapabilitySet, NonoError, Result, try_canonicalize};
 use std::path::{Path, PathBuf};
 
 /// Resolved internal state roots that must not be accessible by the sandboxed child.
@@ -169,10 +169,10 @@ pub(crate) fn emit_protected_root_deny_rules(
 
         // Also emit for the canonical path if it differs (important on macOS
         // where paths like /var resolve to /private/var).
-        if let Ok(canonical) = resolved.canonicalize() {
-            if canonical != resolved {
-                emit_deny_rules_for_path(&canonical, caps)?;
-            }
+        if let Ok(canonical) = resolved.canonicalize()
+            && canonical != resolved
+        {
+            emit_deny_rules_for_path(&canonical, caps)?;
         }
     }
 

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -1,7 +1,7 @@
 use crate::cli::SandboxArgs;
 use crate::launch_runtime::ProxyLaunchOptions;
 use crate::network_policy;
-use crate::sandbox_prepare::{validate_external_proxy_bypass, PreparedSandbox};
+use crate::sandbox_prepare::{PreparedSandbox, validate_external_proxy_bypass};
 #[cfg(not(target_os = "macos"))]
 use nono::AccessMode;
 use nono::{CapabilitySet, NonoError, Result};

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -16,7 +16,7 @@
 //! The supervisor proxies I/O between whoever is connected and the PTY master.
 
 use nix::libc;
-use nix::pty::{openpty, OpenptyResult, Winsize};
+use nix::pty::{OpenptyResult, Winsize, openpty};
 use nix::sys::signal::{self, SigHandler, Signal};
 use nono::{NonoError, Result};
 use std::collections::VecDeque;
@@ -247,50 +247,55 @@ pub fn open_pty() -> Result<PtyPair> {
     Ok(PtyPair { master, slave })
 }
 
+/// Write a message to stderr and abort the child process.
+///
+/// Async-signal-safe: only uses raw `write(2)` and `_exit(2)`.
+fn child_setup_pty_fatal(message: &[u8]) -> ! {
+    // SAFETY: message slice pointer is valid for its length; write(2) and
+    // _exit(2) are async-signal-safe and cannot cause memory unsafety.
+    unsafe {
+        let _ = libc::write(
+            libc::STDERR_FILENO,
+            message.as_ptr().cast::<libc::c_void>(),
+            message.len(),
+        );
+        libc::_exit(126);
+    }
+}
+
 /// Set up the slave PTY as the child's controlling terminal.
 ///
 /// Must be called in the child after fork, before exec.
-/// This is async-signal-safe (only uses raw libc calls).
 ///
 /// # Safety
-/// Must be called in the child process after fork. The slave_fd must be valid.
-unsafe fn child_setup_pty_fatal(message: &[u8]) -> ! {
-    let _ = libc::write(
-        libc::STDERR_FILENO,
-        message.as_ptr().cast::<libc::c_void>(),
-        message.len(),
-    );
-    libc::_exit(126);
-}
-
-/// # Safety
-/// Must be called in the child process after fork. The slave_fd must be valid.
+/// Must be called in a freshly-forked child process. `slave_fd` must be a
+/// valid open file descriptor for the slave side of a PTY pair.
 pub unsafe fn setup_child_pty(slave_fd: RawFd) {
-    // Create a new session so the child can acquire a controlling terminal.
-    if libc::setsid() < 0 {
+    if nix::unistd::setsid().is_err() {
         child_setup_pty_fatal(b"nono: setsid() failed while configuring child PTY\n");
     }
 
-    // Set the slave as the controlling terminal (TIOCSCTTY).
-    // The arg 0 means "don't steal if another process has it".
-    if libc::ioctl(slave_fd, libc::TIOCSCTTY as libc::c_ulong, 0) < 0 {
-        child_setup_pty_fatal(b"nono: ioctl(TIOCSCTTY) failed while configuring child PTY\n");
-    }
+    // SAFETY: post-fork child; slave_fd is valid per caller contract.
+    // ioctl/dup2/close operate on raw fd integers — nix's IO-safe wrappers
+    // require AsFd/OwnedFd which aren't available for STDIN_FILENO et al.
+    unsafe {
+        if libc::ioctl(slave_fd, libc::TIOCSCTTY as libc::c_ulong, 0) < 0 {
+            child_setup_pty_fatal(b"nono: ioctl(TIOCSCTTY) failed while configuring child PTY\n");
+        }
 
-    // Redirect stdin/stdout/stderr to the slave PTY
-    if libc::dup2(slave_fd, libc::STDIN_FILENO) < 0 {
-        child_setup_pty_fatal(b"nono: dup2(stdin) failed while configuring child PTY\n");
-    }
-    if libc::dup2(slave_fd, libc::STDOUT_FILENO) < 0 {
-        child_setup_pty_fatal(b"nono: dup2(stdout) failed while configuring child PTY\n");
-    }
-    if libc::dup2(slave_fd, libc::STDERR_FILENO) < 0 {
-        child_setup_pty_fatal(b"nono: dup2(stderr) failed while configuring child PTY\n");
-    }
+        if libc::dup2(slave_fd, libc::STDIN_FILENO) < 0 {
+            child_setup_pty_fatal(b"nono: dup2(stdin) failed while configuring child PTY\n");
+        }
+        if libc::dup2(slave_fd, libc::STDOUT_FILENO) < 0 {
+            child_setup_pty_fatal(b"nono: dup2(stdout) failed while configuring child PTY\n");
+        }
+        if libc::dup2(slave_fd, libc::STDERR_FILENO) < 0 {
+            child_setup_pty_fatal(b"nono: dup2(stderr) failed while configuring child PTY\n");
+        }
 
-    // Close the original slave fd if it's not one of 0/1/2
-    if slave_fd > 2 {
-        libc::close(slave_fd);
+        if slave_fd > 2 {
+            libc::close(slave_fd);
+        }
     }
 }
 
@@ -632,20 +637,20 @@ impl PtyProxy {
 
         self.record_output(&buf[..n]);
 
-        if let Some((write_fd, is_terminal)) = client {
-            if let Err(err) = write_all_fd(write_fd, &buf[..n]) {
-                if is_terminal {
-                    warn!(
-                        "PTY proxy: terminal output write failed for session {}: {}; detaching terminal client",
-                        self.session_id, err
-                    );
-                    self.detach();
-                    return MasterProxyOutcome::Data;
-                } else {
-                    debug!("PTY proxy: attached socket client disconnected: {}", err);
-                    self.detach();
-                    return MasterProxyOutcome::Data;
-                }
+        if let Some((write_fd, is_terminal)) = client
+            && let Err(err) = write_all_fd(write_fd, &buf[..n])
+        {
+            if is_terminal {
+                warn!(
+                    "PTY proxy: terminal output write failed for session {}: {}; detaching terminal client",
+                    self.session_id, err
+                );
+                self.detach();
+                return MasterProxyOutcome::Data;
+            } else {
+                debug!("PTY proxy: attached socket client disconnected: {}", err);
+                self.detach();
+                return MasterProxyOutcome::Data;
             }
         }
 
@@ -748,14 +753,14 @@ impl PtyProxy {
         };
 
         let forwarded = self.filter_client_input(&buf[..n]);
-        if !forwarded.is_empty() {
-            if let Err(err) = write_all_fd(self.master.as_raw_fd(), &forwarded) {
-                warn!(
-                    "PTY proxy: failed forwarding client input to PTY master for session {}: {}",
-                    self.session_id, err
-                );
-                return false;
-            }
+        if !forwarded.is_empty()
+            && let Err(err) = write_all_fd(self.master.as_raw_fd(), &forwarded)
+        {
+            warn!(
+                "PTY proxy: failed forwarding client input to PTY master for session {}: {}",
+                self.session_id, err
+            );
+            return false;
         }
 
         true
@@ -823,10 +828,9 @@ impl PtyProxy {
             .client
             .as_ref()
             .is_some_and(AttachedClient::is_terminal)
+            && let Some(winsize) = get_terminal_winsize()
         {
-            if let Some(winsize) = get_terminal_winsize() {
-                let _ = self.apply_winsize(&winsize);
-            }
+            let _ = self.apply_winsize(&winsize);
         }
     }
 
@@ -2107,11 +2111,11 @@ where
         // Scroll Up so the user can reach the full final session view by
         // scrolling back. Then restore terminal modes without touching the
         // alternate screen buffer.
-        if let Some(winsize) = get_terminal_winsize() {
-            if winsize.ws_row > 0 {
-                let scroll_up = format!("\x1b[{}S", winsize.ws_row);
-                let _ = write_all_fd(libc::STDOUT_FILENO, scroll_up.as_bytes());
-            }
+        if let Some(winsize) = get_terminal_winsize()
+            && winsize.ws_row > 0
+        {
+            let scroll_up = format!("\x1b[{}S", winsize.ws_row);
+            let _ = write_all_fd(libc::STDOUT_FILENO, scroll_up.as_bytes());
         }
     }
     let _ = write_all_fd(
@@ -2229,53 +2233,53 @@ fn run_attach_loop(
     let mut last_winsize = get_terminal_winsize();
 
     loop {
-        if let Some(deadline) = stdin_deadline {
-            if std::time::Instant::now() < deadline {
-                let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-                let timeout_ms = remaining.as_millis().min(i32::MAX as u128) as i32;
-                let mut warmup_pfd = libc::pollfd {
-                    fd: sock_fd,
-                    events: libc::POLLIN,
-                    revents: 0,
-                };
-                let ret = unsafe { libc::poll(&mut warmup_pfd, 1, timeout_ms) };
-                if ret < 0 {
-                    let err = std::io::Error::last_os_error();
-                    if err.kind() == std::io::ErrorKind::Interrupted {
-                        continue;
-                    }
-                    return Err(NonoError::SandboxInit(format!(
-                        "poll() error in attach warm-up: {}",
-                        err
-                    )));
+        if let Some(deadline) = stdin_deadline
+            && std::time::Instant::now() < deadline
+        {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            let timeout_ms = remaining.as_millis().min(i32::MAX as u128) as i32;
+            let mut warmup_pfd = libc::pollfd {
+                fd: sock_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            let ret = unsafe { libc::poll(&mut warmup_pfd, 1, timeout_ms) };
+            if ret < 0 {
+                let err = std::io::Error::last_os_error();
+                if err.kind() == std::io::ErrorKind::Interrupted {
+                    continue;
                 }
-                if warmup_pfd.revents & libc::POLLIN != 0 {
-                    match read_fd_once(sock_fd, &mut buf) {
-                        Ok(ReadFdOutcome::Data(n)) => {
-                            if let Err(err) = write_stdout_tracked(alt_screen_tracker, &buf[..n]) {
-                                return Err(NonoError::SandboxInit(format!(
-                                    "attach stdout write failed: {}",
-                                    err
-                                )));
-                            }
-                        }
-                        Ok(ReadFdOutcome::Eof) => break,
-                        Ok(ReadFdOutcome::Retry) => continue,
-                        Err(err) if is_socket_disconnect(&err) => break,
-                        Err(err) => {
+                return Err(NonoError::SandboxInit(format!(
+                    "poll() error in attach warm-up: {}",
+                    err
+                )));
+            }
+            if warmup_pfd.revents & libc::POLLIN != 0 {
+                match read_fd_once(sock_fd, &mut buf) {
+                    Ok(ReadFdOutcome::Data(n)) => {
+                        if let Err(err) = write_stdout_tracked(alt_screen_tracker, &buf[..n]) {
                             return Err(NonoError::SandboxInit(format!(
-                                "attach socket read failed: {}",
+                                "attach stdout write failed: {}",
                                 err
                             )));
                         }
                     }
+                    Ok(ReadFdOutcome::Eof) => break,
+                    Ok(ReadFdOutcome::Retry) => continue,
+                    Err(err) if is_socket_disconnect(&err) => break,
+                    Err(err) => {
+                        return Err(NonoError::SandboxInit(format!(
+                            "attach socket read failed: {}",
+                            err
+                        )));
+                    }
                 }
-                if warmup_pfd.revents & (libc::POLLHUP | libc::POLLERR) != 0 {
-                    info!("PTY attach client observed attach socket close during warm-up");
-                    break;
-                }
-                continue;
             }
+            if warmup_pfd.revents & (libc::POLLHUP | libc::POLLERR) != 0 {
+                info!("PTY attach client observed attach socket close during warm-up");
+                break;
+            }
+            continue;
         }
 
         // SAFETY: pfds is a valid array on the stack
@@ -2361,15 +2365,15 @@ fn run_attach_loop(
 
         if pfds[2].revents & libc::POLLIN != 0 {
             drain_attach_resize_pipe();
-            if let Some(socket) = resize_socket {
-                if let Some(winsize) = get_terminal_winsize() {
-                    let changed = last_winsize
-                        .map(|last| last.ws_row != winsize.ws_row || last.ws_col != winsize.ws_col)
-                        .unwrap_or(true);
-                    if changed {
-                        let _ = send_attach_resize(socket, winsize);
-                        last_winsize = Some(winsize);
-                    }
+            if let Some(socket) = resize_socket
+                && let Some(winsize) = get_terminal_winsize()
+            {
+                let changed = last_winsize
+                    .map(|last| last.ws_row != winsize.ws_row || last.ws_col != winsize.ws_col)
+                    .unwrap_or(true);
+                if changed {
+                    let _ = send_attach_resize(socket, winsize);
+                    last_winsize = Some(winsize);
                 }
             }
         }
@@ -2381,11 +2385,11 @@ fn run_attach_loop(
 #[cfg(test)]
 mod tests {
     use super::{
-        decode_attach_handshake, encode_attach_request_frame, read_fd_once,
-        select_attach_replay_bytes, terminal_restore_escape, write_all_fd, AltScreenTracker,
-        AttachedClient, PtyProxy, ReadFdOutcome, ScreenState, ATTACH_HANDSHAKE_MAGIC,
-        ATTACH_REQUEST_ATTACH, ATTACH_SCREEN_ENTER_ESCAPE, DEFAULT_DETACH_SEQUENCE,
-        ERASE_NATIVE_SCROLLBACK, TERMINAL_RESTORE_NORMAL,
+        ATTACH_HANDSHAKE_MAGIC, ATTACH_REQUEST_ATTACH, ATTACH_SCREEN_ENTER_ESCAPE,
+        AltScreenTracker, AttachedClient, DEFAULT_DETACH_SEQUENCE, ERASE_NATIVE_SCROLLBACK,
+        PtyProxy, ReadFdOutcome, ScreenState, TERMINAL_RESTORE_NORMAL, decode_attach_handshake,
+        encode_attach_request_frame, read_fd_once, select_attach_replay_bytes,
+        terminal_restore_escape, write_all_fd,
     };
     use nix::libc;
     use std::collections::VecDeque;

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -5,7 +5,7 @@
 
 use crate::config;
 use colored::Colorize;
-use nono::{try_canonicalize, AccessMode, CapabilitySet, Result};
+use nono::{AccessMode, CapabilitySet, Result, try_canonicalize};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
@@ -77,19 +77,19 @@ pub fn query_path(
 
     // Check if this is a sensitive path (CLI security policy), but skip
     // the check for paths that have been explicitly overridden.
-    if !is_overridden {
-        if let Some(matched) = config::check_sensitive_path(&canonical.to_string_lossy())? {
-            return Ok(QueryResult::Denied {
-                reason: "sensitive_path".to_string(),
-                details: Some(format!(
-                    "Blocked by policy group '{}': {} Use filesystem.bypass_protection to exempt specific paths when appropriate.",
-                    matched.group_name, matched.description
-                )),
-                policy_source: Some(format!("group:{}", matched.group_name)),
-                matching_capability: None,
-                suggested_flag: None,
-            });
-        }
+    if !is_overridden
+        && let Some(matched) = config::check_sensitive_path(&canonical.to_string_lossy())?
+    {
+        return Ok(QueryResult::Denied {
+            reason: "sensitive_path".to_string(),
+            details: Some(format!(
+                "Blocked by policy group '{}': {} Use filesystem.bypass_protection to exempt specific paths when appropriate.",
+                matched.group_name, matched.description
+            )),
+            policy_source: Some(format!("group:{}", matched.group_name)),
+            matching_capability: None,
+            suggested_flag: None,
+        });
     }
 
     // Check capabilities. Prefer the most specific matching grant so broad system
@@ -463,9 +463,11 @@ mod tests {
                 let capability = matching_capability.expect("expected matching capability");
                 assert_eq!(capability.access, "read");
                 assert_eq!(capability.source, "group:dev");
-                assert!(details
-                    .as_deref()
-                    .is_some_and(|d| d.contains("group:dev") && d.contains("write was requested")));
+                assert!(
+                    details.as_deref().is_some_and(
+                        |d| d.contains("group:dev") && d.contains("write was requested")
+                    )
+                );
             }
             _ => panic!("expected denied result"),
         }
@@ -493,12 +495,16 @@ mod tests {
                 ..
             } => {
                 assert_eq!(reason, "sensitive_path");
-                assert!(policy_source
-                    .as_deref()
-                    .is_some_and(|policy| policy.starts_with("group:")));
-                assert!(details
-                    .as_deref()
-                    .is_some_and(|detail| detail.contains("filesystem.bypass_protection")));
+                assert!(
+                    policy_source
+                        .as_deref()
+                        .is_some_and(|policy| policy.starts_with("group:"))
+                );
+                assert!(
+                    details
+                        .as_deref()
+                        .is_some_and(|detail| detail.contains("filesystem.bypass_protection"))
+                );
                 assert!(suggested_flag.is_none());
             }
             _ => panic!("expected denied result"),

--- a/crates/nono-cli/src/registry_client.rs
+++ b/crates/nono-cli/src/registry_client.rs
@@ -219,13 +219,13 @@ fn map_ureq_error(error: ureq::Error) -> NonoError {
 }
 
 fn enforce_content_length(content_length: Option<u64>, limit: u64, url: &str) -> Result<()> {
-    if let Some(content_length) = content_length {
-        if content_length > limit {
-            return Err(NonoError::RegistryError(format!(
-                "registry response from {} exceeds {} bytes",
-                url, limit
-            )));
-        }
+    if let Some(content_length) = content_length
+        && content_length > limit
+    {
+        return Err(NonoError::RegistryError(format!(
+            "registry response from {} exceeds {} bytes",
+            url, limit
+        )));
     }
 
     Ok(())

--- a/crates/nono-cli/src/rollback_commands.rs
+++ b/crates/nono-cli/src/rollback_commands.rs
@@ -10,12 +10,12 @@ use crate::command_display::{format_command_line, truncate_chars};
 use crate::config::user::load_user_config;
 use crate::rollback_base_exclusions;
 use crate::rollback_session::{
-    discover_sessions, format_bytes, load_session, remove_session, rollback_root, SessionInfo,
+    SessionInfo, discover_sessions, format_bytes, load_session, remove_session, rollback_root,
 };
 use crate::theme;
 use colored::Colorize;
 use nono::undo::{MerkleTree, ObjectStore, SnapshotManager};
-use nono::{try_canonicalize, NonoError, Result};
+use nono::{NonoError, Result, try_canonicalize};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -535,19 +535,19 @@ fn print_full_content(changes: &[nono::undo::Change], object_store: &ObjectStore
             _ => change.new_hash.as_ref(),
         };
 
-        if let Some(hash) = content_hash {
-            if let Ok(content) = object_store.retrieve(hash) {
-                if let Ok(text) = String::from_utf8(content) {
-                    for (i, line) in text.lines().enumerate() {
-                        eprintln!(
-                            "  {} {}",
-                            format!("{:4}", i + 1).truecolor(100, 100, 100),
-                            line
-                        );
-                    }
-                } else {
-                    eprintln!("  (binary file)");
+        if let Some(hash) = content_hash
+            && let Ok(content) = object_store.retrieve(hash)
+        {
+            if let Ok(text) = String::from_utf8(content) {
+                for (i, line) in text.lines().enumerate() {
+                    eprintln!(
+                        "  {} {}",
+                        format!("{:4}", i + 1).truecolor(100, 100, 100),
+                        line
+                    );
                 }
+            } else {
+                eprintln!("  (binary file)");
             }
         }
         eprintln!();
@@ -822,10 +822,11 @@ fn cmd_cleanup(args: RollbackCleanupArgs) -> Result<()> {
             .as_secs();
 
         for s in &sessions {
-            if let Some(started) = parse_session_start_time(s) {
-                if now.saturating_sub(started) > cutoff_secs && !s.is_alive {
-                    to_remove.push(s);
-                }
+            if let Some(started) = parse_session_start_time(s)
+                && now.saturating_sub(started) > cutoff_secs
+                && !s.is_alive
+            {
+                to_remove.push(s);
             }
         }
     } else {
@@ -838,12 +839,11 @@ fn cmd_cleanup(args: RollbackCleanupArgs) -> Result<()> {
 
         // Orphaned sessions (process crashed/killed before clean exit)
         for s in &sessions {
-            if s.is_stale {
-                if let Some(started) = parse_session_start_time(s) {
-                    if now.saturating_sub(started) > orphan_grace_secs {
-                        to_remove.push(s);
-                    }
-                }
+            if s.is_stale
+                && let Some(started) = parse_session_start_time(s)
+                && now.saturating_sub(started) > orphan_grace_secs
+            {
+                to_remove.push(s);
             }
         }
 

--- a/crates/nono-cli/src/rollback_runtime.rs
+++ b/crates/nono-cli/src/rollback_runtime.rs
@@ -1,7 +1,7 @@
-use crate::audit_attestation::{write_audit_attestation, AuditSigner};
+use crate::audit_attestation::{AuditSigner, write_audit_attestation};
 use crate::audit_integrity::AuditRecorder;
 use crate::audit_ledger;
-use crate::launch_runtime::{rollback_base_exclusions, RollbackLaunchOptions};
+use crate::launch_runtime::{RollbackLaunchOptions, rollback_base_exclusions};
 use crate::{config, output, rollback_preflight, rollback_session, rollback_ui};
 use nono::undo::ExecutableIdentity;
 use nono::{AccessMode, CapabilitySet, Result};
@@ -552,41 +552,39 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<(
         let _ = manager.cleanup_new_atomic_temp_files(&atomic_temp_before);
     }
 
-    if !audit_saved {
-        if let Some(audit_state) = audit_state {
-            let (tracked_paths, merkle_roots) = match audit_snapshot_state {
-                Some(snap) => {
-                    let final_root = snap.manager.compute_merkle_root()?;
-                    (snap.tracked_paths, vec![snap.baseline_root, final_root])
-                }
-                None => (audit_tracked_paths, Vec::new()),
-            };
-            let mut meta = nono::undo::SessionMetadata {
-                session_id: audit_state.session_id.clone(),
-                started: started.to_string(),
-                ended: Some(ended.to_string()),
-                command: scrubbed_command,
-                executable_identity: executable_identity.cloned(),
-                tracked_paths,
-                snapshot_count: 0,
-                exit_code: Some(exit_code),
-                merkle_roots,
-                network_events,
-                audit_event_count,
-                audit_integrity,
-                audit_attestation: None,
-            };
-            if let Some(signer) = audit_signer {
-                meta.audit_attestation = Some(write_audit_attestation(
-                    &audit_state.session_dir,
-                    &meta,
-                    signer,
-                    redaction_policy,
-                )?);
+    if !audit_saved && let Some(audit_state) = audit_state {
+        let (tracked_paths, merkle_roots) = match audit_snapshot_state {
+            Some(snap) => {
+                let final_root = snap.manager.compute_merkle_root()?;
+                (snap.tracked_paths, vec![snap.baseline_root, final_root])
             }
-            nono::undo::SnapshotManager::write_session_metadata(&audit_state.session_dir, &meta)?;
-            audit_ledger::append_session(&meta)?;
+            None => (audit_tracked_paths, Vec::new()),
+        };
+        let mut meta = nono::undo::SessionMetadata {
+            session_id: audit_state.session_id.clone(),
+            started: started.to_string(),
+            ended: Some(ended.to_string()),
+            command: scrubbed_command,
+            executable_identity: executable_identity.cloned(),
+            tracked_paths,
+            snapshot_count: 0,
+            exit_code: Some(exit_code),
+            merkle_roots,
+            network_events,
+            audit_event_count,
+            audit_integrity,
+            audit_attestation: None,
+        };
+        if let Some(signer) = audit_signer {
+            meta.audit_attestation = Some(write_audit_attestation(
+                &audit_state.session_dir,
+                &meta,
+                signer,
+                redaction_policy,
+            )?);
         }
+        nono::undo::SnapshotManager::write_session_metadata(&audit_state.session_dir, &meta)?;
+        audit_ledger::append_session(&meta)?;
     }
 
     Ok(())
@@ -597,10 +595,10 @@ pub(crate) fn finalize_supervised_exit(ctx: RollbackExitContext<'_>) -> Result<(
 mod tests {
     use super::*;
     use crate::audit_attestation::{
-        signer_from_key_pair, verify_audit_attestation, write_audit_attestation,
-        AUDIT_ATTESTATION_BUNDLE_FILENAME,
+        AUDIT_ATTESTATION_BUNDLE_FILENAME, signer_from_key_pair, verify_audit_attestation,
+        write_audit_attestation,
     };
-    use crate::test_env::{EnvVarGuard, ENV_LOCK};
+    use crate::test_env::{ENV_LOCK, EnvVarGuard};
     use nono::trust;
     use nono::undo::{AuditIntegritySummary, SessionMetadata};
     use nono::{CapabilitySet, CapabilitySource, FsCapability};
@@ -882,9 +880,11 @@ mod tests {
         let mut attested_metadata = metadata.clone();
         attested_metadata.audit_attestation = Some(summary);
 
-        assert!(!rollback_dir
-            .join(AUDIT_ATTESTATION_BUNDLE_FILENAME)
-            .exists());
+        assert!(
+            !rollback_dir
+                .join(AUDIT_ATTESTATION_BUNDLE_FILENAME)
+                .exists()
+        );
         assert!(audit_dir.join(AUDIT_ATTESTATION_BUNDLE_FILENAME).exists());
 
         let verification =

--- a/crates/nono-cli/src/rollback_ui.rs
+++ b/crates/nono-cli/src/rollback_ui.rs
@@ -5,8 +5,8 @@
 
 use crate::theme;
 use colored::Colorize;
-use nono::undo::{Change, ChangeType, SnapshotManager, SnapshotManifest};
 use nono::Result;
+use nono::undo::{Change, ChangeType, SnapshotManager, SnapshotManifest};
 use std::io::{BufRead, IsTerminal, Write};
 
 /// Run the post-exit rollback review UI.

--- a/crates/nono-cli/src/sandbox_log.rs
+++ b/crates/nono-cli/src/sandbox_log.rs
@@ -297,10 +297,10 @@ fn parse_violation_line(filter: &ViolationFilter, line: &str) -> Option<SandboxV
 
 #[cfg(target_os = "macos")]
 fn parse_violation_value(filter: &ViolationFilter, value: &Value) -> Option<SandboxViolation> {
-    if let Some(message) = value.get("eventMessage").and_then(Value::as_str) {
-        if let Some(violation) = parse_event_message(filter, message) {
-            return Some(violation);
-        }
+    if let Some(message) = value.get("eventMessage").and_then(Value::as_str)
+        && let Some(violation) = parse_event_message(filter, message)
+    {
+        return Some(violation);
     }
 
     let metadata = value.get("eventMessage").and_then(|event_message| {

--- a/crates/nono-cli/src/sandbox_log.rs
+++ b/crates/nono-cli/src/sandbox_log.rs
@@ -402,7 +402,7 @@ fn parse_event_message(filter: &ViolationFilter, message: &str) -> Option<Sandbo
 
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
-    use super::{parse_event_message, parse_violation_line, ViolationFilter};
+    use super::{ViolationFilter, parse_event_message, parse_violation_line};
 
     fn pid_filter(pid: i32) -> ViolationFilter {
         ViolationFilter {

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -235,10 +235,10 @@ fn load_claude_oauth_state_from_raw_sources(
     keychain_raw: Option<&str>,
     file_raw: Option<(&str, &str)>,
 ) -> std::result::Result<Option<ClaudeOauthState>, String> {
-    if let Some(raw) = keychain_raw {
-        if let Some(oauth) = parse_claude_oauth_state_json(raw, "Claude OAuth keychain JSON")? {
-            return Ok(Some(oauth));
-        }
+    if let Some(raw) = keychain_raw
+        && let Some(oauth) = parse_claude_oauth_state_json(raw, "Claude OAuth keychain JSON")?
+    {
+        return Ok(Some(oauth));
     }
 
     if let Some((raw, source_label)) = file_raw {
@@ -1138,19 +1138,19 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
 
     // Apply raw Seatbelt rules from the profile (macOS only).
     #[cfg(target_os = "macos")]
-    if let Some(ref profile) = loaded_profile {
-        if !profile.unsafe_macos_seatbelt_rules.is_empty() {
-            info!(
-                "Profile uses {} raw Seatbelt rule(s) via unsafe_macos_seatbelt_rules — review carefully",
-                profile.unsafe_macos_seatbelt_rules.len()
-            );
-            for rule in &profile.unsafe_macos_seatbelt_rules {
-                caps.add_platform_rule(rule).map_err(|e| {
-                    NonoError::ConfigParse(format!(
-                        "unsafe_macos_seatbelt_rules: invalid rule {rule:?}: {e}"
-                    ))
-                })?;
-            }
+    if let Some(ref profile) = loaded_profile
+        && !profile.unsafe_macos_seatbelt_rules.is_empty()
+    {
+        info!(
+            "Profile uses {} raw Seatbelt rule(s) via unsafe_macos_seatbelt_rules — review carefully",
+            profile.unsafe_macos_seatbelt_rules.len()
+        );
+        for rule in &profile.unsafe_macos_seatbelt_rules {
+            caps.add_platform_rule(rule).map_err(|e| {
+                NonoError::ConfigParse(format!(
+                    "unsafe_macos_seatbelt_rules: invalid rule {rule:?}: {e}"
+                ))
+            })?;
         }
     }
 

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -9,8 +9,8 @@ use crate::output;
 use crate::profile;
 use crate::profile::WorkdirAccess;
 use crate::profile_runtime::{prepare_profile, prepare_profile_for_preflight};
-use crate::{policy, protected_paths, sandbox_state};
 use crate::{DETACHED_CWD_PROMPT_RESPONSE_ENV, DETACHED_LAUNCH_ENV};
+use crate::{policy, protected_paths, sandbox_state};
 use colored::Colorize;
 use nono::{AccessMode, CapabilitySet, FsCapability, NonoError, Result, Sandbox};
 #[cfg(target_os = "macos")]
@@ -1073,10 +1073,10 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
                     .open(path)
                     .map(|_| ())
             };
-            if let Err(e) = result {
-                if e.kind() != std::io::ErrorKind::AlreadyExists {
-                    warn!("Failed to pre-create {}: {}", path.display(), e);
-                }
+            if let Err(e) = result
+                && e.kind() != std::io::ErrorKind::AlreadyExists
+            {
+                warn!("Failed to pre-create {}: {}", path.display(), e);
             }
         };
 
@@ -1115,10 +1115,10 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
                 // File doesn't exist yet — pre-create the target so the
                 // sandbox can attach a path rule to it, then symlink.
                 precreate(&redirect_target, false);
-                if let Err(e) = std::os::unix::fs::symlink(".claude/claude.json", &claude_json) {
-                    if e.kind() != std::io::ErrorKind::AlreadyExists {
-                        warn!("Failed to create ~/.claude.json symlink: {}", e);
-                    }
+                if let Err(e) = std::os::unix::fs::symlink(".claude/claude.json", &claude_json)
+                    && e.kind() != std::io::ErrorKind::AlreadyExists
+                {
+                    warn!("Failed to create ~/.claude.json symlink: {}", e);
                 }
             }
         }
@@ -1220,20 +1220,14 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
     if let Some(ref profile) = loaded_profile {
         for pack_ref in &profile.packs {
             let parts: Vec<&str> = pack_ref.splitn(2, '/').collect();
-            if parts.len() == 2 {
-                if let Ok(pack_dir) = crate::package::package_install_dir(parts[0], parts[1]) {
-                    if pack_dir.exists() {
-                        if let Ok(canonical) = pack_dir.canonicalize() {
-                            if !caps.path_covered_with_access(&canonical, nono::AccessMode::Read) {
-                                if let Ok(cap) =
-                                    FsCapability::new_dir(canonical, nono::AccessMode::Read)
-                                {
-                                    caps.add_fs(cap);
-                                }
-                            }
-                        }
-                    }
-                }
+            if parts.len() == 2
+                && let Ok(pack_dir) = crate::package::package_install_dir(parts[0], parts[1])
+                && pack_dir.exists()
+                && let Ok(canonical) = pack_dir.canonicalize()
+                && !caps.path_covered_with_access(&canonical, nono::AccessMode::Read)
+                && let Ok(cap) = FsCapability::new_dir(canonical, nono::AccessMode::Read)
+            {
+                caps.add_fs(cap);
             }
         }
         caps.deduplicate();
@@ -1654,9 +1648,11 @@ mod tests {
             FsCapability::new_dir(dir.path(), AccessMode::ReadWrite).expect("dir capability"),
         );
 
-        assert!(pending_cwd_access_request(&caps, dir.path(), None)
-            .expect("request should evaluate")
-            .is_none());
+        assert!(
+            pending_cwd_access_request(&caps, dir.path(), None)
+                .expect("request should evaluate")
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/session.rs
+++ b/crates/nono-cli/src/session.rs
@@ -173,11 +173,7 @@ fn proc_bsd_info(pid: u32) -> Option<ProcBsdInfo> {
             size,
         )
     };
-    if ret == size {
-        Some(info)
-    } else {
-        None
-    }
+    if ret == size { Some(info) } else { None }
 }
 
 fn reconcile_session_record(record: &mut SessionRecord) -> bool {

--- a/crates/nono-cli/src/session_commands.rs
+++ b/crates/nono-cli/src/session_commands.rs
@@ -486,14 +486,14 @@ pub fn run_prune(args: &PruneArgs) -> Result<()> {
                     e
                 );
             }
-            if events_file.exists() {
-                if let Err(e) = std::fs::remove_file(&events_file) {
-                    debug!(
-                        "Failed to remove events file {}: {}",
-                        events_file.display(),
-                        e
-                    );
-                }
+            if events_file.exists()
+                && let Err(e) = std::fs::remove_file(&events_file)
+            {
+                debug!(
+                    "Failed to remove events file {}: {}",
+                    events_file.display(),
+                    e
+                );
             }
             eprintln!("Removed: {} (started {})", s.session_id, s.started);
         }

--- a/crates/nono-cli/src/setup.rs
+++ b/crates/nono-cli/src/setup.rs
@@ -207,7 +207,9 @@ impl SetupRunner {
             if detected.has_network() {
                 println!("    - Per-port network filtering: available (Landlock V4+)");
             } else {
-                println!("    - Per-port network filtering: unavailable (needs kernel 6.7+ for Landlock V4)");
+                println!(
+                    "    - Per-port network filtering: unavailable (needs kernel 6.7+ for Landlock V4)"
+                );
             }
             println!(
                 "    - Credential proxy (--credential): requires wsl2_proxy_policy profile opt-in"
@@ -561,9 +563,11 @@ mod tests {
     fn test_detected_abi_has_network_for_v4_plus() {
         let detected = nono::DetectedAbi::new(landlock::ABI::V4);
         assert!(detected.has_network());
-        assert!(detected
-            .feature_names()
-            .iter()
-            .any(|n| n.starts_with("TCP network filtering")));
+        assert!(
+            detected
+                .feature_names()
+                .iter()
+                .any(|n| n.starts_with("TCP network filtering"))
+        );
     }
 }

--- a/crates/nono-cli/src/setup.rs
+++ b/crates/nono-cli/src/setup.rs
@@ -128,7 +128,7 @@ impl SetupRunner {
 
             if pid == 0 {
                 // Child process: try to apply sandbox
-                extern "C" {
+                unsafe extern "C" {
                     fn sandbox_init(
                         profile: *const std::os::raw::c_char,
                         flags: u64,

--- a/crates/nono-cli/src/startup_runtime.rs
+++ b/crates/nono-cli/src/startup_runtime.rs
@@ -1,8 +1,8 @@
 use crate::cli::{Commands, RunArgs};
 use crate::sandbox_prepare::resolve_detached_cwd_prompt_response;
 use crate::{
-    output, session, update_check, DETACHED_CWD_PROMPT_RESPONSE_ENV, DETACHED_LAUNCH_ENV,
-    DETACHED_SESSION_ID_ENV,
+    DETACHED_CWD_PROMPT_RESPONSE_ENV, DETACHED_LAUNCH_ENV, DETACHED_SESSION_ID_ENV, output,
+    session, update_check,
 };
 #[cfg(unix)]
 use nix::libc;
@@ -89,10 +89,10 @@ pub(crate) fn show_update_notification(
     handle: &mut Option<update_check::UpdateCheckHandle>,
     silent: bool,
 ) {
-    if let Some(handle) = handle.take() {
-        if let Some(info) = handle.take_result() {
-            output::print_update_notification(&info, silent);
-        }
+    if let Some(handle) = handle.take()
+        && let Some(info) = handle.take_result()
+    {
+        output::print_update_notification(&info, silent);
     }
 }
 
@@ -330,7 +330,9 @@ Capabilities:
 
         assert_eq!(
             summarize_startup_log_contents(contents).as_deref(),
-            Some("2026-03-23T18:08:00.249207Z ERROR Sandbox initialization failed: Profile inheritance error: circular dependency detected: claude-code -> claude-code")
+            Some(
+                "2026-03-23T18:08:00.249207Z ERROR Sandbox initialization failed: Profile inheritance error: circular dependency detected: claude-code -> claude-code"
+            )
         );
     }
 

--- a/crates/nono-cli/src/supervised_runtime.rs
+++ b/crates/nono-cli/src/supervised_runtime.rs
@@ -4,12 +4,12 @@ use crate::launch_runtime::{
     ProxyLaunchOptions, RollbackLaunchOptions, SessionLaunchOptions, TrustLaunchOptions,
 };
 use crate::rollback_runtime::{
-    create_audit_state, finalize_supervised_exit, initialize_audit_snapshots,
-    initialize_rollback_state, warn_if_rollback_flags_ignored, AuditState, RollbackExitContext,
+    AuditState, RollbackExitContext, create_audit_state, finalize_supervised_exit,
+    initialize_audit_snapshots, initialize_rollback_state, warn_if_rollback_flags_ignored,
 };
 use crate::{
-    exec_strategy, output, protected_paths, pty_proxy, session, terminal_approval, trust_intercept,
-    DETACHED_SESSION_ID_ENV,
+    DETACHED_SESSION_ID_ENV, exec_strategy, output, protected_paths, pty_proxy, session,
+    terminal_approval, trust_intercept,
 };
 use colored::Colorize;
 use nono::undo::ExecutableIdentity;

--- a/crates/nono-cli/src/test_env.rs
+++ b/crates/nono-cli/src/test_env.rs
@@ -25,7 +25,8 @@ impl EnvVarGuard {
             .collect::<Vec<_>>();
 
         for (key, value) in vars {
-            std::env::set_var(key, value);
+            // SAFETY: all callers hold ENV_LOCK, preventing concurrent env mutation.
+            unsafe { std::env::set_var(key, value) };
         }
 
         Self { original }
@@ -42,7 +43,8 @@ impl EnvVarGuard {
             "EnvVarGuard::remove called with unmanaged key: '{key}'. \
              Only keys passed to set_all can be removed."
         );
-        std::env::remove_var(key);
+        // SAFETY: callers hold ENV_LOCK.
+        unsafe { std::env::remove_var(key) };
     }
 }
 
@@ -50,9 +52,10 @@ impl EnvVarGuard {
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
         for (key, value) in self.original.iter().rev() {
+            // SAFETY: drop runs while ENV_LOCK is still held by the test.
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                Some(value) => unsafe { std::env::set_var(key, value) },
+                None => unsafe { std::env::remove_var(key) },
             }
         }
     }

--- a/crates/nono-cli/src/trust_cmd.rs
+++ b/crates/nono-cli/src/trust_cmd.rs
@@ -8,10 +8,10 @@ use crate::cli::{
 };
 use crate::trust_keystore::{self, TrustKeyRef};
 use aws_lc_rs::rand::SystemRandom;
-use aws_lc_rs::signature::{EcdsaKeyPair, ECDSA_P256_SHA256_ASN1_SIGNING};
+use aws_lc_rs::signature::{ECDSA_P256_SHA256_ASN1_SIGNING, EcdsaKeyPair};
 use colored::Colorize;
-use nono::trust;
 use nono::Result;
+use nono::trust;
 use std::path::{Path, PathBuf};
 use tracing::debug;
 use zeroize::Zeroizing;
@@ -817,10 +817,9 @@ fn run_verify(args: TrustVerifyArgs) -> Result<()> {
                     // step cannot be reached with a traversal name even if
                     // the inner guard is somehow bypassed in the future.
                     if let Ok(subject_path) = crate::trust_scan::safe_subject_path(scan_root, name)
+                        && let Ok(canon) = std::fs::canonicalize(&subject_path)
                     {
-                        if let Ok(canon) = std::fs::canonicalize(&subject_path) {
-                            multi_verified_paths.insert(canon);
-                        }
+                        multi_verified_paths.insert(canon);
                     }
                 }
             }
@@ -1354,12 +1353,12 @@ fn load_trust_policy(explicit_path: Option<&Path>) -> Result<trust::TrustPolicy>
         verify_policy_if_exists(&cwd_policy)?;
         let project_policy = trust::load_policy_from_file(&cwd_policy)?;
         // Try to load user-level policy and merge
-        if let Some(user_policy_path) = user_trust_policy_path() {
-            if user_policy_path.exists() {
-                verify_policy_if_exists(&user_policy_path)?;
-                let user_policy = trust::load_policy_from_file(&user_policy_path)?;
-                return trust::merge_policies(&[user_policy, project_policy]);
-            }
+        if let Some(user_policy_path) = user_trust_policy_path()
+            && user_policy_path.exists()
+        {
+            verify_policy_if_exists(&user_policy_path)?;
+            let user_policy = trust::load_policy_from_file(&user_policy_path)?;
+            return trust::merge_policies(&[user_policy, project_policy]);
         }
         let user_path = user_trust_policy_path()
             .map(|p| p.display().to_string())
@@ -1385,11 +1384,11 @@ fn load_trust_policy(explicit_path: Option<&Path>) -> Result<trust::TrustPolicy>
     }
 
     // User-level only
-    if let Some(user_path) = user_trust_policy_path() {
-        if user_path.exists() {
-            verify_policy_if_exists(&user_path)?;
-            return trust::load_policy_from_file(&user_path);
-        }
+    if let Some(user_path) = user_trust_policy_path()
+        && user_path.exists()
+    {
+        verify_policy_if_exists(&user_path)?;
+        return trust::load_policy_from_file(&user_path);
     }
 
     // No policy found — return a default empty policy
@@ -1421,19 +1420,19 @@ fn verify_policy_if_exists(policy_path: &Path) -> Result<()> {
 pub(crate) fn user_trust_policy_path() -> Option<PathBuf> {
     #[cfg(feature = "test-trust-overrides")]
     {
-        if let Some(raw_path) = std::env::var_os(TEST_USER_POLICY_PATH_ENV) {
-            if !raw_path.is_empty() {
-                let path = PathBuf::from(&raw_path);
-                if path.is_absolute() {
-                    return Some(path);
-                }
-
-                tracing::warn!(
-                    "Ignoring invalid {}='{}' (must be absolute), falling back to user config dir",
-                    TEST_USER_POLICY_PATH_ENV,
-                    path.display()
-                );
+        if let Some(raw_path) = std::env::var_os(TEST_USER_POLICY_PATH_ENV)
+            && !raw_path.is_empty()
+        {
+            let path = PathBuf::from(&raw_path);
+            if path.is_absolute() {
+                return Some(path);
             }
+
+            tracing::warn!(
+                "Ignoring invalid {}='{}' (must be absolute), falling back to user config dir",
+                TEST_USER_POLICY_PATH_ENV,
+                path.display()
+            );
         }
     }
 

--- a/crates/nono-cli/src/trust_intercept.rs
+++ b/crates/nono-cli/src/trust_intercept.rs
@@ -405,12 +405,16 @@ mod tests {
         let policy = TrustPolicy::default();
         let mut interceptor = TrustInterceptor::new(policy, dir.path().to_path_buf()).unwrap();
 
-        assert!(interceptor
-            .check_path(Path::new("/tmp/README.md"))
-            .is_none());
-        assert!(interceptor
-            .check_path(Path::new("/tmp/src/main.rs"))
-            .is_none());
+        assert!(
+            interceptor
+                .check_path(Path::new("/tmp/README.md"))
+                .is_none()
+        );
+        assert!(
+            interceptor
+                .check_path(Path::new("/tmp/src/main.rs"))
+                .is_none()
+        );
     }
 
     #[test]
@@ -419,12 +423,16 @@ mod tests {
         let policy = TrustPolicy::default();
         let mut interceptor = TrustInterceptor::new(policy, dir.path().to_path_buf()).unwrap();
 
-        assert!(interceptor
-            .check_path(Path::new("/tmp/SKILLS.md.bundle"))
-            .is_none());
-        assert!(interceptor
-            .check_path(Path::new("/tmp/CLAUDE.md.bundle"))
-            .is_none());
+        assert!(
+            interceptor
+                .check_path(Path::new("/tmp/SKILLS.md.bundle"))
+                .is_none()
+        );
+        assert!(
+            interceptor
+                .check_path(Path::new("/tmp/CLAUDE.md.bundle"))
+                .is_none()
+        );
     }
 
     #[test]
@@ -522,18 +530,24 @@ mod tests {
     #[test]
     fn format_outcome_variants() {
         assert!(format_outcome(&VerificationOutcome::Unsigned).contains("unsigned"));
-        assert!(format_outcome(&VerificationOutcome::Blocked {
-            reason: "test".to_string()
-        })
-        .contains("blocklisted"));
-        assert!(format_outcome(&VerificationOutcome::InvalidSignature {
-            detail: "bad sig".to_string()
-        })
-        .contains("bad sig"));
-        assert!(format_outcome(&VerificationOutcome::DigestMismatch {
-            expected: "a".to_string(),
-            actual: "b".to_string()
-        })
-        .contains("does not match"));
+        assert!(
+            format_outcome(&VerificationOutcome::Blocked {
+                reason: "test".to_string()
+            })
+            .contains("blocklisted")
+        );
+        assert!(
+            format_outcome(&VerificationOutcome::InvalidSignature {
+                detail: "bad sig".to_string()
+            })
+            .contains("bad sig")
+        );
+        assert!(
+            format_outcome(&VerificationOutcome::DigestMismatch {
+                expected: "a".to_string(),
+                actual: "b".to_string()
+            })
+            .contains("does not match")
+        );
     }
 }

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -10,8 +10,8 @@
 //! read instruction files at initialization.
 
 use colored::Colorize;
-use nono::trust::{self, Enforcement, TrustPolicy, VerificationOutcome, VerificationResult};
 use nono::Result;
+use nono::trust::{self, Enforcement, TrustPolicy, VerificationOutcome, VerificationResult};
 use std::path::{Path, PathBuf};
 
 /// Load the trust policy for scanning, auto-discovering from the given root and user config.
@@ -431,10 +431,10 @@ pub fn run_pre_exec_scan(
         let file_path = std::path::PathBuf::from(&expanded);
 
         // Skip if already verified via the multi-subject bundle above
-        if let Ok(canon) = std::fs::canonicalize(&file_path) {
-            if multi_verified_paths.contains(&canon) {
-                continue;
-            }
+        if let Ok(canon) = std::fs::canonicalize(&file_path)
+            && multi_verified_paths.contains(&canon)
+        {
+            continue;
         }
 
         let result = verify_instruction_file(&file_path, policy);
@@ -475,10 +475,10 @@ fn expand_home(path: &str) -> String {
         if let Some(home) = dirs::home_dir() {
             return home.join(rest).to_string_lossy().into_owned();
         }
-    } else if path == "~" {
-        if let Some(home) = dirs::home_dir() {
-            return home.to_string_lossy().into_owned();
-        }
+    } else if path == "~"
+        && let Some(home) = dirs::home_dir()
+    {
+        return home.to_string_lossy().into_owned();
     }
     path.to_string()
 }
@@ -825,12 +825,12 @@ pub(crate) fn safe_subject_path(
     let canon_root = std::fs::canonicalize(scan_root)
         .map_err(|e| format!("failed to canonicalize scan root: {e}"))?;
 
-    if let Ok(canon_path) = std::fs::canonicalize(&joined) {
-        if !canon_path.starts_with(&canon_root) {
-            return Err(format!(
-                "subject '{name}' resolves outside scan root via symlink"
-            ));
-        }
+    if let Ok(canon_path) = std::fs::canonicalize(&joined)
+        && !canon_path.starts_with(&canon_root)
+    {
+        return Err(format!(
+            "subject '{name}' resolves outside scan root via symlink"
+        ));
     }
 
     Ok(joined)
@@ -923,7 +923,7 @@ fn verify_multi_subject_bundle(
                     }];
                 }
             };
-            if let Some((_, ref digest)) = subjects.first() {
+            if let Some((_, digest)) = subjects.first() {
                 verify_keyless_crypto(bundle_path, digest, &bundle, bundle_path)
             } else {
                 Err(VerificationOutcome::InvalidSignature {

--- a/crates/nono-cli/src/update_check.rs
+++ b/crates/nono-cli/src/update_check.rs
@@ -140,10 +140,11 @@ pub fn start_background_check() -> Option<UpdateCheckHandle> {
             };
             let _ = save_state(&updated_state);
 
-            if info.update_available && is_newer_version(current, &info.latest_version) {
-                if let Ok(mut guard) = result_clone.lock() {
-                    *guard = Some(info);
-                }
+            if info.update_available
+                && is_newer_version(current, &info.latest_version)
+                && let Ok(mut guard) = result_clone.lock()
+            {
+                *guard = Some(info);
             }
         }
     });

--- a/crates/nono-cli/src/why_runtime.rs
+++ b/crates/nono-cli/src/why_runtime.rs
@@ -19,18 +19,17 @@ fn resolve_allowed_domains(profile: &profile::Profile) -> Vec<String> {
 
     let mut domains = Vec::new();
 
-    if let Some(net_profile_name) = profile.network.resolved_network_profile() {
-        if let Ok(resolved) = network_policy::resolve_network_profile(&net_policy, net_profile_name)
-        {
-            domains.extend(resolved.hosts);
-            for suffix in &resolved.suffixes {
-                let wildcard = if suffix.starts_with('.') {
-                    format!("*{}", suffix)
-                } else {
-                    format!("*.{}", suffix)
-                };
-                domains.push(wildcard);
-            }
+    if let Some(net_profile_name) = profile.network.resolved_network_profile()
+        && let Ok(resolved) = network_policy::resolve_network_profile(&net_policy, net_profile_name)
+    {
+        domains.extend(resolved.hosts);
+        for suffix in &resolved.suffixes {
+            let wildcard = if suffix.starts_with('.') {
+                format!("*{}", suffix)
+            } else {
+                format!("*.{}", suffix)
+            };
+            domains.push(wildcard);
         }
     }
 
@@ -43,7 +42,7 @@ fn resolve_allowed_domains(profile: &profile::Profile) -> Vec<String> {
 }
 
 pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
-    use query_ext::{print_result, query_network, query_path, QueryResult};
+    use query_ext::{QueryResult, print_result, query_network, query_path};
     use sandbox_state::load_sandbox_state;
 
     let ctx: WhyContext = if args.self_query {

--- a/crates/nono-cli/src/wiring.rs
+++ b/crates/nono-cli/src/wiring.rs
@@ -101,15 +101,15 @@ impl<'de> Deserialize<'de> for WiringDirective {
         D: serde::Deserializer<'de>,
     {
         let mut value = serde_json::Value::deserialize(deserializer)?;
-        if let serde_json::Value::Object(object) = &mut value {
-            if let Some(when_value) = object.remove("when") {
-                let when = crate::platform::When::deserialize(when_value)
-                    .map_err(serde::de::Error::custom)?;
-                if !crate::platform::when_matches_current(Some(&when))
-                    .map_err(serde::de::Error::custom)?
-                {
-                    return Ok(Self::Skipped);
-                }
+        if let serde_json::Value::Object(object) = &mut value
+            && let Some(when_value) = object.remove("when")
+        {
+            let when =
+                crate::platform::When::deserialize(when_value).map_err(serde::de::Error::custom)?;
+            if !crate::platform::when_matches_current(Some(&when))
+                .map_err(serde::de::Error::custom)?
+            {
+                return Ok(Self::Skipped);
             }
         }
 
@@ -532,10 +532,10 @@ fn reverse_one(record: &WiringRecord) -> Result<()> {
     match record {
         WiringRecord::Symlink { link } => {
             let path = Path::new(link);
-            if let Ok(meta) = path.symlink_metadata() {
-                if meta.file_type().is_symlink() {
-                    fs::remove_file(path).map_err(NonoError::Io)?;
-                }
+            if let Ok(meta) = path.symlink_metadata()
+                && meta.file_type().is_symlink()
+            {
+                fs::remove_file(path).map_err(NonoError::Io)?;
             }
         }
         WiringRecord::WriteFile { dest, sha256 } => {
@@ -768,13 +768,13 @@ fn copy_file_atomic(source: &Path, dest: &Path) -> Result<CopyOutcome> {
     // Skip-no-op only if existing content matches exactly. Caller has
     // already enforced the conflict policy (only owned files reach
     // here when dest exists), so a hash match is a real no-op re-pull.
-    if let Ok(existing) = fs::read(dest) {
-        if existing == source_bytes {
-            return Ok(CopyOutcome {
-                mutated: false,
-                sha256,
-            });
-        }
+    if let Ok(existing) = fs::read(dest)
+        && existing == source_bytes
+    {
+        return Ok(CopyOutcome {
+            mutated: false,
+            sha256,
+        });
     }
     let tmp = dest.with_extension("nono-tmp");
     fs::write(&tmp, &source_bytes).map_err(NonoError::Io)?;
@@ -1282,7 +1282,7 @@ fn yaml_to_json(v: yaml::Value) -> Result<Value> {
                         return Err(NonoError::PackageInstall(format!(
                             "yaml_merge: mapping key must be a string, got {:?}",
                             other
-                        )))
+                        )));
                     }
                 };
                 obj.insert(key, yaml_to_json(v)?);
@@ -1524,7 +1524,7 @@ fn _suppress_unused() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_env::{EnvVarGuard, ENV_LOCK};
+    use crate::test_env::{ENV_LOCK, EnvVarGuard};
     use tempfile::TempDir;
 
     fn ctx_in(home: &Path, pack_dir: PathBuf) -> WiringContext {
@@ -1623,11 +1623,12 @@ mod tests {
             assert!(report.changed);
             assert_eq!(report.records.len(), 1);
             let link = home.join("link");
-            assert!(link
-                .symlink_metadata()
-                .expect("meta")
-                .file_type()
-                .is_symlink());
+            assert!(
+                link.symlink_metadata()
+                    .expect("meta")
+                    .file_type()
+                    .is_symlink()
+            );
             assert_eq!(fs::read_link(&link).expect("readlink"), pack);
 
             rev(&report.records);

--- a/crates/nono-cli/tests/manifest_roundtrip.rs
+++ b/crates/nono-cli/tests/manifest_roundtrip.rs
@@ -667,8 +667,8 @@ fn arb_profile_json(
 }
 
 /// Strategy producing `(profile_json, groups, workdir_access, network_block, extra_blocked)`.
-fn arb_profile(
-) -> impl Strategy<Value = (serde_json::Value, Vec<String>, String, bool, Vec<String>)> {
+fn arb_profile()
+-> impl Strategy<Value = (serde_json::Value, Vec<String>, String, bool, Vec<String>)> {
     let groups = arb_subset(AVAILABLE_GROUPS);
     let workdir = proptest::sample::select(WORKDIR_ACCESS).prop_map(String::from);
     let network_block = proptest::bool::ANY;

--- a/crates/nono-proxy/Cargo.toml
+++ b/crates/nono-proxy/Cargo.toml
@@ -29,10 +29,10 @@ serde_json.workspace = true
 tracing.workspace = true
 zeroize.workspace = true
 sha2.workspace = true
-getrandom = "0.4"
+getrandom.workspace = true
 base64 = "0.22"
 subtle = "2"
-url = "2"
+url.workspace = true
 urlencoding = "2"
 globset.workspace = true
 
@@ -60,3 +60,6 @@ time = { version = "0.3", default-features = false, features = ["std"] }
 [dev-dependencies]
 tempfile.workspace = true
 tokio = { version = "1", features = ["test-util", "rt-multi-thread", "macros"] }
+
+[lints]
+workspace = true

--- a/crates/nono-proxy/src/credential.rs
+++ b/crates/nono-proxy/src/credential.rs
@@ -406,7 +406,9 @@ mod tests {
                 .collect::<Vec<_>>();
 
             for (key, value) in vars {
-                std::env::set_var(key, value);
+                // SAFETY: test-only helper; tests using EnvVarGuard are
+                // serialised via #[serial] so no concurrent env mutation.
+                unsafe { std::env::set_var(key, value) };
             }
 
             Self { original }
@@ -417,9 +419,10 @@ mod tests {
     impl Drop for EnvVarGuard {
         fn drop(&mut self) {
             for (key, value) in self.original.iter().rev() {
+                // SAFETY: test-only restore; same serialisation guarantee as set_all.
                 match value {
-                    Some(value) => std::env::set_var(key, value),
-                    None => std::env::remove_var(key),
+                    Some(value) => unsafe { std::env::set_var(key, value) },
+                    None => unsafe { std::env::remove_var(key) },
                 }
             }
         }

--- a/crates/nono-proxy/src/forward.rs
+++ b/crates/nono-proxy/src/forward.rs
@@ -277,14 +277,12 @@ fn parse_response_status(data: &[u8]) -> u16 {
 
     if let Ok(line) = std::str::from_utf8(first_line) {
         let mut parts = line.split_whitespace();
-        if let Some(version) = parts.next() {
-            if version.starts_with("HTTP/") {
-                if let Some(code_str) = parts.next() {
-                    if code_str.len() == 3 {
-                        return code_str.parse().unwrap_or(502);
-                    }
-                }
-            }
+        if let Some(version) = parts.next()
+            && version.starts_with("HTTP/")
+            && let Some(code_str) = parts.next()
+            && code_str.len() == 3
+        {
+            return code_str.parse().unwrap_or(502);
         }
     }
     502

--- a/crates/nono-proxy/src/lib.rs
+++ b/crates/nono-proxy/src/lib.rs
@@ -34,4 +34,4 @@ pub mod token;
 
 pub use config::ProxyConfig;
 pub use error::{ProxyError, Result};
-pub use server::{start, ProxyHandle};
+pub use server::{ProxyHandle, start};

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -376,12 +376,11 @@ pub async fn handle_reverse_proxy(
 
     let auth_header_lower = cred.map(|c| c.header_name.to_lowercase());
     for (name, value) in &filtered_headers {
-        if let (Some(cred), Some(header_lower)) = (cred, auth_header_lower.as_ref()) {
-            if matches!(cred.inject_mode, InjectMode::Header | InjectMode::BasicAuth)
-                && name.to_lowercase() == *header_lower
-            {
-                continue;
-            }
+        if let (Some(cred), Some(header_lower)) = (cred, auth_header_lower.as_ref())
+            && matches!(cred.inject_mode, InjectMode::Header | InjectMode::BasicAuth)
+            && name.to_lowercase() == *header_lower
+        {
+            continue;
         }
         request.push_str(&format!("{}: {}\r\n", name, value));
     }
@@ -1002,16 +1001,15 @@ fn validate_phantom_token_in_query(
     if let Some(query_start) = path.find('?') {
         let query = &path[query_start + 1..];
         for pair in query.split('&') {
-            if let Some((name, value)) = pair.split_once('=') {
-                if name == param_name {
-                    // URL-decode the value
-                    let decoded = urlencoding::decode(value).unwrap_or_else(|_| value.into());
-                    if token::constant_time_eq(decoded.as_bytes(), session_token.as_bytes()) {
-                        return Ok(());
-                    }
-                    warn!("Invalid phantom token in query parameter '{}'", param_name);
-                    return Err(ProxyError::InvalidToken);
+            if let Some((name, value)) = pair.split_once('=')
+                && name == param_name
+            {
+                let decoded = urlencoding::decode(value).unwrap_or_else(|_| value.into());
+                if token::constant_time_eq(decoded.as_bytes(), session_token.as_bytes()) {
+                    return Ok(());
                 }
+                warn!("Invalid phantom token in query parameter '{}'", param_name);
+                return Err(ProxyError::InvalidToken);
             }
         }
     }
@@ -1141,11 +1139,11 @@ fn transform_query_param(
         let new_query: Vec<String> = query
             .split('&')
             .map(|pair| {
-                if let Some((name, _)) = pair.split_once('=') {
-                    if name == param_name {
-                        found = true;
-                        return format!("{}={}", param_name, encoded_value);
-                    }
+                if let Some((name, _)) = pair.split_once('=')
+                    && name == param_name
+                {
+                    found = true;
+                    return format!("{}={}", param_name, encoded_value);
                 }
                 pair.to_string()
             })
@@ -1837,16 +1835,18 @@ mod tests {
         let path = "/session456/api/v1/namespaces";
 
         // 1. Proxy-side validation succeeds
-        assert!(validate_phantom_token_for_mode(
-            &InjectMode::UrlPath,
-            b"\r\n\r\n", // no auth header needed for url_path mode
-            path,
-            "Authorization",
-            Some("/{}/"),
-            None,
-            &token,
-        )
-        .is_ok());
+        assert!(
+            validate_phantom_token_for_mode(
+                &InjectMode::UrlPath,
+                b"\r\n\r\n", // no auth header needed for url_path mode
+                path,
+                "Authorization",
+                Some("/{}/"),
+                None,
+                &token,
+            )
+            .is_ok()
+        );
 
         // 2. Strip proxy artifacts
         let cleaned = strip_proxy_artifacts(
@@ -1873,16 +1873,18 @@ mod tests {
         let path = "/api/v1/pods?token=session789&limit=100";
 
         // 1. Proxy-side validation succeeds
-        assert!(validate_phantom_token_for_mode(
-            &InjectMode::QueryParam,
-            b"\r\n\r\n",
-            path,
-            "Authorization",
-            None,
-            Some("token"),
-            &token,
-        )
-        .is_ok());
+        assert!(
+            validate_phantom_token_for_mode(
+                &InjectMode::QueryParam,
+                b"\r\n\r\n",
+                path,
+                "Authorization",
+                None,
+                Some("token"),
+                &token,
+            )
+            .is_ok()
+        );
 
         // 2. Strip proxy artifacts
         let cleaned = strip_proxy_artifacts(

--- a/crates/nono-proxy/src/route.rs
+++ b/crates/nono-proxy/src/route.rs
@@ -565,13 +565,17 @@ mod tests {
 
         let route = store.get("openai").unwrap();
         assert_eq!(route.upstream, "https://api.openai.com");
-        assert!(route
-            .endpoint_rules
-            .is_allowed("POST", "/v1/chat/completions"));
+        assert!(
+            route
+                .endpoint_rules
+                .is_allowed("POST", "/v1/chat/completions")
+        );
         assert!(route.endpoint_rules.is_allowed("GET", "/v1/models"));
-        assert!(!route
-            .endpoint_rules
-            .is_allowed("DELETE", "/v1/files/file-123"));
+        assert!(
+            !route
+                .endpoint_rules
+                .is_allowed("DELETE", "/v1/files/file-123")
+        );
     }
 
     #[test]

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -20,8 +20,8 @@ use crate::tls_intercept::{self, CertCache, EphemeralCa};
 use crate::token;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
 use tokio::sync::watch;
@@ -664,49 +664,50 @@ async fn handle_connection(mut stream: tokio::net::TcpStream, state: &ProxyState
         //
         // Anything else (host not matching any route) falls through to the
         // existing transparent-tunnel / external-proxy paths.
-        if !state.route_store.is_empty() {
-            if let Some(authority) = first_line.split_whitespace().nth(1) {
-                // Normalise authority to host:port. Handle IPv6 brackets:
-                // "[::1]:443" already has port, "[::1]" needs default, "host:443" has port.
-                let host_port = if authority.starts_with('[') {
-                    if authority.contains("]:") {
-                        authority.to_lowercase()
-                    } else {
-                        format!("{}:443", authority.to_lowercase())
-                    }
-                } else if authority.contains(':') {
+        if !state.route_store.is_empty()
+            && let Some(authority) = first_line.split_whitespace().nth(1)
+        {
+            // Normalise authority to host:port. Handle IPv6 brackets:
+            // "[::1]:443" already has port, "[::1]" needs default, "host:443" has port.
+            let host_port = if authority.starts_with('[') {
+                if authority.contains("]:") {
                     authority.to_lowercase()
                 } else {
                     format!("{}:443", authority.to_lowercase())
-                };
+                }
+            } else if authority.contains(':') {
+                authority.to_lowercase()
+            } else {
+                format!("{}:443", authority.to_lowercase())
+            };
 
-                if state.route_store.is_route_upstream(&host_port) {
-                    let route_id = state
-                        .route_store
-                        .lookup_by_upstream(&host_port)
-                        .map(|(prefix, _)| prefix);
-                    let (host, port) = host_port
-                        .rsplit_once(':')
-                        .map(|(h, p)| (h.to_string(), p.parse::<u16>().unwrap_or(443)))
-                        .unwrap_or_else(|| (host_port.clone(), 443));
+            if state.route_store.is_route_upstream(&host_port) {
+                let route_id = state
+                    .route_store
+                    .lookup_by_upstream(&host_port)
+                    .map(|(prefix, _)| prefix);
+                let (host, port) = host_port
+                    .rsplit_once(':')
+                    .map(|(h, p)| (h.to_string(), p.parse::<u16>().unwrap_or(443)))
+                    .unwrap_or_else(|| (host_port.clone(), 443));
 
-                    let intercept_eligible = state.route_store.has_intercept_route(&host_port);
+                let intercept_eligible = state.route_store.has_intercept_route(&host_port);
 
-                    match (intercept_eligible, state.cert_cache.as_ref()) {
-                        // Case 1: intercept-eligible route + cert cache available.
-                        (true, Some(cache)) => {
-                            // Strict OUTER auth: intercept is a privileged op
-                            // (we mint a leaf cert and decrypt traffic), so
-                            // unlike the lenient transparent-tunnel path we
-                            // require Proxy-Authorization here.
-                            if let Err(e) =
-                                token::validate_proxy_auth(&header_bytes, &state.session_token)
-                            {
-                                debug!(
-                                    "tls_intercept: rejecting CONNECT to {}:{} — {}",
-                                    host, port, e
-                                );
-                                audit::log_denied(
+                match (intercept_eligible, state.cert_cache.as_ref()) {
+                    // Case 1: intercept-eligible route + cert cache available.
+                    (true, Some(cache)) => {
+                        // Strict OUTER auth: intercept is a privileged op
+                        // (we mint a leaf cert and decrypt traffic), so
+                        // unlike the lenient transparent-tunnel path we
+                        // require Proxy-Authorization here.
+                        if let Err(e) =
+                            token::validate_proxy_auth(&header_bytes, &state.session_token)
+                        {
+                            debug!(
+                                "tls_intercept: rejecting CONNECT to {}:{} — {}",
+                                host, port, e
+                            );
+                            audit::log_denied(
                                     Some(&state.audit_log),
                                     audit::ProxyMode::ConnectIntercept,
                                     &audit::EventContext {
@@ -726,51 +727,50 @@ async fn handle_connection(mut stream: tokio::net::TcpStream, state: &ProxyState
                                     port,
                                     "proxy auth missing or invalid",
                                 );
-                                let response = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm=\"nono\"\r\nContent-Length: 0\r\n\r\n";
-                                stream.write_all(response.as_bytes()).await?;
-                                return Ok(());
-                            }
-
-                            let ctx = tls_intercept::InterceptCtx {
-                                route_id,
-                                host: &host,
-                                port,
-                                route_store: &state.route_store,
-                                credential_store: &state.credential_store,
-                                session_token: &state.session_token,
-                                cert_cache: Arc::clone(cache),
-                                tls_connector: &state.tls_connector,
-                                filter: &state.filter,
-                                audit_log: Some(&state.audit_log),
-                            };
-                            return tls_intercept::handle_intercept_connect(&mut stream, ctx).await;
-                        }
-                        // Case 2 & 3: route exists but interception is unavailable
-                        // or the route is purely declarative — keep the existing
-                        // 403 to force SDK cooperation with the reverse-proxy path.
-                        _ => {
-                            debug!(
-                                "Blocked CONNECT to route upstream {} — use reverse proxy path instead",
-                                authority
-                            );
-                            audit::log_denied(
-                                Some(&state.audit_log),
-                                audit::ProxyMode::Connect,
-                                &audit::EventContext {
-                                    route_id,
-                                    denial_category: Some(
-                                        nono::undo::NetworkAuditDenialCategory::ConnectBypassesL7,
-                                    ),
-                                    ..audit::EventContext::default()
-                                },
-                                &host,
-                                port,
-                                "route upstream: CONNECT bypasses L7 filtering",
-                            );
-                            let response = "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n";
+                            let response = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm=\"nono\"\r\nContent-Length: 0\r\n\r\n";
                             stream.write_all(response.as_bytes()).await?;
                             return Ok(());
                         }
+
+                        let ctx = tls_intercept::InterceptCtx {
+                            route_id,
+                            host: &host,
+                            port,
+                            route_store: &state.route_store,
+                            credential_store: &state.credential_store,
+                            session_token: &state.session_token,
+                            cert_cache: Arc::clone(cache),
+                            tls_connector: &state.tls_connector,
+                            filter: &state.filter,
+                            audit_log: Some(&state.audit_log),
+                        };
+                        return tls_intercept::handle_intercept_connect(&mut stream, ctx).await;
+                    }
+                    // Case 2 & 3: route exists but interception is unavailable
+                    // or the route is purely declarative — keep the existing
+                    // 403 to force SDK cooperation with the reverse-proxy path.
+                    _ => {
+                        debug!(
+                            "Blocked CONNECT to route upstream {} — use reverse proxy path instead",
+                            authority
+                        );
+                        audit::log_denied(
+                            Some(&state.audit_log),
+                            audit::ProxyMode::Connect,
+                            &audit::EventContext {
+                                route_id,
+                                denial_category: Some(
+                                    nono::undo::NetworkAuditDenialCategory::ConnectBypassesL7,
+                                ),
+                                ..audit::EventContext::default()
+                            },
+                            &host,
+                            port,
+                            "route upstream: CONNECT bypasses L7 filtering",
+                        );
+                        let response = "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n";
+                        stream.write_all(response.as_bytes()).await?;
+                        return Ok(());
                     }
                 }
             }
@@ -1490,7 +1490,9 @@ mod tests {
         };
         let vars_no_env_var = handle_no_env_var.credential_env_vars(&config_no_env_var);
         assert!(
-            vars_no_env_var.iter().all(|(k, _)| k != "ANTHROPIC_API_KEY"),
+            vars_no_env_var
+                .iter()
+                .all(|(k, _)| k != "ANTHROPIC_API_KEY"),
             "pre-fix: ANTHROPIC_API_KEY must not be set when neither env_var nor credential_key is defined (bug reproduced)"
         );
 

--- a/crates/nono-proxy/src/tls_intercept/bundle.rs
+++ b/crates/nono-proxy/src/tls_intercept/bundle.rs
@@ -199,7 +199,7 @@ fn write_with_restrictive_perms(path: &Path, contents: &[u8]) -> Result<()> {
 /// a dep but its config API has churned across versions; doing it ourselves
 /// keeps this stable).
 fn base64_chunked(bytes: &[u8]) -> String {
-    use base64::engine::{general_purpose::STANDARD, Engine};
+    use base64::engine::{Engine, general_purpose::STANDARD};
     let encoded = STANDARD.encode(bytes);
     let mut out = String::with_capacity(encoded.len() + encoded.len() / 64 + 1);
     for chunk in encoded.as_bytes().chunks(64) {

--- a/crates/nono-proxy/src/tls_intercept/ca.rs
+++ b/crates/nono-proxy/src/tls_intercept/ca.rs
@@ -143,8 +143,8 @@ fn system_time_to_offset(t: SystemTime) -> Result<OffsetDateTime> {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use rustls::pki_types::pem::PemObject;
     use rustls::pki_types::CertificateDer;
+    use rustls::pki_types::pem::PemObject;
 
     #[test]
     fn generate_produces_valid_pem() {

--- a/crates/nono-proxy/src/tls_intercept/cert_cache.rs
+++ b/crates/nono-proxy/src/tls_intercept/cert_cache.rs
@@ -24,7 +24,7 @@
 use crate::error::{ProxyError, Result};
 use crate::tls_intercept::ca::EphemeralCa;
 use rcgen::{
-    CertificateParams, DistinguishedName, DnType, KeyPair, SanType, PKCS_ECDSA_P256_SHA256,
+    CertificateParams, DistinguishedName, DnType, KeyPair, PKCS_ECDSA_P256_SHA256, SanType,
 };
 use rustls::pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer};
 use rustls::server::{ClientHello, ResolvesServerCert};

--- a/crates/nono-proxy/src/tls_intercept/handle.rs
+++ b/crates/nono-proxy/src/tls_intercept/handle.rs
@@ -232,34 +232,34 @@ where
     let cred = service.and_then(|s| ctx.credential_store.get(s));
     let oauth2_route = service.and_then(|s| ctx.credential_store.get_oauth2(s));
 
-    if let Some(rt) = route {
-        if rt.missing_managed_credential(cred.is_some(), oauth2_route.is_some()) {
-            let svc = service.unwrap_or("unknown");
-            let reason = format!(
-                "managed credential unavailable for route '{}': intercepted request requires proxy-supplied auth",
-                svc
-            );
-            warn!("tls_intercept: {}", reason);
-            audit::log_denied(
-                ctx.audit_log,
-                audit::ProxyMode::ConnectIntercept,
-                &audit::EventContext {
-                    route_id: service,
-                    auth_mechanism: rt.managed_auth_mechanism.clone(),
-                    auth_outcome: Some(nono::undo::NetworkAuditAuthOutcome::Failed),
-                    managed_credential_active: Some(false),
-                    injection_mode: rt.managed_injection_mode.clone(),
-                    denial_category: Some(
-                        nono::undo::NetworkAuditDenialCategory::ManagedCredentialUnavailable,
-                    ),
-                },
-                ctx.host,
-                ctx.port,
-                &reason,
-            );
-            reverse::send_error_generic(tls_stream, 503, "Service Unavailable").await?;
-            return Ok(());
-        }
+    if let Some(rt) = route
+        && rt.missing_managed_credential(cred.is_some(), oauth2_route.is_some())
+    {
+        let svc = service.unwrap_or("unknown");
+        let reason = format!(
+            "managed credential unavailable for route '{}': intercepted request requires proxy-supplied auth",
+            svc
+        );
+        warn!("tls_intercept: {}", reason);
+        audit::log_denied(
+            ctx.audit_log,
+            audit::ProxyMode::ConnectIntercept,
+            &audit::EventContext {
+                route_id: service,
+                auth_mechanism: rt.managed_auth_mechanism.clone(),
+                auth_outcome: Some(nono::undo::NetworkAuditAuthOutcome::Failed),
+                managed_credential_active: Some(false),
+                injection_mode: rt.managed_injection_mode.clone(),
+                denial_category: Some(
+                    nono::undo::NetworkAuditDenialCategory::ManagedCredentialUnavailable,
+                ),
+            },
+            ctx.host,
+            ctx.port,
+            &reason,
+        );
+        reverse::send_error_generic(tls_stream, 503, "Service Unavailable").await?;
+        return Ok(());
     }
 
     // --- Path / credential transformation ---
@@ -332,12 +332,11 @@ where
     }
     let auth_header_lower = cred.map(|c| c.header_name.to_lowercase());
     for (name, value) in &filtered_headers {
-        if let (Some(cred), Some(hdr)) = (cred, auth_header_lower.as_ref()) {
-            if matches!(cred.inject_mode, InjectMode::Header | InjectMode::BasicAuth)
-                && name.to_lowercase() == *hdr
-            {
-                continue;
-            }
+        if let (Some(cred), Some(hdr)) = (cred, auth_header_lower.as_ref())
+            && matches!(cred.inject_mode, InjectMode::Header | InjectMode::BasicAuth)
+            && name.to_lowercase() == *hdr
+        {
+            continue;
         }
         request.push_str(&format!("{}: {}\r\n", name, value));
     }

--- a/crates/nono-proxy/src/tls_intercept/mod.rs
+++ b/crates/nono-proxy/src/tls_intercept/mod.rs
@@ -37,7 +37,7 @@ pub mod cert_cache;
 pub mod handle;
 
 pub use acceptor::build_server_config;
-pub use bundle::{write_bundle, BundleInputs};
+pub use bundle::{BundleInputs, write_bundle};
 pub use ca::EphemeralCa;
 pub use cert_cache::CertCache;
-pub use handle::{handle_intercept_connect, InterceptCtx};
+pub use handle::{InterceptCtx, handle_intercept_connect};

--- a/crates/nono-proxy/src/token.rs
+++ b/crates/nono-proxy/src/token.rs
@@ -92,8 +92,8 @@ pub fn validate_proxy_auth(header_bytes: &[u8], session_token: &Zeroizing<String
 /// Expected format: base64("username:token"). The username is ignored;
 /// only the password portion is compared against the session token.
 fn validate_basic_auth(encoded: &str, session_token: &Zeroizing<String>) -> Result<()> {
-    use base64::engine::general_purpose::STANDARD;
     use base64::Engine;
+    use base64::engine::general_purpose::STANDARD;
 
     let decoded = STANDARD
         .decode(encoded)
@@ -189,8 +189,8 @@ mod tests {
 
     #[test]
     fn test_validate_proxy_auth_basic() {
-        use base64::engine::general_purpose::STANDARD;
         use base64::Engine;
+        use base64::engine::general_purpose::STANDARD;
         let token = Zeroizing::new("abc123".to_string());
         let encoded = STANDARD.encode("nono:abc123");
         let header = format!("Proxy-Authorization: Basic {}\r\n\r\n", encoded);
@@ -199,8 +199,8 @@ mod tests {
 
     #[test]
     fn test_validate_proxy_auth_basic_wrong_password() {
-        use base64::engine::general_purpose::STANDARD;
         use base64::Engine;
+        use base64::engine::general_purpose::STANDARD;
         let token = Zeroizing::new("abc123".to_string());
         let encoded = STANDARD.encode("nono:wrong");
         let header = format!("Proxy-Authorization: Basic {}\r\n\r\n", encoded);
@@ -209,8 +209,8 @@ mod tests {
 
     #[test]
     fn test_validate_proxy_auth_basic_any_username() {
-        use base64::engine::general_purpose::STANDARD;
         use base64::Engine;
+        use base64::engine::general_purpose::STANDARD;
         let token = Zeroizing::new("abc123".to_string());
         // Any username should work — only password matters
         let encoded = STANDARD.encode("whatever:abc123");

--- a/crates/nono/Cargo.toml
+++ b/crates/nono/Cargo.toml
@@ -25,7 +25,7 @@ serde_json.workspace = true
 tracing.workspace = true
 zeroize.workspace = true
 sha2.workspace = true
-getrandom = "0.4"
+getrandom.workspace = true
 walkdir.workspace = true
 ignore.workspace = true
 globset.workspace = true
@@ -51,20 +51,23 @@ x509-cert = { version = "0.2", default-features = false }
 der = { version = "0.7", default-features = false }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-landlock = "0.4"
-nix = { version = "0.31.3", features = ["fs", "user"] }
+landlock.workspace = true
+nix = { workspace = true, features = ["fs", "user"] }
 keyring = { version = "3", features = ["sync-secret-service"], optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-nix = { version = "0.31.3", features = ["fs", "user"] }
+nix = { workspace = true, features = ["fs", "user"] }
 keyring = { version = "3", features = ["apple-native"], optional = true }
 
 [build-dependencies]
 typify = "0.6"
-serde_json = "1"
+serde_json.workspace = true
 syn = "2"
 prettyplease = "0.2"
 
 [dev-dependencies]
 tempfile.workspace = true
 jsonschema = "0.46"
+
+[lints]
+workspace = true

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -2342,9 +2342,10 @@ mod tests {
     fn test_platform_rule_validation_valid_deny() {
         let mut caps = CapabilitySet::new();
         assert!(caps.add_platform_rule("(deny file-write-unlink)").is_ok());
-        assert!(caps
-            .add_platform_rule("(deny file-read-data (subpath \"/secret\"))")
-            .is_ok());
+        assert!(
+            caps.add_platform_rule("(deny file-read-data (subpath \"/secret\"))")
+                .is_ok()
+        );
     }
 
     #[test]
@@ -2357,46 +2358,54 @@ mod tests {
     #[test]
     fn test_platform_rule_validation_rejects_root_access() {
         let mut caps = CapabilitySet::new();
-        assert!(caps
-            .add_platform_rule("(allow file-read* (subpath \"/\"))")
-            .is_err());
-        assert!(caps
-            .add_platform_rule("(allow file-write* (subpath \"/\"))")
-            .is_err());
+        assert!(
+            caps.add_platform_rule("(allow file-read* (subpath \"/\"))")
+                .is_err()
+        );
+        assert!(
+            caps.add_platform_rule("(allow file-write* (subpath \"/\"))")
+                .is_err()
+        );
         // Specific subpaths should be fine
-        assert!(caps
-            .add_platform_rule("(allow file-read* (subpath \"/usr\"))")
-            .is_ok());
+        assert!(
+            caps.add_platform_rule("(allow file-read* (subpath \"/usr\"))")
+                .is_ok()
+        );
     }
 
     #[test]
     fn test_platform_rule_validation_rejects_whitespace_bypass() {
         let mut caps = CapabilitySet::new();
         // Tab-separated
-        assert!(caps
-            .add_platform_rule("(allow\tfile-read*\t(subpath\t\"/\"))")
-            .is_err());
+        assert!(
+            caps.add_platform_rule("(allow\tfile-read*\t(subpath\t\"/\"))")
+                .is_err()
+        );
         // Extra spaces
-        assert!(caps
-            .add_platform_rule("(allow  file-read*  (subpath  \"/\"))")
-            .is_err());
+        assert!(
+            caps.add_platform_rule("(allow  file-read*  (subpath  \"/\"))")
+                .is_err()
+        );
         // Mixed whitespace
-        assert!(caps
-            .add_platform_rule("(allow \t file-write* \t (subpath \"/\"))")
-            .is_err());
+        assert!(
+            caps.add_platform_rule("(allow \t file-write* \t (subpath \"/\"))")
+                .is_err()
+        );
     }
 
     #[test]
     fn test_platform_rule_validation_rejects_comment_bypass() {
         let mut caps = CapabilitySet::new();
         // Block comment between tokens
-        assert!(caps
-            .add_platform_rule("(allow file-read* #| comment |# (subpath \"/\"))")
-            .is_err());
+        assert!(
+            caps.add_platform_rule("(allow file-read* #| comment |# (subpath \"/\"))")
+                .is_err()
+        );
         // Block comment inside nested expression
-        assert!(caps
-            .add_platform_rule("(allow #| sneaky |# file-write* (subpath \"/\"))")
-            .is_err());
+        assert!(
+            caps.add_platform_rule("(allow #| sneaky |# file-write* (subpath \"/\"))")
+                .is_err()
+        );
     }
 
     #[test]
@@ -2409,12 +2418,14 @@ mod tests {
     #[test]
     fn test_platform_rule_validation_rejects_unterminated_constructs() {
         let mut caps = CapabilitySet::new();
-        assert!(caps
-            .add_platform_rule("(deny file-read* #| unterminated comment")
-            .is_err());
-        assert!(caps
-            .add_platform_rule("(deny file-read* (subpath \"/usr))")
-            .is_err());
+        assert!(
+            caps.add_platform_rule("(deny file-read* #| unterminated comment")
+                .is_err()
+        );
+        assert!(
+            caps.add_platform_rule("(deny file-read* (subpath \"/usr))")
+                .is_err()
+        );
     }
 
     #[test]
@@ -2423,16 +2434,18 @@ mod tests {
         // Minimal IOKit surface: AGXDeviceUserClient is the only class required
         // for Metal compute on Apple Silicon. IOSurfaceRootUserClient is tried
         // opportunistically but Metal continues without it when denied.
-        assert!(caps
-            .add_platform_rule(
+        assert!(
+            caps.add_platform_rule(
                 "(allow iokit-open \
                     (iokit-user-client-class \
                         \"AGXDeviceUserClient\"))"
             )
-            .is_ok());
-        assert!(caps
-            .add_platform_rule("(allow iokit-get-properties)")
-            .is_ok());
+            .is_ok()
+        );
+        assert!(
+            caps.add_platform_rule("(allow iokit-get-properties)")
+                .is_ok()
+        );
         assert_eq!(caps.platform_rules().len(), 2);
     }
 

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -157,12 +157,12 @@ fn sanitize_for_diagnostic(s: &str) -> String {
     while let Some(c) = chars.next() {
         if c == '\x1b' {
             // Skip ESC and the entire escape sequence
-            if let Some(next) = chars.next() {
-                if next == '[' {
-                    for seq_char in chars.by_ref() {
-                        if seq_char.is_ascii_alphabetic() {
-                            break;
-                        }
+            if let Some(next) = chars.next()
+                && next == '['
+            {
+                for seq_char in chars.by_ref() {
+                    if seq_char.is_ascii_alphabetic() {
+                        break;
                     }
                 }
             }
@@ -313,10 +313,10 @@ fn detect_protected_file_in_error_line(
     error_line: &str,
 ) -> Option<String> {
     for path in protected_paths {
-        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-            if error_line.contains(name) {
-                return Some(name.to_string());
-            }
+        if let Some(name) = path.file_name().and_then(|n| n.to_str())
+            && error_line.contains(name)
+        {
+            return Some(name.to_string());
         }
     }
     None
@@ -556,13 +556,13 @@ fn extract_path_from_segment(segment: &str) -> Option<PathBuf> {
 fn infer_access_from_error_line(line: &str, path: &Path) -> AccessMode {
     let lower = line.to_ascii_lowercase();
 
-    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-        if matches!(
+    if let Some(name) = path.file_name().and_then(|n| n.to_str())
+        && matches!(
             name,
             ".profile" | ".bash_profile" | ".bashrc" | ".zprofile" | ".zshrc" | ".zlogin"
-        ) {
-            return AccessMode::Read;
-        }
+        )
+    {
+        return AccessMode::Read;
     }
 
     if lower.contains("cannot create")
@@ -1029,11 +1029,11 @@ impl<'a> DiagnosticFormatter<'a> {
         }
         lines.push("[nono]".to_string());
 
-        if self.blocked_protected_file.is_none() {
-            if let Some(verdict) = primary_verdict.as_ref() {
-                self.format_primary_verdict_guidance(&mut lines, verdict);
-                lines.push("[nono]".to_string());
-            }
+        if self.blocked_protected_file.is_none()
+            && let Some(verdict) = primary_verdict.as_ref()
+        {
+            self.format_primary_verdict_guidance(&mut lines, verdict);
+            lines.push("[nono]".to_string());
         }
 
         // Concise policy summary: show user paths, summarize system/group paths
@@ -1977,11 +1977,7 @@ fn stricter_reason(a: DenialReason, b: DenialReason) -> DenialReason {
             DenialReason::BackendError => 1,
         }
     }
-    if rank(&a) >= rank(&b) {
-        a
-    } else {
-        b
-    }
+    if rank(&a) >= rank(&b) { a } else { b }
 }
 
 /// Map a Seatbelt operation name to an `AccessMode`.
@@ -2900,7 +2896,9 @@ mod tests {
         );
         assert!(output.contains(&missing.display().to_string()));
         assert!(output.contains("To grant additional access, re-run with:"));
-        assert!(output.contains("Query policy: nono why --path <path> --op <read|write|readwrite>"));
+        assert!(
+            output.contains("Query policy: nono why --path <path> --op <read|write|readwrite>")
+        );
     }
 
     #[test]

--- a/crates/nono/src/keystore.rs
+++ b/crates/nono/src/keystore.rs
@@ -129,7 +129,8 @@ const FORBIDDEN_URI_CHARS: &[char] = &[
 ///
 /// let secrets = load_secrets(DEFAULT_SERVICE, &mappings)?;
 /// for secret in secrets {
-///     std::env::set_var(&secret.env_var, secret.value.as_str());
+///     // SAFETY: single-threaded setup before spawning workers.
+///     unsafe { std::env::set_var(&secret.env_var, secret.value.as_str()) };
 /// }
 /// # Ok::<(), nono::NonoError>(())
 /// ```
@@ -534,14 +535,15 @@ pub fn redact_keyring_uri(uri: &str) -> String {
             None => (path, None),
         };
         let mut segments = path_part.splitn(2, '/');
-        if let Some(service) = segments.next() {
-            if !service.is_empty() && segments.next().is_some() {
-                let suffix = match query_part {
-                    Some(q) => format!("?{}", q),
-                    None => String::new(),
-                };
-                return format!("keyring://{}/<redacted>{}", service, suffix);
-            }
+        if let Some(service) = segments.next()
+            && !service.is_empty()
+            && segments.next().is_some()
+        {
+            let suffix = match query_part {
+                Some(q) => format!("?{}", q),
+                None => String::new(),
+            };
+            return format!("keyring://{}/<redacted>{}", service, suffix);
         }
     }
     "keyring://***".to_string()
@@ -964,11 +966,9 @@ fn load_from_op(uri: &str) -> Result<Zeroizing<String>> {
         "1Password CLI",
         "Is 1Password waiting for authentication?",
     )
-    .map_err(|e| {
-        // Kill the process if it timed out
+    .inspect_err(|_| {
         let _ = child.kill();
         let _ = child.wait();
-        e
     })?;
 
     if !output.status.success() {
@@ -1222,10 +1222,11 @@ pub fn redact_op_uri(uri: &str) -> String {
 pub fn redact_apple_password_uri(uri: &str) -> String {
     if let Some(path) = strip_apple_password_prefix(uri) {
         let mut segments = path.splitn(2, '/');
-        if let Some(server) = segments.next() {
-            if !server.is_empty() && segments.next().is_some() {
-                return format!("apple-password://{}/<redacted>", server);
-            }
+        if let Some(server) = segments.next()
+            && !server.is_empty()
+            && segments.next().is_some()
+        {
+            return format!("apple-password://{}/<redacted>", server);
         }
     }
     "apple-password://***".to_string()
@@ -1235,10 +1236,10 @@ pub fn redact_apple_password_uri(uri: &str) -> String {
 /// Keeps the directory structure but replaces the filename.
 /// `file:///run/secrets/api-token` → `file:///run/secrets/[REDACTED]`
 pub fn redact_file_uri(uri: &str) -> String {
-    if let Some(path) = uri.strip_prefix(FILE_URI_PREFIX) {
-        if let Some(last_slash) = path.rfind('/') {
-            return format!("{}{}[REDACTED]", FILE_URI_PREFIX, &path[..=last_slash]);
-        }
+    if let Some(path) = uri.strip_prefix(FILE_URI_PREFIX)
+        && let Some(last_slash) = path.rfind('/')
+    {
+        return format!("{}{}[REDACTED]", FILE_URI_PREFIX, &path[..=last_slash]);
     }
     format!("{}[REDACTED]", FILE_URI_PREFIX)
 }

--- a/crates/nono/src/keystore.rs
+++ b/crates/nono/src/keystore.rs
@@ -1033,10 +1033,9 @@ fn load_from_apple_password(uri: &str) -> Result<Zeroizing<String>> {
             "macOS security CLI",
             "Is Keychain access waiting for user approval?",
         )
-        .map_err(|e| {
+        .inspect_err(|_| {
             let _ = child.kill();
             let _ = child.wait();
-            e
         })?;
 
         if !output.status.success() {

--- a/crates/nono/src/lib.rs
+++ b/crates/nono/src/lib.rs
@@ -72,19 +72,20 @@ pub use diagnostic::{
 };
 pub use error::{NonoError, Result};
 pub use keystore::{
-    is_apple_password_uri, is_env_uri, is_file_uri, is_keyring_uri, is_op_uri, load_secret_by_ref,
-    load_secret_file, load_secrets, redact_apple_password_uri, redact_file_uri, redact_keyring_uri,
-    redact_op_uri, store_secret_file, validate_apple_password_uri, validate_destination_env_var,
-    validate_env_uri, validate_file_uri, validate_keyring_uri, validate_op_uri, LoadedSecret,
+    LoadedSecret, is_apple_password_uri, is_env_uri, is_file_uri, is_keyring_uri, is_op_uri,
+    load_secret_by_ref, load_secret_file, load_secrets, redact_apple_password_uri, redact_file_uri,
+    redact_keyring_uri, redact_op_uri, store_secret_file, validate_apple_password_uri,
+    validate_destination_env_var, validate_env_uri, validate_file_uri, validate_keyring_uri,
+    validate_op_uri,
 };
 pub use net_filter::{FilterResult, HostFilter};
 pub use path::try_canonicalize;
 #[cfg(target_os = "linux")]
-pub use sandbox::{detect_abi, is_wsl2, DetectedAbi};
+pub use sandbox::{DetectedAbi, detect_abi, is_wsl2};
 pub use sandbox::{Sandbox, SupportInfo};
 pub use scrub::{
-    scrub_argv, scrub_argv_with_policy, scrub_header, scrub_header_with_policy, scrub_value,
-    scrub_value_with_policy, ScrubPolicy, ScrubPolicyDiff,
+    ScrubPolicy, ScrubPolicyDiff, scrub_argv, scrub_argv_with_policy, scrub_header,
+    scrub_header_with_policy, scrub_value, scrub_value_with_policy,
 };
 pub use state::SandboxState;
 pub use supervisor::{

--- a/crates/nono/src/manifest.rs
+++ b/crates/nono/src/manifest.rs
@@ -55,19 +55,19 @@ impl CapabilityManifest {
     /// - `query_param` inject mode requires `query_param_name`
     pub fn validate(&self) -> crate::Result<()> {
         // rollback.enabled requires exec_strategy: "supervised"
-        if let Some(ref rb) = self.rollback {
-            if rb.enabled {
-                let exec_strategy = self
-                    .process
-                    .as_ref()
-                    .map_or(ExecStrategy::Monitor, |p| p.exec_strategy);
-                if exec_strategy != ExecStrategy::Supervised {
-                    return Err(crate::NonoError::ConfigParse(
-                        "rollback.enabled: true requires exec_strategy: \"supervised\" \
-                         (rollback needs a parent process for snapshots)"
-                            .to_string(),
-                    ));
-                }
+        if let Some(ref rb) = self.rollback
+            && rb.enabled
+        {
+            let exec_strategy = self
+                .process
+                .as_ref()
+                .map_or(ExecStrategy::Monitor, |p| p.exec_strategy);
+            if exec_strategy != ExecStrategy::Supervised {
+                return Err(crate::NonoError::ConfigParse(
+                    "rollback.enabled: true requires exec_strategy: \"supervised\" \
+                     (rollback needs a parent process for snapshots)"
+                        .to_string(),
+                ));
             }
         }
 

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -4,8 +4,8 @@ use crate::capability::{AccessMode, CapabilitySet, NetworkMode, SignalMode};
 use crate::error::{NonoError, Result};
 use crate::sandbox::SupportInfo;
 use landlock::{
-    Access, AccessFs, AccessNet, BitFlags, CompatLevel, Compatible, NetPort, PathBeneath, PathFd,
-    Ruleset, RulesetAttr, RulesetCreatedAttr, Scope, ABI,
+    ABI, Access, AccessFs, AccessNet, BitFlags, CompatLevel, Compatible, NetPort, PathBeneath,
+    PathFd, Ruleset, RulesetAttr, RulesetCreatedAttr, Scope,
 };
 use std::path::Path;
 use std::sync::OnceLock;
@@ -216,11 +216,11 @@ fn detect_wsl2() -> bool {
 
     // Secondary: kernel version string contains "microsoft" or "WSL2"
     // This is written by the kernel build and cannot be spoofed from userspace.
-    if let Ok(version) = std::fs::read_to_string("/proc/version") {
-        if version.contains("microsoft") || version.contains("WSL") {
-            info!("WSL2 detected via /proc/version kernel string");
-            return true;
-        }
+    if let Ok(version) = std::fs::read_to_string("/proc/version")
+        && (version.contains("microsoft") || version.contains("WSL"))
+    {
+        info!("WSL2 detected via /proc/version kernel string");
+        return true;
     }
 
     // WSL_DISTRO_NAME env var is NOT trusted on its own — it is caller-controlled
@@ -2425,9 +2425,11 @@ mod tests {
         let v4 = DetectedAbi::new(ABI::V4);
         let names = v4.feature_names();
         assert!(names.iter().any(|n| n.starts_with("TCP network filtering")));
-        assert!(names
-            .iter()
-            .any(|n| n == "File rename across directories (Refer)"));
+        assert!(
+            names
+                .iter()
+                .any(|n| n == "File rename across directories (Refer)")
+        );
         assert!(names.iter().any(|n| n == "File truncation (Truncate)"));
     }
 

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -1225,8 +1225,10 @@ mod tests {
         assert!(
             profile.contains("(allow file-read* (extension \"com.apple.app-sandbox.read-write\"))")
         );
-        assert!(profile
-            .contains("(allow file-write* (extension \"com.apple.app-sandbox.read-write\"))"));
+        assert!(
+            profile
+                .contains("(allow file-write* (extension \"com.apple.app-sandbox.read-write\"))")
+        );
     }
 
     #[test]
@@ -1330,8 +1332,11 @@ mod tests {
             profile.contains("(allow network-outbound (path \"/private/var/run/mDNSResponder\"))")
         );
         assert!(profile.contains("(allow network-outbound (path \"/var/run/mDNSResponder\"))"));
-        assert!(profile
-            .contains("(allow system-socket (socket-domain AF_UNIX) (socket-type SOCK_STREAM))"));
+        assert!(
+            profile.contains(
+                "(allow system-socket (socket-domain AF_UNIX) (socket-type SOCK_STREAM))"
+            )
+        );
         // Should NOT have general outbound allow
         assert!(!profile.contains("(allow network-outbound)\n"));
         // Should NOT have bind/inbound without bind_ports
@@ -1708,8 +1713,11 @@ mod tests {
             profile.contains("(allow network-outbound (path \"/private/var/run/mDNSResponder\"))")
         );
         assert!(profile.contains("(allow network-outbound (path \"/var/run/mDNSResponder\"))"));
-        assert!(profile
-            .contains("(allow system-socket (socket-domain AF_UNIX) (socket-type SOCK_STREAM))"));
+        assert!(
+            profile.contains(
+                "(allow system-socket (socket-domain AF_UNIX) (socket-type SOCK_STREAM))"
+            )
+        );
     }
 
     #[test]

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -18,7 +18,7 @@ use tracing::{debug, info};
 // These are private APIs but have been stable for years
 // Reference: https://reverse.put.as/wp-content/uploads/2011/09/Apple-Sandbox-Guide-v1.0.pdf
 
-extern "C" {
+unsafe extern "C" {
     fn sandbox_init(profile: *const c_char, flags: u64, errorbuf: *mut *mut c_char) -> i32;
     fn sandbox_free_error(errorbuf: *mut c_char);
 }
@@ -27,7 +27,7 @@ extern "C" {
 // These are documented in <sandbox.h> and stable across macOS versions.
 // Extensions allow an unsandboxed supervisor to issue tokens that expand
 // a sandboxed process's access for specific paths.
-extern "C" {
+unsafe extern "C" {
     fn sandbox_extension_issue_file(
         extension_class: *const c_char,
         path: *const c_char,
@@ -237,11 +237,11 @@ fn path_filters_for_cap(cap: &crate::capability::FsCapability) -> Result<Vec<Str
 
     // If the original path differs (e.g. /tmp vs /private/tmp), emit a rule
     // for the original too so Seatbelt allows traversing the symlink.
-    if cap.original != cap.resolved {
-        if let Some(original_str) = cap.original.to_str() {
-            let escaped_original = escape_path(original_str)?;
-            filters.push(format!("{} \"{}\"", kind, escaped_original));
-        }
+    if cap.original != cap.resolved
+        && let Some(original_str) = cap.original.to_str()
+    {
+        let escaped_original = escape_path(original_str)?;
+        filters.push(format!("{} \"{}\"", kind, escaped_original));
     }
 
     Ok(filters)
@@ -269,10 +269,10 @@ fn has_explicit_keychain_db_access(caps: &CapabilitySet) -> bool {
         {
             return true;
         }
-        if let Some(ref user_keychain_dbs) = user_keychain_dbs {
-            if user_keychain_dbs.iter().any(|candidate| path == candidate) {
-                return true;
-            }
+        if let Some(ref user_keychain_dbs) = user_keychain_dbs
+            && user_keychain_dbs.iter().any(|candidate| path == candidate)
+        {
+            return true;
         }
         false
     };

--- a/crates/nono/src/sandbox/mod.rs
+++ b/crates/nono/src/sandbox/mod.rs
@@ -20,7 +20,7 @@ pub use macos::{extension_consume, extension_issue_file, extension_release};
 
 // Re-export Linux Landlock ABI detection
 #[cfg(target_os = "linux")]
-pub use linux::{detect_abi, DetectedAbi};
+pub use linux::{DetectedAbi, detect_abi};
 
 // Re-export Linux WSL2 detection
 #[cfg(target_os = "linux")]
@@ -29,12 +29,11 @@ pub use linux::is_wsl2;
 // Re-export Linux seccomp-notify primitives for supervisor use
 #[cfg(target_os = "linux")]
 pub use linux::{
-    classify_access_from_flags, classify_af_unix, continue_notif, deny_notif, inject_fd,
-    install_seccomp_notify, install_seccomp_proxy_filter, notif_id_valid,
-    probe_seccomp_block_network_support, read_notif_path, read_notif_sockaddr, read_open_how,
-    recv_notif, resolve_notif_path, respond_notif_errno, validate_openat2_size, OpenHow,
-    SeccompData, SeccompNetFallback, SeccompNotif, SockaddrInfo, UnixSocketKind, SYS_BIND,
-    SYS_CONNECT, SYS_OPENAT, SYS_OPENAT2,
+    OpenHow, SYS_BIND, SYS_CONNECT, SYS_OPENAT, SYS_OPENAT2, SeccompData, SeccompNetFallback,
+    SeccompNotif, SockaddrInfo, UnixSocketKind, classify_access_from_flags, classify_af_unix,
+    continue_notif, deny_notif, inject_fd, install_seccomp_notify, install_seccomp_proxy_filter,
+    notif_id_valid, probe_seccomp_block_network_support, read_notif_path, read_notif_sockaddr,
+    read_open_how, recv_notif, resolve_notif_path, respond_notif_errno, validate_openat2_size,
 };
 
 /// Information about sandbox support on this platform

--- a/crates/nono/src/scrub.rs
+++ b/crates/nono/src/scrub.rs
@@ -89,11 +89,7 @@ impl ScrubPolicyDiff {
 
     #[must_use]
     pub fn into_option(self) -> Option<Self> {
-        if self.is_empty() {
-            None
-        } else {
-            Some(self)
-        }
+        if self.is_empty() { None } else { Some(self) }
     }
 }
 

--- a/crates/nono/src/supervisor/socket.rs
+++ b/crates/nono/src/supervisor/socket.rs
@@ -380,7 +380,7 @@ pub fn recv_fd_via_socket(sock_fd: RawFd) -> Result<OwnedFd> {
 pub fn peer_credentials(sock_fd: RawFd) -> Result<PeerCredentials> {
     #[cfg(target_os = "linux")]
     {
-        use libc::{getsockopt, socklen_t, ucred, SOL_SOCKET, SO_PEERCRED};
+        use libc::{SO_PEERCRED, SOL_SOCKET, getsockopt, socklen_t, ucred};
 
         // SAFETY: `ucred` is plain old data and will be written by `getsockopt`.
         let mut cred: ucred = unsafe { std::mem::zeroed() };
@@ -507,16 +507,15 @@ fn umask_guard() -> &'static Mutex<()> {
 impl Drop for SupervisorSocket {
     fn drop(&mut self) {
         // Clean up the socket file if we created one
-        if let Some(ref path) = self.socket_path {
-            if let Err(e) = std::fs::remove_file(path) {
-                if e.kind() != std::io::ErrorKind::NotFound {
-                    warn!(
-                        "Failed to remove supervisor socket path {}: {}",
-                        path.display(),
-                        e
-                    );
-                }
-            }
+        if let Some(ref path) = self.socket_path
+            && let Err(e) = std::fs::remove_file(path)
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            warn!(
+                "Failed to remove supervisor socket path {}: {}",
+                path.display(),
+                e
+            );
         }
     }
 }

--- a/crates/nono/src/trust/dsse.rs
+++ b/crates/nono/src/trust/dsse.rs
@@ -675,10 +675,12 @@ mod tests {
         let envelope = DsseEnvelope::from_json(&json).unwrap();
         let result = envelope.extract_statement();
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("unexpected DSSE payloadType"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("unexpected DSSE payloadType")
+        );
     }
 
     #[test]
@@ -884,10 +886,12 @@ mod tests {
         let stmt = InTotoStatement::from_json(&json).unwrap();
         let result = stmt.extract_signer();
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("unknown signer kind"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("unknown signer kind")
+        );
     }
 
     #[test]

--- a/crates/nono/src/trust/mod.rs
+++ b/crates/nono/src/trust/mod.rs
@@ -37,30 +37,30 @@ pub mod signing;
 pub mod types;
 
 pub use bundle::{
-    bundle_path_for, extract_all_subjects, extract_bundle_digest, extract_predicate_type,
-    extract_signer_identity, load_bundle, load_bundle_from_str, load_production_trusted_root,
-    load_trusted_root, load_trusted_root_from_str, multi_subject_bundle_path, parse_cert_info,
-    verify_bundle, verify_bundle_keyed, verify_bundle_subject_name, verify_bundle_with_digest,
-    verify_keyed_signature, Bundle, CertificateInfo, DerPublicKey, Sha256Hash,
-    SigstoreVerificationResult, TrustedRoot, VerificationPolicy,
+    Bundle, CertificateInfo, DerPublicKey, Sha256Hash, SigstoreVerificationResult, TrustedRoot,
+    VerificationPolicy, bundle_path_for, extract_all_subjects, extract_bundle_digest,
+    extract_predicate_type, extract_signer_identity, load_bundle, load_bundle_from_str,
+    load_production_trusted_root, load_trusted_root, load_trusted_root_from_str,
+    multi_subject_bundle_path, parse_cert_info, verify_bundle, verify_bundle_keyed,
+    verify_bundle_subject_name, verify_bundle_with_digest, verify_keyed_signature,
 };
 pub use digest::{bytes_digest, file_digest};
 pub use dsse::{
-    new_envelope, new_instruction_statement, new_multi_subject_statement, new_policy_statement,
-    new_statement, pae, DsseEnvelope, DsseSignature, InTotoStatement, InTotoSubject,
-    IN_TOTO_PAYLOAD_TYPE, IN_TOTO_STATEMENT_TYPE, NONO_MULTI_SUBJECT_PREDICATE_TYPE,
-    NONO_POLICY_PREDICATE_TYPE, NONO_PREDICATE_TYPE,
+    DsseEnvelope, DsseSignature, IN_TOTO_PAYLOAD_TYPE, IN_TOTO_STATEMENT_TYPE, InTotoStatement,
+    InTotoSubject, NONO_MULTI_SUBJECT_PREDICATE_TYPE, NONO_POLICY_PREDICATE_TYPE,
+    NONO_PREDICATE_TYPE, new_envelope, new_instruction_statement, new_multi_subject_statement,
+    new_policy_statement, new_statement, pae,
 };
 pub use policy::{
     evaluate_file, find_included_files, find_included_files_with_skip_dirs, load_policy_from_file,
     load_policy_from_str, merge_policies,
 };
 pub use signing::{
-    export_public_key, generate_signing_key, key_id_hex, public_key_id_hex, sign_bytes, sign_files,
-    sign_instruction_file, sign_policy_bytes, sign_policy_file, sign_statement_bundle,
-    write_bundle, KeyPair, SigningScheme, MAX_MULTI_SUBJECT_FILES,
+    KeyPair, MAX_MULTI_SUBJECT_FILES, SigningScheme, export_public_key, generate_signing_key,
+    key_id_hex, public_key_id_hex, sign_bytes, sign_files, sign_instruction_file,
+    sign_policy_bytes, sign_policy_file, sign_statement_bundle, write_bundle,
 };
 pub use types::{
     BlockedPublisher, Blocklist, BlocklistEntry, Enforcement, IncludePatterns, Publisher,
-    SignerIdentity, TrustPolicy, VerificationOutcome, VerificationResult, TRUST_POLICY_VERSION,
+    SignerIdentity, TRUST_POLICY_VERSION, TrustPolicy, VerificationOutcome, VerificationResult,
 };

--- a/crates/nono/src/trust/policy.rs
+++ b/crates/nono/src/trust/policy.rs
@@ -357,10 +357,10 @@ fn find_files_recursive(
             #[cfg(not(unix))]
             let file_id: Option<(u64, u64)> = None;
 
-            if let Some(file_id) = file_id {
-                if !visited.insert(file_id) {
-                    continue;
-                }
+            if let Some(file_id) = file_id
+                && !visited.insert(file_id)
+            {
+                continue;
             }
 
             find_files_recursive(
@@ -377,10 +377,10 @@ fn find_files_recursive(
                 continue;
             }
 
-            if let Ok(relative) = path.strip_prefix(root) {
-                if matcher.is_match(relative) {
-                    results.push(path);
-                }
+            if let Ok(relative) = path.strip_prefix(root)
+                && matcher.is_match(relative)
+            {
+                results.push(path);
             }
         }
     }
@@ -1090,8 +1090,10 @@ mod tests {
         let files = find_included_files(&policy, dir.path()).unwrap();
 
         assert_eq!(files.len(), 2);
-        assert!(files
-            .iter()
-            .all(|path| !path.to_string_lossy().ends_with(".bundle")));
+        assert!(
+            files
+                .iter()
+                .all(|path| !path.to_string_lossy().ends_with(".bundle"))
+        );
     }
 }

--- a/crates/nono/src/trust/types.rs
+++ b/crates/nono/src/trust/types.rs
@@ -350,11 +350,7 @@ impl Enforcement {
     /// Used during policy merging: project-level cannot weaken user-level.
     #[must_use]
     pub fn strictest(self, other: Self) -> Self {
-        if self >= other {
-            self
-        } else {
-            other
-        }
+        if self >= other { self } else { other }
     }
 
     /// Whether this enforcement mode blocks access on failure.

--- a/crates/nono/src/undo/exclusion.rs
+++ b/crates/nono/src/undo/exclusion.rs
@@ -150,10 +150,10 @@ impl ExclusionFilter {
             } else {
                 // Single component: exact match against each path component
                 for component in path.components() {
-                    if let std::path::Component::Normal(name) = component {
-                        if name.to_string_lossy() == *pattern {
-                            return true;
-                        }
+                    if let std::path::Component::Normal(name) = component
+                        && name.to_string_lossy() == *pattern
+                    {
+                        return true;
                     }
                 }
             }
@@ -163,10 +163,10 @@ impl ExclusionFilter {
 
     /// Check if the filename matches any client-supplied glob pattern.
     fn matches_exclude_globs(&self, path: &Path) -> bool {
-        if let Some(ref globs) = self.exclude_globs {
-            if let Some(filename) = path.file_name() {
-                return globs.is_match(filename);
-            }
+        if let Some(ref globs) = self.exclude_globs
+            && let Some(filename) = path.file_name()
+        {
+            return globs.is_match(filename);
         }
         false
     }
@@ -179,18 +179,16 @@ impl ExclusionFilter {
     fn matches_force_include(&self, path: &Path) -> bool {
         for pattern in &self.force_include {
             if pattern.contains('/') {
-                // Multi-component pattern: substring match on full path
                 let path_str = path.to_string_lossy();
                 if path_str.contains(pattern.as_str()) {
                     return true;
                 }
             } else {
-                // Single component: exact match against each path component
                 for component in path.components() {
-                    if let std::path::Component::Normal(name) = component {
-                        if name.to_string_lossy() == *pattern {
-                            return true;
-                        }
+                    if let std::path::Component::Normal(name) = component
+                        && name.to_string_lossy() == *pattern
+                    {
+                        return true;
                     }
                 }
             }

--- a/crates/nono/src/undo/snapshot.rs
+++ b/crates/nono/src/undo/snapshot.rs
@@ -773,13 +773,13 @@ impl SnapshotManager {
             let exclusion = self.filter_for_root(tracked);
 
             if tracked.is_file() {
-                if !exclusion.is_excluded(tracked) {
-                    if let Ok(state) = file_state_from_metadata(tracked) {
-                        entries_visited = entries_visited.saturating_add(1);
-                        total_bytes = total_bytes.saturating_add(state.size);
-                        self.check_budget(entries_visited, total_bytes)?;
-                        files.insert(tracked.clone(), state);
-                    }
+                if !exclusion.is_excluded(tracked)
+                    && let Ok(state) = file_state_from_metadata(tracked)
+                {
+                    entries_visited = entries_visited.saturating_add(1);
+                    total_bytes = total_bytes.saturating_add(state.size);
+                    self.check_budget(entries_visited, total_bytes)?;
+                    files.insert(tracked.clone(), state);
                 }
                 continue;
             }

--- a/crates/nono/tests/manifest_types.rs
+++ b/crates/nono/tests/manifest_types.rs
@@ -1,13 +1,13 @@
 //! Tests for the manifest module (typify-generated types) and manifest_convert
 //! (TryFrom<&CapabilityManifest> for CapabilitySet).
 
+use nono::CapabilitySet;
 use nono::capability::{
     AccessMode as InternalAccessMode, IpcMode as InternalIpcMode,
     NetworkMode as InternalNetworkMode, ProcessInfoMode as InternalProcessInfoMode,
     SignalMode as InternalSignalMode,
 };
 use nono::manifest::CapabilityManifest;
-use nono::CapabilitySet;
 
 // ─── manifest deserialization ───
 


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #905 

## Summary

Cargo.toml hygiene:
- Promote nix, landlock, url, getrandom to [workspace.dependencies]
- Switch member crates to workspace refs for toml, walkdir, tempfile, serde (build-dep), serde_json (build-dep), and url
- Relax serde_json pin from 1.0.149 to 1
- Add [workspace.lints.clippy] with unwrap_used = deny
- Bump rust-version from 1.74 to 1.95

Edition 2024 migration:
- Bump edition from 2021 to 2024
- Wrap #[no_mangle] as #[unsafe(no_mangle)] in FFI bindings (39 sites)
- Add unsafe blocks around std::env::set_var/remove_var calls, which are now unsafe fn in edition 2024
- Add inner unsafe blocks in unsafe fn bodies (pty_proxy.rs), which are no longer implicitly unsafe in edition 2024
- Remove redundant ref bindings in if-let patterns (edition 2024 implicit borrowing)
- Make child_setup_pty_fatal a safe fn with internal unsafe, and use nix::unistd::setsid() instead of raw libc

Clippy 1.95 fixes:
- Collapse nested if/if-let into if-let chains (~130 sites, leveraging stabilized let-chains)
- map_or(true, ..) -> is_none_or(..)
- map_err -> inspect_err where the error is returned unchanged
- Reformat with rustfmt 2024 style edition
<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
