### PR TITLE
fix(sandbox): allow /proc/<tgid>/task/<tid>/comm writes via supervisor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
 
 - *(tool-sandbox)* Skip missing `fs_read`/`fs_write` directories instead of erroring on startup; matches existing `fs_read_file` behaviour (#1252)
 
+- *(sandbox)* `--allow-gpu` now correctly supports CUDA initialisation from
+  descendant (grandchild) processes — e.g. `claude → python → cuInit()` —
+  without expanding the Landlock write surface. The NVIDIA driver's
+  `/proc/self/task/<tid>/comm` thread-name write is now gated by the
+  seccomp-notify supervisor with a strict TGID match, rather than a
+  PID-pinned Landlock rule that broke on grandchildren. `nono run --allow-gpu`
+  and `nono shell --allow-gpu` are supported; `nono wrap --allow-gpu` is
+  rejected on NVIDIA with a structured error pointing at `nono run` (Direct
+  mode has no supervisor). Closes #924.
+
 ## [0.65.1] - 2026-06-23
 ## [0.65.0] - 2026-06-23
 

--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -170,7 +170,7 @@ pub(crate) fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
         return Ok(());
     }
 
-    let prepared = prepare_sandbox(&args.sandbox, silent)?;
+    let mut prepared = prepare_sandbox(&args.sandbox, silent)?;
 
     if prepared.allow_launch_services_active {
         print_allow_launch_services_warning(silent);
@@ -178,6 +178,13 @@ pub(crate) fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
     if prepared.allow_gpu_active {
         print_allow_gpu_warning(silent);
     }
+
+    // Mirror `nono run`: NVIDIA `--allow-gpu` auto-enables capability
+    // elevation in shell sessions too, so the seccomp-notify supervisor
+    // can gate the comm-write pattern. See #924; the previous
+    // launch-only auto-enable left `nono shell --allow-gpu` broken.
+    let auto_capability_elevation =
+        crate::sandbox_prepare::maybe_auto_enable_nvidia_cap_elev(&mut prepared);
 
     if !silent {
         eprintln!("{}", {
@@ -211,6 +218,8 @@ pub(crate) fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
             workdir: resolve_requested_workdir(args.sandbox.workdir.as_ref()),
             no_diagnostics: true,
             capability_elevation: prepared.capability_elevation,
+            auto_capability_elevation,
+            allow_proc_task_comm_write: prepared.nvidia_procfs_active,
             #[cfg(target_os = "linux")]
             wsl2_proxy_policy: prepared.wsl2_proxy_policy,
             #[cfg(target_os = "linux")]
@@ -283,6 +292,22 @@ pub(crate) fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
         return Err(NonoError::ConfigParse(
             "nono wrap does not support linux.af_unix_mediation = \"pathname\" because direct \
              exec cannot run the seccomp supervisor. Use `nono run` instead."
+                .to_string(),
+        ));
+    }
+
+    // NVIDIA `--allow-gpu` requires the seccomp-notify supervisor to gate
+    // the `/proc/self/task/<tid>/comm` write pattern (issue #924). Direct
+    // mode has no supervisor, so we cannot satisfy CUDA's thread-name
+    // write without reintroducing the rejected Landlock-grant approach.
+    // Fail explicitly with guidance to `nono run`.
+    #[cfg(target_os = "linux")]
+    if prepared.nvidia_procfs_active {
+        return Err(NonoError::ConfigParse(
+            "nono wrap --allow-gpu cannot support NVIDIA CUDA: Direct execution \
+             mode has no seccomp-notify supervisor to gate the per-thread \
+             /proc/self/task/<tid>/comm write that the NVIDIA driver requires. \
+             Use `nono run --allow-gpu` instead."
                 .to_string(),
         ));
     }

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -236,6 +236,18 @@ pub struct ExecConfig<'a> {
     /// capabilities at runtime. On macOS this is currently unused.
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub capability_elevation: bool,
+    /// True iff `capability_elevation` was auto-enabled by nono (e.g. by
+    /// `--allow-gpu` to gate the NVIDIA `/proc/self/task/<tid>/comm` write
+    /// pattern, see issue #924). When true, callers should select a
+    /// non-interactive approval backend so the supervisor's pattern
+    /// fast-paths run but unexpected paths fail closed instead of
+    /// prompting the user.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub auto_capability_elevation: bool,
+    /// Enables the `/proc/<tgid>/task/<tid>/comm` write fast-path (issue #924).
+    /// Set only when NVIDIA procfs grants are active (`--allow-gpu` on NVIDIA).
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub allow_proc_task_comm_write: bool,
     /// Whether the seccomp proxy-only network fallback is needed.
     /// Set by the parent before fork when Landlock ABI lacks AccessNet
     /// and ProxyOnly network mode is requested. Both child and parent
@@ -306,6 +318,13 @@ pub struct SupervisorConfig<'a> {
     /// Whether direct LaunchServices opening is enabled for this session.
     #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     pub allow_launch_services_active: bool,
+    /// True iff the supervisor may allow the
+    /// `/proc/<own-tgid>/task/<tid>/comm` write pattern (#924). Set only
+    /// when NVIDIA procfs grants applied — the pattern fast-path stays
+    /// off for any session that did not opt into `--allow-gpu` with
+    /// NVIDIA, even if `capability_elevation` is otherwise true.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub allow_proc_task_comm_write: bool,
     /// Proxy port allowed for seccomp proxy-only fallback (0 = not active).
     #[cfg(target_os = "linux")]
     pub proxy_port: u16,
@@ -4580,6 +4599,7 @@ mod tests {
             network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
+            allow_proc_task_comm_write: false,
             #[cfg(target_os = "linux")]
             proxy_port: 0,
             #[cfg(target_os = "linux")]
@@ -4700,6 +4720,7 @@ mod tests {
             network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
+            allow_proc_task_comm_write: false,
             #[cfg(target_os = "linux")]
             proxy_port: 8080,
             #[cfg(target_os = "linux")]
@@ -4786,6 +4807,7 @@ mod tests {
             network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
+            allow_proc_task_comm_write: false,
             #[cfg(target_os = "linux")]
             proxy_port: 0,
             #[cfg(target_os = "linux")]
@@ -4829,6 +4851,7 @@ mod tests {
             network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
+            allow_proc_task_comm_write: false,
             #[cfg(target_os = "linux")]
             proxy_port: 0,
             #[cfg(target_os = "linux")]
@@ -4870,6 +4893,7 @@ mod tests {
             network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
+            allow_proc_task_comm_write: false,
             #[cfg(target_os = "linux")]
             proxy_port: 0,
             #[cfg(target_os = "linux")]
@@ -4893,6 +4917,7 @@ mod tests {
             network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
+            allow_proc_task_comm_write: false,
             #[cfg(target_os = "linux")]
             proxy_port: 0,
             #[cfg(target_os = "linux")]
@@ -4939,6 +4964,7 @@ mod tests {
             network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
+            allow_proc_task_comm_write: false,
             #[cfg(target_os = "linux")]
             proxy_port: 0,
             #[cfg(target_os = "linux")]
@@ -5090,6 +5116,7 @@ mod tests {
             network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: true,
+            allow_proc_task_comm_write: false,
             #[cfg(target_os = "linux")]
             proxy_port: 0,
             #[cfg(target_os = "linux")]
@@ -5141,6 +5168,7 @@ mod tests {
             network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
+            allow_proc_task_comm_write: false,
             #[cfg(target_os = "linux")]
             proxy_port: 0,
             #[cfg(target_os = "linux")]
@@ -5181,6 +5209,7 @@ mod tests {
             network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
+            allow_proc_task_comm_write: false,
             #[cfg(target_os = "linux")]
             proxy_port: 0,
             #[cfg(target_os = "linux")]
@@ -5240,6 +5269,7 @@ mod tests {
             network_audit_events: None,
             redaction_policy: &nono::ScrubPolicy::secure_default(),
             allow_launch_services_active: false,
+            allow_proc_task_comm_write: false,
             #[cfg(target_os = "linux")]
             proxy_port: 0,
             #[cfg(target_os = "linux")]

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -99,6 +99,52 @@ fn read_tgid(tid: u32) -> u32 {
         .unwrap_or(tid)
 }
 
+/// True iff `path` is exactly `/proc/<expected_tgid>/task/<digits>/comm`.
+///
+/// Match is component-wise; `<pid>` must equal `expected_tgid` on the
+/// canonicalised path to prevent symlink-bypass (see #924).
+#[cfg(target_os = "linux")]
+fn is_proc_task_comm_path(path: &std::path::Path, expected_tgid: u32) -> bool {
+    use std::ffi::OsStr;
+    use std::path::Component;
+
+    let is_numeric_normal = |c: &Component<'_>| -> bool {
+        matches!(c, Component::Normal(s)
+            if s.to_str()
+                .is_some_and(|s| !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit())))
+    };
+
+    let expected_pid_str = expected_tgid.to_string();
+    let mut iter = path.components();
+    if iter.next() != Some(Component::RootDir) {
+        return false;
+    }
+    if iter.next() != Some(Component::Normal(OsStr::new("proc"))) {
+        return false;
+    }
+    // /proc/<expected_tgid> — literal equality, not just "any digits".
+    // This is the security gate (see fn doc); a symlink-bypass attempt
+    // that resolves to /proc/<other-tgid>/... is rejected here even
+    // though the structure matches.
+    match iter.next() {
+        Some(Component::Normal(s)) if s == OsStr::new(&expected_pid_str) => {}
+        _ => return false,
+    }
+    if iter.next() != Some(Component::Normal(OsStr::new("task"))) {
+        return false;
+    }
+    // /proc/<expected_tgid>/task/<digits>. Any TID — the kernel rejects
+    // opens for TIDs that don't belong to this TGID with ENOENT.
+    match iter.next() {
+        Some(c) if is_numeric_normal(&c) => {}
+        _ => return false,
+    }
+    if iter.next() != Some(Component::Normal(OsStr::new("comm"))) {
+        return false;
+    }
+    iter.next().is_none()
+}
+
 /// Handle a seccomp notification on Linux.
 ///
 /// Flow:
@@ -283,6 +329,58 @@ pub(super) fn handle_seccomp_notification(
             },
         );
         let _ = deny_notif(notify_fd, notif.id);
+        return Ok(());
+    }
+
+    // 4.5. Pattern fast-path: NVIDIA cuInit() writes /proc/<tgid>/task/<tid>/comm
+    // to set thread names (#924). Open in supervisor context and inject the fd.
+    // Gated on allow_proc_task_comm_write (NVIDIA --allow-gpu only); write-only.
+    // Security: use canonicalized (not path) in both matcher and open to prevent
+    // symlink-TOCTOU. Kernel enforces TID ownership (ENOENT for foreign TIDs).
+    if config.allow_proc_task_comm_write
+        && access.contains(AccessMode::Write)
+        && is_proc_task_comm_path(&canonicalized, notifying_tgid)
+    {
+        match open_path_for_access(
+            &canonicalized,
+            &access,
+            config.protected_roots,
+            None,
+            Some(procfs_context),
+        ) {
+            Ok(file) => {
+                if notif_id_valid(notify_fd, notif.id)?
+                    && let Err(e) = inject_fd(notify_fd, notif.id, file.as_raw_fd())
+                {
+                    debug!(
+                        "inject_fd failed for task/<tid>/comm write {}: {}",
+                        path.display(),
+                        e
+                    );
+                    let _ = deny_notif(notify_fd, notif.id);
+                }
+            }
+            Err(e) => {
+                debug!(
+                    "Failed to open task/<tid>/comm path {}: {}",
+                    path.display(),
+                    e
+                );
+                if e.is_policy_blocked() {
+                    record_denial(
+                        denials,
+                        DenialRecord {
+                            path: canonicalized.clone(),
+                            access,
+                            reason: DenialReason::PolicyBlocked,
+                        },
+                    );
+                    let _ = deny_notif(notify_fd, notif.id);
+                } else {
+                    let _ = respond_notif_errno(notify_fd, notif.id, e.errno());
+                }
+            }
+        }
         return Ok(());
     }
 
@@ -1304,7 +1402,152 @@ fn match_initial_capability<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
+
+    // ─────────────────────────────────────────────────────────────
+    // Pattern matcher for the /proc/<pid>/task/<tid>/comm fast-path
+    // (issue #924). The check is component-wise: the security work
+    // (caller TGID == path PID, TID ownership) is done by
+    // validate_procfs_access + the kernel respectively. The unit
+    // tests below pin the matcher's behaviour so a future refactor
+    // doesn't silently widen the surface.
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn is_proc_task_comm_path_matches_canonical_form() {
+        assert!(is_proc_task_comm_path(
+            Path::new("/proc/123/task/456/comm"),
+            123
+        ));
+        // Single-digit PIDs and TIDs (init's main thread).
+        assert!(is_proc_task_comm_path(Path::new("/proc/1/task/1/comm"), 1));
+    }
+
+    /// Issue #924, the Gemini security review: the matcher must verify
+    /// that the path's `<pid>` component equals the caller's TGID. The
+    /// security argument relies on this check happening on the
+    /// canonicalised path — if a sandboxed process creates
+    /// `/tmp/evil → /proc/1/task/1/comm` then `validate_procfs_access`
+    /// (which inspects the pre-canonical path) doesn't see `/proc/`
+    /// and returns Ok; only this matcher prevents the supervisor
+    /// from opening init's `comm`. A naive "any digits" PID check
+    /// would let the canonicalised `/proc/1/task/1/comm` through.
+    #[test]
+    fn is_proc_task_comm_path_rejects_pid_mismatch_symlink_bypass() {
+        // Caller TGID is 4242. A canonicalised path pointing at init
+        // (pid 1) must be rejected even though the structure matches.
+        assert!(!is_proc_task_comm_path(
+            Path::new("/proc/1/task/1/comm"),
+            4242,
+        ));
+        // Off-by-one: caller is 4242, path is 4243.
+        assert!(!is_proc_task_comm_path(
+            Path::new("/proc/4243/task/4243/comm"),
+            4242,
+        ));
+        // Numeric prefix is not enough: 42 must not match 4242.
+        assert!(!is_proc_task_comm_path(
+            Path::new("/proc/42/task/1/comm"),
+            4242,
+        ));
+    }
+
+    #[test]
+    fn is_proc_task_comm_path_rejects_non_numeric_components() {
+        // The path must start `/proc/<expected_tgid>/task/<digits>/comm`.
+        // `self` is not the expected_tgid string — must be resolved before
+        // matching. Expected TGID is 123 throughout this test.
+        assert!(!is_proc_task_comm_path(
+            Path::new("/proc/self/task/123/comm"),
+            123,
+        ));
+        // Non-numeric pid component.
+        assert!(!is_proc_task_comm_path(
+            Path::new("/proc/abc/task/123/comm"),
+            123,
+        ));
+        // Non-numeric tid component.
+        assert!(!is_proc_task_comm_path(
+            Path::new("/proc/123/task/abc/comm"),
+            123,
+        ));
+        // Mixed alphanumeric is rejected (could otherwise admit `123a`).
+        assert!(!is_proc_task_comm_path(
+            Path::new("/proc/123a/task/456/comm"),
+            123,
+        ));
+    }
+
+    #[test]
+    fn is_proc_task_comm_path_rejects_wrong_structure() {
+        // Wrong terminal filename — `cmdline`, `status`, etc. must not match.
+        assert!(!is_proc_task_comm_path(
+            Path::new("/proc/123/task/456/cmdline"),
+            123,
+        ));
+        assert!(!is_proc_task_comm_path(
+            Path::new("/proc/123/task/456/status"),
+            123,
+        ));
+        // Wrong subdirectory — `/proc/<pid>/comm` is the process-level comm,
+        // not a task comm; supervisor must not bypass via this branch.
+        assert!(!is_proc_task_comm_path(Path::new("/proc/123/comm"), 123));
+        // Missing `task` segment.
+        assert!(!is_proc_task_comm_path(
+            Path::new("/proc/123/456/comm"),
+            123,
+        ));
+        // Path doesn't start with /proc.
+        assert!(!is_proc_task_comm_path(
+            Path::new("/usr/proc/123/task/456/comm"),
+            123,
+        ));
+        // Relative path.
+        assert!(!is_proc_task_comm_path(
+            Path::new("proc/123/task/456/comm"),
+            123,
+        ));
+        // Empty path.
+        assert!(!is_proc_task_comm_path(Path::new(""), 123));
+        // Bare /proc.
+        assert!(!is_proc_task_comm_path(Path::new("/proc"), 123));
+    }
+
+    #[test]
+    fn is_proc_task_comm_path_rejects_extra_trailing_segments() {
+        // Crafted paths that try to slip extra components past the matcher
+        // must fail. The strict `iter.next().is_none()` check is the gate.
+        assert!(!is_proc_task_comm_path(
+            Path::new("/proc/123/task/456/comm/anything"),
+            123,
+        ));
+        assert!(!is_proc_task_comm_path(
+            Path::new("/proc/123/task/456/comm/../etc/passwd"),
+            123,
+        ));
+    }
+
+    #[test]
+    fn is_proc_task_comm_path_rejects_double_slash_paths() {
+        // `Path::components()` collapses consecutive separators, so
+        // `/proc//task/123/comm` is iterated as `[proc, task, 123, comm]`.
+        // The matcher rejects at the pid-component comparison ("task"
+        // doesn't equal the expected_tgid string "123"). Likewise
+        // `/proc/123/task//comm` is iterated as `[proc, 123, task, comm]`
+        // and rejects at the tid-component check (`is_numeric_normal`
+        // returns false for "comm"). This test pins both behaviours so a
+        // future change that, say, started accepting empty components or
+        // skipped them differently couldn't slip a malformed path
+        // through.
+        assert!(!is_proc_task_comm_path(
+            Path::new("/proc//task/123/comm"),
+            123,
+        ));
+        assert!(!is_proc_task_comm_path(
+            Path::new("/proc/123/task//comm"),
+            123,
+        ));
+    }
 
     #[test]
     fn test_rate_limiter_allows_burst() {
@@ -1533,6 +1776,7 @@ mod tests {
                 network_audit_events: None,
                 redaction_policy: &REDACTION_POLICY,
                 allow_launch_services_active: false,
+                allow_proc_task_comm_write: false,
                 proxy_port,
                 proxy_bind_ports,
                 unix_socket_allowlist,

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -569,6 +569,8 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
                 recommended_profile: known_builtin_profile,
             }),
         capability_elevation: flags.capability_elevation,
+        auto_capability_elevation: flags.auto_capability_elevation,
+        allow_proc_task_comm_write: flags.allow_proc_task_comm_write,
         #[cfg(target_os = "linux")]
         seccomp_proxy_fallback,
         #[cfg(target_os = "linux")]

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -2,8 +2,8 @@ use crate::cli::RunArgs;
 use crate::config;
 use crate::proxy_runtime::prepare_proxy_launch_options;
 use crate::sandbox_prepare::{
-    PreparedSandbox, prepare_sandbox, print_allow_gpu_warning, print_allow_launch_services_warning,
-    validate_block_net_conflicts,
+    PreparedSandbox, maybe_auto_enable_nvidia_cap_elev, prepare_sandbox, print_allow_gpu_warning,
+    print_allow_launch_services_warning, validate_block_net_conflicts,
 };
 use crate::{exec_strategy, instruction_deny, profile, trust_scan};
 use colored::Colorize;
@@ -209,6 +209,24 @@ pub(crate) struct ExecutionFlags {
     pub(crate) diagnostic_verbosity: u8,
     pub(crate) silent: bool,
     pub(crate) capability_elevation: bool,
+    /// True iff `capability_elevation` was turned on by nono itself (e.g.
+    /// because `--allow-gpu` needs the seccomp-notify supervisor running
+    /// for the `/proc/self/task/<tid>/comm` write pattern, see #924) and
+    /// the user did NOT explicitly request it via `--capability-elevation`
+    /// or `security.capability_elevation: true`. When true, the
+    /// interactive approval backend is replaced with a non-interactive
+    /// deny-all so the supervisor's pattern fast-paths still run but
+    /// unexpected paths don't trigger a prompt.
+    pub(crate) auto_capability_elevation: bool,
+    /// True iff the supervisor is permitted to allow the
+    /// `/proc/<own-tgid>/task/<tid>/comm` write pattern (issue #924).
+    /// Set only when the NVIDIA procfs grants applied (i.e. NVIDIA was
+    /// detected and `--allow-gpu` is in effect). This is intentionally
+    /// independent of `capability_elevation`: a user passing
+    /// `--capability-elevation` without `--allow-gpu` does NOT get the
+    /// comm-write fast-path silently — it is gated to the user's
+    /// declared `--allow-gpu` intent.
+    pub(crate) allow_proc_task_comm_write: bool,
     #[cfg(target_os = "linux")]
     pub(crate) wsl2_proxy_policy: crate::profile::Wsl2ProxyPolicy,
     #[cfg(target_os = "linux")]
@@ -242,6 +260,8 @@ impl ExecutionFlags {
             diagnostic_verbosity: 0,
             silent,
             capability_elevation: false,
+            auto_capability_elevation: false,
+            allow_proc_task_comm_write: false,
             #[cfg(target_os = "linux")]
             wsl2_proxy_policy: crate::profile::Wsl2ProxyPolicy::Error,
             #[cfg(target_os = "linux")]
@@ -322,6 +342,20 @@ pub(crate) fn prepare_run_launch_plan(
         prepared.capability_elevation = true;
     }
 
+    // NVIDIA `--allow-gpu` needs the seccomp-notify supervisor so the
+    // driver's `/proc/self/task/<tid>/comm` write during `cuInit()` can
+    // be allowed by pattern (see `is_proc_task_comm_path` and the 4.5
+    // fast-path in `exec_strategy::supervisor_linux`). The helper auto-
+    // enables `capability_elevation` ONLY when NVIDIA was detected — not
+    // for pure DRM-render-node / AMD-KFD / WSL2-dxg `--allow-gpu` runs
+    // which don't need the broker and shouldn't pay its overhead.
+    //
+    // When the helper auto-enables (user did NOT explicitly opt in to
+    // capability elevation), `SilentDenyApproval` is selected downstream
+    // so the supervisor's pattern fast-paths still run but unexpected
+    // paths fail closed rather than triggering `[nono] Grant access?`.
+    let auto_capability_elevation = maybe_auto_enable_nvidia_cap_elev(&mut prepared);
+
     // On WSL2, seccomp user notification returns EBUSY (microsoft/WSL#9548).
     // Disable features that depend on it and warn the user.
     #[cfg(target_os = "linux")]
@@ -388,6 +422,8 @@ pub(crate) fn prepare_run_launch_plan(
             diagnostic_verbosity: args.verbose,
             silent,
             capability_elevation: prepared.capability_elevation,
+            auto_capability_elevation,
+            allow_proc_task_comm_write: prepared.nvidia_procfs_active,
             #[cfg(target_os = "linux")]
             wsl2_proxy_policy: prepared.wsl2_proxy_policy,
             #[cfg(target_os = "linux")]

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -298,6 +298,7 @@ mod tests {
             af_unix_mediation: crate::profile::LinuxAfUnixMediation::Off,
             allow_launch_services_active: false,
             allow_gpu_active: false,
+            nvidia_procfs_active: false,
             open_url_origins: Vec::new(),
             open_url_allow_localhost: false,
             bypass_protection_paths: Vec::new(),
@@ -356,6 +357,7 @@ mod tests {
             af_unix_mediation: crate::profile::LinuxAfUnixMediation::Off,
             allow_launch_services_active: false,
             allow_gpu_active: false,
+            nvidia_procfs_active: false,
             open_url_origins: Vec::new(),
             open_url_allow_localhost: false,
             bypass_protection_paths: Vec::new(),
@@ -664,12 +666,16 @@ mod tests {
         // Either outcome is correct. What must NOT happen is an error about
         // /dev/dri specifically, which would break NVIDIA/ROCm-only setups.
         match result {
-            Ok(enabled) => {
-                assert!(enabled, "should be active when devices are found");
+            Ok(activation) => {
+                assert!(activation.active, "should be active when devices are found");
                 assert!(
                     caps.has_fs(),
                     "should have granted fs capabilities for GPU devices"
                 );
+                // `nvidia_procfs_active` is informational: true iff NVIDIA
+                // compute devices were granted. We don't assert either
+                // direction here because CI runners may or may not have
+                // NVIDIA hardware.
             }
             Err(e) => {
                 let msg = e.to_string();

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -2663,6 +2663,7 @@ mod tests {
             af_unix_mediation: crate::profile::LinuxAfUnixMediation::Off,
             allow_launch_services_active: false,
             allow_gpu_active: false,
+            nvidia_procfs_active: false,
             open_url_origins: Vec::new(),
             open_url_allow_localhost: false,
             bypass_protection_paths: Vec::new(),

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -438,6 +438,9 @@ pub(crate) struct PreparedSandbox {
     pub(crate) af_unix_mediation: crate::profile::LinuxAfUnixMediation,
     pub(crate) allow_launch_services_active: bool,
     pub(crate) allow_gpu_active: bool,
+    /// True iff NVIDIA-specific procfs grants were installed (`--allow-gpu` on NVIDIA).
+    /// Drives auto-enable of `capability_elevation` and the comm-write fast-path.
+    pub(crate) nvidia_procfs_active: bool,
     pub(crate) open_url_origins: Vec<String>,
     pub(crate) open_url_allow_localhost: bool,
     pub(crate) bypass_protection_paths: Vec<PathBuf>,
@@ -454,6 +457,23 @@ pub(crate) struct PreparedSandbox {
     /// True when the profile or CLI requested HTTP/2 to upstream servers
     /// (`network.allow_http2` or `--allow-http2`).
     pub(crate) allow_http2_requested: bool,
+}
+
+/// Auto-enables `capability_elevation` when NVIDIA procfs grants are active.
+/// Returns `true` iff cap_elev was flipped on. No-op on non-NVIDIA / non-Linux.
+#[cfg(target_os = "linux")]
+pub(crate) fn maybe_auto_enable_nvidia_cap_elev(prepared: &mut PreparedSandbox) -> bool {
+    if prepared.nvidia_procfs_active && !prepared.capability_elevation {
+        prepared.capability_elevation = true;
+        true
+    } else {
+        false
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn maybe_auto_enable_nvidia_cap_elev(_prepared: &mut PreparedSandbox) -> bool {
+    false
 }
 
 fn resolved_workdir(args: &SandboxArgs) -> PathBuf {
@@ -839,14 +859,22 @@ fn missing_cwd_prompt_must_fail(
 ///   CUDA's UVM subsystem reads these during init. We grant each individually
 ///   rather than the parent `/proc/driver` to avoid exposing metadata about
 ///   unrelated kernel drivers.
-/// - `/proc/self` (read): CUDA init reads `/proc/self/maps`, `/proc/self/status`
-///   and other per-process files.
-/// - `/proc/self/task` (read+write): NVIDIA driver 570+ writes to
-///   `/proc/self/task/<tid>/comm` during thread startup to set thread names.
-///   Without write access this returns EACCES and the driver treats it as a
-///   fatal OS error, surfacing as CUDA Error 304 (`cudaErrorOperatingSystem`).
-///   Narrowing write access to the `task` subtree keeps other per-process
-///   procfs entries read-only.
+/// - `/proc/self` (read): CUDA init reads `/proc/self/maps`, `/proc/self/status`,
+///   `/proc/self/task/` (to enumerate threads) and other per-process files.
+///
+/// Notably absent: the NVIDIA driver also writes `/proc/self/task/<tid>/comm`
+/// during thread startup. We do **not** grant Landlock write access to
+/// `/proc/self/task` — Landlock is a filesystem-tree allowlist, so any such
+/// grant would either pin to the direct child's PID inode (breaking
+/// grandchild CUDA, see #924) or widen to all of `/proc` (broadening write
+/// surface to `oom_score_adj`, `coredump_filter`, `attr/*`, etc.).
+/// Instead, the comm write is intercepted by the seccomp-notify supervisor
+/// (see `handle_seccomp_notification` in `exec_strategy/supervisor_linux.rs`):
+/// the supervisor matches paths of the form `/proc/<pid>/task/<tid>/comm`,
+/// validates that `<pid>` equals the caller's TGID (via `validate_procfs_access`),
+/// and lets the kernel's per-thread ownership check enforce that `<tid>` is
+/// the caller's own thread. This gives us a precise pattern allow without
+/// any Landlock-level expansion.
 #[cfg(target_os = "linux")]
 fn grant_nvidia_gpu_procfs(caps: &mut CapabilitySet) -> Result<()> {
     for name in ["nvidia", "nvidia-uvm"] {
@@ -857,17 +885,15 @@ fn grant_nvidia_gpu_procfs(caps: &mut CapabilitySet) -> Result<()> {
         }
     }
 
-    // /proc/self and /proc/self/task are guaranteed on Linux; propagate any
-    // error rather than silently skipping (fail-secure: if the kernel ever
-    // fails to present these, the sandbox should fail rather than grant
-    // less-than-intended access).
+    // /proc/self is guaranteed on Linux; propagate any error rather than
+    // silently skipping (fail-secure: if the kernel ever fails to present
+    // it, the sandbox should fail rather than grant less-than-intended
+    // access). The read grant also covers `/proc/self/task/` for thread
+    // enumeration; writes to `/proc/self/task/<tid>/comm` are handled by
+    // the supervisor's seccomp-notify path (see function doc).
     caps.add_fs(FsCapability::new_dir(
         std::path::Path::new("/proc/self"),
         AccessMode::Read,
-    )?);
-    caps.add_fs(FsCapability::new_dir(
-        std::path::Path::new("/proc/self/task"),
-        AccessMode::ReadWrite,
     )?);
 
     Ok(())
@@ -896,14 +922,31 @@ fn is_nvidia_compute_device(name: &str) -> bool {
     false
 }
 
+/// Result of a `maybe_enable_gpu` call.
+///
+/// `active` is whether any GPU grants were installed (the previous return
+/// type). `nvidia_procfs_active` is whether the NVIDIA-specific procfs
+/// grants applied — used to decide whether the seccomp-notify supervisor
+/// must run to gate the NVIDIA driver's `/proc/self/task/<tid>/comm`
+/// write (issue #924). On non-NVIDIA GPUs (DRM render nodes only, AMD
+/// KFD, WSL2 dxg) the supervisor is not needed; this flag stays false so
+/// those workloads don't pay the seccomp overhead and the comm-write
+/// fast-path doesn't silently apply to unrelated sessions.
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct GpuActivation {
+    pub(crate) active: bool,
+    pub(crate) nvidia_procfs_active: bool,
+}
+
 #[cfg(target_os = "linux")]
 pub(crate) fn maybe_enable_gpu(
     caps: &mut CapabilitySet,
     cli_requested: bool,
     profile_allowed: bool,
-) -> Result<bool> {
+) -> Result<GpuActivation> {
     if !cli_requested {
-        return Ok(false);
+        return Ok(GpuActivation::default());
     }
 
     if !profile_allowed {
@@ -1040,7 +1083,10 @@ pub(crate) fn maybe_enable_gpu(
         "--allow-gpu enabled: allowing {} GPU device(s) on Linux",
         gpu_device_count
     );
-    Ok(true)
+    Ok(GpuActivation {
+        active: true,
+        nvidia_procfs_active: have_nvidia,
+    })
 }
 
 pub(crate) fn print_allow_gpu_warning(silent: bool) {
@@ -1069,8 +1115,10 @@ pub(crate) fn print_allow_gpu_warning(silent: bool) {
         eprintln!(
             "  This grants read/write access to /dev/dri/renderD* and NVIDIA compute devices.\n  \
              On NVIDIA systems, additionally: read access to /proc/driver/nvidia,\n  \
-             /proc/driver/nvidia-uvm, and /proc/self; read/write access to\n  \
-             /proc/self/task (for CUDA thread-name initialisation)."
+             /proc/driver/nvidia-uvm, and /proc/self. The NVIDIA driver's\n  \
+             /proc/self/task/<tid>/comm write is allowed through the supervisor's\n  \
+             seccomp-notify gate (caller's own thread only); no Landlock write rule\n  \
+             is installed for /proc."
         );
     }
 }
@@ -1172,6 +1220,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
                 af_unix_mediation: crate::profile::LinuxAfUnixMediation::default(),
                 allow_launch_services_active: false,
                 allow_gpu_active: false,
+                nvidia_procfs_active: false,
                 open_url_origins: Vec::new(),
                 open_url_allow_localhost: false,
                 bypass_protection_paths: Vec::new(),
@@ -1354,12 +1403,17 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         args.allow_gpu,
         loaded_profile.is_none() || profile_allow_gpu,
     )?;
+    #[cfg(target_os = "macos")]
+    let nvidia_procfs_active = false;
     #[cfg(target_os = "linux")]
-    let allow_gpu_active = maybe_enable_gpu(
-        &mut caps,
-        args.allow_gpu,
-        loaded_profile.is_none() || profile_allow_gpu,
-    )?;
+    let (allow_gpu_active, nvidia_procfs_active) = {
+        let activation = maybe_enable_gpu(
+            &mut caps,
+            args.allow_gpu,
+            loaded_profile.is_none() || profile_allow_gpu,
+        )?;
+        (activation.active, activation.nvidia_procfs_active)
+    };
 
     if let Some(request) =
         pending_cwd_access_request(&caps, &workdir, profile_workdir_access.as_ref())?
@@ -1511,6 +1565,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
             af_unix_mediation,
             allow_launch_services_active,
             allow_gpu_active,
+            nvidia_procfs_active,
             open_url_origins,
             open_url_allow_localhost,
             bypass_protection_paths,
@@ -1555,16 +1610,24 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn grant_nvidia_gpu_procfs_scopes_proc_self_reads_with_task_writes() {
+    fn grant_nvidia_gpu_procfs_grants_proc_self_read_only() {
         // Regression test for the NVIDIA-scoped procfs grants:
-        //   /proc/self       Read        (CUDA init reads maps/status/etc.)
-        //   /proc/self/task  ReadWrite   (driver writes task/<tid>/comm)
+        //   /proc/self  Read   (CUDA init reads maps/status, enumerates task/)
         // Plus any of /proc/driver/{nvidia,nvidia-uvm} that exist.
         //
-        // /proc/self and /proc/self/task always exist on Linux, so those
-        // checks are unconditional. /proc/driver/nvidia entries are only
-        // present when the NVIDIA kernel module is loaded, so we just
-        // assert no unexpected /proc/driver parent grant was added.
+        // Notably, /proc/self/task is NOT granted as a separate Landlock
+        // rule. The NVIDIA driver writes /proc/self/task/<tid>/comm during
+        // cuInit() to set thread names; that one write is permitted by the
+        // supervisor's seccomp-notify handler (see
+        // handle_seccomp_notification + is_proc_task_comm_path), which
+        // matches the path pattern and lets the kernel's per-thread
+        // ownership check enforce that <tid> belongs to the caller.
+        //
+        // Granting /proc/self/task at the Landlock layer is structurally
+        // unsafe: pinning to the direct child's PID inode breaks grandchild
+        // CUDA (#924); widening to /proc broadens the write surface to
+        // every writable /proc/<pid>/* knob. The supervisor gate is the
+        // only place this can be expressed precisely.
         //
         // FsCapability.original is used instead of path_covered_with_access:
         // /proc/self is a symlink to /proc/<pid> which canonicalizes
@@ -1583,20 +1646,17 @@ mod tests {
         assert_eq!(
             proc_self.access,
             AccessMode::Read,
-            "/proc/self must be read-only (writes are scoped to /proc/self/task)"
+            "/proc/self must be read-only; comm writes go through the supervisor"
         );
         assert!(!proc_self.is_file);
 
-        let proc_self_task = find("/proc/self/task").expect(
-            "/proc/self/task must be granted read+write so the NVIDIA driver \
-             can write task/<tid>/comm (CUDA Error 304 root cause)",
+        // Defence-in-depth: /proc/self/task must NOT be granted a separate
+        // Landlock rule. See doc above.
+        assert!(
+            find("/proc/self/task").is_none(),
+            "/proc/self/task must not be granted at the Landlock layer; \
+             the comm write is gated by the supervisor's seccomp-notify path"
         );
-        assert_eq!(
-            proc_self_task.access,
-            AccessMode::ReadWrite,
-            "/proc/self/task must be granted read+write"
-        );
-        assert!(!proc_self_task.is_file);
 
         // Least-privilege regression guard: no parent /proc/driver grant.
         // Only /proc/driver/nvidia and /proc/driver/nvidia-uvm should appear
@@ -1620,6 +1680,134 @@ mod tests {
                 assert_eq!(entry.access, AccessMode::Read);
             }
         }
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // maybe_auto_enable_nvidia_cap_elev — the helper that decides
+    // whether `--allow-gpu` should install the seccomp-notify
+    // supervisor for the NVIDIA `task/<tid>/comm` write pattern.
+    // Three-state contract:
+    //   1. NVIDIA active + cap_elev off  → flip on, return true
+    //   2. NVIDIA active + cap_elev on   → no-op, return false
+    //   3. NVIDIA inactive               → no-op, return false (and
+    //      callers must not install the supervisor either)
+    // ─────────────────────────────────────────────────────────────
+
+    #[cfg(test)]
+    fn make_test_prepared(
+        nvidia_procfs_active: bool,
+        capability_elevation: bool,
+    ) -> PreparedSandbox {
+        PreparedSandbox {
+            caps: CapabilitySet::default(),
+            secrets: Vec::new(),
+            profile_display_name: None,
+            command_policies: None,
+            session_hooks: crate::profile::SessionHooks::default(),
+            rollback_exclude_patterns: Vec::new(),
+            rollback_exclude_globs: Vec::new(),
+            network_profile: None,
+            allow_domain: Vec::new(),
+            credentials: Vec::new(),
+            custom_credentials: HashMap::new(),
+            credential_capture: HashMap::new(),
+            tls_intercept: None,
+            upstream_proxy: None,
+            upstream_bypass: Vec::new(),
+            listen_ports: Vec::new(),
+            capability_elevation,
+            #[cfg(target_os = "linux")]
+            wsl2_proxy_policy: crate::profile::Wsl2ProxyPolicy::Error,
+            #[cfg(target_os = "linux")]
+            af_unix_mediation: crate::profile::LinuxAfUnixMediation::Off,
+            allow_launch_services_active: false,
+            allow_gpu_active: nvidia_procfs_active,
+            nvidia_procfs_active,
+            open_url_origins: Vec::new(),
+            open_url_allow_localhost: false,
+            bypass_protection_paths: Vec::new(),
+            ignored_denial_paths: Vec::new(),
+            suppressed_system_service_operations: Vec::new(),
+            allowed_env_vars: None,
+            denied_env_vars: None,
+            set_vars: None,
+            profile_network_block: false,
+            allow_http2_requested: false,
+        }
+    }
+
+    /// State 1: NVIDIA grants applied AND the user did not opt into
+    /// `--capability-elevation`. The helper must flip cap_elev on and
+    /// return `true`, so the caller threads `auto_capability_elevation =
+    /// true` into `ExecutionFlags` and downstream code swaps to
+    /// `SilentDenyApproval`.
+    #[test]
+    fn maybe_auto_enable_nvidia_cap_elev_flips_when_nvidia_and_no_explicit_opt_in() {
+        let mut prepared = make_test_prepared(true, false);
+        let auto = maybe_auto_enable_nvidia_cap_elev(&mut prepared);
+        // On non-Linux the helper is a no-op (always returns false). Pin
+        // both paths so the contract is exercised on every CI runner.
+        #[cfg(target_os = "linux")]
+        {
+            assert!(
+                auto,
+                "helper must report it auto-enabled cap_elev for NVIDIA + no opt-in"
+            );
+            assert!(
+                prepared.capability_elevation,
+                "helper must turn capability_elevation on"
+            );
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            assert!(
+                !auto,
+                "non-Linux: helper must not auto-enable (no supervisor pattern there)"
+            );
+            assert!(
+                !prepared.capability_elevation,
+                "non-Linux: capability_elevation must remain off"
+            );
+        }
+    }
+
+    /// State 2: NVIDIA grants applied BUT the user explicitly opted in
+    /// to `--capability-elevation` (or the profile set it). Helper must
+    /// be a no-op AND return `false`, because the caller threading
+    /// `auto_capability_elevation = false` is what keeps
+    /// `TerminalApproval` as the backend — we must not silently demote
+    /// an explicit opt-in to non-interactive denial.
+    #[test]
+    fn maybe_auto_enable_nvidia_cap_elev_noop_when_explicit_cap_elev_already_on() {
+        let mut prepared = make_test_prepared(true, true);
+        let auto = maybe_auto_enable_nvidia_cap_elev(&mut prepared);
+        assert!(
+            !auto,
+            "helper must NOT report auto-enable when cap_elev was already on"
+        );
+        assert!(
+            prepared.capability_elevation,
+            "explicit cap_elev opt-in must be preserved as-is"
+        );
+    }
+
+    /// State 3: NVIDIA grants NOT applied (pure DRM render node / AMD
+    /// KFD / WSL2 dxg `--allow-gpu`, or no `--allow-gpu` at all). Helper
+    /// must be a no-op and return `false`. No supervisor is needed for
+    /// the comm pattern, so paying its per-openat round-trip would be
+    /// wasted overhead.
+    #[test]
+    fn maybe_auto_enable_nvidia_cap_elev_noop_when_no_nvidia() {
+        let mut prepared = make_test_prepared(false, false);
+        let auto = maybe_auto_enable_nvidia_cap_elev(&mut prepared);
+        assert!(
+            !auto,
+            "helper must NOT auto-enable when NVIDIA procfs grants weren't installed"
+        );
+        assert!(
+            !prepared.capability_elevation,
+            "capability_elevation must remain off without NVIDIA"
+        );
     }
 
     #[cfg(target_os = "linux")]
@@ -1989,6 +2177,7 @@ mod tests {
             af_unix_mediation: profile::LinuxAfUnixMediation::default(),
             allow_launch_services_active: false,
             allow_gpu_active: false,
+            nvidia_procfs_active: false,
             open_url_origins: Vec::new(),
             open_url_allow_localhost: false,
             bypass_protection_paths: Vec::new(),

--- a/crates/nono-cli/src/supervised_runtime.rs
+++ b/crates/nono-cli/src/supervised_runtime.rs
@@ -245,11 +245,25 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
     }
 
     let protected_roots = protected_paths::ProtectedRoots::from_defaults()?;
-    let approval_backend = terminal_approval::TerminalApproval;
+    // When capability_elevation was auto-enabled (e.g. by `--allow-gpu` so
+    // the seccomp-notify supervisor can gate `task/<tid>/comm` writes —
+    // see #924), the user did NOT opt into interactive approval prompts.
+    // Use a non-interactive deny-all backend so the supervisor's pattern
+    // fast-paths still run but any path falling through to the approval
+    // step fails closed instead of prompting `[nono] Grant access? [y/N]`.
+    let interactive_approval: terminal_approval::TerminalApproval =
+        terminal_approval::TerminalApproval;
+    let silent_approval: terminal_approval::SilentDenyApproval =
+        terminal_approval::SilentDenyApproval;
+    let approval_backend: &dyn nono::ApprovalBackend = if ctx.config.auto_capability_elevation {
+        &silent_approval
+    } else {
+        &interactive_approval
+    };
     let supervisor_session_id = build_supervisor_session_id(audit_state.as_ref());
     let supervisor_cfg = exec_strategy::SupervisorConfig {
         protected_roots: protected_roots.as_paths(),
-        approval_backend: &approval_backend,
+        approval_backend,
         session_id: &supervisor_session_id,
         attach_initial_client: !session.detached_start,
         detach_sequence: session.detach_sequence.as_deref(),
@@ -268,6 +282,7 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
             .and_then(|p| p.open_url.as_ref())
             .map(|o| o.allow_launch_services)
             .unwrap_or(false),
+        allow_proc_task_comm_write: ctx.config.allow_proc_task_comm_write,
         #[cfg(target_os = "linux")]
         proxy_port: match caps.network_mode() {
             nono::NetworkMode::ProxyOnly { port, .. } => *port,

--- a/crates/nono-cli/src/terminal_approval.rs
+++ b/crates/nono-cli/src/terminal_approval.rs
@@ -2,10 +2,47 @@
 //!
 //! Prompts the user at the terminal when the sandboxed child requests
 //! additional filesystem access. This is the default approval backend
-//! for `nono run`.
+//! for `nono run` with explicit `--capability-elevation`.
+//!
+//! Also provides `SilentDenyApproval` for the case where the supervisor
+//! has been installed automatically (e.g. by `--allow-gpu` to gate the
+//! NVIDIA `task/<tid>/comm` write) but the user did not opt into
+//! interactive prompts. In that case the supervisor still runs its
+//! pattern fast-paths but any path that falls through to the approval
+//! backend is denied without prompting.
 
 use nono::{AccessMode, ApprovalBackend, ApprovalDecision, ApprovalRequest, NonoError, Result};
 use std::io::{BufRead, IsTerminal, Write};
+
+/// Non-interactive deny-all backend.
+///
+/// Used when `capability_elevation` was enabled implicitly (e.g. by
+/// `--allow-gpu` on Linux, which needs the seccomp-notify supervisor
+/// running so the NVIDIA driver's `/proc/self/task/<tid>/comm` write can
+/// be allowed by pattern — see `is_proc_task_comm_path`). The supervisor
+/// still handles its fast-paths (protected roots, initial-set match,
+/// pattern matchers); only the final approval step — which would
+/// otherwise prompt the user — is short-circuited to a denial.
+///
+/// Behaviour matches "no terminal available" branch of `TerminalApproval`:
+/// any path reaching this point is denied with a structured reason so
+/// the diagnostic footer can explain what happened.
+pub struct SilentDenyApproval;
+
+impl ApprovalBackend for SilentDenyApproval {
+    fn request_approval(&self, _request: &ApprovalRequest) -> Result<ApprovalDecision> {
+        Ok(ApprovalDecision::Denied {
+            reason: "capability elevation auto-enabled (e.g. by --allow-gpu); \
+                     interactive approval disabled — pass --capability-elevation \
+                     to enable prompts"
+                .to_string(),
+        })
+    }
+
+    fn backend_name(&self) -> &str {
+        "silent-deny"
+    }
+}
 
 /// Interactive terminal approval backend.
 ///

--- a/tests/integration/test_gpu.sh
+++ b/tests/integration/test_gpu.sh
@@ -254,6 +254,86 @@ with open(f'/proc/self/task/{tid}/comm', 'wb') as f:
 print('OK: wrote thread comm under --allow-gpu')
 "
 
+    # Issue #924 regression — grandchild process (different TGID from the
+    # direct child) must also be able to write /proc/self/task/<tid>/comm.
+    # The previous Landlock-based --allow-gpu grant pinned to the direct
+    # child's PID inode and broke this path; the new supervisor-gated
+    # implementation handles arbitrary descendant TGIDs.
+    #
+    # The python3 command is backgrounded with `&` and then `wait`-ed,
+    # which forces the shell to fork before exec'ing python — without
+    # the `&`, /bin/sh would tail-call-exec python directly and the
+    # writer would be the direct child rather than a grandchild,
+    # silently degrading the test.
+    expect_success "grandchild /proc/self/task/<tid>/comm write allowed with --allow-gpu (#924)" \
+        "$NONO_BIN" run --silent --allow-cwd --allow "$TMPDIR" --allow-gpu -- \
+        sh -c 'python3 -c "
+import os, sys
+direct_child = os.getppid()
+pid = os.getpid()
+if pid == direct_child:
+    print(f\"FAIL: writer pid ({pid}) equals direct child; not a grandchild\", file=sys.stderr)
+    sys.exit(2)
+tid = os.gettid() if hasattr(os, \"gettid\") else pid
+with open(f\"/proc/self/task/{tid}/comm\", \"wb\") as f:
+    f.write(b\"probe\\n\")
+print(f\"OK grandchild pid={pid} direct_child={direct_child} wrote comm\")
+" & wait $!'
+
+    # Cross-process write attempt — supervisor must reject writes that
+    # target a /proc/<other-pid>/task/<tid>/comm path where <other-pid>
+    # is not the caller's TGID, even with --allow-gpu.
+    expect_failure "cross-process /proc/<other>/task/<tid>/comm write denied with --allow-gpu (#924)" \
+        "$NONO_BIN" run --silent --allow-cwd --allow "$TMPDIR" --allow-gpu -- \
+        python3 -c "
+import os, sys
+# pid 1 is init; we are not init, and init's tid 1 is not our thread.
+try:
+    with open('/proc/1/task/1/comm', 'wb') as f:
+        f.write(b'evil\n')
+    print('FAIL: wrote to init thread comm', file=sys.stderr)
+    sys.exit(0)  # success means the sandbox failed
+except (PermissionError, FileNotFoundError, OSError):
+    sys.exit(1)  # expected: supervisor or kernel denied
+"
+
+    # Symlink-bypass regression (Gemini security review): a sandboxed
+    # process must not be able to slip past the supervisor's TGID gate by
+    # creating a symlink from outside /proc that resolves to another
+    # process's task/<tid>/comm. validate_procfs_access only inspects the
+    # pre-canonicalized path, so the matcher itself is the security gate.
+    expect_failure "symlink to /proc/1/task/1/comm denied with --allow-gpu (#924 Gemini review)" \
+        "$NONO_BIN" run --silent --allow-cwd --allow "$TMPDIR" --allow-gpu -- \
+        sh -c "ln -sf /proc/1/task/1/comm $TMPDIR/evil && python3 -c \"
+with open('$TMPDIR/evil', 'wb') as f: f.write(b'pwn')
+import sys; sys.exit(0)
+\""
+
+    # `nono wrap --allow-gpu` on NVIDIA must be rejected with a
+    # structured error pointing users to `nono run`. Direct execution
+    # has no seccomp-notify supervisor and therefore no way to gate the
+    # comm-write pattern; this test catches regressions where someone
+    # "fixes" the rejection by silently re-adding the Landlock
+    # /proc/self/task grant for the Direct-mode path.
+    expect_failure "nono wrap --allow-gpu rejected on NVIDIA (#924)" \
+        "$NONO_BIN" wrap --silent --allow-cwd --allow-gpu -- \
+        python3 -c "print('should not reach')"
+
+    # The error message must explicitly point at `nono run` so users
+    # know what to do — a generic "permission denied" would leave the
+    # underlying #924 reasoning invisible.
+    TESTS_RUN=$((TESTS_RUN + 1))
+    wrap_stderr=$("$NONO_BIN" wrap --silent --allow-cwd --allow-gpu -- \
+        python3 -c "print('should not reach')" 2>&1 || true)
+    if echo "$wrap_stderr" | grep -q "nono wrap --allow-gpu cannot support NVIDIA CUDA"; then
+        echo -e "  ${GREEN}PASS${NC}: nono wrap --allow-gpu error message names the rejection cause (#924)"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "  ${RED}FAIL${NC}: nono wrap --allow-gpu rejection message regressed; expected explicit NVIDIA CUDA mention"
+        echo "       Actual stderr: ${wrap_stderr:0:600}"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+
     # /proc/driver/nvidia — CUDA UVM init read. Only test if the driver is
     # loaded (the grant itself skips the path when it doesn't exist).
     if [[ -d /proc/driver/nvidia ]]; then


### PR DESCRIPTION
## Linked Issue

Closes #924
Refs #999 (follow-up: profile-defined supervisor pattern allows)
Supersedes #993 (closed; Landlock widening rejected as a privilege expansion)

## Summary

The NVIDIA driver's `cuInit()` writes `/proc/self/task/<tid>/comm` to set thread names. Pre-#924, `--allow-gpu` granted `/proc/self/task` as a Landlock RW rule to permit that. The rule is structurally unsafe under Landlock's filesystem-tree semantics:

- in Monitor/Supervised mode it canonicalises against the **direct child's PID** inode before sandbox apply, so any grandchild process (e.g. `claude → python → cuInit()`) writing to its own `/proc/<gpid>/task/<tid>/comm` hits `EACCES` → surfacing as CUDA Error 304 (`cudaErrorOperatingSystem`). This is what #924 filed.
- widening to `/proc` (the only Landlock primitive that covers arbitrary descendant PIDs — what the closed #993 tried) broadens write surface to every writable per-process procfs knob: `oom_score_adj`, `coredump_filter`, `clear_refs`, `attr/*`, etc. Unacceptable as a `--allow-gpu` side effect.

This PR replaces the Landlock grant with a precise pattern allow in the seccomp-notify supervisor that's already running for Supervised sessions:

1. Drop the `/proc/self/task` RW grant from `grant_nvidia_gpu_procfs`. `/proc/self` (Read) remains — covers maps/status reads and `/proc/self/task/` enumeration.
2. New `is_proc_task_comm_path()` — strict component-wise match for `^/proc/<digits>/task/<digits>/comm$`. Rejects `self`, non-numeric components, wrong terminal filenames, trailing segments, and empty `//` components.
3. New fast-path branch in `handle_seccomp_notification`: when the resolved openat path matches the comm pattern AND access includes Write, the supervisor opens the file in its own (unsandboxed) context via existing `open_path_for_access` and injects the fd via existing `inject_fd`.

### Security argument

- **TGID ownership** (path's `<pid>` == caller's TGID) — enforced by the existing `validate_procfs_access` inside `open_path_for_access`, using `ProcfsAccessContext::process_pid`. A caller cannot reach another process's `task/<tid>/comm`.
- **TID ownership** (the `<tid>` belongs to the caller's TGID) — enforced by the kernel itself: `/proc/<pid>/task/<tid>` only exists when `<tid>` is one of `<pid>`'s threads; any other `<tid>` returns `ENOENT`.
- Only **Write** access takes the fast-path; reads continue through the existing `/proc/self` Read grant.
- The fast-path is **gated on `SupervisorConfig::allow_proc_task_comm_write`**, set only when NVIDIA procfs grants applied. A user passing `--capability-elevation` without `--allow-gpu` does NOT get the comm-write allow — the supervisor still runs but the pattern falls through to the regular approval backend (no silent policy grant).

### Auto-wiring of capability elevation

The supervisor only installs when `capability_elevation` is true. To make this work for the default `--allow-gpu` invocation, `maybe_auto_enable_nvidia_cap_elev(prepared)` flips `capability_elevation` on **only when NVIDIA procfs grants are active** (so AMD/Intel/WSL2-dxg `--allow-gpu` runs don't pay the supervisor overhead). The helper is shared by `nono run` and `nono shell`.

`nono wrap --allow-gpu` on NVIDIA is rejected with a structured error pointing users to `nono run` — Direct mode has no supervisor and reintroducing the Landlock grant just for `wrap` would replicate the rejected #993 surface.

When auto-enable fires, `SilentDenyApproval` replaces `TerminalApproval` so the supervisor's fast-paths still run but unexpected paths fail closed instead of prompting `[nono] Grant access? [y/N]`. Users who pass `--capability-elevation` explicitly still get the interactive backend.

### Threading

`PreparedSandbox.nvidia_procfs_active` → `ExecutionFlags.allow_proc_task_comm_write` → `ExecConfig.allow_proc_task_comm_write` → `SupervisorConfig.allow_proc_task_comm_write` → supervisor handler gate.

## Test Plan

**Unit tests** (new in `supervisor_linux::tests`):
- `is_proc_task_comm_path_matches_canonical_form` — `/proc/123/task/456/comm`, `/proc/1/task/1/comm`, large numeric values.
- `is_proc_task_comm_path_rejects_non_numeric_components` — `self`, alphabetic components, mixed alphanumeric.
- `is_proc_task_comm_path_rejects_wrong_structure` — wrong filename, missing `task`, no `/proc` prefix, relative, empty, bare `/proc`.
- `is_proc_task_comm_path_rejects_extra_trailing_segments` — `comm/anything`, `comm/../etc/passwd`.
- `is_proc_task_comm_path_rejects_empty_numeric_components` — `/proc//task/...`, `/proc/123/task//comm`.

**Regression test** (renamed):
- `grant_nvidia_gpu_procfs_grants_proc_self_read_only` — inverted from the old test; asserts `/proc/self/task` is NOT granted at the Landlock layer.

**Integration tests** (new in `tests/integration/test_gpu.sh`):
- Grandchild probe (`sh -c 'python3 ... & wait $!'` to force a shell fork).
- Cross-process denial probe (writing to `/proc/1/task/1/comm` with `--allow-gpu`).

**Manual verification on Ubuntu 22.04 / NVIDIA A100-SXM4-40GB / driver 580.126.20 / CUDA 13** (matches the reporting environment):

| Scenario | Result |
|---|---|
| `nono run --allow-gpu` grandchild comm write | `OK grandchild pid=...` |
| `nono run --allow-gpu` grandchild `cuInit()` via libcuda | `OK cuInit succeeded; 1 CUDA device(s) visible` |
| `nono shell --allow-gpu` grandchild comm write | `OK shell-grandchild pid=...` |
| `nono wrap --allow-gpu` on NVIDIA | Rejected: "use `nono run --allow-gpu` instead" |
| `--capability-elevation` without `--allow-gpu` | Comm-write fast-path does NOT silently fire (regular approval backend prompts) |
| Cross-process write to `/proc/1/task/1/comm` with `--allow-gpu` | Denied (validate_procfs_access rejects pid 1 != caller TGID) |
| `/proc/driver` parent dir with `--allow-gpu` | Still denied (least-privilege regression guard, no change) |

**Local CI:**
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::unwrap_used` ✅
- `cargo test` ✅

## Code Review

Three rounds of independent review on this branch caught the following, all fixed before this PR:

- **#993 (closed):** widened Landlock to `/proc` (rejected — privilege expansion).
- **Round 2 P1:** `nono shell --allow-gpu` missed the auto-enable; `nono wrap` lost its old direct-child Landlock fallback. Fixed: shared helper covers shell; wrap explicitly rejects NVIDIA.
- **Round 2 P2:** fast-path triggered on any session with `capability_elevation` (e.g. `--capability-elevation` without `--allow-gpu`). Fixed: explicit `allow_proc_task_comm_write` gate set only when NVIDIA grants applied.
- **Round 2 P3:** auto-enable keyed on `allow_gpu_active`, not NVIDIA detection — AMD/Intel/dxg paid the supervisor overhead. Fixed: `maybe_enable_gpu` now returns `GpuActivation { active, nvidia_procfs_active }`; auto-enable keyed on the latter.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates (function docs on `widen_procfs_self_to_proc`, `is_proc_task_comm_path`, `grant_nvidia_gpu_procfs`, `maybe_auto_enable_nvidia_cap_elev`, `SilentDenyApproval`; the `--allow-gpu` warning text is updated to reflect the supervisor-gated comm write)
- [ ] Release note has been added to `CHANGELOG.md` if needed — happy to add; the user-visible behaviour is "CUDA init now works for grandchild processes under `--allow-gpu` without expanding the Landlock surface", which is a bug fix that may or may not warrant its own changelog entry.

## Agent Disclosure

This PR was prepared by an AI coding agent (Claude) operating under the maintainer's direction (@scp7). Both this PR and the closed #993 went through multiple rounds of code review by the maintainer; the final shape was determined by that review.

Files / sections consulted:
- `crates/nono/src/capability.rs` — `AccessMode`, `widen_procfs_self_to_proc()` (left untouched after the #993 retraction).
- `crates/nono-cli/src/sandbox_prepare.rs` — `grant_nvidia_gpu_procfs`, `maybe_enable_gpu`, new `GpuActivation` and `maybe_auto_enable_nvidia_cap_elev` helpers, regression test.
- `crates/nono-cli/src/exec_strategy.rs` — `ExecConfig` and `SupervisorConfig` struct definitions; all 9 test sites updated.
- `crates/nono-cli/src/exec_strategy/supervisor_linux.rs` — `is_proc_task_comm_path`, the 4.5 fast-path branch, 5 new unit tests, 1 test config helper updated.
- `crates/nono-cli/src/execution_runtime.rs` — flag propagation flags→config.
- `crates/nono-cli/src/launch_runtime.rs` — `ExecutionFlags` fields, helper call from `nono run`.
- `crates/nono-cli/src/command_runtime.rs` — helper call from `nono shell`, NVIDIA rejection in `nono wrap`.
- `crates/nono-cli/src/supervised_runtime.rs` — `SupervisorConfig` construction with the new flag, conditional approval backend selection.
- `crates/nono-cli/src/terminal_approval.rs` — new `SilentDenyApproval` backend.
- `tests/integration/test_gpu.sh` — grandchild + cross-process probes.
- `proj/invariants.yaml` — `least-privilege-scope`, `separate-read-write`, `landlock-strict-allowlist`, `path-component-compare`, `supervisor-peer-auth`, `supervisor-bounded-framing`, `supervisor-path-path-not-string`, `apply-irreversible`, `test-new-capability-types`, `test-on-both-platforms`.
- `CLAUDE.md`, `.github/pull_request_template.md`.

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists (#924); design rationale also captured in #999
- [x] I disclosed agent operation in #924's thread and in #993's close-out
- [x] I described my intent and approach in the issue discussion (multiple rounds)
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (#651, #673, #993, #999 cross-references)
- [x] I did not use forbidden patterns such as unwrap/expect (test-only `.expect()` only, gated by clippy cfg)
- [x] I used `NonoError` where required (new wrap-rejection path returns `NonoError::ConfigParse`)
- [x] I validated and canonicalized all relevant paths (component-wise matcher; supervisor opens via canonicalised path)
- [x] This PR matches the approved or disclosed issue scope