### PR TITLE
fix(cli): preserve macOS future-file grants in why --self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Bug Fixes
-
-- *(cli)* Fix `nono why --self` for macOS future-file grants in sandbox state
-
 ### Notes
 
 - Socket grant state now records explicit socket scope. New subtree socket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- *(cli)* Fix `nono why --self` for macOS future-file grants in sandbox state
+
 ### Notes
 
 - Socket grant state now records explicit socket scope. New subtree socket

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -340,7 +340,7 @@ fn handle_missing_file_capability(
 }
 
 #[cfg(target_os = "macos")]
-fn new_future_file_capability(path: &Path, access: AccessMode) -> Result<FsCapability> {
+pub(crate) fn new_future_file_capability(path: &Path, access: AccessMode) -> Result<FsCapability> {
     let absolute = if path.is_absolute() {
         path.to_path_buf()
     } else {

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -260,59 +260,46 @@ fn try_new_profile_exact_path(
     protected_roots: &ProtectedRoots,
     allow_parent_of_protected: bool,
 ) -> Result<Option<FsCapability>> {
-    validate_requested_file(path, "Profile", protected_roots, allow_parent_of_protected)?;
-    match try_new_file(path, access, label) {
-        Err(NonoError::ExpectedFile(_)) => {
-            handle_exact_directory_path(path, access, protected_roots, allow_parent_of_protected)
+    #[cfg(target_os = "macos")]
+    let _ = label;
+
+    if path.exists() && path.is_dir() {
+        validate_requested_dir(path, "Profile", protected_roots, allow_parent_of_protected)?;
+    } else {
+        validate_requested_file(path, "Profile", protected_roots, allow_parent_of_protected)?;
+    }
+
+    match new_exact_path_capability(path, access) {
+        Ok(cap) => Ok(Some(cap)),
+        #[cfg(not(target_os = "macos"))]
+        Err(NonoError::PathNotFound(_)) => {
+            info!("{}: {}", label, path.display());
+            Ok(None)
         }
-        result => result,
+        Err(err) => Err(err),
     }
 }
 
 #[cfg(target_os = "macos")]
-fn handle_exact_directory_path(
-    path: &Path,
-    access: AccessMode,
-    protected_roots: &ProtectedRoots,
-    allow_parent_of_protected: bool,
-) -> Result<Option<FsCapability>> {
-    validate_requested_dir(path, "Profile", protected_roots, allow_parent_of_protected)?;
-    let resolved = path.canonicalize().map_err(|source| {
-        if source.kind() == std::io::ErrorKind::NotFound {
-            NonoError::PathNotFound(path.to_path_buf())
-        } else {
-            NonoError::PathCanonicalization {
-                path: path.to_path_buf(),
-                source,
-            }
+pub(crate) fn new_exact_path_capability(path: &Path, access: AccessMode) -> Result<FsCapability> {
+    match FsCapability::new_file(path, access) {
+        Ok(cap) => Ok(cap),
+        Err(NonoError::ExpectedFile(_)) => new_exact_directory_path_capability(path, access),
+        Err(NonoError::PathNotFound(_)) => {
+            let cap = new_future_file_capability(path, access)?;
+            debug!(
+                "Granting future exact file capability on macOS for missing path: {}",
+                path.display()
+            );
+            Ok(cap)
         }
-    })?;
-
-    debug!(
-        "Profile exact-file path resolved as directory; granting exact macOS literal path access: {}",
-        path.display()
-    );
-
-    Ok(Some(FsCapability {
-        original: path.to_path_buf(),
-        resolved,
-        access,
-        // On macOS, `is_file = true` makes Seatbelt emit a literal path rule
-        // rather than a recursive subpath rule. The target may still be a
-        // directory; the important property is exact-path matching.
-        is_file: true,
-        source: CapabilitySource::Profile,
-    }))
+        Err(err) => Err(err),
+    }
 }
 
 #[cfg(not(target_os = "macos"))]
-fn handle_exact_directory_path(
-    path: &Path,
-    _access: AccessMode,
-    _protected_roots: &ProtectedRoots,
-    _allow_parent_of_protected: bool,
-) -> Result<Option<FsCapability>> {
-    Err(NonoError::ExpectedFile(path.to_path_buf()))
+fn new_exact_path_capability(path: &Path, access: AccessMode) -> Result<FsCapability> {
+    FsCapability::new_file(path, access)
 }
 
 #[cfg(target_os = "macos")]
@@ -337,6 +324,36 @@ fn handle_missing_file_capability(
 ) -> Result<Option<FsCapability>> {
     info!("{}: {}", label, path.display());
     Ok(None)
+}
+
+#[cfg(target_os = "macos")]
+fn new_exact_directory_path_capability(path: &Path, access: AccessMode) -> Result<FsCapability> {
+    let resolved = path.canonicalize().map_err(|source| {
+        if source.kind() == std::io::ErrorKind::NotFound {
+            NonoError::PathNotFound(path.to_path_buf())
+        } else {
+            NonoError::PathCanonicalization {
+                path: path.to_path_buf(),
+                source,
+            }
+        }
+    })?;
+
+    debug!(
+        "Profile exact-file path resolved as directory; granting exact macOS literal path access: {}",
+        path.display()
+    );
+
+    Ok(FsCapability {
+        original: path.to_path_buf(),
+        resolved,
+        access,
+        // On macOS, `is_file = true` makes Seatbelt emit a literal path rule
+        // rather than a recursive subpath rule. The target may still be a
+        // directory; the important property is exact-path matching.
+        is_file: true,
+        source: CapabilitySource::Profile,
+    })
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/nono-cli/src/sandbox_state.rs
+++ b/crates/nono-cli/src/sandbox_state.rs
@@ -4,11 +4,13 @@
 //! and passes the path via NONO_CAP_FILE. This allows sandboxed processes
 //! to query their own capabilities using `nono why --self`.
 
-use nono::{AccessMode, CapabilitySet, FsCapability, NonoError, Result};
+#[cfg(target_os = "macos")]
+use crate::capability_ext::new_future_file_capability;
+use nono::{AccessMode, CapabilitySet, CapabilitySource, FsCapability, NonoError, Result};
 use serde::{Deserialize, Serialize};
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::debug;
 
 #[cfg(unix)]
@@ -45,6 +47,9 @@ pub struct FsCapState {
     pub access: String,
     /// Whether this is a single file (vs directory)
     pub is_file: bool,
+    /// Capability source for diagnostics (`user`, `profile`, `group:<name>`, `system`)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }
 
 impl SandboxState {
@@ -67,6 +72,7 @@ impl SandboxState {
                         AccessMode::ReadWrite => "readwrite".to_string(),
                     },
                     is_file: c.is_file,
+                    source: Some(c.source.to_string()),
                 })
                 .collect(),
             net_blocked: caps.is_network_blocked(),
@@ -90,30 +96,32 @@ impl SandboxState {
 
     /// Convert back to a CapabilitySet
     ///
-    /// Paths are re-validated through the standard constructors which
-    /// canonicalize paths and verify existence. This prevents crafted
-    /// state files from injecting arbitrary paths that bypass validation.
+    /// Paths are re-validated through the standard constructors whenever
+    /// possible. On macOS, exact-file grants for missing leaf paths are
+    /// reconstructed with the same future-file logic used at profile load time.
+    /// In all cases, the reconstructed canonical path must match the path
+    /// serialized in the state file.
     ///
-    /// Returns an error if any path no longer exists or fails validation.
+    /// Returns an error if a stored grant fails validation or if the current
+    /// filesystem state no longer matches the serialized grant.
     pub fn to_caps(&self) -> Result<CapabilitySet> {
         let mut caps = CapabilitySet::new();
 
         for fs_cap in &self.fs {
-            let access = match fs_cap.access.as_str() {
-                "read" => AccessMode::Read,
-                "write" => AccessMode::Write,
-                "readwrite" => AccessMode::ReadWrite,
-                other => {
-                    return Err(NonoError::ConfigParse(format!(
-                        "invalid access mode in sandbox state: {other}"
-                    )));
-                }
-            };
+            let access = parse_access_mode(&fs_cap.access)?;
+            let source = parse_capability_source(fs_cap.source.as_deref())?;
 
             let cap = if fs_cap.is_file {
-                FsCapability::new_file(&fs_cap.original, access)?
+                match restore_existing_file_capability(fs_cap, access, &source) {
+                    Ok(cap) => cap,
+                    #[cfg(target_os = "macos")]
+                    Err(NonoError::PathNotFound(_)) => {
+                        restore_missing_file_capability(fs_cap, access, &source)?
+                    }
+                    Err(err) => return Err(err),
+                }
             } else {
-                FsCapability::new_dir(&fs_cap.original, access)?
+                restore_directory_capability(fs_cap, access, &source)?
             };
             caps.add_fs(cap);
         }
@@ -178,6 +186,83 @@ impl SandboxState {
 
         Ok(())
     }
+}
+
+fn parse_access_mode(access: &str) -> Result<AccessMode> {
+    match access {
+        "read" => Ok(AccessMode::Read),
+        "write" => Ok(AccessMode::Write),
+        "readwrite" => Ok(AccessMode::ReadWrite),
+        other => Err(NonoError::ConfigParse(format!(
+            "invalid access mode in sandbox state: {other}"
+        ))),
+    }
+}
+
+fn parse_capability_source(source: Option<&str>) -> Result<CapabilitySource> {
+    match source {
+        None | Some("") | Some("user") => Ok(CapabilitySource::User),
+        Some("profile") => Ok(CapabilitySource::Profile),
+        Some("system") => Ok(CapabilitySource::System),
+        Some(group) if let Some(name) = group.strip_prefix("group:") => {
+            if name.is_empty() {
+                return Err(NonoError::ConfigParse(
+                    "invalid capability source in sandbox state: empty group name".to_string(),
+                ));
+            }
+            Ok(CapabilitySource::Group(name.to_string()))
+        }
+        Some(other) => Err(NonoError::ConfigParse(format!(
+            "invalid capability source in sandbox state: {other}"
+        ))),
+    }
+}
+
+fn validate_restored_path(fs_cap: &FsCapState, actual: &Path) -> Result<()> {
+    let serialized = Path::new(&fs_cap.path);
+    if actual != serialized {
+        return Err(NonoError::ConfigParse(format!(
+            "sandbox state path drifted at reload: serialized resolved={}, actual resolved={}",
+            serialized.display(),
+            actual.display(),
+        )));
+    }
+
+    Ok(())
+}
+
+fn restore_existing_file_capability(
+    fs_cap: &FsCapState,
+    access: AccessMode,
+    source: &CapabilitySource,
+) -> Result<FsCapability> {
+    let mut cap = FsCapability::new_file(&fs_cap.original, access)?;
+    validate_restored_path(fs_cap, &cap.resolved)?;
+    cap.source = source.clone();
+    Ok(cap)
+}
+
+fn restore_directory_capability(
+    fs_cap: &FsCapState,
+    access: AccessMode,
+    source: &CapabilitySource,
+) -> Result<FsCapability> {
+    let mut cap = FsCapability::new_dir(&fs_cap.original, access)?;
+    validate_restored_path(fs_cap, &cap.resolved)?;
+    cap.source = source.clone();
+    Ok(cap)
+}
+
+#[cfg(target_os = "macos")]
+fn restore_missing_file_capability(
+    fs_cap: &FsCapState,
+    access: AccessMode,
+    source: &CapabilitySource,
+) -> Result<FsCapability> {
+    let mut cap = new_future_file_capability(Path::new(&fs_cap.original), access)?;
+    validate_restored_path(fs_cap, &cap.resolved)?;
+    cap.source = source.clone();
+    Ok(cap)
 }
 
 /// Maximum size for capability state files (1 MB is more than enough)
@@ -370,6 +455,7 @@ pub fn cleanup_stale_state_files() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nono::CapabilitySource;
     use tempfile::tempdir;
 
     #[test]
@@ -404,5 +490,94 @@ mod tests {
         let loaded: SandboxState = serde_json::from_str(&content).expect("Failed to parse state");
 
         assert!(loaded.net_blocked);
+    }
+
+    #[test]
+    fn test_sandbox_state_roundtrip_preserves_source() {
+        let dir = tempdir().expect("tempdir");
+        let file_path = dir.path().join("granted.txt");
+        std::fs::write(&file_path, b"ok").expect("write test file");
+
+        let mut cap = FsCapability::new_file(&file_path, AccessMode::Read).expect("create cap");
+        cap.source = CapabilitySource::Group("system_read_macos".to_string());
+
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(cap);
+
+        let state = SandboxState::from_caps(&caps, &[], &[]);
+        let restored = state.to_caps().expect("restore caps");
+
+        assert_eq!(restored.fs_capabilities().len(), 1);
+        assert_eq!(
+            restored.fs_capabilities()[0].source,
+            CapabilitySource::Group("system_read_macos".to_string())
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_sandbox_state_restores_missing_future_file() {
+        let dir = tempdir().expect("tempdir");
+        let missing = dir.path().join("future.lock");
+
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: missing.clone(),
+            resolved: dir
+                .path()
+                .canonicalize()
+                .expect("canonicalize dir")
+                .join("future.lock"),
+            access: AccessMode::ReadWrite,
+            is_file: true,
+            source: CapabilitySource::Profile,
+        });
+
+        let state = SandboxState::from_caps(&caps, &[], &[]);
+        let restored = state.to_caps().expect("restore future file cap");
+
+        assert_eq!(restored.fs_capabilities().len(), 1);
+        assert_eq!(restored.fs_capabilities()[0].original, missing);
+        assert_eq!(restored.fs_capabilities()[0].access, AccessMode::ReadWrite);
+        assert_eq!(
+            restored.fs_capabilities()[0].source,
+            CapabilitySource::Profile
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_sandbox_state_rejects_drifted_future_file_path() {
+        let dir = tempdir().expect("tempdir");
+        let missing = dir.path().join("future.lock");
+
+        let state = SandboxState {
+            fs: vec![FsCapState {
+                original: missing.display().to_string(),
+                path: dir
+                    .path()
+                    .canonicalize()
+                    .expect("canonicalize dir")
+                    .join("other.lock")
+                    .display()
+                    .to_string(),
+                access: "readwrite".to_string(),
+                is_file: true,
+                source: Some("profile".to_string()),
+            }],
+            net_blocked: false,
+            allowed_commands: vec![],
+            blocked_commands: vec![],
+            bypass_protection_paths: vec![],
+            allowed_domains: vec![],
+        };
+
+        let err = state
+            .to_caps()
+            .expect_err("drifted future file must be rejected");
+        assert!(
+            format!("{err}").contains("sandbox state path drifted"),
+            "error should mention path drift"
+        );
     }
 }

--- a/crates/nono-cli/src/sandbox_state.rs
+++ b/crates/nono-cli/src/sandbox_state.rs
@@ -5,7 +5,7 @@
 //! to query their own capabilities using `nono why --self`.
 
 #[cfg(target_os = "macos")]
-use crate::capability_ext::new_future_file_capability;
+use crate::capability_ext::new_exact_path_capability;
 use nono::{AccessMode, CapabilitySet, CapabilitySource, FsCapability, NonoError, Result};
 use serde::{Deserialize, Serialize};
 use std::fs::OpenOptions;
@@ -112,14 +112,7 @@ impl SandboxState {
             let source = parse_capability_source(fs_cap.source.as_deref())?;
 
             let cap = if fs_cap.is_file {
-                match restore_existing_file_capability(fs_cap, access, &source) {
-                    Ok(cap) => cap,
-                    #[cfg(target_os = "macos")]
-                    Err(NonoError::PathNotFound(_)) => {
-                        restore_missing_file_capability(fs_cap, access, &source)?
-                    }
-                    Err(err) => return Err(err),
-                }
+                restore_exact_path_capability(fs_cap, access, &source)?
             } else {
                 restore_directory_capability(fs_cap, access, &source)?
             };
@@ -231,7 +224,20 @@ fn validate_restored_path(fs_cap: &FsCapState, actual: &Path) -> Result<()> {
     Ok(())
 }
 
-fn restore_existing_file_capability(
+#[cfg(target_os = "macos")]
+fn restore_exact_path_capability(
+    fs_cap: &FsCapState,
+    access: AccessMode,
+    source: &CapabilitySource,
+) -> Result<FsCapability> {
+    let mut cap = new_exact_path_capability(Path::new(&fs_cap.original), access)?;
+    validate_restored_path(fs_cap, &cap.resolved)?;
+    cap.source = source.clone();
+    Ok(cap)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn restore_exact_path_capability(
     fs_cap: &FsCapState,
     access: AccessMode,
     source: &CapabilitySource,
@@ -248,18 +254,6 @@ fn restore_directory_capability(
     source: &CapabilitySource,
 ) -> Result<FsCapability> {
     let mut cap = FsCapability::new_dir(&fs_cap.original, access)?;
-    validate_restored_path(fs_cap, &cap.resolved)?;
-    cap.source = source.clone();
-    Ok(cap)
-}
-
-#[cfg(target_os = "macos")]
-fn restore_missing_file_capability(
-    fs_cap: &FsCapState,
-    access: AccessMode,
-    source: &CapabilitySource,
-) -> Result<FsCapability> {
-    let mut cap = new_future_file_capability(Path::new(&fs_cap.original), access)?;
     validate_restored_path(fs_cap, &cap.resolved)?;
     cap.source = source.clone();
     Ok(cap)
@@ -542,6 +536,39 @@ mod tests {
         assert_eq!(
             restored.fs_capabilities()[0].source,
             CapabilitySource::Profile
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_sandbox_state_restores_exact_directory_literal_path() {
+        let dir = tempdir().expect("tempdir");
+        let lock_dir = dir.path().join("claude.lock");
+        std::fs::create_dir_all(&lock_dir).expect("create lock dir");
+        let child = lock_dir.join("child.txt");
+
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: lock_dir.clone(),
+            resolved: lock_dir.canonicalize().expect("canonicalize lock dir"),
+            access: AccessMode::ReadWrite,
+            is_file: true,
+            source: CapabilitySource::Profile,
+        });
+
+        let state = SandboxState::from_caps(&caps, &[], &[]);
+        let restored = state.to_caps().expect("restore exact directory literal");
+
+        assert_eq!(restored.fs_capabilities().len(), 1);
+        assert_eq!(restored.fs_capabilities()[0].original, lock_dir);
+        assert!(restored.fs_capabilities()[0].is_file);
+        assert_eq!(
+            restored.fs_capabilities()[0].source,
+            CapabilitySource::Profile
+        );
+        assert!(
+            !restored.path_covered(&child),
+            "exact-path directory literal must not recursively cover descendants"
         );
     }
 


### PR DESCRIPTION
## Linked Issue

Closes #943

## Summary

Fix the macOS-only `nono why --self` regression where sandbox state replay failed on valid future exact-file grants for missing files like `$HOME/my.lock`.

The restore path in `crates/nono-cli/src/sandbox_state.rs` now preserves macOS future-file grants for self-query while still validating serialized access metadata and rejecting drifted or tampered resolved paths. It also preserves capability sources during replay. `crates/nono-cli/src/capability_ext.rs` exposes the existing macOS future-file helper so the self-query restore path can reuse the same parent-canonicalization logic already used when profile grants are loaded.

## Agent Disclosure

I am an automated agent contributor.

Consulted files/sections:
- `AGENTS.md` (Coding Agent Contribution Policy, PR requirements, Agent Compliance Check)
- `.github/pull_request_template.md`
- `crates/nono-cli/src/sandbox_state.rs`
- `crates/nono-cli/src/capability_ext.rs`

This contribution complies with the repository coding and security requirements to the best of my knowledge: it keeps validation strict, rejects drifted/tampered state, uses `NonoError` for explicit failures, and adds regression coverage for the affected restore path.

## Test Plan

- `cargo fmt --all && make build && make test && make check && make lint-aliases && make lint-docs`
- `cargo test -p nono-cli sandbox_state`
- `./target/debug/nono run --allow-cwd --profile <repro-profile> -- ./target/debug/nono why --self --path /tmp`

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope
