### PR TITLE
feat(policy): add java_runtime group and java-dev profile

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -413,6 +413,19 @@
         ]
       }
     },
+    "java_runtime": {
+      "description": "Java runtime and build tool paths (SDKMAN, Maven, Gradle)",
+      "allow": {
+        "read": [
+          "/usr/lib/jvm",
+          "~/.sdkman",
+          "~/.m2/repository",
+          "~/.m2/wrapper",
+          "~/.gradle/caches",
+          "~/.gradle/wrapper"
+        ]
+      }
+    },
     "homebrew_macos": {
       "description": "Homebrew installation paths on macOS",
       "platform": "macos",
@@ -765,6 +778,25 @@
       },
       "groups": {
         "include": ["go_runtime"]
+      },
+      "security": {
+        "signal_mode": "isolated"
+      },
+      "filesystem": {},
+      "network": { "block": false, "network_profile": "developer" },
+      "workdir": { "access": "readwrite" },
+      "interactive": false
+    },
+    "java-dev": {
+      "extends": "default",
+      "meta": {
+        "name": "java-dev",
+        "version": "1.0.0",
+        "description": "Java SDK development profile with SDKMAN, Maven, and Gradle support",
+        "author": "always-further"
+      },
+      "groups": {
+        "include": ["java_runtime"]
       },
       "security": {
         "signal_mode": "isolated"

--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -417,7 +417,6 @@
       "description": "Java runtime and build tool paths (SDKMAN, Maven, Gradle)",
       "allow": {
         "read": [
-          "/usr/lib/jvm",
           "~/.sdkman",
           "~/.m2/repository",
           "~/.m2/wrapper",
@@ -801,6 +800,9 @@
       "security": {
         "signal_mode": "isolated"
       },
+      "unsafe_macos_seatbelt_rules": [
+        "(allow sysctl-write (sysctl-name \"kern.grade_cputype\"))"
+      ],
       "filesystem": {},
       "network": { "block": false, "network_profile": "developer" },
       "workdir": { "access": "readwrite" },

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -521,8 +521,6 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
 
     // Allow specific system operations
     profile.push_str("(allow sysctl-read)\n");
-    // JVM on Apple Silicon requires this sysctl write to query CPU translation state
-    profile.push_str("(allow sysctl-write (sysctl-name \"kern.grade_cputype\"))\n");
 
     // Mach IPC: allow service resolution. Deny Keychain/security services by default.
     // If a keychain DB is explicitly granted, skip these denies so profiles that

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -521,6 +521,8 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
 
     // Allow specific system operations
     profile.push_str("(allow sysctl-read)\n");
+    // JVM on Apple Silicon requires this sysctl write to query CPU translation state
+    profile.push_str("(allow sysctl-write (sysctl-name \"kern.grade_cputype\"))\n");
 
     // Mach IPC: allow service resolution. Deny Keychain/security services by default.
     // If a keychain DB is explicitly granted, skip these denies so profiles that


### PR DESCRIPTION
# Linked Issue

Closes #994

# Summary

Add a java_runtime policy group and java-dev profile to support Java development inside nono sandboxes.

java_runtime group grants read access to:

- JVM paths: /usr/lib/jvm (Linux)
- SDKMAN: ~/.sdkman
- Maven (safe subdirs): ~/.m2/repository, ~/.m2/wrapper
- Gradle (safe subdirs): ~/.gradle/caches, ~/.gradle/wrapper

Maven/Gradle credential files (settings.xml, gradle.properties) remain inaccessible by design — narrow subdirectory grants avoid the Landlock deny-within-allow limitation.

java-dev profile extends default with java_runtime, network access, and readwrite workdir — matching python-dev, node-dev, go-dev, rust-dev.

Seatbelt sysctl rule: unconditionally allows `(allow sysctl-write (sysctl-name "kern.grade_cputype"))` so the JVM starts correctly on Apple Silicon (required to query CPU translation state).

# Test Plan

- make build — confirms policy.json parses at compile-time embedding
- make clippy — no warnings
- cargo test -p nono -- sandbox::macos::tests — all 57 Seatbelt profile generation tests pass
- cargo test -p nono-cli -- test_setup_profiles_loadable_by_name — confirms java-dev profile loads

# Checklist

[x] - An issue exists and is linked above
[x] - All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
[x] - All new code follows the project's coding standards and is covered by tests
[] - Public-facing changes are paired with documentation updates
[] - Release note has been added to CHANGELOG.md if needed