### PR TITLE
feat(profile): add JSONC support for profile files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,6 +1466,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonc-parser"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840785e1a8b4fdb27be18440a35a81af64820dc185c3973ff8b012d4c6282512"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "jsonschema"
 version = "0.46.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,6 +1692,7 @@ dependencies = [
  "dirs",
  "dns-lookup",
  "ignore",
+ "jsonc-parser",
  "jsonschema",
  "keyring",
  "landlock",

--- a/crates/nono-cli/Cargo.toml
+++ b/crates/nono-cli/Cargo.toml
@@ -80,6 +80,7 @@ url.workspace = true
 tempfile.workspace = true
 vt100 = "0.16.2"
 shlex = "1"
+jsonc-parser = { version = "0.32", features = ["serde"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { workspace = true, features = ["process", "signal", "fs", "user", "term"] }

--- a/crates/nono-cli/src/learn_runtime.rs
+++ b/crates/nono-cli/src/learn_runtime.rs
@@ -265,7 +265,7 @@ fn prepare_profile_save(
     profile_name: &str,
     compared_profile: Option<&str>,
 ) -> Result<PreparedProfileSave> {
-    let profile_path = profile::get_user_profile_path(profile_name)?;
+    let profile_path = profile::resolve_user_profile_path(profile_name)?;
 
     if profile_path.exists() {
         let mut existing = profile::load_raw_profile_from_path(&profile_path)?;
@@ -280,6 +280,7 @@ fn prepare_profile_save(
         });
     }
 
+    let profile_path = profile::get_user_profile_path(profile_name)?;
     let extends = compared_profile
         .filter(|name| profile::is_valid_profile_name(name) && *name != profile_name)
         .map(|name| vec![name.to_string()]);

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1640,7 +1640,7 @@ pub fn is_user_override(name: &str) -> bool {
     if !is_valid_profile_name(name) {
         return false;
     }
-    get_user_profile_path(name)
+    resolve_user_profile_path(name)
         .map(|p| p.exists())
         .unwrap_or(false)
 }
@@ -1672,7 +1672,7 @@ pub fn load_profile_extends(name_or_path: &str) -> Option<Vec<String>> {
     }
 
     // User profile
-    if let Ok(profile_path) = get_user_profile_path(name_or_path)
+    if let Ok(profile_path) = resolve_user_profile_path(name_or_path)
         && profile_path.exists()
     {
         return parse_profile_file(&profile_path)
@@ -1810,7 +1810,10 @@ fn load_profile_inner(name_or_path: &str) -> Result<Option<Profile>> {
     if is_registry_ref(name_or_path) {
         return load_registry_profile(name_or_path).map(Some);
     }
-    if name_or_path.contains('/') || name_or_path.ends_with(".json") {
+    if name_or_path.contains('/')
+        || name_or_path.ends_with(".json")
+        || name_or_path.ends_with(".jsonc")
+    {
         return load_profile_from_path(Path::new(name_or_path)).map(Some);
     }
     if !is_valid_profile_name(name_or_path) {
@@ -1819,7 +1822,7 @@ fn load_profile_inner(name_or_path: &str) -> Result<Option<Profile>> {
             name_or_path
         )));
     }
-    let profile_path = get_user_profile_path(name_or_path)?;
+    let profile_path = resolve_user_profile_path(name_or_path)?;
     if profile_path.exists() {
         tracing::info!("Loading user profile from: {}", profile_path.display());
         return finalize_profile(load_from_file(&profile_path)?).map(Some);
@@ -2165,8 +2168,17 @@ fn parse_profile_file(path: &Path) -> Result<Profile> {
 }
 
 pub(crate) fn parse_profile_bytes(content: &[u8]) -> Result<Profile> {
-    let profile: Profile =
-        serde_json::from_slice(content).map_err(|e| NonoError::ProfileParse(e.to_string()))?;
+    let text = std::str::from_utf8(content)
+        .map_err(|e| NonoError::ProfileParse(format!("invalid UTF-8: {e}")))?;
+
+    let parse_options = jsonc_parser::ParseOptions {
+        allow_comments: true,
+        allow_trailing_commas: true,
+        ..Default::default()
+    };
+
+    let profile: Profile = jsonc_parser::parse_to_serde_value(text, &parse_options)
+        .map_err(|e| NonoError::ProfileParse(e.to_string()))?;
 
     // Validate custom credentials for security issues
     validate_profile_custom_credentials(&profile)?;
@@ -2331,7 +2343,7 @@ fn load_base_profile_raw(
     }
 
     // 1. User profiles take precedence.
-    let profile_path = get_user_profile_path(name)?;
+    let profile_path = resolve_user_profile_path(name)?;
     if profile_path.exists() {
         return Ok(ResolvedBase::Global(parse_profile_file(&profile_path)?));
     }
@@ -2583,9 +2595,23 @@ pub(crate) fn dedup_append<T: Eq + std::hash::Hash + Clone>(base: &[T], child: &
     result
 }
 
-/// Get the path to a user profile
+/// Get the path to a user profile (default `.json` extension, used for writes).
 pub(crate) fn get_user_profile_path(name: &str) -> Result<PathBuf> {
     Ok(user_profile_dir()?.join(format!("{}.json", name)))
+}
+
+/// Resolve an existing user profile, preferring `.jsonc` over `.json`.
+///
+/// Returns the path to the first file that exists, checking `.jsonc` first.
+/// Falls back to the default `.json` path if neither exists (for callers
+/// that check `.exists()` themselves).
+pub(crate) fn resolve_user_profile_path(name: &str) -> Result<PathBuf> {
+    let dir = user_profile_dir()?;
+    let jsonc_path = dir.join(format!("{name}.jsonc"));
+    if jsonc_path.exists() {
+        return Ok(jsonc_path);
+    }
+    Ok(dir.join(format!("{name}.json")))
 }
 
 pub(crate) fn user_profile_dir() -> Result<PathBuf> {
@@ -2768,13 +2794,17 @@ pub fn list_profiles() -> Vec<String> {
     let mut profiles = builtin::list_builtin();
 
     // Add user profiles (if home directory is available)
-    if let Ok(profile_path) = get_user_profile_path("")
-        && let Some(dir) = profile_path.parent()
+    if let Ok(dir) = user_profile_dir()
         && dir.exists()
         && let Ok(entries) = fs::read_dir(dir)
     {
         for entry in entries.flatten() {
-            if let Some(name) = entry.path().file_stem() {
+            let path = entry.path();
+            let is_profile_ext = path
+                .extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|ext| ext == "json" || ext == "jsonc");
+            if is_profile_ext && let Some(name) = path.file_stem() {
                 let name_str = name.to_string_lossy().to_string();
                 if !profiles.contains(&name_str) {
                     profiles.push(name_str);
@@ -6344,6 +6374,64 @@ mod tests {
         assert!(
             err.to_string().contains("unknown field"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn jsonc_comments_and_trailing_commas() {
+        let jsonc = br#"{
+            // Profile for my agent
+            "meta": {
+                "name": "jsonc-test",
+                "description": "Testing JSONC features", // inline comment
+            },
+            "filesystem": {
+                /* Grant read to source,
+                   write to output */
+                "read": ["/src"],
+                "write": ["/output"],
+            },
+            "network": {
+                "block": true, // no network access
+            },
+        }"#;
+
+        let profile = parse_profile_bytes(jsonc).expect("JSONC with comments and trailing commas");
+        assert_eq!(profile.meta.name, "jsonc-test");
+        assert_eq!(profile.filesystem.read, vec!["/src"]);
+        assert_eq!(profile.filesystem.write, vec!["/output"]);
+        assert!(profile.network.block);
+    }
+
+    #[test]
+    fn jsonc_resolve_prefers_jsonc_extension() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let dir = tempfile::tempdir().expect("temp dir");
+        let canonical = dir.path().canonicalize().expect("canonicalize tempdir");
+        let canonical_str = canonical.to_str().expect("tempdir is valid UTF-8");
+        let _env = crate::test_env::EnvVarGuard::set_all(&[("XDG_CONFIG_HOME", canonical_str)]);
+
+        let profiles_dir = canonical.join("nono").join("profiles");
+        std::fs::create_dir_all(&profiles_dir).expect("create profiles dir");
+
+        std::fs::write(
+            profiles_dir.join("myprofile.jsonc"),
+            b"{ \"meta\": { \"name\": \"from-jsonc\" } }",
+        )
+        .expect("write jsonc");
+        std::fs::write(
+            profiles_dir.join("myprofile.json"),
+            b"{ \"meta\": { \"name\": \"from-json\" } }",
+        )
+        .expect("write json");
+
+        let resolved = resolve_user_profile_path("myprofile").expect("resolve");
+        assert!(
+            resolved.extension().and_then(|e| e.to_str()) == Some("jsonc"),
+            "should prefer .jsonc: {resolved:?}"
         );
     }
 }

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -341,7 +341,7 @@ fn profile_exists(name: &str) -> bool {
     if profile::builtin::get_builtin(name).is_some() {
         return true;
     }
-    if let Ok(path) = profile::get_user_profile_path(name)
+    if let Ok(path) = profile::resolve_user_profile_path(name)
         && path.exists()
     {
         return true;
@@ -2250,10 +2250,10 @@ fn resolve_validate_target(input: &std::path::Path) -> std::path::PathBuf {
     let Some(name) = input.to_str() else {
         return input.to_path_buf();
     };
-    if name.contains('/') || name.ends_with(".json") {
+    if name.contains('/') || name.ends_with(".json") || name.ends_with(".jsonc") {
         return input.to_path_buf();
     }
-    if let Ok(p) = profile::get_user_profile_path(name)
+    if let Ok(p) = profile::resolve_user_profile_path(name)
         && p.exists()
     {
         return p;

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -798,7 +798,7 @@ pub(crate) fn prepare_profile_save_from_patch(
     profile_name: &str,
     compared_profile: Option<&str>,
 ) -> Result<PreparedProfileSave> {
-    let profile_path = profile::get_user_profile_path(profile_name)?;
+    let profile_path = profile::resolve_user_profile_path(profile_name)?;
 
     if profile_path.exists() {
         let mut existing = profile::load_raw_profile_from_path(&profile_path)?;
@@ -812,6 +812,7 @@ pub(crate) fn prepare_profile_save_from_patch(
         });
     }
 
+    let profile_path = profile::get_user_profile_path(profile_name)?;
     let mut new_profile = patch.clone();
     let extends = compared_profile
         .filter(|name| profile::is_valid_profile_name(name) && *name != profile_name)

--- a/docs/cli/features/profile-authoring.mdx
+++ b/docs/cli/features/profile-authoring.mdx
@@ -5,6 +5,29 @@ description: Scaffolding, schema validation, and tooling for creating custom pro
 
 The `nono profile` command provides scaffolding and tooling for creating custom profiles. Instead of reverse-engineering the JSON structure from existing profiles, you can generate skeleton files, get editor autocomplete via JSON Schema, and access an LLM-oriented authoring guide.
 
+## File Format
+
+Profile files use **JSONC** (JSON with Comments): standard JSON plus `//` line comments, `/* */` block comments, and trailing commas. Both `.json` and `.jsonc` file extensions are accepted.
+
+```jsonc
+{
+  // Extend the official Claude Code profile
+  "extends": "claude-code",
+  "meta": {
+    "name": "my-claude",
+    "description": "Custom Claude profile with extra tooling access",
+  },
+  "filesystem": {
+    "allow": ["/opt/my-tools"], // custom tooling directory
+    "read": ["/etc/my-app"],
+  },
+}
+```
+
+<Tip>
+  When both `my-profile.jsonc` and `my-profile.json` exist, the `.jsonc` file takes priority.
+</Tip>
+
 <Tip>
   For an overview of what profiles are and how they compose with groups, see [Profiles & Groups](/cli/features/profiles-groups).
 </Tip>
@@ -167,7 +190,7 @@ In VS Code, you can also configure schema association in `.vscode/settings.json`
 {
   "json.schemas": [
     {
-      "fileMatch": ["**/profiles/*.json"],
+      "fileMatch": ["**/profiles/*.json", "**/profiles/*.jsonc"],
       "url": "./nono-profile.schema.json"
     }
   ]

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -34,7 +34,7 @@ Profiles can come from three sources, in order of precedence:
 | Source | Location | Trust Level |
 |--------|----------|-------------|
 | CLI flags | Command line | Highest - explicit user intent |
-| User profiles | `~/.config/nono/profiles/` | Medium - user-defined |
+| User profiles | `~/.config/nono/profiles/*.json` or `*.jsonc` | Medium - user-defined |
 | Pack / preset profiles | Installed packs or compiled presets | Base - audited defaults |
 
 CLI flags always override profile settings.


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #966

## Summary

Allow comments (// and /* */) and trailing commas in profile files. Uses jsonc-parser crate to parse profiles, matching the JSONC format familiar from VS Code/TypeScript configs. Both .json and .jsonc extensions are supported; .jsonc takes priority when both exist.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
