### PR TITLE
fix(musl): fix libc::Ioctl type mismatches for x86_64-unknown-linux-musl target

### DIFF
--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -1767,7 +1767,7 @@ extern "C" fn forward_signal(sig: libc::c_int) {
                 let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
                 unsafe {
                     if libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, &mut ws) == 0 {
-                        libc::ioctl(master_fd, libc::TIOCSWINSZ as libc::c_ulong, &ws);
+                        libc::ioctl(master_fd, libc::TIOCSWINSZ, &ws);
                     }
                 }
             }

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -279,7 +279,7 @@ pub unsafe fn setup_child_pty(slave_fd: RawFd) {
     // ioctl/dup2/close operate on raw fd integers — nix's IO-safe wrappers
     // require AsFd/OwnedFd which aren't available for STDIN_FILENO et al.
     unsafe {
-        if libc::ioctl(slave_fd, libc::TIOCSCTTY as libc::c_ulong, 0) < 0 {
+        if libc::ioctl(slave_fd, libc::TIOCSCTTY, 0) < 0 {
             child_setup_pty_fatal(b"nono: ioctl(TIOCSCTTY) failed while configuring child PTY\n");
         }
 
@@ -887,7 +887,7 @@ impl PtyProxy {
         unsafe {
             let _ = libc::ioctl(
                 self.master.as_raw_fd(),
-                libc::TIOCSWINSZ as libc::c_ulong,
+                libc::TIOCSWINSZ,
                 winsize as *const Winsize,
             );
         }

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -279,7 +279,7 @@ pub unsafe fn setup_child_pty(slave_fd: RawFd) {
     // ioctl/dup2/close operate on raw fd integers — nix's IO-safe wrappers
     // require AsFd/OwnedFd which aren't available for STDIN_FILENO et al.
     unsafe {
-        if libc::ioctl(slave_fd, libc::TIOCSCTTY, 0) < 0 {
+        if libc::ioctl(slave_fd, libc::TIOCSCTTY as _, 0) < 0 {
             child_setup_pty_fatal(b"nono: ioctl(TIOCSCTTY) failed while configuring child PTY\n");
         }
 

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -844,8 +844,10 @@ const SECCOMP_FILTER_FLAG_NEW_LISTENER: libc::c_uint = 1 << 3;
 const SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV: libc::c_uint = 1 << 4;
 
 // ioctl request codes for seccomp notifications
-const SECCOMP_IOCTL_NOTIF_RECV: libc::Ioctl = 0xc0502100 as libc::Ioctl;
-const SECCOMP_IOCTL_NOTIF_SEND: libc::Ioctl = 0xc0182101 as libc::Ioctl;
+// Cast via u32 first: on glibc Ioctl=c_ulong (u64) this widens safely;
+// on musl Ioctl=c_int (i32) the u32→i32 bit-reinterpret is a valid cast.
+const SECCOMP_IOCTL_NOTIF_RECV: libc::Ioctl = 0xc0502100u32 as libc::Ioctl;
+const SECCOMP_IOCTL_NOTIF_SEND: libc::Ioctl = 0xc0182101u32 as libc::Ioctl;
 const SECCOMP_IOCTL_NOTIF_ID_VALID: libc::Ioctl = 0x40082102 as libc::Ioctl;
 const SECCOMP_IOCTL_NOTIF_ADDFD: libc::Ioctl = 0x40182103 as libc::Ioctl;
 

--- a/docker/Dockerfile-musl
+++ b/docker/Dockerfile-musl
@@ -12,7 +12,7 @@
 # Build with:
 #   docker buildx build -f docker/Dockerfile-musl -t nono-musl .
 
-FROM rust:alpine AS builder
+FROM rust:alpine3.21 AS builder
 
 # cmake + clang — required by aws-lc-rs to compile AWS-LC crypto library
 # perl + make   — required by ring's build script
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release -p nono-cli --no-default-features && \
     cp target/release/nono /usr/local/bin/nono
 
-FROM alpine:3
+FROM alpine:3.21
 
 LABEL org.opencontainers.image.source="https://github.com/always-further/nono"
 LABEL org.opencontainers.image.description="Capability-based sandboxing for untrusted AI agents (musl, statically linked)"

--- a/docker/Dockerfile-musl
+++ b/docker/Dockerfile-musl
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1.7
+#
+# Musl (statically linked) build — no glibc dependency.
+#
+# Uses Alpine Linux as the builder so musl is the native libc — no
+# cross-compilation or special linker wrappers needed. The resulting binary
+# is statically linked against musl libc, making it portable across any
+# Linux distribution without shared library requirements.
+# Credentials must be supplied via env://, file://, or op:// references
+# instead of the system keyring (D-Bus is unavailable in this build).
+#
+# Build with:
+#   docker buildx build -f docker/Dockerfile-musl -t nono-musl .
+
+FROM rust:alpine AS builder
+
+# cmake + clang — required by aws-lc-rs to compile AWS-LC crypto library
+# perl + make   — required by ring's build script
+# g++           — required by aws-lc-rs cmake build
+RUN apk add --no-cache \
+    cmake \
+    clang \
+    clang-dev \
+    musl-dev \
+    pkgconfig \
+    perl \
+    make \
+    g++
+
+WORKDIR /build
+COPY . .
+
+# Alpine is musl-native: build for the host target, no --target flag needed.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/build/target \
+    cargo build --release -p nono-cli --no-default-features && \
+    cp target/release/nono /usr/local/bin/nono
+
+FROM alpine:3
+
+LABEL org.opencontainers.image.source="https://github.com/always-further/nono"
+LABEL org.opencontainers.image.description="Capability-based sandboxing for untrusted AI agents (musl, statically linked)"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+RUN addgroup -S nono && adduser -S -G nono -s /sbin/nologin nono && \
+    apk add --no-cache ca-certificates && \
+    mkdir /work
+
+COPY --from=builder /usr/local/bin/nono /usr/bin/nono
+
+WORKDIR /work
+USER nono
+ENTRYPOINT ["nono"]

--- a/docker/Dockerfile-musl-cross
+++ b/docker/Dockerfile-musl-cross
@@ -45,7 +45,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
         --target x86_64-unknown-linux-musl && \
     cp target/x86_64-unknown-linux-musl/release/nono /usr/local/bin/nono
 
-FROM alpine:3
+FROM --platform=linux/amd64 alpine:3.21
 
 LABEL org.opencontainers.image.source="https://github.com/always-further/nono"
 LABEL org.opencontainers.image.description="Capability-based sandboxing for untrusted AI agents (x86_64-unknown-linux-musl)"

--- a/docker/Dockerfile-musl-cross
+++ b/docker/Dockerfile-musl-cross
@@ -1,0 +1,62 @@
+# syntax=docker/dockerfile:1.7
+#
+# Cross-compile to x86_64-unknown-linux-musl from a Debian builder.
+#
+# Unlike Dockerfile-musl (which uses Alpine as a musl-native builder),
+# this file uses rust:bookworm and explicitly cross-compiles to the
+# x86_64-unknown-linux-musl Rust target. Useful when you need to
+# produce a musl binary from a glibc-based CI environment or want to
+# pin to a specific Rust toolchain version on Debian.
+#
+# Credentials must be supplied via env://, file://, or op:// references
+# instead of the system keyring (D-Bus is unavailable in this build).
+#
+# Build with:
+#   docker buildx build -f docker/Dockerfile-musl-cross -t nono-musl-cross .
+
+# Force x86_64 so musl-gcc is native and understands -m64 (passed by ring/aws-lc-rs).
+# On Apple Silicon Docker runs ARM64 by default; without this, musl-gcc rejects -m64.
+FROM --platform=linux/amd64 rust:1-bookworm AS builder
+
+# musl-tools — provides musl-gcc, the GCC wrapper that links against musl
+# cmake + clang — required by aws-lc-rs to compile the AWS-LC crypto library
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        musl-tools \
+        cmake \
+        clang \
+        pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN rustup target add x86_64-unknown-linux-musl
+
+# cc-rs looks for "x86_64-linux-musl-gcc" by convention, but Debian's
+# musl-tools only ships "musl-gcc". Point cc-rs and the cargo linker at it
+# explicitly so ring, aws-lc-rs, and other C-using crates find the compiler.
+ENV CC_x86_64_unknown_linux_musl=musl-gcc
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
+
+WORKDIR /build
+COPY . .
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/build/target \
+    cargo build --release -p nono-cli --no-default-features \
+        --target x86_64-unknown-linux-musl && \
+    cp target/x86_64-unknown-linux-musl/release/nono /usr/local/bin/nono
+
+FROM alpine:3
+
+LABEL org.opencontainers.image.source="https://github.com/always-further/nono"
+LABEL org.opencontainers.image.description="Capability-based sandboxing for untrusted AI agents (x86_64-unknown-linux-musl)"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+RUN addgroup -S nono && adduser -S -G nono -s /sbin/nologin nono && \
+    apk add --no-cache ca-certificates && \
+    mkdir /work
+
+COPY --from=builder /usr/local/bin/nono /usr/bin/nono
+
+WORKDIR /work
+USER nono
+ENTRYPOINT ["nono"]


### PR DESCRIPTION
## Summary

Fixes #934

Fixes build failures when targeting `x86_64-unknown-linux-musl`. The root cause is that `libc::Ioctl` is `c_ulong` (`u64`) on glibc but `c_int` (`i32`) on musl, and ioctl constants have different types across platforms.

## Changes

**`crates/nono/src/sandbox/linux.rs`**
- `SECCOMP_IOCTL_NOTIF_RECV` and `SECCOMP_IOCTL_NOTIF_SEND` literals (`0xc0502100`, `0xc0182101`) overflow `i32` on musl. Fixed by casting from `u32` first — valid bit-reinterpret on musl (`u32 as i32`), widening on glibc (`u32 as u64`).

**`crates/nono-cli/src/exec_strategy.rs` and `crates/nono-cli/src/pty_proxy.rs`**
- `TIOCSWINSZ as libc::c_ulong`: redundant cast removed — `TIOCSWINSZ` is already `c_ulong` on macOS and `libc::Ioctl` on Linux, both matching their platform's `ioctl` signature.
- `TIOCSCTTY as libc::c_ulong`: replaced with `as _` — `TIOCSCTTY` is `c_int` on all platforms, but `ioctl`'s request parameter is `c_ulong` on macOS/glibc and `c_int` on musl. Using `as _` lets Rust infer the correct target type per platform.

**`docker/Dockerfile-musl`** — Alpine-native builder (musl is the host libc, no cross-compilation needed)

**`docker/Dockerfile-musl-cross`** — Debian builder with explicit `--target x86_64-unknown-linux-musl` and `--platform=linux/amd64` to ensure native musl-gcc is used

## Test plan

- [x] All CI checks pass (Ubuntu + macOS, Clippy, Tests, Integration, Rustfmt, DCO, Cargo Audit)
- [x] `docker build -f docker/Dockerfile-musl-cross -t nono-musl-cross .` builds successfully
- [x] `docker build -f docker/Dockerfile-musl -t nono-musl .` builds successfully

## Agent compliance

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists (#934)
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope

> This PR was authored with AI assistance (Claude Sonnet 4.6 via Claude Code). The contributor is Arnaud Sahuguet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)