### PR TITLE
fix(macos): emit platform rules after user write allows

### DIFF
--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -663,20 +663,7 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
         profile.push_str("(allow file-write* (extension \"com.apple.app-sandbox.read-write\"))\n");
     }
 
-    // SECURITY: Platform deny rules are placed BETWEEN read and write rules.
-    // This matches the research CLI pattern where sensitive path denials come
-    // after read allows but before write allows. In Seatbelt, more specific rules
-    // always win regardless of order; for equal specificity, last-match wins.
-    // Placing deny rules here ensures they override read allows when equally specific,
-    // while write allows below can still override deny-unlink for user-granted paths.
-    for rule in caps.platform_rules() {
-        profile.push_str(rule);
-        profile.push('\n');
-    }
-
     // Add write rules for all capabilities with Write or ReadWrite access.
-    // These come AFTER platform deny rules so user-granted write paths can
-    // override global denials like (deny file-write-unlink).
     // Emits rules for both original and resolved paths when they differ.
     for cap in caps.fs_capabilities() {
         match cap.access {
@@ -689,6 +676,13 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
                 // Read-only doesn't need write access
             }
         }
+    }
+
+    // Emit platform rules last so targeted denies win under Seatbelt's
+    // last-rule-wins semantics. See #970.
+    for rule in caps.platform_rules() {
+        profile.push_str(rule);
+        profile.push('\n');
     }
 
     // Network rules
@@ -1061,7 +1055,7 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_profile_platform_rules_between_reads_and_writes() {
+    fn test_generate_profile_platform_rules_after_writes() {
         let mut caps = CapabilitySet::new();
         caps.add_fs(FsCapability {
             original: PathBuf::from("/test"),
@@ -1070,28 +1064,29 @@ mod tests {
             is_file: false,
             source: CapabilitySource::User,
         });
-        caps.add_platform_rule("(deny file-write-unlink)").unwrap();
+        caps.add_platform_rule("(deny file-write* (subpath \"/test/protected\"))")
+            .unwrap();
 
         let profile = generate_profile(&caps).unwrap();
 
         let read_pos = profile
             .find("(allow file-read* (subpath \"/test\"))")
             .expect("read rule not found");
-        let deny_pos = profile
-            .find("(deny file-write-unlink)")
-            .expect("deny rule not found");
         let write_pos = profile
             .find("(allow file-write* (subpath \"/test\"))")
             .expect("write rule not found");
+        let deny_pos = profile
+            .find("(deny file-write* (subpath \"/test/protected\"))")
+            .expect("deny rule not found");
 
-        // Order: read rules -> platform deny rules -> write rules
+        // read -> write -> platform; see #970.
         assert!(
-            read_pos < deny_pos,
-            "read rules must come before platform deny rules"
+            read_pos < write_pos,
+            "read rules must come before write rules"
         );
         assert!(
-            deny_pos < write_pos,
-            "platform deny rules must come before write rules"
+            write_pos < deny_pos,
+            "platform rules must come after write rules so targeted denies override broad allows"
         );
     }
 
@@ -1132,7 +1127,6 @@ mod tests {
 
     #[test]
     fn test_generate_profile_gpu_rules_ordering() {
-        // GPU rules (as platform rules) should appear between read and write rules
         let mut caps = CapabilitySet::new();
         caps.add_fs(FsCapability {
             original: PathBuf::from("/test"),
@@ -1149,20 +1143,20 @@ mod tests {
         let read_pos = profile
             .find("(allow file-read* (subpath \"/test\"))")
             .expect("read rule not found");
-        let iokit_pos = profile
-            .find("(allow iokit-get-properties)")
-            .expect("iokit rule not found");
         let write_pos = profile
             .find("(allow file-write* (subpath \"/test\"))")
             .expect("write rule not found");
+        let iokit_pos = profile
+            .find("(allow iokit-get-properties)")
+            .expect("iokit rule not found");
 
         assert!(
-            read_pos < iokit_pos,
-            "read rules must come before GPU/IOKit platform rules"
+            read_pos < write_pos,
+            "read rules must come before write rules"
         );
         assert!(
-            iokit_pos < write_pos,
-            "GPU/IOKit platform rules must come before write rules"
+            write_pos < iokit_pos,
+            "platform rules emit after write rules"
         );
     }
 


### PR DESCRIPTION
## Linked Issue

  Fixes #970

  ## Summary

  Move the `caps.platform_rules()` emission in `crates/nono/src/sandbox/macos.rs` from between read-allows and write-allows to AFTER write-allows. Targeted denies from `add_deny_access`, group deny rules, and
  `unsafe_macos_seatbelt_rules` were silently overridden by broader user write allows because Seatbelt is last-rule-wins for filtered rules of the same operation.

  The deny-unlink case that the previous ordering was protecting (the inline comment cited `(deny file-write-unlink)`) is preserved either way — unselectored denies block regardless of order, verified via direct
  `sandbox-exec`.

  See #970

  ## Agent Disclosure

  This PR was prepared by an AI agent (Anthropic Claude) under direct human supervision (the commit author). The agent:

  - Read `CLAUDE.md` and the affected file's existing inline documentation.
  - Consulted `crates/nono/src/sandbox/macos.rs` (the production code path) and the existing seatbelt order-asserting tests (`test_generate_profile_platform_rules_between_reads_and_writes`,
  `test_generate_profile_gpu_rules_ordering`, `test_generate_profile_extensions_before_platform_deny_rules`).
  - Verified compliance with the project's coding standards: no new `.unwrap()` / `.expect()` in production code (test code retains the existing pattern, which is allowed by the workspace clippy config); no new path
  handling; no new error paths; no changes to `NonoError` usage.
  - Provided attribution for the moved block (originally authored by Luke Hinds in [`8bc6af29`](https://github.com/always-further/nono/commit/8bc6af29)). No external code was adapted; this is a pure re-ordering of
  existing in-tree logic.

  ## Test Plan

  - `make ci` — green
  - `cargo test -p nono --lib sandbox::macos` — 57 passed, 0 failed
  - Updated two existing order-asserting unit tests; added one new assertion for filtered `(deny file-write* (subpath …))` landing after a broad write allow
  - Reproduction in #970 fails before this change and passes after

  ## Checklist

  - [x] An issue exists and is linked above
  - [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
  - [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
  - [x] Public-facing changes are paired with documentation updates *(N/A — no user-facing API or docs change)*
  - [ ] Release note has been added to `CHANGELOG.md` if needed *(left for maintainer judgement — this is a security-relevant fix)*

  ## Agent Compliance Check

  - [x] I am not prohibited from contributing under this policy
  - [x] An issue already exists
  - [x] I disclosed that I am an agent in the issue discussion
  - [x] I described my intent and approach in the issue discussion
  - [x] I reviewed repository coding and security rules for the affected area
  - [x] I provided required attribution for reused or adapted code
  - [x] I did not use forbidden patterns such as unwrap/expect *(production code; existing test patterns retained)*
  - [x] I used NonoError where required *(N/A — no error paths added or changed)*
  - [x] I validated and canonicalized all relevant paths *(N/A — no path handling added or changed)*
  - [x] This PR matches the approved or disclosed issue scope