### PR TITLE
feat(cli): add option to configure process startup timeout

### DIFF
--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1662,6 +1662,12 @@ pub struct RunArgs {
     #[arg(long, help_heading = "OPTIONS")]
     pub no_diagnostics: bool,
 
+    /// Startup timeout in seconds for known interactive agents (e.g. opencode, claude).
+    /// Set to 0 to disable. Only applies when no --profile is specified.
+    /// Default: 5. Overrides NONO_STARTUP_TIMEOUT.
+    #[arg(long = "startup-timeout", value_name = "SECS", env = "NONO_STARTUP_TIMEOUT", help_heading = "OPTIONS")]
+    pub startup_timeout_secs: Option<u64>,
+
     /// Disable the audit trail for this session
     #[arg(
         long,
@@ -1726,6 +1732,12 @@ pub struct ShellArgs {
     #[arg(long, value_name = "NAME", help_heading = "OPTIONS")]
     pub name: Option<String>,
 
+    /// Startup timeout in seconds for known interactive agents (e.g. opencode, claude).
+    /// Set to 0 to disable. Only applies when no --profile is specified.
+    /// Default: 5. Overrides NONO_STARTUP_TIMEOUT.
+    #[arg(long = "startup-timeout", value_name = "SECS", env = "NONO_STARTUP_TIMEOUT", help_heading = "OPTIONS")]
+    pub startup_timeout_secs: Option<u64>,
+
     /// Print help
     #[arg(long, short = 'h', action = clap::ArgAction::Help, help_heading = "OPTIONS")]
     pub help: Option<bool>,
@@ -1740,6 +1752,12 @@ pub struct WrapArgs {
     /// Suppress diagnostic footer on command failure
     #[arg(long, help_heading = "OPTIONS")]
     pub no_diagnostics: bool,
+
+    /// Startup timeout in seconds for known interactive agents (e.g. opencode, claude).
+    /// Set to 0 to disable. Only applies when no --profile is specified.
+    /// Default: 5. Overrides NONO_STARTUP_TIMEOUT.
+    #[arg(long = "startup-timeout", value_name = "SECS", env = "NONO_STARTUP_TIMEOUT", help_heading = "OPTIONS")]
+    pub startup_timeout_secs: Option<u64>,
 
     /// Command to run inside the sandbox
     #[arg(required = true, hide = true)]

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1665,7 +1665,12 @@ pub struct RunArgs {
     /// Kill the process if it has not entered alt-screen mode after this many seconds.
     /// Startup banners and log lines do not count; only a full-screen TUI transition satisfies the check.
     /// Set to 0 to disable. Env: NONO_STARTUP_TIMEOUT.
-    #[arg(long = "startup-timeout", value_name = "SECS", env = "NONO_STARTUP_TIMEOUT", help_heading = "OPTIONS")]
+    #[arg(
+        long = "startup-timeout",
+        value_name = "SECS",
+        env = "NONO_STARTUP_TIMEOUT",
+        help_heading = "OPTIONS"
+    )]
     pub startup_timeout_secs: Option<u64>,
 
     /// Disable the audit trail for this session
@@ -1735,7 +1740,12 @@ pub struct ShellArgs {
     /// Kill the process if it has not entered alt-screen mode after this many seconds.
     /// Startup banners and log lines do not count; only a full-screen TUI transition satisfies the check.
     /// Set to 0 to disable. Env: NONO_STARTUP_TIMEOUT.
-    #[arg(long = "startup-timeout", value_name = "SECS", env = "NONO_STARTUP_TIMEOUT", help_heading = "OPTIONS")]
+    #[arg(
+        long = "startup-timeout",
+        value_name = "SECS",
+        env = "NONO_STARTUP_TIMEOUT",
+        help_heading = "OPTIONS"
+    )]
     pub startup_timeout_secs: Option<u64>,
 
     /// Print help

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1662,9 +1662,8 @@ pub struct RunArgs {
     #[arg(long, help_heading = "OPTIONS")]
     pub no_diagnostics: bool,
 
-    /// Startup timeout in seconds for known interactive agents (e.g. opencode, claude).
-    /// Set to 0 to disable. Only applies when no --profile is specified.
-    /// Default: 5. Overrides NONO_STARTUP_TIMEOUT.
+    /// Kill the process if it has not become interactive after this many seconds.
+    /// Set to 0 to disable. Env: NONO_STARTUP_TIMEOUT.
     #[arg(long = "startup-timeout", value_name = "SECS", env = "NONO_STARTUP_TIMEOUT", help_heading = "OPTIONS")]
     pub startup_timeout_secs: Option<u64>,
 
@@ -1732,9 +1731,8 @@ pub struct ShellArgs {
     #[arg(long, value_name = "NAME", help_heading = "OPTIONS")]
     pub name: Option<String>,
 
-    /// Startup timeout in seconds for known interactive agents (e.g. opencode, claude).
-    /// Set to 0 to disable. Only applies when no --profile is specified.
-    /// Default: 5. Overrides NONO_STARTUP_TIMEOUT.
+    /// Kill the process if it has not become interactive after this many seconds.
+    /// Set to 0 to disable. Env: NONO_STARTUP_TIMEOUT.
     #[arg(long = "startup-timeout", value_name = "SECS", env = "NONO_STARTUP_TIMEOUT", help_heading = "OPTIONS")]
     pub startup_timeout_secs: Option<u64>,
 
@@ -1752,12 +1750,6 @@ pub struct WrapArgs {
     /// Suppress diagnostic footer on command failure
     #[arg(long, help_heading = "OPTIONS")]
     pub no_diagnostics: bool,
-
-    /// Startup timeout in seconds for known interactive agents (e.g. opencode, claude).
-    /// Set to 0 to disable. Only applies when no --profile is specified.
-    /// Default: 5. Overrides NONO_STARTUP_TIMEOUT.
-    #[arg(long = "startup-timeout", value_name = "SECS", env = "NONO_STARTUP_TIMEOUT", help_heading = "OPTIONS")]
-    pub startup_timeout_secs: Option<u64>,
 
     /// Command to run inside the sandbox
     #[arg(required = true, hide = true)]

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1662,7 +1662,8 @@ pub struct RunArgs {
     #[arg(long, help_heading = "OPTIONS")]
     pub no_diagnostics: bool,
 
-    /// Kill the process if it has not become interactive after this many seconds.
+    /// Kill the process if it has not entered alt-screen mode after this many seconds.
+    /// Startup banners and log lines do not count; only a full-screen TUI transition satisfies the check.
     /// Set to 0 to disable. Env: NONO_STARTUP_TIMEOUT.
     #[arg(long = "startup-timeout", value_name = "SECS", env = "NONO_STARTUP_TIMEOUT", help_heading = "OPTIONS")]
     pub startup_timeout_secs: Option<u64>,
@@ -1731,7 +1732,8 @@ pub struct ShellArgs {
     #[arg(long, value_name = "NAME", help_heading = "OPTIONS")]
     pub name: Option<String>,
 
-    /// Kill the process if it has not become interactive after this many seconds.
+    /// Kill the process if it has not entered alt-screen mode after this many seconds.
+    /// Startup banners and log lines do not count; only a full-screen TUI transition satisfies the check.
     /// Set to 0 to disable. Env: NONO_STARTUP_TIMEOUT.
     #[arg(long = "startup-timeout", value_name = "SECS", env = "NONO_STARTUP_TIMEOUT", help_heading = "OPTIONS")]
     pub startup_timeout_secs: Option<u64>,

--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -150,6 +150,7 @@ pub(crate) fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
             ignored_denial_paths: prepared.ignored_denial_paths,
             allowed_env_vars: prepared.allowed_env_vars,
             denied_env_vars: prepared.denied_env_vars,
+            startup_timeout_secs: args.startup_timeout_secs,
             proxy,
             redaction_policy: load_configured_redaction_policy()?,
             session: SessionLaunchOptions {
@@ -166,6 +167,7 @@ pub(crate) fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
     let args: SandboxArgs = wrap_args.sandbox.into();
     let command = wrap_args.command;
     let no_diagnostics = wrap_args.no_diagnostics;
+    let startup_timeout_secs = wrap_args.startup_timeout_secs;
 
     if command.is_empty() {
         return Err(NonoError::NoCommand);
@@ -232,6 +234,7 @@ pub(crate) fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
             ignored_denial_paths: prepared.ignored_denial_paths,
             allowed_env_vars: prepared.allowed_env_vars,
             denied_env_vars: prepared.denied_env_vars,
+            startup_timeout_secs,
             ..ExecutionFlags::defaults(silent)?
         },
     })

--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -167,7 +167,6 @@ pub(crate) fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
     let args: SandboxArgs = wrap_args.sandbox.into();
     let command = wrap_args.command;
     let no_diagnostics = wrap_args.no_diagnostics;
-    let startup_timeout_secs = wrap_args.startup_timeout_secs;
 
     if command.is_empty() {
         return Err(NonoError::NoCommand);
@@ -234,7 +233,6 @@ pub(crate) fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
             ignored_denial_paths: prepared.ignored_denial_paths,
             allowed_env_vars: prepared.allowed_env_vars,
             denied_env_vars: prepared.denied_env_vars,
-            startup_timeout_secs,
             ..ExecutionFlags::defaults(silent)?
         },
     })

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -1572,18 +1572,19 @@ fn wait_for_child_with_pty(
 
         match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
             Ok(WaitStatus::StillAlive) => {
-                if let Some((deadline, timeout_cfg)) = startup_deadline {
-                    if Instant::now() >= deadline && !pty.is_interactive() {
-                        notify_startup_termination_for_child(
-                            timeout_cfg,
-                            pty.has_visible_output(),
-                            Some(pty),
-                        );
-                        *killed_by_timeout = true;
-                        let _ = signal::kill(child, Signal::SIGKILL);
-                        let status = wait_for_child(child)?;
-                        return Ok(status);
-                    }
+                if let Some((deadline, timeout_cfg)) = startup_deadline
+                    && Instant::now() >= deadline
+                    && !pty.is_interactive()
+                {
+                    notify_startup_termination_for_child(
+                        timeout_cfg,
+                        pty.has_visible_output(),
+                        Some(pty),
+                    );
+                    *killed_by_timeout = true;
+                    let _ = signal::kill(child, Signal::SIGKILL);
+                    let status = wait_for_child(child)?;
+                    return Ok(status);
                 }
                 continue;
             }
@@ -2050,19 +2051,18 @@ fn run_supervisor_loop(
 
         match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
             Ok(WaitStatus::StillAlive) => {
-                if let Some((deadline, timeout_cfg)) = startup_deadline {
-                    if Instant::now() >= deadline
-                        && !pty.as_ref().is_some_and(|p| p.is_interactive())
-                    {
-                        notify_startup_termination_for_child(
-                            timeout_cfg,
-                            pty.as_ref().is_some_and(|p| p.has_visible_output()),
-                            pty.as_deref_mut(),
-                        );
-                        *killed_by_timeout = true;
-                        let _ = signal::kill(child, Signal::SIGKILL);
-                        return Ok((wait_for_child(child)?, denials));
-                    }
+                if let Some((deadline, timeout_cfg)) = startup_deadline
+                    && Instant::now() >= deadline
+                    && !pty.as_ref().is_some_and(|p| p.is_interactive())
+                {
+                    notify_startup_termination_for_child(
+                        timeout_cfg,
+                        pty.as_ref().is_some_and(|p| p.has_visible_output()),
+                        pty.as_deref_mut(),
+                    );
+                    *killed_by_timeout = true;
+                    let _ = signal::kill(child, Signal::SIGKILL);
+                    return Ok((wait_for_child(child)?, denials));
                 }
                 continue;
             }

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -249,7 +249,9 @@ pub struct ExecConfig<'a> {
 pub struct StartupTimeoutConfig<'a> {
     pub timeout: Duration,
     pub program: &'a str,
-    pub profile: &'a str,
+    /// Populated only when the binary matches a known built-in profile; used
+    /// solely to enrich the "try --profile X" hint message.
+    pub recommended_profile: Option<&'a str>,
 }
 
 /// Configuration for supervisor IPC in supervised execution mode.
@@ -1122,6 +1124,7 @@ pub fn execute_supervised(
                     .collect()
             };
 
+            let mut killed_by_timeout = false;
             let (status, denials, ipc_denials) =
                 if let (Some(sup_cfg), Some(mut sup_sock)) = (supervisor, supervisor_sock) {
                     #[cfg(target_os = "linux")]
@@ -1136,6 +1139,7 @@ pub fn execute_supervised(
                             &initial_caps,
                             trust_interceptor,
                             pty_proxy.as_mut(),
+                            &mut killed_by_timeout,
                         )?;
                         (status, denials, ipc_denials)
                     }
@@ -1148,12 +1152,17 @@ pub fn execute_supervised(
                             config.startup_timeout,
                             trust_interceptor,
                             pty_proxy.as_mut(),
+                            &mut killed_by_timeout,
                         )?;
                         (status, denials, Vec::new())
                     }
                 } else {
-                    let status =
-                        wait_for_child_with_pty(child, pty_proxy.as_mut(), config.startup_timeout)?;
+                    let status = wait_for_child_with_pty(
+                        child,
+                        pty_proxy.as_mut(),
+                        config.startup_timeout,
+                        &mut killed_by_timeout,
+                    )?;
                     (status, Vec::new(), Vec::new())
                 };
 
@@ -1173,14 +1182,14 @@ pub fn execute_supervised(
                 WaitStatus::Exited(_, code) => {
                     debug!("Supervised child exited with code {}", code);
                     let by_signal = (129..=143).contains(&code);
-                    if by_signal && !config.no_diagnostics {
+                    if by_signal && !config.no_diagnostics && !killed_by_timeout {
                         print_terminal_safe_stderr("[nono] Session stopped.");
                     }
                     code
                 }
                 WaitStatus::Signaled(_, sig, _) => {
                     debug!("Supervised child killed by signal {}", sig);
-                    if !config.no_diagnostics {
+                    if !config.no_diagnostics && !killed_by_timeout {
                         print_terminal_safe_stderr("[nono] Session stopped.");
                     }
                     128 + sig as i32
@@ -1232,14 +1241,15 @@ pub fn execute_supervised(
             let prompt_policy_explanations = policy_explanations.clone();
             let prompt_error_observation = error_observation.clone();
 
-            let should_print_diagnostics = should_print_diagnostic_footer(
-                config.no_diagnostics,
-                exit_code,
-                &denials,
-                &ipc_denials,
-                &sandbox_violations,
-                &error_observation,
-            );
+            let should_print_diagnostics = !killed_by_timeout
+                && should_print_diagnostic_footer(
+                    config.no_diagnostics,
+                    exit_code,
+                    &denials,
+                    &ipc_denials,
+                    &sandbox_violations,
+                    &error_observation,
+                );
 
             // Print diagnostic footer on non-zero exit or when the PTY
             // output or OS sandbox logs show a likely sandbox-related issue.
@@ -1497,10 +1507,11 @@ fn wait_for_child_with_pty(
     child: Pid,
     pty: Option<&mut crate::pty_proxy::PtyProxy>,
     startup_timeout: Option<StartupTimeoutConfig<'_>>,
+    killed_by_timeout: &mut bool,
 ) -> Result<WaitStatus> {
     let pty = match pty {
         Some(pty) => pty,
-        None => return wait_for_child_with_startup_timeout(child, startup_timeout),
+        None => return wait_for_child_with_startup_timeout(child, startup_timeout, killed_by_timeout),
     };
     let startup_deadline = startup_timeout.map(|cfg| (Instant::now() + cfg.timeout, cfg));
     let mut startup_prompted = false;
@@ -1561,16 +1572,16 @@ fn wait_for_child_with_pty(
         match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
             Ok(WaitStatus::StillAlive) => {
                 if let Some((deadline, timeout_cfg)) = startup_deadline {
-                    let has_output = pty.has_visible_output();
-                    if Instant::now() >= deadline && !has_output && !startup_prompted {
+                    if Instant::now() >= deadline && !pty.is_interactive() && !startup_prompted {
                         startup_prompted = true;
                         let terminate = prompt_startup_termination_for_child(
                             child,
                             timeout_cfg,
-                            has_output,
+                            pty.has_visible_output(),
                             Some(pty),
                         );
                         if terminate {
+                            *killed_by_timeout = true;
                             let _ = signal::kill(child, Signal::SIGKILL);
                             let status = wait_for_child(child)?;
                             return Ok(status);
@@ -1601,6 +1612,7 @@ fn wait_for_child_with_pty(
 fn wait_for_child_with_startup_timeout(
     child: Pid,
     startup_timeout: Option<StartupTimeoutConfig<'_>>,
+    killed_by_timeout: &mut bool,
 ) -> Result<WaitStatus> {
     let startup_deadline = startup_timeout.map(|cfg| (Instant::now() + cfg.timeout, cfg));
     let mut startup_prompted = false;
@@ -1614,6 +1626,7 @@ fn wait_for_child_with_startup_timeout(
                 {
                     startup_prompted = true;
                     if prompt_startup_termination_for_child(child, timeout_cfg, true, None) {
+                        *killed_by_timeout = true;
                         let _ = signal::kill(child, Signal::SIGKILL);
                         return wait_for_child(child);
                     }
@@ -1942,6 +1955,7 @@ fn run_supervisor_loop(
     startup_timeout: Option<StartupTimeoutConfig<'_>>,
     mut trust_interceptor: Option<crate::trust_intercept::TrustInterceptor>,
     mut pty: Option<&mut crate::pty_proxy::PtyProxy>,
+    killed_by_timeout: &mut bool,
 ) -> Result<(WaitStatus, Vec<DenialRecord>)> {
     let sock_fd = sock.as_raw_fd();
     let mut denials = Vec::new();
@@ -2045,16 +2059,19 @@ fn run_supervisor_loop(
         match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
             Ok(WaitStatus::StillAlive) => {
                 if let Some((deadline, timeout_cfg)) = startup_deadline {
-                    let has_output = pty.as_ref().is_some_and(|p| p.has_visible_output());
-                    if Instant::now() >= deadline && !has_output && !startup_prompted {
+                    if Instant::now() >= deadline
+                        && !pty.as_ref().is_some_and(|p| p.is_interactive())
+                        && !startup_prompted
+                    {
                         startup_prompted = true;
                         let terminate = prompt_startup_termination_for_child(
                             child,
                             timeout_cfg,
-                            has_output,
+                            pty.as_ref().is_some_and(|p| p.has_visible_output()),
                             pty.as_deref_mut(),
                         );
                         if terminate {
+                            *killed_by_timeout = true;
                             let _ = signal::kill(child, Signal::SIGKILL);
                             return Ok((wait_for_child(child)?, denials));
                         }
@@ -2118,6 +2135,7 @@ fn run_supervisor_loop(
     initial_caps: &[supervisor_linux::InitialCapability],
     mut trust_interceptor: Option<crate::trust_intercept::TrustInterceptor>,
     mut pty: Option<&mut crate::pty_proxy::PtyProxy>,
+    killed_by_timeout: &mut bool,
 ) -> Result<(
     WaitStatus,
     Vec<DenialRecord>,
@@ -2292,16 +2310,19 @@ fn run_supervisor_loop(
         match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
             Ok(WaitStatus::StillAlive) => {
                 if let Some((deadline, timeout_cfg)) = startup_deadline {
-                    let has_output = pty.as_ref().is_some_and(|p| p.has_visible_output());
-                    if Instant::now() >= deadline && !has_output && !startup_prompted {
+                    if Instant::now() >= deadline
+                        && !pty.as_ref().is_some_and(|p| p.is_interactive())
+                        && !startup_prompted
+                    {
                         startup_prompted = true;
                         let terminate = prompt_startup_termination_for_child(
                             child,
                             timeout_cfg,
-                            has_output,
+                            pty.as_ref().is_some_and(|p| p.has_visible_output()),
                             pty.as_deref_mut(),
                         );
                         if terminate {
+                            *killed_by_timeout = true;
                             let _ = signal::kill(child, Signal::SIGTERM);
                             return Ok((wait_for_child(child)?, denials, ipc_denials));
                         }
@@ -3839,6 +3860,7 @@ mod tests {
                     child, &mut sock, &sup_cfg, None, // no startup timeout
                     None, // no trust interceptor
                     None, // no PTY relay
+                    &mut false,
                 );
 
                 #[cfg(target_os = "linux")]

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -2295,19 +2295,18 @@ fn run_supervisor_loop(
 
         match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
             Ok(WaitStatus::StillAlive) => {
-                if let Some((deadline, timeout_cfg)) = startup_deadline {
-                    if Instant::now() >= deadline
-                        && !pty.as_ref().is_some_and(|p| p.is_interactive())
-                    {
-                        notify_startup_termination_for_child(
-                            timeout_cfg,
-                            pty.as_ref().is_some_and(|p| p.has_visible_output()),
-                            pty.as_deref_mut(),
-                        );
-                        *killed_by_timeout = true;
-                        let _ = signal::kill(child, Signal::SIGKILL);
-                        return Ok((wait_for_child(child)?, denials, ipc_denials));
-                    }
+                if let Some((deadline, timeout_cfg)) = startup_deadline
+                    && Instant::now() >= deadline
+                    && !pty.as_ref().is_some_and(|p| p.is_interactive())
+                {
+                    notify_startup_termination_for_child(
+                        timeout_cfg,
+                        pty.as_ref().is_some_and(|p| p.has_visible_output()),
+                        pty.as_deref_mut(),
+                    );
+                    *killed_by_timeout = true;
+                    let _ = signal::kill(child, Signal::SIGKILL);
+                    return Ok((wait_for_child(child)?, denials, ipc_denials));
                 }
                 continue;
             }

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -14,7 +14,7 @@ mod env_sanitization;
 #[cfg(target_os = "linux")]
 mod supervisor_linux;
 
-use crate::startup_prompt::{print_terminal_safe_stderr, prompt_startup_termination_for_child};
+use crate::startup_prompt::{notify_startup_termination_for_child, print_terminal_safe_stderr};
 use crate::{DETACHED_CWD_PROMPT_RESPONSE_ENV, DETACHED_LAUNCH_ENV, DETACHED_SESSION_ID_ENV};
 use nix::libc;
 use nix::sys::signal::{self, Signal};
@@ -1511,10 +1511,11 @@ fn wait_for_child_with_pty(
 ) -> Result<WaitStatus> {
     let pty = match pty {
         Some(pty) => pty,
-        None => return wait_for_child_with_startup_timeout(child, startup_timeout, killed_by_timeout),
+        None => {
+            return wait_for_child_with_startup_timeout(child, startup_timeout, killed_by_timeout);
+        }
     };
     let startup_deadline = startup_timeout.map(|cfg| (Instant::now() + cfg.timeout, cfg));
-    let mut startup_prompted = false;
 
     loop {
         let (master_fd, client_fd, attach_fd, resize_fd) = pty.poll_fds();
@@ -1572,20 +1573,16 @@ fn wait_for_child_with_pty(
         match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
             Ok(WaitStatus::StillAlive) => {
                 if let Some((deadline, timeout_cfg)) = startup_deadline {
-                    if Instant::now() >= deadline && !pty.is_interactive() && !startup_prompted {
-                        startup_prompted = true;
-                        let terminate = prompt_startup_termination_for_child(
-                            child,
+                    if Instant::now() >= deadline && !pty.is_interactive() {
+                        notify_startup_termination_for_child(
                             timeout_cfg,
                             pty.has_visible_output(),
                             Some(pty),
                         );
-                        if terminate {
-                            *killed_by_timeout = true;
-                            let _ = signal::kill(child, Signal::SIGKILL);
-                            let status = wait_for_child(child)?;
-                            return Ok(status);
-                        }
+                        *killed_by_timeout = true;
+                        let _ = signal::kill(child, Signal::SIGKILL);
+                        let status = wait_for_child(child)?;
+                        return Ok(status);
                     }
                 }
                 continue;
@@ -1615,21 +1612,17 @@ fn wait_for_child_with_startup_timeout(
     killed_by_timeout: &mut bool,
 ) -> Result<WaitStatus> {
     let startup_deadline = startup_timeout.map(|cfg| (Instant::now() + cfg.timeout, cfg));
-    let mut startup_prompted = false;
 
     loop {
         match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
             Ok(WaitStatus::StillAlive) => {
                 if let Some((deadline, timeout_cfg)) = startup_deadline
                     && Instant::now() >= deadline
-                    && !startup_prompted
                 {
-                    startup_prompted = true;
-                    if prompt_startup_termination_for_child(child, timeout_cfg, true, None) {
-                        *killed_by_timeout = true;
-                        let _ = signal::kill(child, Signal::SIGKILL);
-                        return wait_for_child(child);
-                    }
+                    notify_startup_termination_for_child(timeout_cfg, true, None);
+                    *killed_by_timeout = true;
+                    let _ = signal::kill(child, Signal::SIGKILL);
+                    return wait_for_child(child);
                 }
                 std::thread::sleep(Duration::from_millis(200));
             }
@@ -1961,7 +1954,6 @@ fn run_supervisor_loop(
     let mut denials = Vec::new();
     let mut seen_request_ids = HashSet::new();
     let startup_deadline = startup_timeout.map(|cfg| (Instant::now() + cfg.timeout, cfg));
-    let mut startup_prompted = false;
 
     loop {
         let (pty_master, pty_client, pty_attach, pty_resize) =
@@ -2061,20 +2053,15 @@ fn run_supervisor_loop(
                 if let Some((deadline, timeout_cfg)) = startup_deadline {
                     if Instant::now() >= deadline
                         && !pty.as_ref().is_some_and(|p| p.is_interactive())
-                        && !startup_prompted
                     {
-                        startup_prompted = true;
-                        let terminate = prompt_startup_termination_for_child(
-                            child,
+                        notify_startup_termination_for_child(
                             timeout_cfg,
                             pty.as_ref().is_some_and(|p| p.has_visible_output()),
                             pty.as_deref_mut(),
                         );
-                        if terminate {
-                            *killed_by_timeout = true;
-                            let _ = signal::kill(child, Signal::SIGKILL);
-                            return Ok((wait_for_child(child)?, denials));
-                        }
+                        *killed_by_timeout = true;
+                        let _ = signal::kill(child, Signal::SIGKILL);
+                        return Ok((wait_for_child(child)?, denials));
                     }
                 }
                 continue;
@@ -2150,7 +2137,6 @@ fn run_supervisor_loop(
     let mut seen_request_ids = HashSet::new();
     let mut sock_fd_active = true;
     let startup_deadline = startup_timeout.map(|cfg| (Instant::now() + cfg.timeout, cfg));
-    let mut startup_prompted = false;
 
     loop {
         let mut pfds: Vec<libc::pollfd> = vec![libc::pollfd {
@@ -2312,20 +2298,15 @@ fn run_supervisor_loop(
                 if let Some((deadline, timeout_cfg)) = startup_deadline {
                     if Instant::now() >= deadline
                         && !pty.as_ref().is_some_and(|p| p.is_interactive())
-                        && !startup_prompted
                     {
-                        startup_prompted = true;
-                        let terminate = prompt_startup_termination_for_child(
-                            child,
+                        notify_startup_termination_for_child(
                             timeout_cfg,
                             pty.as_ref().is_some_and(|p| p.has_visible_output()),
                             pty.as_deref_mut(),
                         );
-                        if terminate {
-                            *killed_by_timeout = true;
-                            let _ = signal::kill(child, Signal::SIGTERM);
-                            return Ok((wait_for_child(child)?, denials, ipc_denials));
-                        }
+                        *killed_by_timeout = true;
+                        let _ = signal::kill(child, Signal::SIGKILL);
+                        return Ok((wait_for_child(child)?, denials, ipc_denials));
                     }
                 }
                 continue;

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -3853,6 +3853,7 @@ mod tests {
                     &[],  // no initial caps
                     None, // no trust interceptor
                     None, // no PTY relay — this is what we're testing
+                    &mut false,
                 );
 
                 #[cfg(not(target_os = "linux"))]
@@ -3967,6 +3968,7 @@ mod tests {
                     &[],  // no initial caps
                     None, // no trust interceptor
                     None, // no PTY relay
+                    &mut false,
                 );
 
                 let (status, denials, ipc_denials) = result

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -12,8 +12,6 @@ use std::path::Path;
 use std::time::Duration;
 use tracing::{error, info};
 
-const PROFILE_HINT_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
-
 fn apply_pre_fork_sandbox(
     strategy: exec_strategy::ExecStrategy,
     caps: &CapabilitySet,
@@ -129,25 +127,6 @@ fn recommended_builtin_profile(program: &Path) -> Option<&'static str> {
     }
 }
 
-fn should_apply_startup_timeout(
-    recommended_profile: Option<&str>,
-    cmd_args: &[impl AsRef<std::ffi::OsStr>],
-) -> bool {
-    recommended_profile.is_some() && cmd_args.is_empty()
-}
-
-fn startup_timeout_profile<'a>(
-    recommended_profile: Option<&'a str>,
-    explicit_profile: Option<&str>,
-) -> Option<&'a str> {
-    let recommended = recommended_profile?;
-    if let Some(explicit) = explicit_profile
-        && (explicit == recommended || explicit == format!("{recommended}-local"))
-    {
-        return None;
-    }
-    Some(recommended)
-}
 
 pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     let LaunchPlan {
@@ -190,8 +169,6 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     } else {
         None
     };
-    let startup_timeout_profile =
-        startup_timeout_profile(known_builtin_profile, flags.session.profile_name.as_deref());
 
     let recommended_program_name = resolved_program
         .file_name()
@@ -329,15 +306,14 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
             .as_deref()
             .or(recommended_profile),
         ignored_denial_paths: &flags.ignored_denial_paths,
-        startup_timeout: if should_apply_startup_timeout(startup_timeout_profile, &cmd_args) {
-            startup_timeout_profile.map(|profile| exec_strategy::StartupTimeoutConfig {
-                timeout: PROFILE_HINT_STARTUP_TIMEOUT,
+        startup_timeout: flags
+            .startup_timeout_secs
+            .filter(|&secs| secs > 0)
+            .map(|secs| exec_strategy::StartupTimeoutConfig {
+                timeout: Duration::from_secs(secs),
                 program: recommended_program_name,
-                profile,
-            })
-        } else {
-            None
-        },
+                recommended_profile: known_builtin_profile,
+            }),
         capability_elevation: flags.capability_elevation,
         #[cfg(target_os = "linux")]
         seccomp_proxy_fallback,
@@ -432,10 +408,7 @@ fn write_capability_state_file(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        compute_executable_identity, recommended_builtin_profile, should_apply_startup_timeout,
-        startup_timeout_profile,
-    };
+    use super::{compute_executable_identity, recommended_builtin_profile};
     use sha2::{Digest, Sha256};
     use std::fs;
     use std::path::Path;
@@ -455,38 +428,6 @@ mod tests {
     #[test]
     fn recommended_builtin_profile_ignores_unknown_commands() {
         assert_eq!(recommended_builtin_profile(Path::new("/usr/bin/env")), None);
-    }
-
-    #[test]
-    fn startup_timeout_applies_only_to_bare_interactive_profiled_tools() {
-        let no_args: [&str; 0] = [];
-        assert!(should_apply_startup_timeout(Some("claude-code"), &no_args));
-        assert!(!should_apply_startup_timeout(
-            Some("claude-code"),
-            &["--version"]
-        ));
-        assert!(!should_apply_startup_timeout(None, &no_args));
-    }
-
-    #[test]
-    fn startup_timeout_profile_ignores_matching_explicit_profile_only() {
-        assert_eq!(
-            startup_timeout_profile(Some("claude-code"), None),
-            Some("claude-code")
-        );
-        assert_eq!(
-            startup_timeout_profile(Some("claude-code"), Some("default")),
-            Some("claude-code")
-        );
-        assert_eq!(
-            startup_timeout_profile(Some("claude-code"), Some("claude-code")),
-            None
-        );
-        assert_eq!(
-            startup_timeout_profile(Some("claude-code"), Some("claude-code-local")),
-            None
-        );
-        assert_eq!(startup_timeout_profile(None, Some("default")), None);
     }
 
     #[test]

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -127,7 +127,6 @@ fn recommended_builtin_profile(program: &Path) -> Option<&'static str> {
     }
 }
 
-
 pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     let LaunchPlan {
         program,

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -106,6 +106,7 @@ pub(crate) struct ExecutionFlags {
     pub(crate) redaction_policy: nono::ScrubPolicy,
     pub(crate) allowed_env_vars: Option<Vec<String>>,
     pub(crate) denied_env_vars: Option<Vec<String>>,
+    pub(crate) startup_timeout_secs: Option<u64>,
 }
 
 impl ExecutionFlags {
@@ -134,6 +135,7 @@ impl ExecutionFlags {
             redaction_policy: nono::ScrubPolicy::secure_default(),
             allowed_env_vars: None,
             denied_env_vars: None,
+            startup_timeout_secs: None,
         })
     }
 }
@@ -154,6 +156,7 @@ pub(crate) fn prepare_run_launch_plan(
     let no_audit_integrity = run_args.no_audit_integrity;
     let audit_sign_key = run_args.audit_sign_key.clone();
     let trust_override = run_args.trust_override;
+    let startup_timeout_secs = run_args.startup_timeout_secs;
 
     if audit_sign_key
         .as_deref()
@@ -267,6 +270,7 @@ pub(crate) fn prepare_run_launch_plan(
             redaction_policy,
             allowed_env_vars: prepared.allowed_env_vars,
             denied_env_vars: prepared.denied_env_vars,
+            startup_timeout_secs,
         },
     })
 }

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -447,6 +447,48 @@ pub fn print_warning(message: &str) {
     eprintln!("  {} {}", fg("warning:", t.red).bold(), fg(message, t.text),);
 }
 
+/// Format startup-blocked lines for writing to /dev/tty or stderr.
+/// Returns a Vec of lines ready to write (without trailing newline).
+pub fn format_startup_blocked(
+    program: &str,
+    timeout_secs: u64,
+    has_output: bool,
+    recommended_profile: Option<&str>,
+) -> Vec<String> {
+    let t = theme::current();
+    let label = fg("blocked:", t.yellow).bold().to_string();
+    let reason = if has_output {
+        format!(
+            "`{}` has not become interactive after {} seconds.",
+            program, timeout_secs
+        )
+    } else {
+        format!(
+            "`{}` produced no terminal output after {} seconds.",
+            program, timeout_secs
+        )
+    };
+    let mut lines = vec![
+        format!("  {} {}", label, fg(&reason, t.text)),
+        format!(
+            "  {}",
+            fg(
+                "Terminating process — re-run with -v to inspect denied paths.",
+                t.subtext
+            )
+        ),
+    ];
+    if let Some(profile) = recommended_profile {
+        lines.push(format!(
+            "  {} nono run --profile {} -- {}",
+            fg("Try:", t.green).bold(),
+            profile,
+            program,
+        ));
+    }
+    lines
+}
+
 /// Print a styled diagnostic footer emitted by the core diagnostic formatter.
 pub fn print_diagnostic_footer(footer: &str) {
     let rendered = render_diagnostic_footer(footer);

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -981,12 +981,13 @@ impl PtyProxy {
             .any(|ch| !ch.is_whitespace())
     }
 
-    /// Returns true once the child appears interactive: either it has entered
-    /// alt-screen (TUI) or it has written visible non-whitespace output (REPL,
-    /// shell, readline prompt). Both signals mean the process is running and
-    /// the startup-timeout should not fire.
+    /// Returns true once the child has entered alt-screen mode. This is the
+    /// reliable signal that a TUI has become interactive. Plain log lines or
+    /// startup banners written to the PTY do not activate alt-screen and do
+    /// not count, so a process that prints output and then hangs is still
+    /// subject to the startup timeout.
     pub fn is_interactive(&self) -> bool {
-        self.screen.alternate_screen_active() || self.has_visible_output()
+        self.screen.alternate_screen_active()
     }
 
     fn attach_replay_bytes(&self) -> Vec<u8> {

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -981,6 +981,13 @@ impl PtyProxy {
             .any(|ch| !ch.is_whitespace())
     }
 
+    /// Returns true once the child has entered alt-screen mode, which is the
+    /// reliable signal that a TUI has become interactive. Plain log output
+    /// written to the PTY does not activate alt-screen and does not count.
+    pub fn is_interactive(&self) -> bool {
+        self.screen.alternate_screen_active()
+    }
+
     fn attach_replay_bytes(&self) -> Vec<u8> {
         let plaintext = self.screen.render_plaintext();
         let raw_scrollback_present = !self.scrollback.is_empty();

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -799,28 +799,6 @@ impl PtyProxy {
         }
     }
 
-    /// Re-enter raw mode and redraw the current PTY screen after a prompt.
-    pub fn resume_terminal_after_prompt(&mut self) {
-        if !self
-            .client
-            .as_ref()
-            .is_some_and(AttachedClient::is_terminal)
-        {
-            return;
-        }
-
-        self.saved_termios = set_terminal_raw();
-        // The replay bytes from `attach_replay_bytes` now include the
-        // alt-screen entry escape themselves when the child is in alt-screen,
-        // so no separate `enter_attach_screen()` call is needed. Staying in
-        // normal-screen mode for non-TUI sessions preserves the outer
-        // terminal's scrollback and mouse-wheel handling.
-        let replay = self.attach_replay_bytes();
-        if let Some(client) = self.client.as_ref() {
-            let _ = write_all_fd(client.write_fd(), &replay);
-        }
-    }
-
     /// Restore terminal settings.
     fn restore_terminal(&mut self) {
         if let Some(ref termios) = self.saved_termios {

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -981,11 +981,12 @@ impl PtyProxy {
             .any(|ch| !ch.is_whitespace())
     }
 
-    /// Returns true once the child has entered alt-screen mode, which is the
-    /// reliable signal that a TUI has become interactive. Plain log output
-    /// written to the PTY does not activate alt-screen and does not count.
+    /// Returns true once the child appears interactive: either it has entered
+    /// alt-screen (TUI) or it has written visible non-whitespace output (REPL,
+    /// shell, readline prompt). Both signals mean the process is running and
+    /// the startup-timeout should not fire.
     pub fn is_interactive(&self) -> bool {
-        self.screen.alternate_screen_active()
+        self.screen.alternate_screen_active() || self.has_visible_output()
     }
 
     fn attach_replay_bytes(&self) -> Vec<u8> {

--- a/crates/nono-cli/src/startup_prompt.rs
+++ b/crates/nono-cli/src/startup_prompt.rs
@@ -1,9 +1,6 @@
 use crate::exec_strategy::StartupTimeoutConfig;
 use crate::output::format_startup_blocked;
-use nix::sys::signal::{self, Signal};
-use nix::unistd::Pid;
 use std::io::{self, IsTerminal, Write};
-use std::time::Duration;
 
 pub(crate) fn print_terminal_safe_stderr(message: &str) {
     let mut stderr = io::stderr();
@@ -15,7 +12,7 @@ pub(crate) fn print_terminal_safe_stderr(message: &str) {
     }
 }
 
-fn prompt_startup_termination(timeout_cfg: StartupTimeoutConfig<'_>, has_output: bool) -> bool {
+fn notify_startup_termination(timeout_cfg: StartupTimeoutConfig<'_>, has_output: bool) {
     let lines = format_startup_blocked(
         timeout_cfg.program,
         timeout_cfg.timeout.as_secs(),
@@ -29,7 +26,7 @@ fn prompt_startup_termination(timeout_cfg: StartupTimeoutConfig<'_>, has_output:
             for line in &lines {
                 print_terminal_safe_stderr(line);
             }
-            return true;
+            return;
         }
     };
 
@@ -38,94 +35,19 @@ fn prompt_startup_termination(timeout_cfg: StartupTimeoutConfig<'_>, has_output:
         let _ = writeln!(tty_out, "{}", line);
     }
     let _ = tty_out.flush();
-    true
 }
 
-struct StartupPromptTerminalGuard {
-    tty: Option<std::fs::File>,
-    saved_termios: Option<nix::sys::termios::Termios>,
-    child: Pid,
-    child_stopped: bool,
-}
-
-impl StartupPromptTerminalGuard {
-    fn pause_without_pty(child: Pid) -> Self {
-        // SIGSTOP freezes the direct child so its output doesn't interleave with
-        // the prompt. Descendants keep running, and the child's network peers
-        // may time out if the prompt is answered "no". Acceptable tradeoff:
-        // the prompt only fires after the startup timeout already elapsed.
-        let child_stopped = signal::kill(child, Signal::SIGSTOP).is_ok();
-        if child_stopped {
-            std::thread::sleep(Duration::from_millis(20));
-        }
-
-        let mut guard = Self {
-            tty: None,
-            saved_termios: None,
-            child,
-            child_stopped,
-        };
-
-        let tty = match std::fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open("/dev/tty")
-        {
-            Ok(tty) => tty,
-            Err(_) => return guard,
-        };
-
-        let original = match nix::sys::termios::tcgetattr(&tty) {
-            Ok(termios) => termios,
-            Err(_) => return guard,
-        };
-
-        let mut prompt_termios = original.clone();
-        crate::profile_save_runtime::configure_prompt_termios(&mut prompt_termios);
-        if nix::sys::termios::tcsetattr(&tty, nix::sys::termios::SetArg::TCSANOW, &prompt_termios)
-            .is_err()
-        {
-            return guard;
-        }
-
-        let _ = nix::sys::termios::tcflush(&tty, nix::sys::termios::FlushArg::TCIFLUSH);
-        guard.saved_termios = Some(original);
-        guard.tty = Some(tty);
-        guard
-    }
-
-    fn finish(self, resume_child: bool) {
-        if let (Some(tty), Some(saved_termios)) = (self.tty.as_ref(), self.saved_termios.as_ref()) {
-            let _ = nix::sys::termios::tcsetattr(
-                tty,
-                nix::sys::termios::SetArg::TCSANOW,
-                saved_termios,
-            );
-        }
-
-        if self.child_stopped && resume_child {
-            let _ = signal::kill(self.child, Signal::SIGCONT);
-        }
-    }
-}
-
-pub(crate) fn prompt_startup_termination_for_child(
-    child: Pid,
+pub(crate) fn notify_startup_termination_for_child(
     timeout_cfg: StartupTimeoutConfig<'_>,
     has_output: bool,
     pty: Option<&mut crate::pty_proxy::PtyProxy>,
-) -> bool {
+) {
     if let Some(proxy) = pty {
-        let paused_terminal = proxy.pause_terminal_for_prompt();
-        let terminate = prompt_startup_termination(timeout_cfg, has_output);
-        if paused_terminal && !terminate {
-            proxy.resume_terminal_after_prompt();
-        }
-        return terminate;
+        // Restore the terminal from raw mode so the message renders cleanly.
+        proxy.pause_terminal_for_prompt();
+        notify_startup_termination(timeout_cfg, has_output);
+        return;
     }
 
-    let guard = StartupPromptTerminalGuard::pause_without_pty(child);
-    let terminate = prompt_startup_termination(timeout_cfg, has_output);
-    guard.finish(!terminate);
-    terminate
+    notify_startup_termination(timeout_cfg, has_output);
 }

--- a/crates/nono-cli/src/startup_prompt.rs
+++ b/crates/nono-cli/src/startup_prompt.rs
@@ -1,4 +1,5 @@
 use crate::exec_strategy::StartupTimeoutConfig;
+use crate::output::format_startup_blocked;
 use nix::sys::signal::{self, Signal};
 use nix::unistd::Pid;
 use std::io::{self, IsTerminal, Write};
@@ -15,51 +16,27 @@ pub(crate) fn print_terminal_safe_stderr(message: &str) {
 }
 
 fn prompt_startup_termination(timeout_cfg: StartupTimeoutConfig<'_>, has_output: bool) -> bool {
-    let description = if has_output {
-        format!(
-            "[nono] Startup appears blocked: `{}` has not become interactive after {} seconds.",
-            timeout_cfg.program,
-            timeout_cfg.timeout.as_secs()
-        )
-    } else {
-        format!(
-            "[nono] Startup appears blocked: `{}` produced no terminal output after {} seconds.",
-            timeout_cfg.program,
-            timeout_cfg.timeout.as_secs()
-        )
-    };
+    let lines = format_startup_blocked(
+        timeout_cfg.program,
+        timeout_cfg.timeout.as_secs(),
+        has_output,
+        timeout_cfg.recommended_profile,
+    );
 
     let mut tty_out = match std::fs::OpenOptions::new().write(true).open("/dev/tty") {
         Ok(file) => file,
         Err(_) => {
-            print_terminal_safe_stderr(&format!(
-                "{}\n[nono] `{}` usually needs the built-in `{}` profile.\n[nono] Try: nono run --profile {} -- {}\n[nono] Terminating startup-blocked process so diagnostics can show denied paths.",
-                description,
-                timeout_cfg.program,
-                timeout_cfg.profile,
-                timeout_cfg.profile,
-                timeout_cfg.program,
-            ));
+            for line in &lines {
+                print_terminal_safe_stderr(line);
+            }
             return true;
         }
     };
 
     let _ = writeln!(tty_out);
-    let _ = writeln!(tty_out, "{}", description);
-    let _ = writeln!(
-        tty_out,
-        "[nono] `{}` usually needs the built-in `{}` profile.",
-        timeout_cfg.program, timeout_cfg.profile
-    );
-    let _ = writeln!(
-        tty_out,
-        "[nono] Try: nono run --profile {} -- {}",
-        timeout_cfg.profile, timeout_cfg.program
-    );
-    let _ = writeln!(
-        tty_out,
-        "[nono] Terminating startup-blocked process so diagnostics can show denied paths."
-    );
+    for line in &lines {
+        let _ = writeln!(tty_out, "{}", line);
+    }
     let _ = tty_out.flush();
     true
 }

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -1028,9 +1028,9 @@ nono run --skip-dir vendor-cache --skip-dir generated --allow-cwd -- my-agent
 
 #### `--startup-timeout`
 
-Set a startup timeout in seconds for the sandboxed process. If the process does not enter interactive (alt-screen) mode within the given time, nono prints a warning and terminates it. Set to `0` to disable entirely.
+Set a startup timeout in seconds for the sandboxed process. If the process does not enter alt-screen mode within the given time, nono prints a warning and terminates it. Startup banners or log lines printed before the TUI initialises do not count as interactive — only entering alt-screen (the escape sequence used by full-screen TUIs) satisfies the check. Set to `0` to disable entirely.
 
-Applies to `nono run`, `nono shell`, and `nono wrap`.
+Applies to `nono run` and `nono shell`. Not available on `nono wrap` (which uses direct exec with no supervisor).
 
 | Environment Variable | `NONO_STARTUP_TIMEOUT` |
 |---------------------|------------------------|

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -1026,6 +1026,29 @@ nono run --skip-dir vendor-cache --skip-dir generated --allow-cwd -- my-agent
   `--skip-dir` does not change sandbox permissions. It only prunes trust discovery and rollback preflight traversal. Hidden directories are still scanned unless they are in the built-in heavy-dir list or explicitly named here.
 </Note>
 
+#### `--startup-timeout`
+
+Set a startup timeout in seconds for the sandboxed process. If the process does not enter interactive (alt-screen) mode within the given time, nono prints a warning and terminates it. Set to `0` to disable entirely.
+
+Applies to `nono run`, `nono shell`, and `nono wrap`.
+
+| Environment Variable | `NONO_STARTUP_TIMEOUT` |
+|---------------------|------------------------|
+| Example | `NONO_STARTUP_TIMEOUT=10` |
+
+```bash
+# Kill the process if it hasn't become interactive after 10 seconds
+nono run --startup-timeout 10 --allow-cwd -- opencode
+
+# Disable the timeout entirely
+nono run --startup-timeout 0 --allow-cwd -- opencode
+
+# Via environment variable
+NONO_STARTUP_TIMEOUT=10 nono run --allow-cwd -- opencode
+```
+
+No timeout is applied by default. When a known built-in profile exists for the binary (e.g. `opencode`, `claude`), the warning message also suggests the recommended profile.
+
 #### `--no-diagnostics`
 
 Suppress the diagnostic footer when the command exits non-zero. Useful for scripts that parse stderr and need stable output.
@@ -1422,6 +1445,7 @@ CLI flags always take precedence over environment variables.
 | `--credential` | `NONO_CREDENTIAL` | `NONO_CREDENTIAL=openai` |
 | `--env-credential` | `NONO_ENV_CREDENTIAL` | `NONO_ENV_CREDENTIAL=key1,key2` |
 | `--capability-elevation` | `NONO_CAPABILITY_ELEVATION` | `NONO_CAPABILITY_ELEVATION=true` |
+| `--startup-timeout` | `NONO_STARTUP_TIMEOUT` | `NONO_STARTUP_TIMEOUT=10` |
 | `--upstream-proxy` | `NONO_UPSTREAM_PROXY` | `NONO_UPSTREAM_PROXY=squid.corp:3128` |
 | `--upstream-bypass` | `NONO_UPSTREAM_BYPASS` | `NONO_UPSTREAM_BYPASS=internal.corp,*.private.net` (comma-separated) |
 


### PR DESCRIPTION
This introduces the `--startup-timeout` command-line argument and `NONO_STARTUP_TIMEOUT` environment variable to `run`, `shell`, and `wrap` commands. This allows users to explicitly control the duration Nono waits for a supervised process to be come interactive before prompting for termination.

<img width="1136" height="543" alt="image" src="https://github.com/user-attachments/assets/553fa5a7-0515-4aa1-af0d-ddf22ae674a3" />

The underlying startup timeout detection logic has been significantly refactored:

- Timeout duration is now explicitly set by the new argument, removing previous implicit behaviors tied to known profile
s.
- Improved detection of interactive terminal UIs (TUIs) by checking for alt-screen mode instead of merely any output to
the PTY.
- When a process is terminated due to startup timeout, specific, formatted messages are displayed, suppressing general "
session stopped" notices and diagnostic footers. These messages include a "try --profile" hint when applicable.
- The internal `StartupTimeoutConfig` now stores `recommended_profile` solely for enriching diagnostic hints, cleanly se
parating it from the timeout decision itself.

Also removed the flawed logic that only allowed timeouts to inbuilt profiles, now any given profile or even direct execution without profile can use the timeout flag. 

Signed-off-by: Luke Hinds <lukehinds@gmail.com>

Closes: #952 

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed
