### PR TITLE
feat(keyring): add NONO_KEYRING_TIMEOUT_SECS for keychain access

### DIFF
--- a/crates/nono-proxy/src/credential.rs
+++ b/crates/nono-proxy/src/credential.rs
@@ -139,13 +139,8 @@ impl CredentialStore {
                         let redacted = redact_credential_ref(key);
                         warn!(
                             "Credential '{}' not available for route '{}': {}. \
-                             Managed-credential requests on this route will be denied until the credential is available.",
-                            redacted, normalized_prefix, msg
-                        );
-                        eprintln!(
-                            "[nono] Credential '{}' not available for route '{}': {}\n\
-                             \x20      Managed-credential requests on this route will be denied.\n\
-                             \x20      Set NONO_KEYRING_TIMEOUT_SECS=N (default 120) to wait longer for keychain unlock; 0 disables the timeout.",
+                             Managed-credential requests on this route will be denied until the credential is available. \
+                             Set NONO_KEYRING_TIMEOUT_SECS=N (default 120) to wait longer for keychain unlock; 0 disables the timeout.",
                             redacted, normalized_prefix, msg
                         );
                         continue;
@@ -222,13 +217,8 @@ impl CredentialStore {
                         let redacted = redact_credential_ref(&oauth2.client_id);
                         warn!(
                             "OAuth2 client_id '{}' not available for route '{}': {}. \
-                                 Managed-credential requests on this route will be denied.",
-                            redacted, route.prefix, msg
-                        );
-                        eprintln!(
-                            "[nono] OAuth2 client_id '{}' not available for route '{}': {}\n\
-                                 \x20      Managed-credential requests on this route will be denied.\n\
-                                 \x20      Set NONO_KEYRING_TIMEOUT_SECS=N (default 120) to wait longer for keychain unlock; 0 disables the timeout.",
+                                 Managed-credential requests on this route will be denied. \
+                                 Set NONO_KEYRING_TIMEOUT_SECS=N (default 120) to wait longer for keychain unlock; 0 disables the timeout.",
                             redacted, route.prefix, msg
                         );
                         continue;
@@ -246,13 +236,8 @@ impl CredentialStore {
                         let redacted = redact_credential_ref(&oauth2.client_secret);
                         warn!(
                             "OAuth2 client_secret '{}' not available for route '{}': {}. \
-                             Managed-credential requests on this route will be denied.",
-                            redacted, route.prefix, msg
-                        );
-                        eprintln!(
-                            "[nono] OAuth2 client_secret '{}' not available for route '{}': {}\n\
-                             \x20      Managed-credential requests on this route will be denied.\n\
-                             \x20      Set NONO_KEYRING_TIMEOUT_SECS=N (default 120) to wait longer for keychain unlock; 0 disables the timeout.",
+                             Managed-credential requests on this route will be denied. \
+                             Set NONO_KEYRING_TIMEOUT_SECS=N (default 120) to wait longer for keychain unlock; 0 disables the timeout.",
                             redacted, route.prefix, msg
                         );
                         continue;

--- a/crates/nono-proxy/src/credential.rs
+++ b/crates/nono-proxy/src/credential.rs
@@ -340,6 +340,8 @@ fn redact_credential_ref(key: &str) -> String {
         nono::keystore::redact_apple_password_uri(key)
     } else if nono::keystore::is_keyring_uri(key) {
         nono::keystore::redact_keyring_uri(key)
+    } else if nono::keystore::is_bw_uri(key) {
+        nono::keystore::redact_bw_uri(key)
     } else if nono::keystore::is_file_uri(key) {
         nono::keystore::redact_file_uri(key)
     } else {

--- a/crates/nono-proxy/src/credential.rs
+++ b/crates/nono-proxy/src/credential.rs
@@ -136,10 +136,17 @@ impl CredentialStore {
                         continue;
                     }
                     Err(nono::NonoError::KeystoreAccess(msg)) => {
+                        let redacted = redact_credential_ref(key);
                         warn!(
                             "Credential '{}' not available for route '{}': {}. \
                              Managed-credential requests on this route will be denied until the credential is available.",
-                            key, normalized_prefix, msg
+                            redacted, normalized_prefix, msg
+                        );
+                        eprintln!(
+                            "[nono] Credential '{}' not available for route '{}': {}\n\
+                             \x20      Managed-credential requests on this route will be denied.\n\
+                             \x20      Set NONO_KEYRING_TIMEOUT_SECS=N (default 120) to wait longer for keychain unlock; 0 disables the timeout.",
+                            redacted, normalized_prefix, msg
                         );
                         continue;
                     }
@@ -205,20 +212,29 @@ impl CredentialStore {
                     route.prefix
                 );
 
-                let client_id =
-                    match nono::keystore::load_secret_by_ref(KEYRING_SERVICE, &oauth2.client_id) {
-                        Ok(s) => s,
-                        Err(nono::NonoError::SecretNotFound(msg))
-                        | Err(nono::NonoError::KeystoreAccess(msg)) => {
-                            warn!(
-                                "OAuth2 client_id not available for route '{}': {}. \
+                let client_id = match nono::keystore::load_secret_by_ref(
+                    KEYRING_SERVICE,
+                    &oauth2.client_id,
+                ) {
+                    Ok(s) => s,
+                    Err(nono::NonoError::SecretNotFound(msg))
+                    | Err(nono::NonoError::KeystoreAccess(msg)) => {
+                        let redacted = redact_credential_ref(&oauth2.client_id);
+                        warn!(
+                            "OAuth2 client_id '{}' not available for route '{}': {}. \
                                  Managed-credential requests on this route will be denied.",
-                                route.prefix, msg
-                            );
-                            continue;
-                        }
-                        Err(e) => return Err(ProxyError::Credential(e.to_string())),
-                    };
+                            redacted, route.prefix, msg
+                        );
+                        eprintln!(
+                            "[nono] OAuth2 client_id '{}' not available for route '{}': {}\n\
+                                 \x20      Managed-credential requests on this route will be denied.\n\
+                                 \x20      Set NONO_KEYRING_TIMEOUT_SECS=N (default 120) to wait longer for keychain unlock; 0 disables the timeout.",
+                            redacted, route.prefix, msg
+                        );
+                        continue;
+                    }
+                    Err(e) => return Err(ProxyError::Credential(e.to_string())),
+                };
 
                 let client_secret = match nono::keystore::load_secret_by_ref(
                     KEYRING_SERVICE,
@@ -227,10 +243,17 @@ impl CredentialStore {
                     Ok(s) => s,
                     Err(nono::NonoError::SecretNotFound(msg))
                     | Err(nono::NonoError::KeystoreAccess(msg)) => {
+                        let redacted = redact_credential_ref(&oauth2.client_secret);
                         warn!(
-                            "OAuth2 client_secret not available for route '{}': {}. \
+                            "OAuth2 client_secret '{}' not available for route '{}': {}. \
                              Managed-credential requests on this route will be denied.",
-                            route.prefix, msg
+                            redacted, route.prefix, msg
+                        );
+                        eprintln!(
+                            "[nono] OAuth2 client_secret '{}' not available for route '{}': {}\n\
+                             \x20      Managed-credential requests on this route will be denied.\n\
+                             \x20      Set NONO_KEYRING_TIMEOUT_SECS=N (default 120) to wait longer for keychain unlock; 0 disables the timeout.",
+                            redacted, route.prefix, msg
                         );
                         continue;
                     }
@@ -320,6 +343,24 @@ impl CredentialStore {
 /// The keyring service name used by nono for all credentials.
 /// Uses the same constant as `nono::keystore::DEFAULT_SERVICE` to ensure consistency.
 const KEYRING_SERVICE: &str = nono::keystore::DEFAULT_SERVICE;
+
+/// Redact a credential reference for safe display in warnings.
+///
+/// Delegates to the appropriate URI-specific redaction helper so that
+/// secrets (account names, file paths, field names) are never echoed raw.
+fn redact_credential_ref(key: &str) -> String {
+    if nono::keystore::is_op_uri(key) {
+        nono::keystore::redact_op_uri(key)
+    } else if nono::keystore::is_apple_password_uri(key) {
+        nono::keystore::redact_apple_password_uri(key)
+    } else if nono::keystore::is_keyring_uri(key) {
+        nono::keystore::redact_keyring_uri(key)
+    } else if nono::keystore::is_file_uri(key) {
+        nono::keystore::redact_file_uri(key)
+    } else {
+        key.to_string()
+    }
+}
 
 /// Build a hint for the credential-not-found warning that probes other
 /// credential sources for the same name.

--- a/crates/nono/src/keystore.rs
+++ b/crates/nono/src/keystore.rs
@@ -24,6 +24,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Stdio};
+#[cfg(feature = "system-keyring")]
 use std::sync::mpsc;
 use std::time::Duration;
 use zeroize::Zeroizing;

--- a/crates/nono/src/keystore.rs
+++ b/crates/nono/src/keystore.rs
@@ -24,6 +24,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Stdio};
+use std::sync::mpsc;
 use std::time::Duration;
 use zeroize::Zeroizing;
 
@@ -31,6 +32,86 @@ use zeroize::Zeroizing;
 ///
 /// Generous enough to allow biometric prompts in password manager CLIs.
 const SECRET_MANAGER_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Default timeout for system keyring calls (seconds).
+///
+/// 120 s covers the realistic worst-case keychain unlock workflow:
+/// notice the prompt, switch windows, type a master password, click approve.
+/// Rationale for choosing 120 over a shorter value: issue #967 reports that
+/// a shorter timeout fired before the user could complete the KeePassXC
+/// unlock sequence on Linux. We go materially longer while still bounding
+/// an unattended hang.
+///
+/// Override with `NONO_KEYRING_TIMEOUT_SECS`. Set to `0` to disable the
+/// timeout entirely and restore the old "block forever" behaviour.
+#[cfg(feature = "system-keyring")]
+const KEYRING_TIMEOUT_SECS: u64 = 120;
+
+/// Return the effective keyring timeout.
+///
+/// - `NONO_KEYRING_TIMEOUT_SECS` unset → `Some(120 s)` (the default).
+/// - `NONO_KEYRING_TIMEOUT_SECS=0` → `None` (wait forever).
+/// - `NONO_KEYRING_TIMEOUT_SECS=N` (N > 0) → `Some(N s)`.
+/// - Invalid value → logs a warning and returns `Some(120 s)`.
+#[cfg(feature = "system-keyring")]
+fn keyring_timeout() -> Option<Duration> {
+    match std::env::var("NONO_KEYRING_TIMEOUT_SECS") {
+        Err(_) => Some(Duration::from_secs(KEYRING_TIMEOUT_SECS)),
+        Ok(s) => match s.trim().parse::<u64>() {
+            Ok(0) => None,
+            Ok(n) => Some(Duration::from_secs(n)),
+            Err(_) => {
+                tracing::warn!(
+                    "NONO_KEYRING_TIMEOUT_SECS='{}' is not a valid integer; \
+                     using default {}s",
+                    s.trim(),
+                    KEYRING_TIMEOUT_SECS
+                );
+                Some(Duration::from_secs(KEYRING_TIMEOUT_SECS))
+            }
+        },
+    }
+}
+
+/// Call a blocking keyring function with an optional timeout.
+///
+/// When `timeout` is `None`, the closure is called inline on the current
+/// thread — no extra thread is spawned.
+///
+/// When `timeout` is `Some(d)`, the closure is moved onto a new thread and
+/// the result is sent back through an `mpsc` channel. If the channel
+/// `recv_timeout` fires, a `KeystoreAccess` error is returned.
+///
+/// **macOS note**: if the timeout fires while `Security.framework` is
+/// displaying a keychain unlock dialog, the spawned thread stays alive and
+/// blocked until the user responds or the process exits. Rust cannot cancel
+/// a blocking syscall; this is the expected behaviour. No secret material
+/// leaks because the `Zeroizing<String>` result is dropped on the thread
+/// side once the channel receiver is gone.
+#[cfg(feature = "system-keyring")]
+fn call_with_keyring_timeout<F, T>(timeout: Option<Duration>, label: &str, f: F) -> Result<T>
+where
+    F: FnOnce() -> Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    let Some(dur) = timeout else {
+        return f();
+    };
+
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(f());
+    });
+
+    rx.recv_timeout(dur).unwrap_or_else(|_| {
+        Err(NonoError::KeystoreAccess(format!(
+            "{} timed out after {}s waiting for keychain access. \
+             Set NONO_KEYRING_TIMEOUT_SECS=N to adjust (0 = wait forever).",
+            label,
+            dur.as_secs()
+        )))
+    })
+}
 
 /// A credential loaded from the keystore
 pub struct LoadedSecret {
@@ -980,32 +1061,36 @@ pub fn store_secret_file(path: &Path, secret: &str) -> Result<()> {
 /// keyring crate that we cannot address from the caller side.
 #[cfg(feature = "system-keyring")]
 fn load_single_secret(service: &str, account: &str) -> Result<Zeroizing<String>> {
-    let entry = keyring::Entry::new(service, account).map_err(|e| {
-        NonoError::KeystoreAccess(format!(
-            "Failed to access keystore for '{}': {}",
-            account, e
-        ))
-    })?;
+    let timeout = keyring_timeout();
+    let service = service.to_string();
+    let account = account.to_string();
+    let label = format!("keyring lookup for '{}'", account);
 
-    match entry.get_password() {
-        Ok(password) => {
-            // Immediately wrap in Zeroizing so the String's heap buffer is
-            // zeroed when the secret is dropped. The move does not copy the
-            // heap allocation - it transfers ownership of the same buffer.
-            tracing::debug!("Successfully loaded secret '{}'", account);
-            Ok(Zeroizing::new(password))
+    call_with_keyring_timeout(timeout, &label, move || {
+        let entry = keyring::Entry::new(&service, &account).map_err(|e| {
+            NonoError::KeystoreAccess(format!(
+                "Failed to access keystore for '{}': {}",
+                account, e
+            ))
+        })?;
+
+        match entry.get_password() {
+            Ok(password) => {
+                tracing::debug!("Successfully loaded secret '{}'", account);
+                Ok(Zeroizing::new(password))
+            }
+            Err(keyring::Error::NoEntry) => Err(NonoError::SecretNotFound(account.to_string())),
+            Err(keyring::Error::Ambiguous(creds)) => Err(NonoError::KeystoreAccess(format!(
+                "Multiple entries ({}) found for '{}' - please resolve manually",
+                creds.len(),
+                account
+            ))),
+            Err(e) => Err(NonoError::KeystoreAccess(format!(
+                "Cannot access '{}': {}",
+                account, e
+            ))),
         }
-        Err(keyring::Error::NoEntry) => Err(NonoError::SecretNotFound(account.to_string())),
-        Err(keyring::Error::Ambiguous(creds)) => Err(NonoError::KeystoreAccess(format!(
-            "Multiple entries ({}) found for '{}' - please resolve manually",
-            creds.len(),
-            account
-        ))),
-        Err(e) => Err(NonoError::KeystoreAccess(format!(
-            "Cannot access '{}': {}",
-            account, e
-        ))),
-    }
+    })
 }
 
 #[cfg(not(feature = "system-keyring"))]
@@ -1354,34 +1439,43 @@ fn load_from_keyring_uri(uri: &str) -> Result<Zeroizing<String>> {
     let redacted = redact_keyring_uri(uri);
     tracing::debug!("Loading secret from system keyring: {}", redacted);
 
-    let entry = keyring::Entry::new(parts.service, parts.account).map_err(|e| {
-        NonoError::KeystoreAccess(format!(
-            "Failed to access keyring for '{}': {}",
-            redacted, e
-        ))
-    })?;
+    let timeout = keyring_timeout();
+    let service = parts.service.to_string();
+    let account = parts.account.to_string();
+    let decode = parts.decode;
+    let redacted_clone = redacted.clone();
+    let label = format!("keyring lookup for '{}'", redacted);
 
-    match entry.get_password() {
-        Ok(password) => {
-            tracing::debug!("Successfully loaded secret '{}'", redacted);
-            let decoded = apply_keyring_decode(password, parts.decode, &redacted)?;
-            Ok(decoded)
+    call_with_keyring_timeout(timeout, &label, move || {
+        let entry = keyring::Entry::new(&service, &account).map_err(|e| {
+            NonoError::KeystoreAccess(format!(
+                "Failed to access keyring for '{}': {}",
+                redacted_clone, e
+            ))
+        })?;
+
+        match entry.get_password() {
+            Ok(password) => {
+                tracing::debug!("Successfully loaded secret '{}'", redacted_clone);
+                let decoded = apply_keyring_decode(password, decode, &redacted_clone)?;
+                Ok(decoded)
+            }
+            Err(keyring::Error::NoEntry) => Err(NonoError::SecretNotFound(format!(
+                "keyring entry not found: '{}'. \
+                 Verify the service and account match the stored credential.",
+                redacted_clone
+            ))),
+            Err(keyring::Error::Ambiguous(creds)) => Err(NonoError::KeystoreAccess(format!(
+                "Multiple entries ({}) found for '{}' - please resolve manually",
+                creds.len(),
+                redacted_clone
+            ))),
+            Err(e) => Err(NonoError::KeystoreAccess(format!(
+                "Cannot access '{}': {}",
+                redacted_clone, e
+            ))),
         }
-        Err(keyring::Error::NoEntry) => Err(NonoError::SecretNotFound(format!(
-            "keyring entry not found: '{}'. \
-             Verify the service and account match the stored credential.",
-            redacted
-        ))),
-        Err(keyring::Error::Ambiguous(creds)) => Err(NonoError::KeystoreAccess(format!(
-            "Multiple entries ({}) found for '{}' - please resolve manually",
-            creds.len(),
-            redacted
-        ))),
-        Err(e) => Err(NonoError::KeystoreAccess(format!(
-            "Cannot access '{}': {}",
-            redacted, e
-        ))),
-    }
+    })
 }
 
 #[cfg(not(feature = "system-keyring"))]
@@ -3639,6 +3733,112 @@ mod tests {
             "got: {}",
             err
         );
+    }
+
+    // =========================================================================
+    // keyring_timeout() and call_with_keyring_timeout() tests
+    // =========================================================================
+
+    #[cfg(feature = "system-keyring")]
+    mod keyring_timeout_tests {
+        use super::*;
+        use std::sync::Mutex;
+        use std::time::Duration;
+
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+        struct EnvGuard {
+            key: &'static str,
+            original: Option<String>,
+        }
+
+        impl EnvGuard {
+            #[allow(clippy::disallowed_methods)]
+            fn set(key: &'static str, val: &str) -> Self {
+                let original = std::env::var(key).ok();
+                // SAFETY: serialised via ENV_LOCK
+                unsafe { std::env::set_var(key, val) };
+                Self { key, original }
+            }
+
+            #[allow(clippy::disallowed_methods)]
+            fn remove(key: &'static str) -> Self {
+                let original = std::env::var(key).ok();
+                // SAFETY: serialised via ENV_LOCK
+                unsafe { std::env::remove_var(key) };
+                Self { key, original }
+            }
+        }
+
+        #[allow(clippy::disallowed_methods)]
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match &self.original {
+                    // SAFETY: serialised via ENV_LOCK
+                    Some(v) => unsafe { std::env::set_var(self.key, v) },
+                    None => unsafe { std::env::remove_var(self.key) },
+                }
+            }
+        }
+
+        const KEY: &str = "NONO_KEYRING_TIMEOUT_SECS";
+
+        #[test]
+        fn keyring_timeout_unset_returns_default_120s() {
+            let _lock = ENV_LOCK.lock().unwrap();
+            let _g = EnvGuard::remove(KEY);
+            assert_eq!(keyring_timeout(), Some(Duration::from_secs(120)));
+        }
+
+        #[test]
+        fn keyring_timeout_zero_returns_none() {
+            let _lock = ENV_LOCK.lock().unwrap();
+            let _g = EnvGuard::set(KEY, "0");
+            assert_eq!(keyring_timeout(), None);
+        }
+
+        #[test]
+        fn keyring_timeout_valid_value_returns_some() {
+            let _lock = ENV_LOCK.lock().unwrap();
+            let _g = EnvGuard::set(KEY, "300");
+            assert_eq!(keyring_timeout(), Some(Duration::from_secs(300)));
+        }
+
+        #[test]
+        fn keyring_timeout_invalid_falls_back_to_default() {
+            let _lock = ENV_LOCK.lock().unwrap();
+            let _g = EnvGuard::set(KEY, "banana");
+            assert_eq!(keyring_timeout(), Some(Duration::from_secs(120)));
+        }
+
+        #[test]
+        fn call_with_keyring_timeout_none_runs_inline() {
+            // None = no timeout; closure runs directly, no thread spawned
+            let result: Result<u32> = call_with_keyring_timeout(None, "test", || Ok(42_u32));
+            assert_eq!(result.unwrap(), 42);
+        }
+
+        #[test]
+        fn call_with_keyring_timeout_fast_call_returns_value() {
+            let result: Result<u32> =
+                call_with_keyring_timeout(Some(Duration::from_secs(5)), "test", || Ok(99_u32));
+            assert_eq!(result.unwrap(), 99);
+        }
+
+        #[test]
+        fn call_with_keyring_timeout_slow_call_fires() {
+            let result: Result<u32> =
+                call_with_keyring_timeout(Some(Duration::from_millis(50)), "slow-test", || {
+                    std::thread::sleep(Duration::from_secs(10));
+                    Ok(0_u32)
+                });
+            let err = result.unwrap_err().to_string();
+            assert!(
+                err.contains("timed out") && err.contains("NONO_KEYRING_TIMEOUT_SECS"),
+                "got: {}",
+                err
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #967

## Summary

Adds `NONO_KEYRING_TIMEOUT_SECS` to bound how long nono will block on the
system keyring (macOS Keychain / Linux Secret Service / KeePassXC). Default
is 120 seconds -- long enough for a real keychain-unlock workflow, finite
enough that an unattended nono cannot hang forever. `0` preserves the old
"wait forever" behaviour for users who want it.

Also surfaces credential-load failures on the proxy path with proper
redaction: previously a locked keychain caused the proxy to start silently
without the credential, which the issue author flagged as easy to overlook.

Key design decisions:

1. **Default 120 s** -- covers a real human unlock workflow (notice prompt,
   switch windows, type a master password, click approve). Documented in
   the source with rationale.
2. **`0` means "wait forever"** -- explicit opt-in to the old behaviour.
3. **Invalid env value falls back to default** with a warning -- a typo
   here should not block startup.
4. **No thread overhead when not needed** -- when `keyring_timeout()` returns
   `None`, `call_with_keyring_timeout` calls the closure inline.
5. **Detached thread on timeout** -- documented. Rust cannot cancel a
   blocking syscall; the spawned thread stays alive until the underlying
   call returns or the process exits. No secret material leaks because
   the `Zeroizing<String>` result is dropped on the thread side once the
   channel receiver is gone.
6. **Proxy warnings use existing redaction helpers** -- credential refs are
   never echoed raw in warning output.

## Changes

- `crates/nono/src/keystore.rs`: `KEYRING_TIMEOUT_SECS = 120`,
  `keyring_timeout()` env reader, `call_with_keyring_timeout()` wrapper.
  Applied at `load_single_secret` and `load_from_keyring_uri`, gated on
  `feature = "system-keyring"`.
- `crates/nono-proxy/src/credential.rs`: `redact_credential_ref()` helper
  covering `op://`, `apple-password://`, `keyring://`, `bw://`, and
  `file://` URI schemes. Warning messages on all three skip branches in
  `CredentialStore::load` (static `KeystoreAccess`, OAuth2 `client_id`,
  OAuth2 `client_secret`) now include the timeout env var hint.

## Test Plan

- Unit tests in `keystore.rs` (`keyring_timeout_tests` submodule) covering
  env-var parsing (unset / 0 / valid value / invalid), the inline path when
  timeout is `None`, the fast-success path, and the timeout-fires path.
  All env-var tests serialise via an in-module `ENV_LOCK` + `EnvGuard`.
- Manual verification on Linux VM with KeePassXC: locked-DB timeout fires,
  unlock-in-time succeeds, `0` waits forever, invalid value falls back to
  default.
- `make ci`.

_AI-assisted development. All code reviewed and tested by the author._
