### PR TITLE
fix(proxy): return 502 with audit entry on upstream connect failure

### DIFF
--- a/crates/nono-proxy/src/connect.rs
+++ b/crates/nono-proxy/src/connect.rs
@@ -16,7 +16,7 @@ use crate::filter::ProxyFilter;
 use crate::token;
 use std::net::SocketAddr;
 use std::time::Duration;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tracing::debug;
 use zeroize::Zeroizing;
@@ -72,27 +72,27 @@ pub async fn handle_connect(
     let resolved = &check.resolved_addrs;
     if resolved.is_empty() {
         let reason = "DNS resolution returned no addresses".to_string();
-        audit::log_denied(
-            audit_log,
-            audit::ProxyMode::Connect,
-            &audit::EventContext {
-                denial_category: Some(
-                    nono::undo::NetworkAuditDenialCategory::UpstreamConnectFailed,
-                ),
-                ..audit::EventContext::default()
-            },
-            &host,
-            port,
-            &reason,
-        );
-        send_response(stream, 502, "DNS resolution failed").await?;
+        write_upstream_failure(stream, audit_log, &host, port, &reason).await?;
         return Err(ProxyError::UpstreamConnect {
             host: host.clone(),
             reason,
         });
     }
 
-    let mut upstream = connect_to_resolved(resolved, &host).await?;
+    let mut upstream = match connect_to_resolved(resolved, &host).await {
+        Ok(stream) => stream,
+        Err(err) => {
+            // Mirror the empty-DNS branch above: surface the upstream
+            // failure with a 502 and an audit entry instead of dropping
+            // the client socket silently. See issue #998.
+            let reason = match &err {
+                ProxyError::UpstreamConnect { reason, .. } => reason.clone(),
+                other => other.to_string(),
+            };
+            write_upstream_failure(stream, audit_log, &host, port, &reason).await?;
+            return Err(err);
+        }
+    };
 
     // Send 200 Connection Established
     send_response(stream, 200, "Connection Established").await?;
@@ -170,11 +170,43 @@ fn validate_proxy_auth(header_bytes: &[u8], session_token: &Zeroizing<String>) -
 }
 
 /// Send an HTTP response line to the client.
-async fn send_response(stream: &mut TcpStream, status: u16, reason: &str) -> Result<()> {
+async fn send_response<S: AsyncWrite + Unpin>(
+    stream: &mut S,
+    status: u16,
+    reason: &str,
+) -> Result<()> {
     let response = format!("HTTP/1.1 {} {}\r\n\r\n", status, reason);
     stream.write_all(response.as_bytes()).await?;
     stream.flush().await?;
     Ok(())
+}
+
+/// Surface an upstream-connect failure to both the client and the audit log.
+///
+/// Used by the two failure branches in [`handle_connect`] that cannot
+/// establish the upstream TCP leg: empty DNS resolution, and a refused or
+/// timed-out connect to a resolved address. Both shapes share the same
+/// observable contract — `502 Bad Gateway` to the client, `log_denied` with
+/// [`NetworkAuditDenialCategory::UpstreamConnectFailed`] in the audit log.
+async fn write_upstream_failure<S: AsyncWrite + Unpin>(
+    stream: &mut S,
+    audit_log: Option<&audit::SharedAuditLog>,
+    host: &str,
+    port: u16,
+    reason: &str,
+) -> Result<()> {
+    audit::log_denied(
+        audit_log,
+        audit::ProxyMode::Connect,
+        &audit::EventContext {
+            denial_category: Some(nono::undo::NetworkAuditDenialCategory::UpstreamConnectFailed),
+            ..audit::EventContext::default()
+        },
+        host,
+        port,
+        reason,
+    );
+    send_response(stream, 502, &format!("Upstream connect failed: {}", reason)).await
 }
 
 #[cfg(test)]
@@ -228,5 +260,105 @@ mod tests {
         let token = Zeroizing::new("abc123".to_string());
         let header = b"Host: example.com\r\n\r\n";
         assert!(validate_proxy_auth(header, &token).is_err());
+    }
+
+    use nono::undo::{NetworkAuditDecision, NetworkAuditDenialCategory, NetworkAuditMode};
+    use tokio::io::{AsyncReadExt, duplex};
+
+    /// Drain the reader end of a duplex pair until EOF and return the bytes
+    /// as a String.
+    async fn read_to_string<R: tokio::io::AsyncRead + Unpin>(mut reader: R) -> String {
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf).await.unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[tokio::test]
+    async fn write_upstream_failure_sends_502_status_line() {
+        let (server, client) = duplex(1024);
+        let mut server = server;
+
+        write_upstream_failure(&mut server, None, "example.com", 443, "connection refused")
+            .await
+            .unwrap();
+        drop(server);
+
+        let response = read_to_string(client).await;
+        assert!(
+            response.starts_with("HTTP/1.1 502 "),
+            "expected 502 status line, got: {:?}",
+            response
+        );
+        assert!(
+            response.contains("Upstream connect failed: connection refused"),
+            "expected reason on status line, got: {:?}",
+            response
+        );
+    }
+
+    #[tokio::test]
+    async fn write_upstream_failure_records_audit_entry() {
+        let (mut server, _client) = duplex(1024);
+        let log = audit::new_audit_log();
+
+        write_upstream_failure(
+            &mut server,
+            Some(&log),
+            "example.com",
+            443,
+            "connection refused",
+        )
+        .await
+        .unwrap();
+
+        let events = audit::drain_audit_events(&log);
+        assert_eq!(events.len(), 1);
+        let event = &events[0];
+        assert_eq!(event.mode, NetworkAuditMode::Connect);
+        assert_eq!(event.decision, NetworkAuditDecision::Deny);
+        assert_eq!(
+            event.denial_category,
+            Some(NetworkAuditDenialCategory::UpstreamConnectFailed)
+        );
+        assert_eq!(event.target, "example.com");
+        assert_eq!(event.port, Some(443));
+        assert_eq!(event.reason.as_deref(), Some("connection refused"));
+    }
+
+    #[tokio::test]
+    async fn write_upstream_failure_without_audit_log_still_writes_response() {
+        let (mut server, client) = duplex(1024);
+
+        write_upstream_failure(&mut server, None, "example.com", 443, "connection refused")
+            .await
+            .unwrap();
+        drop(server);
+
+        let response = read_to_string(client).await;
+        assert!(response.starts_with("HTTP/1.1 502 "));
+    }
+
+    #[tokio::test]
+    async fn write_upstream_failure_round_trips_timeout_reason() {
+        let (mut server, client) = duplex(1024);
+        let log = audit::new_audit_log();
+
+        write_upstream_failure(
+            &mut server,
+            Some(&log),
+            "slow.example.com",
+            443,
+            "connection timed out",
+        )
+        .await
+        .unwrap();
+        drop(server);
+
+        let response = read_to_string(client).await;
+        assert!(response.contains("connection timed out"));
+
+        let events = audit::drain_audit_events(&log);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].reason.as_deref(), Some("connection timed out"));
     }
 }

--- a/crates/nono-proxy/src/connect.rs
+++ b/crates/nono-proxy/src/connect.rs
@@ -72,7 +72,11 @@ pub async fn handle_connect(
     let resolved = &check.resolved_addrs;
     if resolved.is_empty() {
         let reason = "DNS resolution returned no addresses".to_string();
-        write_upstream_failure(stream, audit_log, &host, port, &reason).await?;
+        // Discard the write result so a client-side hangup during the 502
+        // doesn't shadow the more descriptive UpstreamConnect error below.
+        // The audit entry is recorded inside write_upstream_failure before
+        // the response is sent, so audit coverage is preserved regardless.
+        let _ = write_upstream_failure(stream, audit_log, &host, port, &reason).await;
         return Err(ProxyError::UpstreamConnect {
             host: host.clone(),
             reason,
@@ -89,7 +93,9 @@ pub async fn handle_connect(
                 ProxyError::UpstreamConnect { reason, .. } => reason.clone(),
                 other => other.to_string(),
             };
-            write_upstream_failure(stream, audit_log, &host, port, &reason).await?;
+            // Discard the write result for the same reason as the empty-DNS
+            // branch above: preserve the original UpstreamConnect error.
+            let _ = write_upstream_failure(stream, audit_log, &host, port, &reason).await;
             return Err(err);
         }
     };
@@ -170,12 +176,19 @@ fn validate_proxy_auth(header_bytes: &[u8], session_token: &Zeroizing<String>) -
 }
 
 /// Send an HTTP response line to the client.
+///
+/// The `reason` phrase is sanitised by replacing `\r` and `\n` with spaces
+/// before being inlined into the status line. This is defence in depth
+/// against HTTP response splitting: today's call sites all produce safe
+/// strings, but `send_response` is on a protocol-formatting boundary and
+/// guarding it makes future call sites safe by construction.
 async fn send_response<S: AsyncWrite + Unpin>(
     stream: &mut S,
     status: u16,
     reason: &str,
 ) -> Result<()> {
-    let response = format!("HTTP/1.1 {} {}\r\n\r\n", status, reason);
+    let sanitised_reason = reason.replace(['\r', '\n'], " ");
+    let response = format!("HTTP/1.1 {} {}\r\n\r\n", status, sanitised_reason);
     stream.write_all(response.as_bytes()).await?;
     stream.flush().await?;
     Ok(())
@@ -336,6 +349,49 @@ mod tests {
 
         let response = read_to_string(client).await;
         assert!(response.starts_with("HTTP/1.1 502 "));
+    }
+
+    #[tokio::test]
+    async fn write_upstream_failure_sanitises_crlf_in_reason() {
+        let (mut server, client) = duplex(1024);
+
+        write_upstream_failure(
+            &mut server,
+            None,
+            "example.com",
+            443,
+            "connection refused\r\nX-Injected: yes",
+        )
+        .await
+        .unwrap();
+        drop(server);
+
+        let response = read_to_string(client).await;
+
+        // The status line must contain neither raw CR nor LF until the
+        // single CRLFCRLF terminator at the end. Response splitting via a
+        // crafted reason string must not be possible.
+        let terminator = "\r\n\r\n";
+        let body_end = response.find(terminator).expect("response must terminate");
+        let status_line = &response[..body_end];
+        assert!(
+            !status_line.contains('\r'),
+            "status line must not contain CR, got: {:?}",
+            status_line
+        );
+        assert!(
+            !status_line.contains('\n'),
+            "status line must not contain LF, got: {:?}",
+            status_line
+        );
+
+        // The injected header name should not appear as a real header
+        // (i.e., must not be split out of the reason phrase).
+        assert!(
+            !response.contains("\r\nX-Injected:"),
+            "injected header must not be split into a real header: {:?}",
+            response
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Linked Issue

Fixes #998

## Summary

When `nono-proxy` accepts a `CONNECT host:port` (allowlist + DNS pass) but then fails to establish the upstream TCP connection, `handle_connect` previously propagated the error via `?` without writing any HTTP response or audit entry. The client saw `Proxy CONNECT aborted` and `nono audit show <session> --json` had no `network_events` entry for the host — indistinguishable from a nono bug.

This PR mirrors the empty-DNS branch sitting directly above the bug site: on `Err` from `connect_to_resolved`, write a `502 Bad Gateway` with the underlying reason and call `audit::log_denied` with `NetworkAuditDenialCategory::UpstreamConnectFailed`. A small private `write_upstream_failure` helper is shared between the two failure branches, removing the prior duplication. `send_response` and the new helper are generic over `AsyncWrite + Unpin` so tests can exercise them with `tokio::io::duplex` pipes instead of real TCP sockets.

**Note for reviewer:** the empty-DNS branch's 502 status-line reason text changes from `DNS resolution failed` to `Upstream connect failed: DNS resolution returned no addresses`. The audit-log `reason` field is unchanged on that branch. If you'd prefer to preserve the old status-line text byte-for-byte, I can inline the new branch and drop the shared helper — happy to switch in review.

## Agent Disclosure

This PR was prepared by an AI agent (Anthropic Claude, via Claude Code) under direct human supervision (the commit author). The agent:

- Read [`AGENTS.md`](https://github.com/always-further/nono/blob/ad0777cccd6abcbc5aa149deec2acd4e274ebab2/AGENTS.md) and [`CLAUDE.md`](https://github.com/always-further/nono/blob/ad0777cccd6abcbc5aa149deec2acd4e274ebab2/CLAUDE.md) — coding standards, security considerations, and the coding-agent contribution policy.
- Consulted [`crates/nono-proxy/src/connect.rs`](https://github.com/always-further/nono/blob/ad0777cccd6abcbc5aa149deec2acd4e274ebab2/crates/nono-proxy/src/connect.rs) — the production code path, in particular the existing host-denied (403) and empty-DNS (502) denial branches inside `handle_connect`. The new failure handling mirrors the empty-DNS branch directly.
- Consulted [`crates/nono-proxy/src/audit.rs`](https://github.com/always-further/nono/blob/ad0777cccd6abcbc5aa149deec2acd4e274ebab2/crates/nono-proxy/src/audit.rs) — the `log_denied` / `EventContext` / `NetworkAuditDenialCategory` API shape and the existing test patterns in its `mod tests`.
- Reviewed recent comparable fix PRs (#948, #971) for housekeeping conventions (commit shape, agent disclosure, PR template usage, branch naming).
- Verified compliance with project coding standards: no new `.unwrap()` / `.expect()` in production code; no new path handling; no changes to error-type ownership; the new helper returns `Result` with `?` propagation only.
- No external code was adapted; the new branch and helper mirror an in-tree pattern by the original author of the empty-DNS branch in the same function. No third-party attribution is required.

## Test Plan

- `make ci` runs green locally on Linux (toolchain pinned via the workspace `rust-version = "1.95"`): clippy with `-D warnings -D clippy::unwrap_used`, fmt check, `test-lib` + `test-cli` + `test-ffi`, `cargo audit`, `lint-aliases`, `lint-docs`.
- New unit tests in `crates/nono-proxy/src/connect.rs::tests` exercise `write_upstream_failure` against in-memory `tokio::io::duplex` pipes:
  - `write_upstream_failure_sends_502_status_line` — client receives `HTTP/1.1 502 ` with `Upstream connect failed: <reason>` on the wire.
  - `write_upstream_failure_records_audit_entry` — audit log records `decision = Deny`, `denial_category = UpstreamConnectFailed`, correct target/port/reason, `mode = Connect`.
  - `write_upstream_failure_without_audit_log_still_writes_response` — helper is a no-op for audit when `audit_log` is `None` but still writes the 502.
  - `write_upstream_failure_round_trips_timeout_reason` — `connection timed out` reason appears verbatim on the wire and in the audit `reason` field.
- Manual reproduction per the steps in #998: with a host firewall rule blocking `nono-proxy` from reaching an allowlisted host, `curl -v` through the proxy now receives `HTTP/1.1 502 Upstream connect failed: connection refused` (or `: connection timed out`), and `nono audit show <session> --json` contains a `network_events` entry for the host with `denial_category = UpstreamConnectFailed`.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates *(N/A — no doc-comment, README, or CLI flag changes; the one 502 status-line text change is called out in Summary)*
- [x] Release note has been added to `CHANGELOG.md` if needed *(N/A — `CHANGELOG.md` is generated from conventional commit subjects at release-cut time; this PR's `fix(proxy):` commit will be captured automatically)*

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code *(no external code adapted; in-tree pattern mirrored, noted in Agent Disclosure)*
- [x] I did not use forbidden patterns such as unwrap/expect *(production code; existing `mod tests` `#[allow(clippy::unwrap_used)]` retained, which the workspa
ce clippy configuration permits)*
- [x] I used NonoError where required *(N/A — `nono-proxy` uses `ProxyError` / `Result`, unchanged)*
- [x] I validated and canonicalized all relevant paths *(N/A — no path handling in this change)*
- [x] This PR matches the approved or disclosed issue scope