### PR TITLE
feat(profile): allow profiles to specify a target binary

### DIFF
--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1714,8 +1714,8 @@ pub struct RunArgs {
     #[arg(long, env = "NONO_CAPABILITY_ELEVATION", help_heading = "OPTIONS")]
     pub capability_elevation: bool,
 
-    /// Command to run inside the sandbox
-    #[arg(required = true, hide = true)]
+    /// Command to run inside the sandbox (optional if profile specifies `binary`)
+    #[arg(hide = true)]
     pub command: Vec<String>,
 
     /// Print help

--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -19,16 +19,79 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 use tracing::warn;
 
+/// Check whether the loaded profile specifies a `binary` field that should be
+/// honoured. Only user-authored profiles (user overrides or file-path based)
+/// are allowed to set the target binary. Pack/registry and built-in profiles
+/// are not trusted to dictate which binary runs.
+fn resolve_profile_binary(
+    profile_name: &str,
+    loaded: &profile::Profile,
+    silent: bool,
+) -> Option<String> {
+    let binary = loaded.binary.as_ref()?;
+
+    let is_path_based = (profile_name.contains('/') || profile_name.ends_with(".json"))
+        && !profile::is_registry_ref(profile_name);
+    let is_user_profile = profile::is_user_override(profile_name) || is_path_based;
+
+    if !is_user_profile {
+        if !silent {
+            warn!(
+                "Profile '{profile_name}' specifies binary '{binary}' but is not a user profile; ignoring",
+            );
+        }
+        return None;
+    }
+    Some(binary.clone())
+}
+
+/// Resolve the program to execute: if the profile specifies a `binary` field
+/// (and is a user profile), use it. If the CLI also provides a trailing
+/// command, warn that the profile binary takes precedence.
+fn resolve_program_from_profile_or_cli(
+    cli_command: &[String],
+    loaded_profile: Option<(&str, &profile::Profile)>,
+    silent: bool,
+) -> Result<(OsString, Vec<OsString>)> {
+    let profile_binary = loaded_profile
+        .and_then(|(name, prof)| resolve_profile_binary(name, prof, silent));
+
+    if let Some(binary) = profile_binary {
+        if !cli_command.is_empty() && !silent {
+            crate::output::print_warning(&format!(
+                "Profile specifies binary '{}'; ignoring trailing command '{}'",
+                binary,
+                cli_command.join(" ")
+            ));
+        }
+        let program = OsString::from(&binary);
+        Ok((program, Vec::new()))
+    } else if !cli_command.is_empty() {
+        let mut iter = cli_command.iter();
+        let program = OsString::from(iter.next().ok_or(NonoError::NoCommand)?);
+        let cmd_args: Vec<OsString> = iter.map(OsString::from).collect();
+        Ok((program, cmd_args))
+    } else {
+        Err(NonoError::NoCommand)
+    }
+}
+
 pub(crate) fn run_sandbox(mut run_args: RunArgs, silent: bool) -> Result<()> {
     let command = run_args.command.clone();
 
-    if command.is_empty() {
-        return Err(NonoError::NoCommand);
-    }
+    // Load profile once and reuse for binary resolution and command_args.
+    let loaded_profile = match run_args.sandbox.profile.as_ref() {
+        Some(name) => Some((name.clone(), profile::load_profile(name)?)),
+        None => None,
+    };
 
-    let mut command_iter = command.into_iter();
-    let program = OsString::from(command_iter.next().ok_or(NonoError::NoCommand)?);
-    let mut cmd_args: Vec<OsString> = command_iter.map(OsString::from).collect();
+    // Resolve the program: profile `binary` takes precedence over CLI trailing command.
+    let (program, mut cmd_args) = resolve_program_from_profile_or_cli(
+        &command,
+        loaded_profile.as_ref().map(|(n, p)| (n.as_str(), p)),
+        silent,
+    )?;
+
     if should_auto_enable_claude_launch_services(&run_args.sandbox, &program, &cmd_args) {
         warn!(
             "Auto-enabling --allow-launch-services for Claude Code because no refresh-capable local auth was detected"
@@ -37,29 +100,29 @@ pub(crate) fn run_sandbox(mut run_args: RunArgs, silent: bool) -> Result<()> {
     }
     let args = run_args.sandbox.clone();
 
-    if let Some(ref profile_name) = args.profile {
-        let loaded = profile::load_profile(profile_name)?;
-        if !loaded.command_args.is_empty() {
-            let all_packs_installed = loaded.packs.iter().all(|pack_ref| {
-                let parts: Vec<&str> = pack_ref.splitn(2, '/').collect();
-                if parts.len() != 2 {
-                    return false;
-                }
-                crate::package::package_install_dir(parts[0], parts[1])
-                    .map(|dir| dir.exists())
-                    .unwrap_or(false)
-            });
+    // Append profile command_args if applicable
+    if let Some((_, ref loaded)) = loaded_profile
+        && !loaded.command_args.is_empty()
+    {
+        let all_packs_installed = loaded.packs.iter().all(|pack_ref| {
+            let parts: Vec<&str> = pack_ref.splitn(2, '/').collect();
+            if parts.len() != 2 {
+                return false;
+            }
+            crate::package::package_install_dir(parts[0], parts[1])
+                .map(|dir| dir.exists())
+                .unwrap_or(false)
+        });
 
-            if all_packs_installed || loaded.packs.is_empty() {
-                let workdir = args
-                    .workdir
-                    .clone()
-                    .or_else(|| std::env::current_dir().ok())
-                    .unwrap_or_else(|| PathBuf::from("."));
-                for arg in &loaded.command_args {
-                    let expanded = profile::expand_vars(arg, &workdir)?;
-                    cmd_args.push(OsString::from(expanded));
-                }
+        if all_packs_installed || loaded.packs.is_empty() {
+            let workdir = args
+                .workdir
+                .clone()
+                .or_else(|| std::env::current_dir().ok())
+                .unwrap_or_else(|| PathBuf::from("."));
+            for arg in &loaded.command_args {
+                let expanded = profile::expand_vars(arg, &workdir)?;
+                cmd_args.push(OsString::from(expanded));
             }
         }
     }

--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -30,9 +30,8 @@ fn resolve_profile_binary(
 ) -> Option<String> {
     let binary = loaded.binary.as_ref()?;
 
-    let is_path_based = (profile_name.contains('/') || profile_name.ends_with(".json"))
-        && !profile::is_registry_ref(profile_name);
-    let is_user_profile = profile::is_user_override(profile_name) || is_path_based;
+    let is_user_profile =
+        profile::is_user_override(profile_name) || profile::is_file_path_ref(profile_name);
 
     if !is_user_profile {
         if !silent {
@@ -53,8 +52,8 @@ fn resolve_program_from_profile_or_cli(
     loaded_profile: Option<(&str, &profile::Profile)>,
     silent: bool,
 ) -> Result<(OsString, Vec<OsString>)> {
-    let profile_binary = loaded_profile
-        .and_then(|(name, prof)| resolve_profile_binary(name, prof, silent));
+    let profile_binary =
+        loaded_profile.and_then(|(name, prof)| resolve_profile_binary(name, prof, silent));
 
     if let Some(binary) = profile_binary {
         if !cli_command.is_empty() && !silent {

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -176,6 +176,7 @@ impl ProfileDef {
             interactive: self.interactive,
             skipdirs: Vec::new(),
             packs: self.packs.clone(),
+            binary: None,
             command_args: self.command_args.clone(),
             unsafe_macos_seatbelt_rules: self.unsafe_macos_seatbelt_rules.clone(),
         }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1669,7 +1669,7 @@ pub fn load_profile_extends(name_or_path: &str) -> Option<Vec<String>> {
     let _suppress = crate::deprecation_warnings::WarningSuppressionGuard::begin();
 
     // Direct file path
-    if name_or_path.contains('/') || name_or_path.ends_with(".json") {
+    if is_file_path_ref(name_or_path) {
         return parse_profile_file(Path::new(name_or_path))
             .ok()
             .and_then(|p| p.extends);
@@ -1818,10 +1818,7 @@ fn load_profile_inner(name_or_path: &str) -> Result<Option<Profile>> {
     if is_registry_ref(name_or_path) {
         return load_registry_profile(name_or_path).map(Some);
     }
-    if name_or_path.contains('/')
-        || name_or_path.ends_with(".json")
-        || name_or_path.ends_with(".jsonc")
-    {
+    if is_file_path_ref(name_or_path) {
         return load_profile_from_path(Path::new(name_or_path)).map(Some);
     }
     if !is_valid_profile_name(name_or_path) {
@@ -2007,6 +2004,13 @@ pub(crate) fn is_registry_ref(s: &str) -> bool {
         && !s.starts_with('/')
         && !s.ends_with(".json")
         && parts.iter().all(|p| !p.is_empty())
+}
+
+/// Returns true if the profile name looks like a direct filesystem path
+/// (contains path separators or has a recognized profile file extension)
+/// rather than a simple profile name or registry reference.
+pub(crate) fn is_file_path_ref(s: &str) -> bool {
+    !is_registry_ref(s) && (s.contains('/') || s.ends_with(".json") || s.ends_with(".jsonc"))
 }
 
 /// Load a profile from a registry pack. If the pack isn't installed locally,

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1503,6 +1503,11 @@ pub struct Profile {
     /// Each entry is a `<namespace>/<name>` reference to an installed pack.
     #[serde(default)]
     pub packs: Vec<String>,
+    /// Binary path or command name to run when no trailing `-- <command>` is given.
+    /// Resolved via `PATH` lookup or canonicalized if absolute. Only honoured
+    /// for user-authored profiles (ignored for pack and built-in profiles).
+    #[serde(default)]
+    pub binary: Option<String>,
     /// Extra arguments appended to the child command at launch.
     /// Supports variable expansion (e.g. `$NONO_PACKAGES`).
     #[serde(default)]
@@ -1571,6 +1576,8 @@ struct ProfileDeserialize {
     skipdirs: Vec<String>,
     #[serde(default)]
     packs: Vec<String>,
+    #[serde(default)]
+    binary: Option<String>,
     /// ALIAS(canonical="command_args", introduced="v0.0.0", remove_by="indefinite", issue="N/A")
     #[serde(default)]
     #[serde(alias = "brokered_commands")]
@@ -1607,6 +1614,7 @@ impl From<ProfileDeserialize> for Profile {
             interactive: raw.interactive,
             skipdirs: raw.skipdirs,
             packs: raw.packs,
+            binary: raw.binary,
             command_args: raw.command_args,
             unsafe_macos_seatbelt_rules: raw.unsafe_macos_seatbelt_rules,
         };
@@ -2575,6 +2583,7 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
         interactive: base.interactive || child.interactive,
         skipdirs: dedup_append(&base.skipdirs, &child.skipdirs),
         packs: dedup_append(&base.packs, &child.packs),
+        binary: child.binary.or(base.binary),
         command_args: dedup_append(&base.command_args, &child.command_args),
         unsafe_macos_seatbelt_rules: dedup_append(
             &base.unsafe_macos_seatbelt_rules,
@@ -4417,6 +4426,7 @@ mod tests {
             interactive: false,
             skipdirs: vec!["vendor".to_string()],
             packs: vec![],
+            binary: None,
             command_args: vec![],
             unsafe_macos_seatbelt_rules: vec![],
         }
@@ -4495,6 +4505,7 @@ mod tests {
             interactive: false,
             skipdirs: vec!["dist".to_string()],
             packs: vec![],
+            binary: None,
             command_args: vec![],
             unsafe_macos_seatbelt_rules: vec![],
         }
@@ -6432,6 +6443,44 @@ mod tests {
         assert!(
             resolved.extension().and_then(|e| e.to_str()) == Some("jsonc"),
             "should prefer .jsonc: {resolved:?}"
+        );
+    }
+
+    #[test]
+    fn profile_binary_field_parses_and_inherits() {
+        let base = br#"{
+            "meta": { "name": "base" },
+            "binary": "/usr/bin/base-agent"
+        }"#;
+        let base_profile = parse_profile_bytes(base).expect("parse base");
+        assert_eq!(base_profile.binary.as_deref(), Some("/usr/bin/base-agent"));
+
+        let child = br#"{
+            "meta": { "name": "child" },
+            "binary": "/opt/child-agent"
+        }"#;
+        let child_profile = parse_profile_bytes(child).expect("parse child");
+        assert_eq!(child_profile.binary.as_deref(), Some("/opt/child-agent"));
+
+        let merged = merge_profiles(base_profile, child_profile);
+        assert_eq!(
+            merged.binary.as_deref(),
+            Some("/opt/child-agent"),
+            "child binary should override base"
+        );
+
+        let no_binary = br#"{ "meta": { "name": "no-bin" } }"#;
+        let no_bin_profile = parse_profile_bytes(no_binary).expect("parse no-binary");
+        assert!(no_bin_profile.binary.is_none());
+
+        let base2 =
+            parse_profile_bytes(br#"{ "meta": { "name": "b2" }, "binary": "/usr/bin/inherited" }"#)
+                .expect("parse");
+        let merged2 = merge_profiles(base2, no_bin_profile);
+        assert_eq!(
+            merged2.binary.as_deref(),
+            Some("/usr/bin/inherited"),
+            "child without binary should inherit from base"
         );
     }
 }

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -2250,7 +2250,7 @@ fn resolve_validate_target(input: &std::path::Path) -> std::path::PathBuf {
     let Some(name) = input.to_str() else {
         return input.to_path_buf();
     };
-    if name.contains('/') || name.ends_with(".json") || name.ends_with(".jsonc") {
+    if profile::is_file_path_ref(name) {
         return input.to_path_buf();
     }
     if let Ok(p) = profile::resolve_user_profile_path(name)

--- a/docs/cli/features/profile-authoring.mdx
+++ b/docs/cli/features/profile-authoring.mdx
@@ -393,6 +393,33 @@ them as `read`, `read_file`, `allow`, or `allow_file` grants.
 }
 ```
 
+## Target Binary
+
+User profiles can declare a `binary` field to specify the program that nono should execute. This makes the trailing `-- <command>` optional:
+
+```jsonc
+{
+  "extends": "claude-code",
+  "meta": { "name": "my-claude" },
+  "binary": "/home/user/.local/bin/claude"
+}
+```
+
+```bash
+# No trailing command needed — the profile knows what to run
+nono run --profile ./my-claude.jsonc --allow-cwd
+```
+
+If both a profile `binary` and a CLI trailing command are provided, the profile binary takes precedence and a warning is emitted.
+
+### Restrictions
+
+The `binary` field is only honoured for **user-authored profiles** — profiles loaded from a filesystem path (e.g. `./my-profile.jsonc`) or from the user profile directory (`~/.config/nono/profiles/`). Pack and built-in profiles cannot set `binary`; the field is silently ignored for security reasons.
+
+### Inheritance
+
+When profiles are composed via `extends`, the child's `binary` overrides the parent's. If the child does not specify `binary`, it inherits the parent's value.
+
 ## CLI Reference
 
 | Command | Description |


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #965

## Summary

Add 'binary' field to profiles so user-authored profiles can declare the program to execute, making the trailing '-- <command>' optional. When both a profile binary and a CLI command are provided, the profile binary takes precedence with a warning. The field is only honoured for user profiles; pack and built-in profiles log a warning and ignore it.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
