### PR TITLE
feat(macos): treat open_port 0 as localhost:* outbound

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -423,7 +423,7 @@
         "open_port": {
           "type": "array",
           "items": { "type": "integer" },
-          "description": "Localhost TCP ports to allow bidirectional IPC (connect + bind)."
+          "description": "Localhost TCP IPC (connect+bind). Port 0: macOS only (localhost:* outbound); Linux needs explicit ports."
         },
         "port_allow": {
           "type": "array",

--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -119,7 +119,7 @@ All path fields support variable expansion (see Section 6).
 | `network_profile`       | string or null                    | inherit  | Name from `network-policy.json` for proxy filtering. Set to `null` to clear inherited value. |
 | `allow_domain`          | array of string                   | `[]`     | Additional domains to allow through the proxy. Aliases: `proxy_allow`, `allow_proxy`. |
 | `credentials`           | array of string                   | `[]`     | Credential services to enable via reverse proxy. Alias: `proxy_credentials`. |
-| `open_port`             | array of integer                  | `[]`     | Localhost TCP ports for bidirectional IPC. Aliases: `port_allow`, `allow_port`. |
+| `open_port`             | array of integer                  | `[]`     | Localhost TCP IPC. Aliases: `port_allow`, `allow_port`. Port **0**: macOS only (`localhost:*` outbound); Linux: explicit ports. |
 | `listen_port`           | array of integer                  | `[]`     | TCP ports the sandboxed child may listen on. |
 | `custom_credentials`    | map of string to credential def   | `{}`     | Custom credential route definitions (see below). |
 | `upstream_proxy`        | string                            | `null`   | Enterprise proxy address (`host:port`). Alias: `external_proxy`. |

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -993,10 +993,7 @@ pub struct NetworkConfig {
         skip_serializing_if = "Option::is_none"
     )]
     pub credentials: Option<Vec<String>>,
-    /// Localhost TCP ports to allow bidirectional IPC (connect + bind).
-    /// Equivalent to `--open-port` CLI flag.
-    /// Canonical profile key: `open_port` (legacy `port_allow` and `allow_port`
-    /// are also accepted).
+    /// Localhost TCP IPC (`--open-port`). **`0`**: macOS only, means `localhost:*` outbound.
     /// ALIAS(canonical="open_port", introduced="v0.0.0", remove_by="indefinite", issue="#415")
     #[serde(
         default,

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -1226,7 +1226,7 @@ impl CapabilitySet {
         self.tcp_bind_ports.push(port);
     }
 
-    /// Add a localhost IPC port (mutable)
+    /// Localhost IPC port; `0` is macOS-only (`localhost:*` TCP outbound).
     pub fn add_localhost_port(&mut self, port: u16) {
         self.localhost_ports.push(port);
     }

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -590,6 +590,14 @@ pub fn apply_with_abi(caps: &CapabilitySet, abi: &DetectedAbi) -> Result<Seccomp
     // When a seccomp fallback is active (BlockAll or ProxyOnly), the ruleset was
     // created without handle_access(AccessNet), so adding NetPort rules would fail.
     if matches!(seccomp_net_fallback, SeccompNetFallback::None) {
+        if !matches!(caps.network_mode(), NetworkMode::AllowAll)
+            && caps.localhost_ports().contains(&0)
+        {
+            return Err(NonoError::SandboxInit(
+                "open_port 0 (localhost TCP wildcard) is macOS-only; on Linux use explicit ports or a network profile."
+                    .to_string(),
+            ));
+        }
         // Add per-port TCP connect rules (ProxyOnly port + explicit tcp_connect_ports)
         if let NetworkMode::ProxyOnly { port, bind_ports } = caps.network_mode() {
             debug!("Adding ProxyOnly TCP connect rule for port {}", port);
@@ -3207,6 +3215,22 @@ mod tests {
             seccomp_network_fallback_mode(&caps),
             SeccompNetFallback::None
         );
+    }
+
+    /// `open_port: [0]` is macOS-only (Landlock cannot express it).
+    #[test]
+    fn test_reject_localhost_port_wildcard_zero_under_landlock_net() {
+        let Ok(detected) = detect_abi() else {
+            return;
+        };
+        if AccessNet::from_all(detected.abi).is_empty() {
+            return;
+        }
+        let mut caps = CapabilitySet::new().block_network();
+        caps.add_localhost_port(0);
+        let err = apply_with_abi(&caps, &detected).expect_err("port 0 wildcard must be rejected");
+        let msg = format!("{err}");
+        assert!(msg.contains("macOS-only"), "unexpected error: {msg}");
     }
 
     #[test]

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -479,6 +479,14 @@ pub fn apply_with_abi(caps: &CapabilitySet, abi: &DetectedAbi) -> Result<Seccomp
     info!("Using Landlock ABI {:?}", target_abi);
     let scopes = requested_scopes(caps, abi)?;
 
+    if !matches!(caps.network_mode(), NetworkMode::AllowAll) && caps.localhost_ports().contains(&0)
+    {
+        return Err(NonoError::SandboxInit(
+            "open_port 0 (localhost TCP wildcard) is macOS-only; on Linux use explicit ports or a network profile."
+                .to_string(),
+        ));
+    }
+
     // Determine which access rights to handle based on ABI
     let handled_fs = AccessFs::from_all(target_abi);
 
@@ -590,14 +598,6 @@ pub fn apply_with_abi(caps: &CapabilitySet, abi: &DetectedAbi) -> Result<Seccomp
     // When a seccomp fallback is active (BlockAll or ProxyOnly), the ruleset was
     // created without handle_access(AccessNet), so adding NetPort rules would fail.
     if matches!(seccomp_net_fallback, SeccompNetFallback::None) {
-        if !matches!(caps.network_mode(), NetworkMode::AllowAll)
-            && caps.localhost_ports().contains(&0)
-        {
-            return Err(NonoError::SandboxInit(
-                "open_port 0 (localhost TCP wildcard) is macOS-only; on Linux use explicit ports or a network profile."
-                    .to_string(),
-            ));
-        }
         // Add per-port TCP connect rules (ProxyOnly port + explicit tcp_connect_ports)
         if let NetworkMode::ProxyOnly { port, bind_ports } = caps.network_mode() {
             debug!("Adding ProxyOnly TCP connect rule for port {}", port);
@@ -3217,15 +3217,12 @@ mod tests {
         );
     }
 
-    /// `open_port: [0]` is macOS-only (Landlock cannot express it).
+    /// Rejects `open_port: [0]` on Linux for any restricted network mode (not Landlock-only).
     #[test]
-    fn test_reject_localhost_port_wildcard_zero_under_landlock_net() {
+    fn test_reject_localhost_port_wildcard_zero_on_linux() {
         let Ok(detected) = detect_abi() else {
             return;
         };
-        if AccessNet::from_all(detected.abi).is_empty() {
-            return;
-        }
         let mut caps = CapabilitySet::new().block_network();
         caps.add_localhost_port(0);
         let err = apply_with_abi(&caps, &detected).expect_err("port 0 wildcard must be rejected");

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -458,6 +458,24 @@ fn emit_unix_socket_rules(profile: &mut String, caps: &CapabilitySet) -> Result<
     Ok(())
 }
 
+/// Seatbelt rules: one `(remote tcp "localhost:N")` per non-zero port; `0` adds
+/// a single `localhost:*` outbound rule (`localhost:0` is invalid in Seatbelt).
+fn push_localhost_tcp_outbound_seatbelt_rules(profile: &mut String, localhost_ports: &[u16]) {
+    let wildcard = localhost_ports.contains(&0);
+    for &lp in localhost_ports {
+        if lp == 0 {
+            continue;
+        }
+        profile.push_str(&format!(
+            "(allow network-outbound (remote tcp \"localhost:{}\"))\n",
+            lp
+        ));
+    }
+    if wildcard {
+        profile.push_str("(allow network-outbound (remote tcp \"localhost:*\"))\n");
+    }
+}
+
 /// Generate a Seatbelt profile from capabilities
 ///
 /// This is a pure primitive - it generates rules ONLY for paths in the CapabilitySet.
@@ -705,12 +723,7 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
                 profile.push_str(
                     "(allow system-socket (socket-domain AF_INET6) (socket-type SOCK_STREAM))\n",
                 );
-                for lp in localhost_ports {
-                    profile.push_str(&format!(
-                        "(allow network-outbound (remote tcp \"localhost:{}\"))\n",
-                        lp
-                    ));
-                }
+                push_localhost_tcp_outbound_seatbelt_rules(&mut profile, localhost_ports);
                 // Seatbelt cannot filter bind/inbound by port
                 profile.push_str("(allow network-bind)\n");
                 profile.push_str("(allow network-inbound)\n");
@@ -726,12 +739,7 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
                 "(allow network-outbound (remote tcp \"localhost:{}\"))\n",
                 port
             ));
-            for lp in localhost_ports {
-                profile.push_str(&format!(
-                    "(allow network-outbound (remote tcp \"localhost:{}\"))\n",
-                    lp
-                ));
-            }
+            push_localhost_tcp_outbound_seatbelt_rules(&mut profile, localhost_ports);
             // Scope system-socket for TCP (required for connect/bind to proxy).
             profile.push_str(
                 "(allow system-socket (socket-domain AF_INET) (socket-type SOCK_STREAM))\n",
@@ -1776,6 +1784,31 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_profile_blocked_with_localhost_port_zero_wildcard() {
+        let caps = CapabilitySet::new().block_network().allow_localhost_port(0);
+        let profile = generate_profile(&caps).unwrap();
+
+        assert!(profile.contains("(deny network*)"));
+        assert!(profile.contains("(allow network-outbound (remote tcp \"localhost:*\"))"));
+        assert!(!profile.contains("(allow network-outbound (remote tcp \"localhost:0\"))"));
+        assert!(profile.contains("(allow network-bind)"));
+        assert!(profile.contains("(allow network-inbound)"));
+    }
+
+    #[test]
+    fn test_generate_profile_blocked_mixed_localhost_zero_and_fixed_port() {
+        let caps = CapabilitySet::new()
+            .block_network()
+            .allow_localhost_port(0)
+            .allow_localhost_port(7654);
+        let profile = generate_profile(&caps).unwrap();
+
+        assert!(profile.contains("(allow network-outbound (remote tcp \"localhost:7654\"))"));
+        assert!(profile.contains("(allow network-outbound (remote tcp \"localhost:*\"))"));
+        assert!(!profile.contains("(allow network-outbound (remote tcp \"localhost:0\"))"));
+    }
+
+    #[test]
     fn test_generate_profile_proxy_with_localhost_ports() {
         let caps = CapabilitySet::new()
             .proxy_only(54321)
@@ -1790,6 +1823,18 @@ mod tests {
         // Bind/inbound enabled because localhost_ports is non-empty
         assert!(profile.contains("(allow network-bind)"));
         assert!(profile.contains("(allow network-inbound)"));
+    }
+
+    #[test]
+    fn test_generate_profile_proxy_with_localhost_port_zero_wildcard() {
+        let caps = CapabilitySet::new()
+            .proxy_only(54321)
+            .allow_localhost_port(0);
+        let profile = generate_profile(&caps).unwrap();
+
+        assert!(profile.contains("(allow network-outbound (remote tcp \"localhost:54321\"))"));
+        assert!(profile.contains("(allow network-outbound (remote tcp \"localhost:*\"))"));
+        assert!(!profile.contains("(allow network-outbound (remote tcp \"localhost:0\"))"));
     }
 
     #[test]


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #930

## Summary

Seatbelt emitted invalid localhost:0; port 0 now adds a single (remote tcp 'localhost:*') rule alongside per-port rules, matching the listen_port [0] pattern on macOS (non-empty list drives broader bind/inbound; open_port 0 now similarly widens loopback TCP connect).

Linux Landlock rejects open_port 0 with a clear macOS-only error; docs/schema/profile comments updated. Tests for Seatbelt output and Landlock rejection.

cc @panga let me know :)

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
