### PR TITLE
docs(installation): add Arch Linux (AUR) section

### DIFF
--- a/docs/cli/getting_started/installation.mdx
+++ b/docs/cli/getting_started/installation.mdx
@@ -40,6 +40,20 @@ nix shell nixpkgs#nono
 nix-shell -p nono
 ```
 
+### Arch Linux (AUR)
+
+nono is available on the [Arch User Repository](https://aur.archlinux.org/packages/nono-ai-bin) as `nono-ai-bin`, a community-maintained binary package that tracks official GitHub releases and verifies SHA256 checksums. It supports `x86_64` and `aarch64`.
+
+```bash
+# Using yay
+yay -S nono-ai-bin
+
+# Using paru
+paru -S nono-ai-bin
+```
+
+This package is not maintained by the nono team. For issues with the AUR package itself, please report them on the [AUR page](https://aur.archlinux.org/packages/nono-ai-bin).
+
 Other distributions are in the process of being packaged. In the meantime, you can use the prebuilt binaries or build from source.
 
 ## Building from Source

--- a/docs/cli/getting_started/installation.mdx
+++ b/docs/cli/getting_started/installation.mdx
@@ -50,9 +50,16 @@ yay -S nono-ai-bin
 
 # Using paru
 paru -S nono-ai-bin
+
+# Manual install with makepkg
+git clone https://aur.archlinux.org/nono-ai-bin.git
+cd nono-ai-bin
+makepkg -si
 ```
 
-This package is not maintained by the nono team. For issues with the AUR package itself, please report them on the [AUR page](https://aur.archlinux.org/packages/nono-ai-bin).
+<Note>
+  This package is not maintained by the nono team. For issues with the AUR package itself, please report them on the [AUR page](https://aur.archlinux.org/packages/nono-ai-bin).
+</Note>
 
 Other distributions are in the process of being packaged. In the meantime, you can use the prebuilt binaries or build from source.
 


### PR DESCRIPTION
Document the community-maintained `nono-ai-bin` AUR package as a Linux install option alongside Homebrew, Debian/Ubuntu, and Nix. Includes a `not maintained by the nono team` disclaimer pointing users to the AUR page for package-specific issues.

Refs: #917