### PR TITLE
fix: correct Quick Start profile reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Other options in the [Installation Guide](https://docs.nono.sh/cli/getting_start
 `nono pull` agent packages from the [registry](https://registry.nono.sh) for all popular agents — Claude Code, Codex, Pi, Hermes, OpenCode, OpenClaw, and more — or [build your own](https://nono.sh/docs/cli/features/package-publishing) and securely share plugins, SKILLS, and hooks with the community or your team.
 
 ```bash
-nono run --profile always-further/claude-code -- claude
+nono run --profile claude-code -- claude
 ```
 
 ## Libraries and Bindings

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Other options in the [Installation Guide](https://docs.nono.sh/cli/getting_start
 `nono pull` agent packages from the [registry](https://registry.nono.sh) for all popular agents — Claude Code, Codex, Pi, Hermes, OpenCode, OpenClaw, and more — or [build your own](https://nono.sh/docs/cli/features/package-publishing) and securely share plugins, SKILLS, and hooks with the community or your team.
 
 ```bash
-nono run --profile claude-code -- claude
+nono run --profile always-further/claude -- claude
 ```
 
 ## Libraries and Bindings


### PR DESCRIPTION
## Summary

- The Quick Start example in the root README used `--profile always-further/claude-code`, but there is no pack called `always-further/claude-code`. The correct fully qualified registry pack name is `always-further/claude`.
- Changed to `--profile always-further/claude` per maintainer feedback that the project is moving towards fully qualified registry pack names.

## Test plan

- [x] Verified all source code references use `always-further/claude` as the pack ref
- [x] Confirmed via `migration.rs` tests that `always-further/claude` is the canonical pack ref
- [x] Confirmed direction with maintainer in PR comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)