### PR TITLE
feat: session lifecycle hooks (#954)

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -72,6 +72,10 @@
       "$ref": "#/$defs/HooksConfig",
       "description": "Hook configurations for target applications. Maps application names to their hook definitions."
     },
+    "session_hooks": {
+      "$ref": "#/$defs/SessionHooks",
+      "description": "Session lifecycle hooks. Scripts run outside the sandbox with host privileges before and after the sandboxed process."
+    },
     "rollback": {
       "$ref": "#/$defs/RollbackConfig",
       "description": "Rollback snapshot configuration controlling which files are excluded from undo snapshots."
@@ -752,6 +756,38 @@
         "script": {
           "type": "string",
           "description": "Script filename from data/hooks/ to install."
+        }
+      }
+    },
+    "SessionHooks": {
+      "type": "object",
+      "description": "Session lifecycle hooks. before runs before the sandboxed child is forked; after runs after it exits. Both run outside the sandbox with host privileges.",
+      "additionalProperties": false,
+      "properties": {
+        "before": {
+          "$ref": "#/$defs/SessionHook",
+          "description": "Hook executed before the sandboxed process starts. May export environment variables to the sandboxed child via NONO_ENV_FILE."
+        },
+        "after": {
+          "$ref": "#/$defs/SessionHook",
+          "description": "Hook executed after the sandboxed process exits. Receives the child exit code via NONO_EXIT_CODE."
+        }
+      }
+    },
+    "SessionHook": {
+      "type": "object",
+      "description": "A single session lifecycle hook configuration.",
+      "additionalProperties": false,
+      "required": ["script"],
+      "properties": {
+        "script": {
+          "type": "string",
+          "description": "Absolute path to the hook script. Must be an executable regular file owned by the current user or root, not located in a world-writable directory. Validated at execution time."
+        },
+        "timeout_secs": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Optional timeout in seconds. If set, the hook is killed (SIGTERM then SIGKILL) after this duration. If absent, no timeout is enforced."
         }
       }
     },

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -1,4 +1,5 @@
 use crate::audit_attestation::prepare_audit_signer;
+#[cfg(unix)]
 use crate::hook_runtime;
 use crate::launch_runtime::{LaunchPlan, select_threading_context};
 use crate::proxy_runtime::start_proxy_runtime;
@@ -257,7 +258,8 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
                 .unwrap_or_else(session::generate_session_id)
         });
 
-    // ---- Before-hook execution ----
+    // ---- Before-hook execution (Unix-only) ----
+    #[cfg(unix)]
     let hook_env_vars_owned: Vec<(String, String)> = flags
         .session_hooks
         .before
@@ -282,6 +284,8 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
             }
         })
         .unwrap_or_default();
+    #[cfg(not(unix))]
+    let hook_env_vars_owned: Vec<(String, String)> = Vec::new();
 
     let mut env_vars: Vec<(&str, &str)> = loaded_secrets
         .iter()
@@ -414,7 +418,8 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
                 silent: flags.silent,
             })?;
 
-            // ---- After-hook execution ----
+            // ---- After-hook execution (Unix-only) ----
+            #[cfg(unix)]
             if let (Some(after), Some(session_id)) = (
                 flags.session_hooks.after.as_ref(),
                 hook_session_id.as_deref(),

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -1,8 +1,12 @@
 use crate::audit_attestation::prepare_audit_signer;
+use crate::hook_runtime;
 use crate::launch_runtime::{LaunchPlan, select_threading_context};
 use crate::proxy_runtime::start_proxy_runtime;
 use crate::supervised_runtime::{SupervisedRuntimeContext, execute_supervised_runtime};
-use crate::{command_blocking_deprecation, config, exec_strategy, output, sandbox_state};
+use crate::{
+    DETACHED_SESSION_ID_ENV, command_blocking_deprecation, config, exec_strategy, output,
+    sandbox_state, session,
+};
 use nono::undo::{ContentHash, ExecutableIdentity};
 use nono::{CapabilitySet, NonoError, Result, Sandbox};
 use sha2::{Digest, Sha256};
@@ -10,7 +14,7 @@ use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 use std::time::Duration;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 const PROFILE_HINT_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -242,12 +246,54 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     }
     apply_pre_fork_sandbox(strategy, &caps, flags.silent)?;
 
+    // Session id shared across before- and after-hook so paired setup/teardown
+    // scripts see the same NONO_SESSION_ID. Only allocated when at least one
+    // hook is configured.
+    let hook_session_id: Option<String> =
+        (flags.session_hooks.before.is_some() || flags.session_hooks.after.is_some()).then(|| {
+            std::env::var(DETACHED_SESSION_ID_ENV)
+                .ok()
+                .filter(|id| !id.is_empty())
+                .unwrap_or_else(session::generate_session_id)
+        });
+
+    // ---- Before-hook execution ----
+    let hook_env_vars_owned: Vec<(String, String)> = flags
+        .session_hooks
+        .before
+        .as_ref()
+        .zip(hook_session_id.as_deref())
+        .map(|(before, session_id)| {
+            match hook_runtime::execute_before_hook(before, session_id, &current_dir) {
+                Ok(env) => {
+                    if !env.is_empty() {
+                        info!(
+                            "Before-hook exported {} env vars (script: {})",
+                            env.len(),
+                            before.script.display()
+                        );
+                    }
+                    env
+                }
+                Err(e) => {
+                    warn!("Before-hook failed (continuing): {e}");
+                    Vec::new()
+                }
+            }
+        })
+        .unwrap_or_default();
+
     let mut env_vars: Vec<(&str, &str)> = loaded_secrets
         .iter()
         .map(|secret| (secret.env_var.as_str(), secret.value.as_str()))
         .collect();
     for (key, value) in &proxy_env_vars {
         env_vars.push((key.as_str(), value.as_str()));
+    }
+
+    // Hook env vars have lowest priority: prepend so secrets and proxy override.
+    for (key, value) in hook_env_vars_owned.iter().rev() {
+        env_vars.insert(0, (key.as_str(), value.as_str()));
     }
 
     let threading = select_threading_context(
@@ -367,6 +413,16 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
                 redaction_policy: &flags.redaction_policy,
                 silent: flags.silent,
             })?;
+
+            // ---- After-hook execution ----
+            if let (Some(after), Some(session_id)) = (
+                flags.session_hooks.after.as_ref(),
+                hook_session_id.as_deref(),
+            ) && let Err(e) =
+                hook_runtime::execute_after_hook(after, session_id, &current_dir, exit_code)
+            {
+                warn!("After-hook failed: {e}");
+            }
 
             cleanup_capability_state_file(&cap_file_path);
             drop(config);

--- a/crates/nono-cli/src/hook_runtime.rs
+++ b/crates/nono-cli/src/hook_runtime.rs
@@ -3,6 +3,10 @@
 //! Handles execution of before/after hooks for sandbox sessions.
 //! All hooks run outside the sandbox with host privileges.
 //!
+//! Unix-only: relies on POSIX uid/mode metadata, `pre_exec`, and process
+//! group signalling. Gated by `#[cfg(unix)]` at the module declaration in
+//! `main.rs`.
+//!
 //! # Security
 //!
 //! - Script paths are validated before every execution
@@ -14,9 +18,7 @@
 
 use crate::{exec_strategy, profile, session};
 use nono::{NonoError, Result};
-#[cfg(unix)]
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
-#[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -186,7 +188,6 @@ fn build_hook_command(
 
     // SAFETY: setpgid(0,0) places the child in its own process group for
     // clean timeout killing. POSIX guarantees setpgid is async-signal-safe.
-    #[cfg(unix)]
     unsafe {
         cmd.pre_exec(|| {
             let _ =
@@ -294,26 +295,14 @@ impl EnvFileGuard {
             ))
         })?;
 
-        #[cfg(unix)]
-        {
-            let _ =
-                std::fs::set_permissions(&session_env_dir, std::fs::Permissions::from_mode(0o700));
-        }
+        let _ = std::fs::set_permissions(&session_env_dir, std::fs::Permissions::from_mode(0o700));
 
         let path = session_env_dir.join("env");
 
-        #[cfg(unix)]
         std::fs::OpenOptions::new()
             .create_new(true)
             .write(true)
             .mode(0o600)
-            .open(&path)
-            .map_err(|e| NonoError::ConfigParse(format!("Failed to create env file: {e}")))?;
-
-        #[cfg(not(unix))]
-        std::fs::OpenOptions::new()
-            .create_new(true)
-            .write(true)
             .open(&path)
             .map_err(|e| NonoError::ConfigParse(format!("Failed to create env file: {e}")))?;
 

--- a/crates/nono-cli/src/hook_runtime.rs
+++ b/crates/nono-cli/src/hook_runtime.rs
@@ -1,0 +1,610 @@
+//! Session lifecycle hook execution.
+//!
+//! Handles execution of before/after hooks for sandbox sessions.
+//! All hooks run outside the sandbox with host privileges.
+//!
+//! # Security
+//!
+//! - Script paths are validated before every execution
+//!   (absolute, canonical, regular file, executable, owned by user, not world-writable)
+//! - Hooks run as subprocesses with minimal environment
+//! - Process group isolation for timeout-based killing
+//! - NONO_ENV_FILE is used for env var export (not stdout parsing)
+//! - Dangerous env vars are filtered before injection
+
+use crate::{exec_strategy, profile, session};
+use nono::{NonoError, Result};
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+use tracing::{debug, warn};
+
+/// Result of executing a session hook.
+struct HookOutput {
+    exit_code: i32,
+    timed_out: bool,
+}
+
+/// Discriminator for the two hook variants.
+///
+/// `Before` carries the path to the env file the hook is expected to populate.
+/// `After` carries the exit code of the sandboxed child process.
+enum HookKind<'a> {
+    Before { env_file: &'a Path },
+    After { exit_code: i32 },
+}
+
+impl HookKind<'_> {
+    fn type_env(&self) -> &'static str {
+        match self {
+            HookKind::Before { .. } => "before",
+            HookKind::After { .. } => "after",
+        }
+    }
+}
+
+/// Execute a before-hook and return exported environment variables.
+///
+/// Steps:
+/// 1. Validate script path
+/// 2. Create NONO_ENV_FILE in private session directory (RAII guard)
+/// 3. Spawn hook with isolated environment
+/// 4. Wait for completion with optional timeout
+/// 5. Read and parse NONO_ENV_FILE
+/// 6. Filter dangerous env vars
+pub(crate) fn execute_before_hook(
+    hook: &profile::SessionHook,
+    session_id: &str,
+    workdir: &Path,
+) -> Result<Vec<(String, String)>> {
+    let script_path = validate_hook_script(&hook.script)?;
+    let env_file = EnvFileGuard::create(session_id)?;
+
+    let mut cmd = build_hook_command(
+        &script_path,
+        session_id,
+        workdir,
+        &HookKind::Before {
+            env_file: env_file.path(),
+        },
+    );
+    let output = run_hook(&mut cmd, hook.timeout_secs)?;
+
+    if output.timed_out {
+        warn!(
+            "Before-hook timed out ({}s): {}",
+            hook.timeout_secs.unwrap_or(0),
+            script_path.display()
+        );
+        return Ok(Vec::new());
+    }
+
+    if output.exit_code != 0 {
+        warn!(
+            "Before-hook exited with code {}: {}",
+            output.exit_code,
+            script_path.display()
+        );
+    }
+
+    let raw = read_env_file(env_file.path())?;
+    let total = raw.len();
+    let filtered: Vec<(String, String)> = raw
+        .into_iter()
+        .filter(|(k, _)| !exec_strategy::is_dangerous_env_var(k))
+        .collect();
+
+    debug!(
+        "Before-hook exported {} env vars ({} filtered out)",
+        filtered.len(),
+        total.saturating_sub(filtered.len())
+    );
+
+    Ok(filtered)
+}
+
+/// Execute an after-hook for cleanup.
+///
+/// Steps:
+/// 1. Validate script path
+/// 2. Execute with isolated env, passing child exit code via NONO_EXIT_CODE
+/// 3. Log result
+pub(crate) fn execute_after_hook(
+    hook: &profile::SessionHook,
+    session_id: &str,
+    workdir: &Path,
+    child_exit_code: i32,
+) -> Result<()> {
+    let script_path = validate_hook_script(&hook.script)?;
+    let mut cmd = build_hook_command(
+        &script_path,
+        session_id,
+        workdir,
+        &HookKind::After {
+            exit_code: child_exit_code,
+        },
+    );
+    let output = run_hook(&mut cmd, hook.timeout_secs)?;
+
+    if output.timed_out {
+        warn!(
+            "After-hook timed out ({}s): {}",
+            hook.timeout_secs.unwrap_or(0),
+            script_path.display()
+        );
+        return Ok(());
+    }
+
+    if output.exit_code != 0 {
+        warn!(
+            "After-hook exited with code {}: {}",
+            output.exit_code,
+            script_path.display()
+        );
+    }
+
+    Ok(())
+}
+
+// ===================== Internal Helpers =====================
+
+/// Build a `Command` configured for a hook execution.
+///
+/// Sets `NONO_SESSION_ID` / `NONO_WORKDIR` / `NONO_HOOK_TYPE` plus the
+/// kind-specific env vars and stdio. Installs the `setpgid` pre-exec hook so
+/// the child can be killed as a process group on timeout.
+fn build_hook_command(
+    script: &Path,
+    session_id: &str,
+    workdir: &Path,
+    kind: &HookKind<'_>,
+) -> Command {
+    let mut cmd = Command::new(script);
+    cmd.env_clear();
+    cmd.env("NONO_SESSION_ID", session_id);
+    cmd.env("NONO_WORKDIR", workdir);
+    cmd.env("NONO_HOOK_TYPE", kind.type_env());
+    cmd.stdin(Stdio::null());
+    cmd.stderr(Stdio::piped());
+
+    match kind {
+        HookKind::Before { env_file } => {
+            cmd.env("NONO_ENV_FILE", env_file);
+            cmd.stdout(Stdio::piped());
+        }
+        HookKind::After { exit_code } => {
+            cmd.env("NONO_EXIT_CODE", exit_code.to_string());
+            cmd.stdout(Stdio::null());
+        }
+    }
+
+    // SAFETY: setpgid(0,0) places the child in its own process group for
+    // clean timeout killing. POSIX guarantees setpgid is async-signal-safe.
+    #[cfg(unix)]
+    unsafe {
+        cmd.pre_exec(|| {
+            let _ =
+                nix::unistd::setpgid(nix::unistd::Pid::from_raw(0), nix::unistd::Pid::from_raw(0));
+            Ok(())
+        });
+    }
+
+    cmd
+}
+
+/// Validate a hook script path.
+///
+/// Security checks:
+/// - Absolute path
+/// - Path exists and is a regular file
+/// - File is executable
+/// - File is owned by current user or root
+/// - File is not in a world-writable directory
+fn validate_hook_script(path: &Path) -> Result<PathBuf> {
+    if !path.is_absolute() {
+        return Err(NonoError::ConfigParse(format!(
+            "Hook script path must be absolute: {}",
+            path.display()
+        )));
+    }
+
+    let canonical = path.canonicalize().map_err(|e| {
+        NonoError::ConfigParse(format!("Hook script not found: {}: {}", path.display(), e))
+    })?;
+
+    let metadata = canonical.metadata().map_err(|e| {
+        NonoError::ConfigParse(format!(
+            "Cannot read hook script metadata: {}: {}",
+            canonical.display(),
+            e
+        ))
+    })?;
+
+    if !metadata.is_file() {
+        return Err(NonoError::ConfigParse(format!(
+            "Hook script is not a regular file: {}",
+            canonical.display()
+        )));
+    }
+
+    let mode = metadata.permissions().mode();
+    if (mode & 0o111) == 0 {
+        return Err(NonoError::ConfigParse(format!(
+            "Hook script is not executable: {}",
+            canonical.display()
+        )));
+    }
+
+    let uid = metadata.uid();
+    let my_uid = nix::unistd::geteuid().as_raw();
+    if uid != my_uid && uid != 0 {
+        return Err(NonoError::ConfigParse(format!(
+            "Hook script owned by uid {} (expected {} or root): {}",
+            uid,
+            my_uid,
+            canonical.display()
+        )));
+    }
+
+    if let Some(parent) = canonical.parent()
+        && is_world_writable(parent)
+    {
+        return Err(NonoError::ConfigParse(format!(
+            "Hook script must not be in a world-writable directory: {} (resolved: {})",
+            path.display(),
+            canonical.display()
+        )));
+    }
+
+    Ok(canonical)
+}
+
+/// Check if a directory is world-writable.
+/// Rejects ALL world-writable dirs including /tmp with sticky bit.
+fn is_world_writable(path: &Path) -> bool {
+    path.metadata()
+        .map(|m| (m.permissions().mode() & 0o002) != 0)
+        .unwrap_or(false)
+}
+
+/// RAII guard for the per-session env file.
+///
+/// `EnvFileGuard::create` builds `~/.nono/sessions/<id>/env` with `O_EXCL`
+/// and 0o600 permissions. On `Drop` the file is best-effort zeroed and
+/// unlinked, so it disappears even on early `?` returns from the caller.
+struct EnvFileGuard {
+    path: PathBuf,
+}
+
+impl EnvFileGuard {
+    fn create(session_id: &str) -> Result<Self> {
+        let sessions_dir = session::ensure_sessions_dir()?;
+        let session_env_dir = sessions_dir.join(session_id);
+
+        std::fs::create_dir_all(&session_env_dir).map_err(|e| {
+            NonoError::ConfigParse(format!(
+                "Failed to create session env directory {}: {e}",
+                session_env_dir.display()
+            ))
+        })?;
+
+        #[cfg(unix)]
+        {
+            let _ =
+                std::fs::set_permissions(&session_env_dir, std::fs::Permissions::from_mode(0o700));
+        }
+
+        let path = session_env_dir.join("env");
+
+        #[cfg(unix)]
+        std::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| NonoError::ConfigParse(format!("Failed to create env file: {e}")))?;
+
+        #[cfg(not(unix))]
+        std::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&path)
+            .map_err(|e| NonoError::ConfigParse(format!("Failed to create env file: {e}")))?;
+
+        Ok(Self { path })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for EnvFileGuard {
+    fn drop(&mut self) {
+        if let Ok(mut file) = std::fs::OpenOptions::new().write(true).open(&self.path)
+            && let Ok(metadata) = file.metadata()
+        {
+            use std::io::Write;
+            let zeros = vec![0u8; metadata.len() as usize];
+            let _ = file.write_all(&zeros);
+            let _ = file.sync_all();
+        }
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Read and parse `KEY=VALUE` pairs from the env file.
+fn read_env_file(path: &Path) -> Result<Vec<(String, String)>> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| NonoError::ConfigParse(format!("Failed to read env file: {e}")))?;
+
+    let vars = content
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .filter_map(|line| line.split_once('='))
+        .map(|(k, v)| (k.trim().to_string(), v.trim().to_string()))
+        .filter(|(k, _)| !k.is_empty())
+        .collect();
+
+    Ok(vars)
+}
+
+/// Run a command, wait for completion with optional timeout.
+///
+/// A worker thread owns the `Child` so the main thread can `recv_timeout`
+/// without polling. On timeout the whole process group is killed.
+fn run_hook(cmd: &mut Command, timeout_secs: Option<u64>) -> Result<HookOutput> {
+    let child = cmd.spawn().map_err(|e| {
+        NonoError::CommandExecution(std::io::Error::other(format!("Failed to spawn hook: {e}")))
+    })?;
+    let pid = child.id();
+
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let _ = tx.send(child.wait_with_output());
+    });
+
+    let received = match timeout_secs {
+        Some(secs) => rx.recv_timeout(Duration::from_secs(secs)).map_err(|_| ()),
+        None => rx.recv().map_err(|_| ()),
+    };
+
+    match received {
+        Ok(Ok(output)) => Ok(HookOutput {
+            exit_code: output.status.code().unwrap_or(-1),
+            timed_out: false,
+        }),
+        Ok(Err(e)) => Err(NonoError::CommandExecution(e)),
+        Err(()) if timeout_secs.is_some() => {
+            kill_process_group(pid);
+            Ok(HookOutput {
+                exit_code: -1,
+                timed_out: true,
+            })
+        }
+        Err(()) => Err(NonoError::CommandExecution(std::io::Error::other(
+            "Hook channel closed unexpectedly",
+        ))),
+    }
+}
+
+/// Kill a process group by leader PID.
+fn kill_process_group(pid: u32) {
+    use nix::sys::signal::{Signal, killpg};
+    use nix::unistd::Pid;
+
+    let pgid = Pid::from_raw(pid as i32);
+    let _ = killpg(pgid, Signal::SIGTERM);
+    thread::sleep(Duration::from_millis(100));
+    let _ = killpg(pgid, Signal::SIGKILL);
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::TempDir;
+
+    /// Acquire an isolated HOME for tests that touch `~/.nono/sessions/`.
+    /// Returns the lock guard, env-var guard, and the HOME tempdir; all three
+    /// must stay in scope for the duration of the test.
+    fn isolated_home() -> (
+        std::sync::MutexGuard<'static, ()>,
+        crate::test_env::EnvVarGuard,
+        TempDir,
+    ) {
+        let lock = match crate::test_env::ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let home = TempDir::new().unwrap();
+        let home_str = home.path().to_str().unwrap();
+        let env = crate::test_env::EnvVarGuard::set_all(&[("HOME", home_str)]);
+        (lock, env, home)
+    }
+
+    // ---- Path validation ----
+
+    #[test]
+    fn test_validate_script_accepts_valid_path() {
+        let dir = TempDir::new().unwrap();
+        let script = dir.path().join("hook.sh");
+        std::fs::write(&script, "#!/bin/sh\necho hello").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(validate_hook_script(&script).is_ok());
+    }
+
+    #[test]
+    fn test_validate_script_rejects_relative_path() {
+        assert!(validate_hook_script(Path::new("relative/path.sh")).is_err());
+    }
+
+    #[test]
+    fn test_validate_script_rejects_nonexistent() {
+        assert!(validate_hook_script(Path::new("/nonexistent/path.sh")).is_err());
+    }
+
+    #[test]
+    fn test_validate_script_rejects_non_executable() {
+        let dir = TempDir::new().unwrap();
+        let script = dir.path().join("hook.sh");
+        std::fs::write(&script, "#!/bin/sh\necho hello").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(validate_hook_script(&script).is_err());
+    }
+
+    #[test]
+    fn test_validate_script_rejects_world_writable_directory() {
+        let dir = TempDir::new().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o777)).unwrap();
+        let script = dir.path().join("hook.sh");
+        std::fs::write(&script, "#!/bin/sh\necho hello").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(validate_hook_script(&script).is_err());
+    }
+
+    #[test]
+    fn test_validate_script_rejects_directory() {
+        let dir = TempDir::new().unwrap();
+        assert!(validate_hook_script(dir.path()).is_err());
+    }
+
+    // ---- Env file parsing ----
+
+    #[test]
+    fn test_read_env_file_basic() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("env");
+        std::fs::write(&file, "FOO=bar\nBAZ=qux\n").unwrap();
+        let vars = read_env_file(&file).unwrap();
+        assert_eq!(
+            vars,
+            vec![("FOO".into(), "bar".into()), ("BAZ".into(), "qux".into())]
+        );
+    }
+
+    #[test]
+    fn test_read_env_file_skips_comments_and_blanks() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("env");
+        std::fs::write(&file, "# comment\n\nFOO=bar\n").unwrap();
+        let vars = read_env_file(&file).unwrap();
+        assert_eq!(vars, vec![("FOO".into(), "bar".into())]);
+    }
+
+    #[test]
+    fn test_read_env_file_value_with_equals() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("env");
+        std::fs::write(&file, "FLAG=--foo=bar\n").unwrap();
+        let vars = read_env_file(&file).unwrap();
+        assert_eq!(vars, vec![("FLAG".into(), "--foo=bar".into())]);
+    }
+
+    #[test]
+    fn test_read_env_file_whitespace_trimming() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("env");
+        std::fs::write(&file, "  KEY  =  value  \n").unwrap();
+        let vars = read_env_file(&file).unwrap();
+        assert_eq!(vars, vec![("KEY".into(), "value".into())]);
+    }
+
+    // ---- End-to-end before-hook ----
+
+    #[test]
+    fn test_execute_before_hook_basic() {
+        let (_lock, _env, _home) = isolated_home();
+
+        let dir = TempDir::new().unwrap();
+        let script = dir.path().join("hook.sh");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\nprintf 'TMPDIR=/tmp/nono-test\\nLD_PRELOAD=/evil.so\\nCUSTOM_VAR=hello' > \"$NONO_ENV_FILE\"\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let hook = profile::SessionHook {
+            script: script.clone(),
+            timeout_secs: Some(5),
+        };
+
+        let result = execute_before_hook(&hook, "test-basic", Path::new("/tmp")).unwrap();
+
+        // LD_PRELOAD must be filtered out as a dangerous var.
+        assert!(result.contains(&("TMPDIR".into(), "/tmp/nono-test".into())));
+        assert!(result.contains(&("CUSTOM_VAR".into(), "hello".into())));
+        assert!(!result.iter().any(|(k, _)| k == "LD_PRELOAD"));
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_execute_before_hook_timeout() {
+        let (_lock, _env, _home) = isolated_home();
+
+        let dir = TempDir::new().unwrap();
+        let script = dir.path().join("sleep.sh");
+        std::fs::write(&script, "#!/bin/sh\nsleep 60\n").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let hook = profile::SessionHook {
+            script,
+            timeout_secs: Some(1),
+        };
+
+        let start = std::time::Instant::now();
+        let result = execute_before_hook(&hook, "test-timeout", Path::new("/tmp"));
+        let elapsed = start.elapsed();
+
+        assert!(elapsed < Duration::from_secs(10), "timeout took too long");
+        match result {
+            Ok(vars) => assert!(vars.is_empty(), "timed-out hook should return no vars"),
+            Err(e) => panic!("timed-out hook should not propagate error: {e}"),
+        }
+    }
+
+    #[test]
+    fn test_execute_before_hook_fail_open() {
+        let (_lock, _env, _home) = isolated_home();
+
+        let dir = TempDir::new().unwrap();
+        let script = dir.path().join("fail.sh");
+        std::fs::write(&script, "#!/bin/sh\nexit 1\n").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let hook = profile::SessionHook {
+            script,
+            timeout_secs: Some(5),
+        };
+
+        let result = execute_before_hook(&hook, "test-fail", Path::new("/tmp"));
+        match result {
+            Ok(vars) => assert!(vars.is_empty(), "failed hook should return no vars"),
+            Err(e) => panic!("fail-open contract broken: {e}"),
+        }
+    }
+
+    /// Exercise the `Drop` impl on `EnvFileGuard` so the file disappears
+    /// even when the caller bails before the happy path completes.
+    #[test]
+    fn test_env_file_guard_removes_file_on_drop() {
+        let (_lock, _env, _home) = isolated_home();
+
+        let path;
+        {
+            let guard = EnvFileGuard::create("guard-drop-test").unwrap();
+            path = guard.path().to_path_buf();
+            assert!(path.exists(), "env file should exist while guard is alive");
+        }
+        assert!(!path.exists(), "env file must be removed when guard drops");
+    }
+}

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -104,6 +104,7 @@ pub(crate) struct ExecutionFlags {
     pub(crate) trust: TrustLaunchOptions,
     pub(crate) proxy: ProxyLaunchOptions,
     pub(crate) redaction_policy: nono::ScrubPolicy,
+    pub(crate) session_hooks: profile::SessionHooks,
     pub(crate) allowed_env_vars: Option<Vec<String>>,
     pub(crate) denied_env_vars: Option<Vec<String>>,
 }
@@ -132,6 +133,7 @@ impl ExecutionFlags {
             },
             proxy: ProxyLaunchOptions::default(),
             redaction_policy: nono::ScrubPolicy::secure_default(),
+            session_hooks: profile::SessionHooks::default(),
             allowed_env_vars: None,
             denied_env_vars: None,
         })
@@ -265,6 +267,7 @@ pub(crate) fn prepare_run_launch_plan(
             trust,
             proxy,
             redaction_policy,
+            session_hooks: prepared.session_hooks,
             allowed_env_vars: prepared.allowed_env_vars,
             denied_env_vars: prepared.denied_env_vars,
         },

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -22,6 +22,7 @@ mod deprecated_schema;
 mod deprecation_warnings;
 mod exec_strategy;
 mod execution_runtime;
+#[cfg(unix)]
 mod hook_runtime;
 mod instruction_deny;
 mod launch_runtime;

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -22,6 +22,7 @@ mod deprecated_schema;
 mod deprecation_warnings;
 mod exec_strategy;
 mod execution_runtime;
+mod hook_runtime;
 mod instruction_deny;
 mod launch_runtime;
 mod learn;
@@ -255,6 +256,7 @@ mod tests {
         let prepared = PreparedSandbox {
             caps: CapabilitySet::new(),
             secrets: Vec::new(),
+            session_hooks: crate::profile::SessionHooks::default(),
             rollback_exclude_patterns: Vec::new(),
             rollback_exclude_globs: Vec::new(),
             network_profile: Some("developer".to_string()),
@@ -302,6 +304,7 @@ mod tests {
         let prepared = PreparedSandbox {
             caps: CapabilitySet::new(),
             secrets: Vec::new(),
+            session_hooks: crate::profile::SessionHooks::default(),
             rollback_exclude_patterns: Vec::new(),
             rollback_exclude_globs: Vec::new(),
             network_profile: Some("developer".to_string()),

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -168,6 +168,7 @@ impl ProfileDef {
             environment: None,
             workdir: self.workdir.clone(),
             hooks: self.hooks.clone(),
+            session_hooks: profile::SessionHooks::default(),
             rollback: self.rollback.clone(),
             open_urls: self.open_urls.clone(),
             allow_launch_services: self.allow_launch_services,
@@ -2341,6 +2342,13 @@ mod tests {
         // We filter to Linux-applicable groups (platform: None or "linux")
         // and check directly from parsed policy so this catches regressions
         // on all CI platforms (including macOS).
+        //
+        // We hold ENV_LOCK because expand_path() reads HOME/TMPDIR from the
+        // process env, and other tests in the suite mutate those vars.
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
         let policy = load_embedded_policy().expect("embedded policy must load");
 
         let is_linux_applicable =

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1138,6 +1138,41 @@ pub struct HooksConfig {
     pub hooks: HashMap<String, HookConfig>,
 }
 
+/// A single session lifecycle hook configuration.
+///
+/// Defines a script to execute before or after the sandboxed session.
+/// Scripts run with the user's full host privileges.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SessionHook {
+    /// Absolute path to the hook script.
+    /// Must be an executable regular file. Validated at execution time.
+    pub script: PathBuf,
+
+    /// Optional timeout in seconds.
+    /// If set, the hook is killed after this duration.
+    /// If absent, no timeout is enforced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
+}
+
+/// Session lifecycle hooks for a profile.
+///
+/// `before`: executed in the parent process before the sandboxed child is forked.
+///           Has host privileges. Can export env vars via NONO_ENV_FILE.
+///
+/// `after`: executed in the parent process after the sandboxed child exits.
+///          Has host privileges. Cleanup only.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SessionHooks {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub before: Option<SessionHook>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub after: Option<SessionHook>,
+}
+
 /// Working directory access level for profiles
 ///
 /// Controls whether and how the current working directory is automatically
@@ -1467,6 +1502,11 @@ pub struct Profile {
     pub workdir: WorkdirConfig,
     #[serde(default)]
     pub hooks: HooksConfig,
+    /// Session lifecycle hooks (before/after sandbox).
+    /// Runs outside the sandbox with host privileges.
+    /// `before` can export env vars via NONO_ENV_FILE.
+    #[serde(default)]
+    pub session_hooks: SessionHooks,
     /// ALIAS(canonical="rollback", introduced="v0.0.0", remove_by="indefinite", issue="#124")
     #[serde(default, alias = "undo")]
     pub rollback: RollbackConfig,
@@ -1555,6 +1595,8 @@ struct ProfileDeserialize {
     workdir: WorkdirConfig,
     #[serde(default)]
     hooks: HooksConfig,
+    #[serde(default)]
+    session_hooks: SessionHooks,
     /// ALIAS(canonical="rollback", introduced="v0.0.0", remove_by="indefinite", issue="#124")
     #[serde(default, alias = "undo")]
     rollback: RollbackConfig,
@@ -1599,6 +1641,7 @@ impl From<ProfileDeserialize> for Profile {
             environment: raw.environment,
             workdir: raw.workdir,
             hooks: raw.hooks,
+            session_hooks: raw.session_hooks,
             rollback: raw.rollback,
             open_urls: raw.open_urls,
             allow_launch_services: raw.allow_launch_services,
@@ -2511,6 +2554,10 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
                 merged.extend(child.hooks.hooks);
                 merged
             },
+        },
+        session_hooks: SessionHooks {
+            before: child.session_hooks.before.or(base.session_hooks.before),
+            after: child.session_hooks.after.or(base.session_hooks.after),
         },
         rollback: RollbackConfig {
             exclude_patterns: dedup_append(
@@ -4344,6 +4391,7 @@ mod tests {
             hooks: HooksConfig {
                 hooks: HashMap::new(),
             },
+            session_hooks: SessionHooks::default(),
             rollback: RollbackConfig {
                 exclude_patterns: vec!["node_modules".to_string()],
                 exclude_globs: vec!["*.pyc".to_string()],
@@ -4422,6 +4470,7 @@ mod tests {
             hooks: HooksConfig {
                 hooks: HashMap::new(),
             },
+            session_hooks: SessionHooks::default(),
             rollback: RollbackConfig {
                 exclude_patterns: vec![],
                 exclude_globs: vec![],
@@ -4519,6 +4568,126 @@ mod tests {
         let merged = merge_profiles(base_profile(), child_profile());
         assert_eq!(merged.meta.name, "child");
         assert_eq!(merged.meta.version, "2.0");
+    }
+
+    // ============================================================================
+    // session_hooks: type-level + merge semantics
+    // ============================================================================
+
+    #[test]
+    fn test_session_hook_deserializes() {
+        let json = r#"{
+            "meta": { "name": "p" },
+            "session_hooks": {
+                "before": { "script": "/usr/local/bin/setup.sh", "timeout_secs": 10 },
+                "after":  { "script": "/usr/local/bin/cleanup.sh" }
+            }
+        }"#;
+        let profile: Profile = serde_json::from_str(json).expect("parse session_hooks profile");
+        let before = profile
+            .session_hooks
+            .before
+            .as_ref()
+            .expect("before is set");
+        assert_eq!(before.script, PathBuf::from("/usr/local/bin/setup.sh"));
+        assert_eq!(before.timeout_secs, Some(10));
+        let after = profile.session_hooks.after.as_ref().expect("after is set");
+        assert_eq!(after.script, PathBuf::from("/usr/local/bin/cleanup.sh"));
+        assert_eq!(after.timeout_secs, None);
+    }
+
+    #[test]
+    fn test_session_hook_optional_timeout_omitted() {
+        let json = r#"{
+            "meta": { "name": "p" },
+            "session_hooks": { "before": { "script": "/x/y.sh" } }
+        }"#;
+        let profile: Profile = serde_json::from_str(json).expect("parse profile");
+        assert_eq!(profile.session_hooks.before.unwrap().timeout_secs, None);
+    }
+
+    #[test]
+    fn test_session_hook_rejects_unknown_field() {
+        let json = r#"{
+            "meta": { "name": "p" },
+            "session_hooks": {
+                "before": {
+                    "script": "/x/y.sh",
+                    "args": ["--foo"]
+                }
+            }
+        }"#;
+        let result = serde_json::from_str::<Profile>(json);
+        assert!(
+            result.is_err(),
+            "SessionHook should reject unknown fields, got: {:?}",
+            result.ok()
+        );
+    }
+
+    #[test]
+    fn test_session_hooks_rejects_unknown_field() {
+        // Catches typos like "befor" or "after_run".
+        let json = r#"{
+            "meta": { "name": "p" },
+            "session_hooks": { "befor": { "script": "/x/y.sh" } }
+        }"#;
+        let result = serde_json::from_str::<Profile>(json);
+        assert!(
+            result.is_err(),
+            "SessionHooks must reject unknown fields, got: {:?}",
+            result.ok()
+        );
+    }
+
+    #[test]
+    fn test_merge_profiles_session_hooks_child_overrides_per_field() {
+        let mut base = base_profile();
+        base.session_hooks = SessionHooks {
+            before: Some(SessionHook {
+                script: PathBuf::from("/base/before.sh"),
+                timeout_secs: Some(5),
+            }),
+            after: Some(SessionHook {
+                script: PathBuf::from("/base/after.sh"),
+                timeout_secs: None,
+            }),
+        };
+        let mut child = child_profile();
+        child.session_hooks = SessionHooks {
+            before: Some(SessionHook {
+                script: PathBuf::from("/child/before.sh"),
+                timeout_secs: None,
+            }),
+            after: None,
+        };
+
+        let merged = merge_profiles(base, child);
+        let merged_before = merged.session_hooks.before.expect("before present");
+        assert_eq!(merged_before.script, PathBuf::from("/child/before.sh"));
+        assert_eq!(merged_before.timeout_secs, None);
+        let merged_after = merged
+            .session_hooks
+            .after
+            .expect("after preserved from base");
+        assert_eq!(merged_after.script, PathBuf::from("/base/after.sh"));
+    }
+
+    #[test]
+    fn test_merge_profiles_session_hooks_child_inherits_when_absent() {
+        let mut base = base_profile();
+        base.session_hooks = SessionHooks {
+            before: Some(SessionHook {
+                script: PathBuf::from("/base/before.sh"),
+                timeout_secs: Some(7),
+            }),
+            after: None,
+        };
+        let merged = merge_profiles(base, child_profile());
+        let before = merged.session_hooks.before.expect("inherited from base");
+        assert_eq!(before.script, PathBuf::from("/base/before.sh"));
+        assert_eq!(before.timeout_secs, Some(7));
+        assert!(merged.session_hooks.after.is_none());
     }
 
     #[test]

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -417,6 +417,7 @@ struct PendingCwdAccessRequest {
 pub(crate) struct PreparedSandbox {
     pub(crate) caps: CapabilitySet,
     pub(crate) secrets: Vec<nono::LoadedSecret>,
+    pub(crate) session_hooks: profile::SessionHooks,
     pub(crate) rollback_exclude_patterns: Vec<String>,
     pub(crate) rollback_exclude_globs: Vec<String>,
     pub(crate) network_profile: Option<String>,
@@ -1005,6 +1006,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
             PreparedSandbox {
                 caps,
                 secrets: Vec::new(),
+                session_hooks: profile::SessionHooks::default(),
                 rollback_exclude_patterns,
                 rollback_exclude_globs,
                 network_profile: None,
@@ -1061,6 +1063,11 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         allowed_env_vars: profile_allowed_env_vars,
         denied_env_vars: profile_denied_env_vars,
     } = prepared_profile;
+
+    let session_hooks = loaded_profile
+        .as_ref()
+        .map(|p| p.session_hooks.clone())
+        .unwrap_or_default();
 
     if let Some(profile) = loaded_profile.as_ref() {
         let profile_warnings = command_blocking_deprecation::collect_profile_warnings(profile);
@@ -1278,6 +1285,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         PreparedSandbox {
             caps,
             secrets: loaded_secrets,
+            session_hooks,
             rollback_exclude_patterns: profile_rollback_patterns,
             rollback_exclude_globs: profile_rollback_globs,
             network_profile: profile_network_profile,

--- a/crates/nono-cli/tests/schema_shape.rs
+++ b/crates/nono-cli/tests/schema_shape.rs
@@ -113,6 +113,54 @@ fn test_schema_does_not_advertise_legacy_policy_namespace() {
 }
 
 #[test]
+fn test_schema_has_session_hooks_property_and_defs() {
+    let schema = load_schema();
+    assert!(
+        schema.pointer("/properties/session_hooks").is_some(),
+        "schema is missing canonical /properties/session_hooks"
+    );
+
+    let hooks_props = schema
+        .pointer("/$defs/SessionHooks/properties")
+        .and_then(Value::as_object)
+        .expect("SessionHooks.properties is an object");
+    assert!(
+        hooks_props.contains_key("before"),
+        "SessionHooks.before missing"
+    );
+    assert!(
+        hooks_props.contains_key("after"),
+        "SessionHooks.after missing"
+    );
+
+    let hook_props = schema
+        .pointer("/$defs/SessionHook/properties")
+        .and_then(Value::as_object)
+        .expect("SessionHook.properties is an object");
+    assert!(
+        hook_props.contains_key("script"),
+        "SessionHook.script missing"
+    );
+    assert!(
+        hook_props.contains_key("timeout_secs"),
+        "SessionHook.timeout_secs missing"
+    );
+
+    // Both objects must reject unknown fields to match the Rust struct's
+    // #[serde(deny_unknown_fields)] guarantee.
+    assert_eq!(
+        schema.pointer("/$defs/SessionHooks/additionalProperties"),
+        Some(&Value::Bool(false)),
+        "SessionHooks must set additionalProperties: false"
+    );
+    assert_eq!(
+        schema.pointer("/$defs/SessionHook/additionalProperties"),
+        Some(&Value::Bool(false)),
+        "SessionHook must set additionalProperties: false"
+    );
+}
+
+#[test]
 fn test_schema_security_has_no_legacy_groups_or_allowed_commands() {
     let schema = load_schema();
     let props = schema

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -80,8 +80,56 @@ Profiles use JSON format:
   },
   "network": {
     "block": false
+  },
+  "session_hooks": {
+    "before": {
+      "script": "/path/to/setup.sh",
+      "timeout_secs": 30
+    },
+    "after": {
+      "script": "/path/to/cleanup.sh",
+      "timeout_secs": 10
+    }
   }
 }
+
+## Session Hooks
+
+Session hooks are scripts that run before or after the sandboxed process, outside the sandbox with host privileges. Useful for setup and cleanup tasks the sandboxed process should not have access to -- for example, creating a private TMPDIR per session.
+
+### Configuration
+
+Both `before` and `after` are optional. Each hook specifies a script path and an optional timeout:
+
+```json
+{
+  "session_hooks": {
+    "before": { "script": "/path/to/setup.sh", "timeout_secs": 30 },
+    "after":  { "script": "/path/to/cleanup.sh", "timeout_secs": 10 }
+  }
+}
+```
+
+- `script` (required): absolute path to an executable script.
+- `timeout_secs` (optional): kills the script if it exceeds this duration.
+
+### Before hook
+
+Runs before the sandboxed process starts. The script receives `NONO_SESSION_ID`, `NONO_WORKDIR`, and `NONO_ENV_FILE` -- a temporary file where `KEY=VALUE` lines can be written to export environment variables to the sandboxed process.
+
+```sh
+#!/bin/sh
+mkdir -p "/tmp/$NONO_SESSION_ID"
+echo "TMPDIR=/tmp/$NONO_SESSION_ID" >> "$NONO_ENV_FILE"
+```
+
+### After hook
+
+Runs after the sandboxed process exits. Receives `NONO_SESSION_ID`, `NONO_WORKDIR`, and `NONO_EXIT_CODE`. Cleanup only -- does not export environment variables.
+
+```sh
+#!/bin/sh
+rm -rf "/tmp/$NONO_SESSION_ID"
 ```
 
 ### AF_UNIX Socket Grants


### PR DESCRIPTION
## Linked Issue

Closes #954

## Summary

Adds `session_hooks` to profiles -- `before` and `after` scripts that run outside the sandbox with host privileges. Useful for per-session TMPDIR setup, env var export (via `NONO_ENV_FILE`), and cleanup.

Config in profile:

```json
{
  "session_hooks": {
    "before": { "script": "/path/to/setup.sh", "timeout_secs": 30 },
    "after":  { "script": "/path/to/cleanup.sh", "timeout_secs": 10 }
  }
}
```

After is approved I will work on documentation.

## AI assistance
AI was used as a development tool while preparing this change. All code, design decisions, and the final review were done by me; I'm submitting this PR as the author and take responsibility for it.

## Test Plan

Unit tests in `hook_runtime.rs` (path validation, env file parsing, env var filtering, end-to-end hook execution) and profile module (merge + serialization). Run `make ci`.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed
