### PR TITLE
fix(sandbox): widen /proc/self/task for grandchild CUDA init

### DIFF
--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -1325,28 +1325,58 @@ impl CapabilitySet {
         self.deduplicate();
     }
 
-    /// Widen `/proc/<pid>` READ-only Landlock rules to `/proc` so that
-    /// grandchild processes can access their own procfs entries.
+    /// Widen `/proc/<pid>` Landlock rules to `/proc` so that grandchild
+    /// processes can access their own procfs entries.
     ///
-    /// This is needed because Landlock rules are fixed at sandbox setup time with
-    /// the direct child's PID. When a grandchild (e.g. nono→sh→bun) forks, it
-    /// gets a new PID and its `/proc/self` resolves to a different inode than the
-    /// direct child's `/proc/<sh_pid>`. By widening to `/proc`, we allow any
-    /// descendant to read its own procfs entries.
+    /// This is needed because Landlock rules are fixed at sandbox setup time
+    /// with the direct child's PID. When a grandchild (e.g. nono→sh→bun) forks,
+    /// it gets a new PID and its `/proc/self` resolves to a different inode
+    /// than the direct child's `/proc/<sh_pid>`. By widening to `/proc`, we
+    /// allow any descendant to access its own procfs entries.
     ///
-    /// Only applies to READ capabilities at the `/proc/self` level (not
-    /// subdirectories like `/proc/self/fd` which may have write access).
+    /// Two narrow rewrites are performed:
+    ///
+    /// 1. **`/proc/self` (Read)** → `/proc` (Read). Reads under `/proc/<pid>`
+    ///    are essentially free to widen: the kernel already permits cross-PID
+    ///    reads on most procfs entries (subject to `hidepid` and
+    ///    `ptrace_scope`), so coarsening the Landlock rule does not hand out
+    ///    anything the kernel would not already allow.
+    ///
+    /// 2. **`/proc/self/task` (ReadWrite)** → `/proc` (ReadWrite). This rule
+    ///    is granted by `--allow-gpu` on NVIDIA systems so the CUDA driver
+    ///    can write `/proc/self/task/<tid>/comm` (the thread name) during
+    ///    `cuInit()`. Without widening, only the direct child can perform
+    ///    that write; a grandchild's `/proc/self/task/<tid>/comm` resolves
+    ///    to a different inode and gets `EACCES`, surfacing as CUDA Error 304
+    ///    (`cudaErrorOperatingSystem`). See issue #924.
+    ///
+    ///    Trade-off: widening to `/proc` necessarily covers other writable
+    ///    per-process knobs under `/proc/<pid>/` (e.g. `oom_score_adj`,
+    ///    `coredump_filter`). Two factors bound the impact:
+    ///
+    ///    - Landlock cannot express "any `/proc/<pid>/task`" without covering
+    ///      the parent — it is a filesystem-tree allowlist, not a glob.
+    ///    - The kernel still enforces per-file ownership: a process can only
+    ///      write to its own `/proc/<pid>/*` writable knobs, not another
+    ///      process's. So the widened Landlock rule defers to kernel
+    ///      ownership checks rather than handing out cross-process write.
+    ///
+    /// Other capabilities (e.g. `/proc/self/fd` writes, profile-specific
+    /// grants) are unaffected.
     pub fn widen_procfs_self_to_proc(&mut self) {
         for cap in &mut self.fs {
-            if cap.access == AccessMode::Read {
-                let is_proc_self_dir = cap
-                    .original
-                    .to_str()
-                    .map(|s| s == "/proc/self" || s == "/proc/self/")
-                    .unwrap_or(false);
-                if is_proc_self_dir {
-                    cap.resolved = std::path::PathBuf::from("/proc");
-                }
+            let original_str = cap.original.to_str().unwrap_or("");
+            let is_proc_self_dir = original_str == "/proc/self" || original_str == "/proc/self/";
+            let is_proc_self_task_dir =
+                original_str == "/proc/self/task" || original_str == "/proc/self/task/";
+
+            if is_proc_self_dir && cap.access == AccessMode::Read {
+                cap.resolved = std::path::PathBuf::from("/proc");
+            } else if is_proc_self_task_dir {
+                // NVIDIA --allow-gpu grant: keep the original access mode
+                // (ReadWrite today) so kernel ownership checks remain the
+                // effective limit; see function doc for the trade-off.
+                cap.resolved = std::path::PathBuf::from("/proc");
             }
         }
         self.deduplicate();
@@ -1875,6 +1905,141 @@ mod procfs_remap_tests {
         assert_eq!(
             caps.fs_capabilities()[1].resolved,
             PathBuf::from("/proc/4242/fd/1")
+        );
+    }
+
+    /// Widening rewrites the `/proc/self` Read rule to `/proc`.
+    #[test]
+    fn widen_procfs_self_to_proc_widens_read_rule() {
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/proc/self"),
+            resolved: PathBuf::from("/proc/4242"),
+            access: AccessMode::Read,
+            is_file: false,
+            source: CapabilitySource::Group("system_read_linux".to_string()),
+        });
+
+        caps.widen_procfs_self_to_proc();
+
+        let proc_self = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| c.original == Path::new("/proc/self"))
+            .expect("/proc/self capability must survive widening");
+        assert_eq!(
+            proc_self.resolved,
+            PathBuf::from("/proc"),
+            "Read /proc/self must widen to /proc so grandchildren can read their own procfs"
+        );
+        assert_eq!(proc_self.access, AccessMode::Read);
+    }
+
+    /// Issue #924 regression: widening must also rewrite the
+    /// `/proc/self/task` ReadWrite rule (the NVIDIA --allow-gpu grant) to
+    /// `/proc`. Without this, a grandchild process (e.g. `claude → python`)
+    /// cannot write to its own `/proc/<pid>/task/<tid>/comm`, surfacing as
+    /// CUDA Error 304 during `cuInit()`.
+    #[test]
+    fn widen_procfs_self_to_proc_widens_proc_self_task_write_rule() {
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/proc/self/task"),
+            resolved: PathBuf::from("/proc/4242/task"),
+            access: AccessMode::ReadWrite,
+            is_file: false,
+            source: CapabilitySource::Group("nvidia_gpu_procfs".to_string()),
+        });
+
+        caps.widen_procfs_self_to_proc();
+
+        let proc_self_task = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| c.original == Path::new("/proc/self/task"))
+            .expect("/proc/self/task capability must survive widening");
+        assert_eq!(
+            proc_self_task.resolved,
+            PathBuf::from("/proc"),
+            "/proc/self/task ReadWrite must widen to /proc so grandchild CUDA \
+             init can write task/<tid>/comm (issue #924)"
+        );
+        assert_eq!(
+            proc_self_task.access,
+            AccessMode::ReadWrite,
+            "widening must preserve the original ReadWrite access mode"
+        );
+    }
+
+    /// The combined widening + dedup case: both the `/proc/self` Read rule
+    /// and the `/proc/self/task` ReadWrite rule rewrite to `/proc`. After
+    /// dedup, a single `/proc` ReadWrite rule should remain (Linux dedup
+    /// keys on `resolved` and merges complementary access modes).
+    #[test]
+    fn widen_procfs_self_to_proc_merges_after_dedup_on_linux() {
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/proc/self"),
+            resolved: PathBuf::from("/proc/4242"),
+            access: AccessMode::Read,
+            is_file: false,
+            source: CapabilitySource::Group("system_read_linux".to_string()),
+        });
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/proc/self/task"),
+            resolved: PathBuf::from("/proc/4242/task"),
+            access: AccessMode::ReadWrite,
+            is_file: false,
+            source: CapabilitySource::Group("nvidia_gpu_procfs".to_string()),
+        });
+
+        caps.widen_procfs_self_to_proc();
+
+        // Both originals must still appear so output and audit code stay
+        // accurate; dedup behaviour itself is platform-specific and tested
+        // elsewhere — here we only assert that no /proc/self/task ReadWrite
+        // rule remains pinned to a stale PID.
+        for cap in caps.fs_capabilities() {
+            let original_str = cap.original.to_str().unwrap_or("");
+            if matches!(
+                original_str,
+                "/proc/self" | "/proc/self/" | "/proc/self/task" | "/proc/self/task/"
+            ) {
+                assert_eq!(
+                    cap.resolved,
+                    PathBuf::from("/proc"),
+                    "{original_str} must widen to /proc after widen_procfs_self_to_proc()"
+                );
+            }
+        }
+    }
+
+    /// Defence-in-depth: widening must NOT touch `/proc/self/fd` (or other
+    /// `/proc/self/<sub>` paths that are not `task`). Those capabilities
+    /// have legitimate per-PID inode bindings and must keep their direct
+    /// child resolution.
+    #[test]
+    fn widen_procfs_self_to_proc_leaves_proc_self_fd_alone() {
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability {
+            original: PathBuf::from("/proc/self/fd"),
+            resolved: PathBuf::from("/proc/4242/fd"),
+            access: AccessMode::ReadWrite,
+            is_file: false,
+            source: CapabilitySource::Group("system_read_linux".to_string()),
+        });
+
+        caps.widen_procfs_self_to_proc();
+
+        let proc_self_fd = caps
+            .fs_capabilities()
+            .iter()
+            .find(|c| c.original == Path::new("/proc/self/fd"))
+            .expect("/proc/self/fd capability must survive widening");
+        assert_eq!(
+            proc_self_fd.resolved,
+            PathBuf::from("/proc/4242/fd"),
+            "/proc/self/fd must NOT be widened — it is per-PID by design"
         );
     }
 }

--- a/tests/integration/test_gpu.sh
+++ b/tests/integration/test_gpu.sh
@@ -254,6 +254,22 @@ with open(f'/proc/self/task/{tid}/comm', 'wb') as f:
 print('OK: wrote thread comm under --allow-gpu')
 "
 
+    # Issue #924 regression: grandchild process (different PID from the
+    # direct child) must also be able to write to its own
+    # /proc/<pid>/task/<tid>/comm. Without the widening of
+    # /proc/self/task → /proc inside widen_procfs_self_to_proc(), this
+    # write would be denied because the Landlock rule is bound to the
+    # direct child's PID inode, surfacing as CUDA Error 304.
+    expect_success "grandchild /proc/self/task/<tid>/comm write allowed with --allow-gpu (#924)" \
+        "$NONO_BIN" run --silent --allow-cwd --allow "$TMPDIR" --allow-gpu -- \
+        sh -c "python3 -c \"
+import os
+tid = os.gettid() if hasattr(os, 'gettid') else os.getpid()
+with open(f'/proc/self/task/{tid}/comm', 'wb') as f:
+    f.write(b'probe\n')
+print(f'OK: grandchild (pid={os.getpid()}) wrote thread comm')
+\""
+
     # /proc/driver/nvidia — CUDA UVM init read. Only test if the driver is
     # loaded (the grant itself skips the path when it doesn't exist).
     if [[ -d /proc/driver/nvidia ]]; then


### PR DESCRIPTION
## Linked Issue

Closes #924

## Summary

`--allow-gpu` grants `/proc/self/task` as ReadWrite on NVIDIA systems so the CUDA driver can write `/proc/self/task/<tid>/comm` during `cuInit()`. In Monitor mode that rule is canonicalised against the direct child's PID inode before Landlock is installed, so any grandchild process (e.g. `claude → python → cuInit()`) writing to its own `/proc/<gpid>/task/<tid>/comm` hits `EACCES` and surfaces as CUDA Error 304 (`cudaErrorOperatingSystem`).

The read-side widening in `widen_procfs_self_to_proc()` already covers this case for `/proc/self`. This PR extends the same widening to `/proc/self/task`, preserving the original ReadWrite access mode.

### Trade-off

Landlock cannot express "any `/proc/<pid>/task`" without covering the `/proc` parent — it is a filesystem-tree allowlist, not a glob. So the widened rule necessarily covers other writable per-process knobs (`oom_score_adj`, `coredump_filter`, …). The kernel's own per-file ownership check remains the effective limit on which writes succeed: a process can only write to its own `/proc/<pid>/*` writable entries. The trade-off and the security reasoning are documented inline on `widen_procfs_self_to_proc()`.

Related history:
- #651 / #673 added the original `--allow-gpu` NVIDIA procfs grants but only validated the direct-child case.
- #658 tracks the broader `--allow-gpu` sweep; this fix is scoped narrowly to the write-widening gap and intentionally kept separate.

## Test Plan

**Unit tests** (new, in `crates/nono/src/capability.rs::procfs_remap_tests`):
- `widen_procfs_self_to_proc_widens_read_rule` — existing `/proc/self` Read widening, now under explicit coverage.
- `widen_procfs_self_to_proc_widens_proc_self_task_write_rule` — regression for #924: the RW grant widens to `/proc` and keeps `AccessMode::ReadWrite`.
- `widen_procfs_self_to_proc_merges_after_dedup_on_linux` — both widenings + dedup leave no stale PID-pinned rule.
- `widen_procfs_self_to_proc_leaves_proc_self_fd_alone` — defence-in-depth: `/proc/self/fd` is per-PID by design and must not be widened.

**Integration test** (added to `tests/integration/test_gpu.sh`): `grandchild /proc/self/task/<tid>/comm write allowed with --allow-gpu (#924)` runs the comm-write under `sh -c "python3 -c …"` so the writer PID differs from the direct child.

**Manual verification on Ubuntu 22.04 / NVIDIA A100-SXM4-40GB / driver 580.126.20 / CUDA 13** — matches the reporter's environment:

1. Minimal grandchild comm write — direct child `sh` pid `435468`, grandchild `python3` pid `435470`, write to `/proc/self/task/435470/comm` succeeded.
2. Real `cuInit()` via `libcuda.so.1` from a grandchild — `OK cuInit succeeded; 1 CUDA device(s) visible`. Pre-fix the same call returned 304.
3. Defence-in-depth — `/proc/driver` parent still denied even with `--allow-gpu`; grandchild comm write still denied without `--allow-gpu`.

Local CI:
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::unwrap_used` ✅
- `cargo test` ✅

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates (function doc on `widen_procfs_self_to_proc()` rewritten; no user-facing CLI/flag changes)
- [ ] Release note has been added to `CHANGELOG.md` if needed — happy to add one on request; the user-visible behaviour is "CUDA init now works for grandchild processes under `--allow-gpu`", which is arguably a bug fix that does not need a separate note.

## Agent Disclosure

This PR was prepared by an AI coding agent (Claude) operating under the maintainer's direction (@scp7). The fix follows the implementation sketch the maintainer posted in #924's comment thread: extending `widen_procfs_self_to_proc()` to widen `/proc/self/task` alongside `/proc/self`.

Files / sections consulted:
- `crates/nono/src/capability.rs` — `widen_procfs_self_to_proc()`, `remap_procfs_self_references()`, `AccessMode`, `deduplicate()`.
- `crates/nono-cli/src/sandbox_prepare.rs` — `grant_nvidia_gpu_procfs()`, `maybe_enable_gpu()` (no changes; reviewed for grant shape).
- `crates/nono-cli/src/exec_strategy.rs` — Monitor-mode call sequence (`remap_procfs_self_references` then `widen_procfs_self_to_proc`).
- `crates/nono/src/sandbox/linux.rs` — `access_to_landlock()` to understand the AccessFs flags `Write` expands into.
- `proj/invariants.yaml` — `least-privilege-scope`, `separate-read-write`, `landlock-strict-allowlist`, `test-new-capability-types`, `test-on-both-platforms`.
- `CLAUDE.md` and `.github/pull_request_template.md`.

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists (#924)
- [x] I disclosed that I am an agent in this PR (the issue discussion already contains the maintainer's implementation sketch)
- [x] I described my intent and approach in the issue discussion (see #924 maintainer comment)
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (#651, #673, #658 cross-references)
- [x] I did not use forbidden patterns such as unwrap/expect (test-only `.expect()` only, gated by clippy cfg)
- [x] I used `NonoError` where required (no new fallible paths added)
- [x] I validated and canonicalized all relevant paths (widening preserves canonical `/proc` resolution; access mode preserved)
- [x] This PR matches the approved or disclosed issue scope