### PR TITLE
fix(pty): forward bare ESC immediately in filter_client_input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- *(pty)* Forward bare ESC immediately instead of buffering for CSI-u detach match, fixing ESC key in TUI apps inside tmux with `extended-keys-format csi-u` (#941)
+
 ### Notes
 
 - Socket grant state now records explicit socket scope. New subtree socket

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -1035,7 +1035,7 @@ impl PtyProxy {
     }
     fn filter_client_input(&mut self, bytes: &[u8]) -> Vec<u8> {
         let mut forwarded = Vec::with_capacity(bytes.len());
-        for &byte in bytes {
+        for (i, &byte) in bytes.iter().enumerate() {
             if self.maybe_consume_enhanced_detach_byte(byte, &mut forwarded) {
                 continue;
             }
@@ -1058,7 +1058,12 @@ impl PtyProxy {
                 continue;
             }
 
-            if self.should_start_enhanced_detach_match(byte) {
+            // Only buffer \x1b for enhanced CSI-u detach matching when '['
+            // immediately follows in the same read batch. A bare ESC with no
+            // '[' following is a standalone Escape key and must be forwarded immediately.
+            if self.should_start_enhanced_detach_match(byte)
+                && bytes.get(i + 1).copied() == Some(b'[')
+            {
                 self.pending_detach_escape.push(byte);
                 continue;
             }
@@ -2723,6 +2728,27 @@ mod tests {
         assert!(proxy.pending_detach_escape.is_empty());
         let forwarded = proxy.filter_client_input(b"x");
         assert_eq!(forwarded, b"x");
+        assert!(!proxy.take_detach_request());
+    }
+
+    #[test]
+    fn filter_client_input_forwards_bare_esc_immediately() {
+        // Regression test for issue #941: bare ESC must be forwarded right away,
+        // not buffered waiting for a possible CSI-u detach sequence.
+        let mut proxy = build_test_proxy(&DEFAULT_DETACH_SEQUENCE);
+        let forwarded = proxy.filter_client_input(b"\x1b");
+        assert_eq!(forwarded, b"\x1b");
+        assert!(proxy.pending_detach_escape.is_empty());
+        assert!(!proxy.take_detach_request());
+    }
+
+    #[test]
+    fn filter_client_input_forwards_esc_not_paired_with_next_key() {
+        // ESC followed by a non-'[' byte must both be forwarded as-is, not
+        // delayed and reordered into an Alt+key sequence.
+        let mut proxy = build_test_proxy(&DEFAULT_DETACH_SEQUENCE);
+        let forwarded = proxy.filter_client_input(b"\x1ba");
+        assert_eq!(forwarded, b"\x1ba");
         assert!(!proxy.take_detach_request());
     }
 


### PR DESCRIPTION
## Linked Issue

Closes #941 

## Summary

When ESC is pressed alone inside tmux with `extended-keys-format csi-u`, `filter_client_input` buffers the bare `\x1b` byte waiting to see if a CSI-u detach sequence follows. It gets held until the next keystroke — at that point `\x1b` + the next byte arrive together, which the terminal interprets as Alt+key instead of plain ESC. This broke ESC in TUI apps like pi and opencode, introduced as a regression in v0.52.0.

To fix this:
- `filter_client_input` now uses `enumerate()` to look ahead in the current read batch.
- `\x1b` is only buffered for enhanced detach matching when `[` immediately follows in the same batch.
- A bare ESC with no `[` following is forwarded immediately.<!-- Briefly describe what this PR does and why. -->

I used AI to help me investigate the issue and reviewing the changes, they are plausible.

## Test Plan

Two regression tests added:
- `filter_client_input_forwards_bare_esc_immediately` — bare ESC is forwarded right away
- `filter_client_input_forwards_esc_not_paired_with_next_key` — ESC + non-`[` byte are both forwarded as-is

All existing `filter_client_input` tests pass, including chunked and full CSI-u detach sequences.

Also, tested with opencode and pi on ghostty/wezterm and it seems to be working.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [x] Release note has been added to `CHANGELOG.md` if needed
