### PR TITLE
feat(cli): centralize timeout constants and make user-facing timeouts configurable

### DIFF
--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1614,6 +1614,17 @@ pub struct RunArgs {
     #[arg(long, help_heading = "OPTIONS")]
     pub detached: bool,
 
+    /// How long (seconds) to wait for a detached session to become attachable.
+    /// Only meaningful with --detached. Env: NONO_DETACH_STARTUP_TIMEOUT.
+    #[arg(
+        long = "detach-timeout",
+        value_name = "SECS",
+        requires = "detached",
+        env = "NONO_DETACH_STARTUP_TIMEOUT",
+        help_heading = "OPTIONS"
+    )]
+    pub detach_timeout_secs: Option<u64>,
+
     // ── Rollback ──────────────────────────────────────────────────────
     /// Enable atomic rollback snapshots for the session
     #[arg(long, conflicts_with = "no_rollback", help_heading = "ROLLBACK")]

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -69,9 +69,7 @@ const MAX_CRYPTO_THREADS: usize = 7;
 const MAX_DENIAL_RECORDS: usize = 1000;
 /// Hard cap on request IDs tracked for replay detection.
 const MAX_TRACKED_REQUEST_IDS: usize = 4096;
-/// Quiet period used to drain final PTY output after child exit before parent
-/// diagnostics/prompts take over the terminal.
-const POST_EXIT_PTY_DRAIN_TIMEOUT: Duration = Duration::from_millis(100);
+use crate::timeouts;
 
 struct ProfileSaveOffer<'a> {
     policy_explanations: &'a [nono::diagnostic::PolicyExplanation],
@@ -1173,7 +1171,7 @@ pub fn execute_supervised(
             // attaching client gets EPIPE ("Broken pipe") when it
             // tries to send the handshake.
             if let Some(ref mut p) = pty_proxy {
-                p.drain_master_output(POST_EXIT_PTY_DRAIN_TIMEOUT);
+                p.drain_master_output(timeouts::pty_drain_timeout());
                 p.shutdown_attach_listener();
                 p.release_terminal_for_prompt();
             }
@@ -1625,7 +1623,7 @@ fn wait_for_child_with_startup_timeout(
                     let _ = signal::kill(child, Signal::SIGKILL);
                     return wait_for_child(child);
                 }
-                std::thread::sleep(Duration::from_millis(200));
+                std::thread::sleep(timeouts::CHILD_POLL_INTERVAL);
             }
             Ok(status) => return Ok(status),
             Err(nix::errno::Errno::EINTR) => continue,

--- a/crates/nono-cli/src/learn.rs
+++ b/crates/nono-cli/src/learn.rs
@@ -565,7 +565,7 @@ fn run_fs_usage_and_nettop(
     // Wait for fs_usage to attach the kernel trace facility before
     // spawning the child. A fixed sleep is acceptable here: the previous
     // pipe+peek approach was unreliable due to stdout buffering.
-    std::thread::sleep(Duration::from_secs(2));
+    std::thread::sleep(crate::timeouts::FS_USAGE_SETTLE_TIME);
 
     // Now spawn the target command
     let mut child = Command::new(&command[0])
@@ -604,7 +604,7 @@ fn run_fs_usage_and_nettop(
                 nix::libc::kill(child_id as i32, nix::libc::SIGTERM);
             }
             // Grace period: if the child ignores SIGTERM, escalate to SIGKILL
-            std::thread::sleep(Duration::from_secs(3));
+            std::thread::sleep(crate::timeouts::SIGTERM_GRACE_PERIOD);
             unsafe {
                 nix::libc::kill(child_id as i32, nix::libc::SIGKILL);
             }

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -63,6 +63,7 @@ mod startup_runtime;
 mod supervised_runtime;
 mod terminal_approval;
 mod theme;
+mod timeouts;
 mod trust_cmd;
 mod trust_intercept;
 mod trust_keystore;

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -28,6 +28,8 @@ use std::sync::atomic::{AtomicI32, Ordering};
 use std::time::{Duration, Instant};
 use tracing::{debug, info, warn};
 
+use crate::timeouts;
+
 #[cfg(unix)]
 use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 
@@ -471,7 +473,7 @@ impl PtyProxy {
                     return false;
                 }
 
-                let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+                let _ = stream.set_read_timeout(Some(timeouts::ATTACH_SOCKET_READ_TIMEOUT));
                 let mut request_kind = [0u8; 1];
                 match stream.read_exact(&mut request_kind) {
                     Ok(()) => {}
@@ -2093,7 +2095,7 @@ where
         Ok(()) => run_attach_loop(
             sock_fd,
             resize_socket.as_ref(),
-            Some(Duration::from_millis(250)),
+            Some(timeouts::ATTACH_STDIN_DELAY),
             &mut alt_screen_tracker,
         ),
         Err(e) => Err(e),
@@ -2189,12 +2191,12 @@ pub fn attach_to_session(session_id: &str) -> Result<()> {
             // The supervisor may have been mid-shutdown. Wait briefly and
             // retry once so we can distinguish "exited just now" from a
             // persistent problem.
-            std::thread::sleep(Duration::from_millis(150));
+            std::thread::sleep(timeouts::ATTACH_RETRY_DELAY);
             connect_to_session(session_id)?
         }
         other => other?,
     };
-    wait_for_attach_ready(stream.as_raw_fd(), 1000)?;
+    wait_for_attach_ready(stream.as_raw_fd(), timeouts::pty_attach_timeout_ms())?;
     attach_to_stream(stream, Some(session_id))
 }
 

--- a/crates/nono-cli/src/session_commands.rs
+++ b/crates/nono-cli/src/session_commands.rs
@@ -277,7 +277,7 @@ pub fn run_stop(args: &StopArgs) -> Result<()> {
                 eprintln!("Stopped session {} (forced).", record.session_id);
                 break;
             }
-            std::thread::sleep(std::time::Duration::from_millis(200));
+            std::thread::sleep(crate::timeouts::STOP_POLL_INTERVAL);
         }
     }
 
@@ -593,7 +593,7 @@ fn follow_event_log(path: &Path, tail: Option<usize>, as_json: bool) -> Result<(
                 source: e,
             })?;
         if bytes == 0 {
-            std::thread::sleep(std::time::Duration::from_millis(250));
+            std::thread::sleep(crate::timeouts::LOG_TAIL_POLL_INTERVAL);
             continue;
         }
         print!("{}", line);

--- a/crates/nono-cli/src/startup_runtime.rs
+++ b/crates/nono-cli/src/startup_runtime.rs
@@ -53,7 +53,11 @@ pub(crate) fn run_detached_launch(args: RunArgs, silent: bool) -> Result<()> {
 
     let session_path = session::session_file_path(&session_id)?;
     let attach_path = session::session_socket_path(&session_id)?;
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    let detach_timeout = args
+        .detach_timeout_secs
+        .map(std::time::Duration::from_secs)
+        .unwrap_or_else(crate::timeouts::detach_startup_timeout);
+    let deadline = std::time::Instant::now() + detach_timeout;
     while std::time::Instant::now() < deadline {
         if session_path.exists() && attach_path.exists() {
             cleanup_startup_log(&startup_log_path);
@@ -75,7 +79,7 @@ pub(crate) fn run_detached_launch(args: RunArgs, silent: bool) -> Result<()> {
             )));
         }
 
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        std::thread::sleep(crate::timeouts::SESSION_READY_POLL_INTERVAL);
     }
 
     terminate_detached_launch(&mut launched);
@@ -282,7 +286,7 @@ fn terminate_detached_launch(child: &mut Child) {
             if child.try_wait().ok().flatten().is_some() {
                 return;
             }
-            std::thread::sleep(std::time::Duration::from_millis(25));
+            std::thread::sleep(crate::timeouts::TERMINATE_POLL_INTERVAL);
         }
         if pid > 0 {
             unsafe {

--- a/crates/nono-cli/src/startup_runtime.rs
+++ b/crates/nono-cli/src/startup_runtime.rs
@@ -55,7 +55,7 @@ pub(crate) fn run_detached_launch(args: RunArgs, silent: bool) -> Result<()> {
     let attach_path = session::session_socket_path(&session_id)?;
     let detach_timeout = args
         .detach_timeout_secs
-        .map(std::time::Duration::from_secs)
+        .map(|secs| std::time::Duration::from_secs(secs.min(3600)))
         .unwrap_or_else(crate::timeouts::detach_startup_timeout);
     let deadline = std::time::Instant::now() + detach_timeout;
     while std::time::Instant::now() < deadline {

--- a/crates/nono-cli/src/timeouts.rs
+++ b/crates/nono-cli/src/timeouts.rs
@@ -1,0 +1,120 @@
+//! Named timeout and polling-interval constants used across the CLI.
+//!
+//! User-facing timeouts can be overridden via environment variables.
+//! Internal poll intervals use fixed defaults.
+
+use std::time::Duration;
+use tracing::warn;
+
+// exec_strategy
+
+/// Quiet period to drain final PTY output after child exit before parent
+/// diagnostics/prompts take over the terminal.
+pub const POST_EXIT_PTY_DRAIN_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Poll interval for the non-blocking `waitpid` loop.
+pub const CHILD_POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+// pty_proxy
+
+/// Read timeout on the attach socket when reading the request-kind byte.
+pub const ATTACH_SOCKET_READ_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Delay before forwarding stdin in the attach warm-up loop, giving the
+/// supervisor time to replay buffered screen content.
+pub const ATTACH_STDIN_DELAY: Duration = Duration::from_millis(250);
+
+/// Sleep before retrying a session connection that failed with `SessionGone`.
+pub const ATTACH_RETRY_DELAY: Duration = Duration::from_millis(150);
+
+// startup_runtime
+
+/// Maximum time to wait for a detached session to create its session file
+/// and attach socket.
+pub const DETACH_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Poll interval while waiting for a detached session to become attachable.
+pub const SESSION_READY_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Poll interval while waiting for a detached launch process to exit after
+/// SIGTERM.
+pub const TERMINATE_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+// session_commands
+
+/// Poll interval while waiting for a session to exit after SIGTERM.
+pub const STOP_POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+/// Poll interval when tailing a log file and the reader reaches EOF.
+pub const LOG_TAIL_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+// learn
+
+/// Delay after spawning `fs_usage` to let it attach the kernel trace
+/// facility before the child command starts (macOS).
+#[cfg(target_os = "macos")]
+pub const FS_USAGE_SETTLE_TIME: Duration = Duration::from_secs(2);
+
+/// Grace period after SIGTERM before escalating to SIGKILL (learn mode).
+#[cfg(target_os = "macos")]
+pub const SIGTERM_GRACE_PERIOD: Duration = Duration::from_secs(3);
+
+// Configurable user-facing timeouts
+
+/// Read `NONO_DETACH_STARTUP_TIMEOUT` (seconds). Returns the default when
+/// the variable is absent or unparseable.
+pub fn detach_startup_timeout() -> Duration {
+    env_duration_secs("NONO_DETACH_STARTUP_TIMEOUT", DETACH_STARTUP_TIMEOUT)
+}
+
+/// Read `NONO_PTY_DRAIN_TIMEOUT` (milliseconds). Returns the default when
+/// the variable is absent or unparseable.
+pub fn pty_drain_timeout() -> Duration {
+    env_duration_millis("NONO_PTY_DRAIN_TIMEOUT", POST_EXIT_PTY_DRAIN_TIMEOUT)
+}
+
+/// Read `NONO_PTY_ATTACH_TIMEOUT` (milliseconds). Returns the default when
+/// the variable is absent or unparseable.
+pub fn pty_attach_timeout_ms() -> i32 {
+    match std::env::var("NONO_PTY_ATTACH_TIMEOUT") {
+        Ok(val) => match val.parse::<i32>() {
+            Ok(ms) if ms > 0 => ms,
+            _ => {
+                warn!(
+                    "NONO_PTY_ATTACH_TIMEOUT={val:?} is not a valid positive integer, using default"
+                );
+                PTY_ATTACH_TIMEOUT_MS
+            }
+        },
+        Err(_) => PTY_ATTACH_TIMEOUT_MS,
+    }
+}
+
+/// Default for `wait_for_attach_ready` poll timeout.
+pub const PTY_ATTACH_TIMEOUT_MS: i32 = 1000;
+
+fn env_duration_secs(var: &str, default: Duration) -> Duration {
+    match std::env::var(var) {
+        Ok(val) => match val.parse::<u64>() {
+            Ok(secs) => Duration::from_secs(secs),
+            Err(_) => {
+                warn!("{var}={val:?} is not a valid integer, using default");
+                default
+            }
+        },
+        Err(_) => default,
+    }
+}
+
+fn env_duration_millis(var: &str, default: Duration) -> Duration {
+    match std::env::var(var) {
+        Ok(val) => match val.parse::<u64>() {
+            Ok(ms) => Duration::from_millis(ms),
+            Err(_) => {
+                warn!("{var}={val:?} is not a valid integer, using default");
+                default
+            }
+        },
+        Err(_) => default,
+    }
+}

--- a/crates/nono-cli/src/timeouts.rs
+++ b/crates/nono-cli/src/timeouts.rs
@@ -97,7 +97,10 @@ fn env_duration_secs(var: &str, default: Duration) -> Duration {
             Ok(secs) => {
                 let d = Duration::from_secs(secs);
                 if d > MAX_TIMEOUT {
-                    warn!("{var}={val} exceeds maximum ({} s), clamping", MAX_TIMEOUT.as_secs());
+                    warn!(
+                        "{var}={val} exceeds maximum ({} s), clamping",
+                        MAX_TIMEOUT.as_secs()
+                    );
                     MAX_TIMEOUT
                 } else {
                     d
@@ -118,7 +121,10 @@ fn env_duration_millis(var: &str, default: Duration) -> Duration {
             Ok(ms) => {
                 let d = Duration::from_millis(ms);
                 if d > MAX_TIMEOUT {
-                    warn!("{var}={val} exceeds maximum ({} s), clamping", MAX_TIMEOUT.as_secs());
+                    warn!(
+                        "{var}={val} exceeds maximum ({} s), clamping",
+                        MAX_TIMEOUT.as_secs()
+                    );
                     MAX_TIMEOUT
                 } else {
                     d

--- a/crates/nono-cli/src/timeouts.rs
+++ b/crates/nono-cli/src/timeouts.rs
@@ -76,29 +76,35 @@ pub fn pty_drain_timeout() -> Duration {
 /// Read `NONO_PTY_ATTACH_TIMEOUT` (milliseconds). Returns the default when
 /// the variable is absent or unparseable.
 pub fn pty_attach_timeout_ms() -> i32 {
-    match std::env::var("NONO_PTY_ATTACH_TIMEOUT") {
-        Ok(val) => match val.parse::<i32>() {
-            Ok(ms) if ms > 0 => ms,
-            _ => {
-                warn!(
-                    "NONO_PTY_ATTACH_TIMEOUT={val:?} is not a valid positive integer, using default"
-                );
-                PTY_ATTACH_TIMEOUT_MS
-            }
-        },
-        Err(_) => PTY_ATTACH_TIMEOUT_MS,
-    }
+    env_duration_millis(
+        "NONO_PTY_ATTACH_TIMEOUT",
+        Duration::from_millis(PTY_ATTACH_TIMEOUT_MS as u64),
+    )
+    .as_millis()
+    .min(i32::MAX as u128) as i32
 }
 
 /// Default for `wait_for_attach_ready` poll timeout.
 pub const PTY_ATTACH_TIMEOUT_MS: i32 = 1000;
 
+/// Upper bound for any user-supplied timeout. Prevents `Instant + Duration`
+/// overflow from user-controlled values (u64::MAX seconds would panic).
+const MAX_TIMEOUT: Duration = Duration::from_secs(3600);
+
 fn env_duration_secs(var: &str, default: Duration) -> Duration {
     match std::env::var(var) {
         Ok(val) => match val.parse::<u64>() {
-            Ok(secs) => Duration::from_secs(secs),
+            Ok(secs) => {
+                let d = Duration::from_secs(secs);
+                if d > MAX_TIMEOUT {
+                    warn!("{var}={val} exceeds maximum ({} s), clamping", MAX_TIMEOUT.as_secs());
+                    MAX_TIMEOUT
+                } else {
+                    d
+                }
+            }
             Err(_) => {
-                warn!("{var}={val:?} is not a valid integer, using default");
+                warn!("{var}={val:?} is not a valid number of seconds, using default");
                 default
             }
         },
@@ -109,9 +115,17 @@ fn env_duration_secs(var: &str, default: Duration) -> Duration {
 fn env_duration_millis(var: &str, default: Duration) -> Duration {
     match std::env::var(var) {
         Ok(val) => match val.parse::<u64>() {
-            Ok(ms) => Duration::from_millis(ms),
+            Ok(ms) => {
+                let d = Duration::from_millis(ms);
+                if d > MAX_TIMEOUT {
+                    warn!("{var}={val} exceeds maximum ({} s), clamping", MAX_TIMEOUT.as_secs());
+                    MAX_TIMEOUT
+                } else {
+                    d
+                }
+            }
             Err(_) => {
-                warn!("{var}={val:?} is not a valid integer, using default");
+                warn!("{var}={val:?} is not a valid number of milliseconds, using default");
                 default
             }
         },

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -824,6 +824,22 @@ nono run --detached --name gold-core --allow-cwd -- my-agent
 
 Detached launches print the generated session ID and the attach command once the session becomes ready.
 
+#### `--detach-timeout`
+
+How long (in seconds) to wait for a detached session to become attachable before giving up. Defaults to 30 seconds. Increase this for programs with slow startup (e.g. npm/network initialisation phases).
+
+| Environment Variable | `NONO_DETACH_STARTUP_TIMEOUT` |
+|---------------------|-------------------------------|
+| Example | `NONO_DETACH_STARTUP_TIMEOUT=60` |
+
+```bash
+# Give a slow app 60 seconds to initialise
+nono run --detached --detach-timeout 60 --allow-cwd -- opencode
+
+# Via environment variable
+NONO_DETACH_STARTUP_TIMEOUT=60 nono run --detached --allow-cwd -- opencode
+```
+
 #### `--name`
 
 Assign a human-friendly name to the supervised session. The name is shown in `nono ps` and can be used to recognize the session in later `attach`, `stop`, `logs`, and `inspect` workflows.
@@ -1446,6 +1462,7 @@ CLI flags always take precedence over environment variables.
 | `--env-credential` | `NONO_ENV_CREDENTIAL` | `NONO_ENV_CREDENTIAL=key1,key2` |
 | `--capability-elevation` | `NONO_CAPABILITY_ELEVATION` | `NONO_CAPABILITY_ELEVATION=true` |
 | `--startup-timeout` | `NONO_STARTUP_TIMEOUT` | `NONO_STARTUP_TIMEOUT=10` |
+| `--detach-timeout` | `NONO_DETACH_STARTUP_TIMEOUT` | `NONO_DETACH_STARTUP_TIMEOUT=60` |
 | `--upstream-proxy` | `NONO_UPSTREAM_PROXY` | `NONO_UPSTREAM_PROXY=squid.corp:3128` |
 | `--upstream-bypass` | `NONO_UPSTREAM_BYPASS` | `NONO_UPSTREAM_BYPASS=internal.corp,*.private.net` (comma-separated) |
 
@@ -1467,6 +1484,17 @@ nono run -- cargo build
 |----------|-------------|
 | `NONO_NO_UPDATE_CHECK` | Disable automatic update checks |
 | `NONO_UPDATE_URL` | Custom update service URL |
+
+### Timeout tuning
+
+These environment variables override internal timing defaults. They have no CLI flag equivalents and are only needed when the defaults cause problems for specific workloads.
+
+| Variable | Unit | Default | Description |
+|----------|------|---------|-------------|
+| `NONO_PTY_DRAIN_TIMEOUT` | ms | `100` | Quiet period to drain PTY output after child exit |
+| `NONO_PTY_ATTACH_TIMEOUT` | ms | `1000` | How long `nono attach` waits for supervisor readiness |
+
+Invalid values are ignored with a warning and the default is used.
 
 ## Examples
 


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #953 

## Summary

Replace inline Duration literals across exec_strategy.rs, pty_proxy.rs, startup_runtime.rs, session_commands.rs, and learn.rs with named constants in a new timeouts.rs module.

User-facing timeouts are now overridable via environment variables:
   - NONO_DETACH_STARTUP_TIMEOUT (also --detach-timeout flag)
   - NONO_PTY_DRAIN_TIMEOUT
   - NONO_PTY_ATTACH_TIMEOUT

No behaviour change when defaults are used.
<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
