### PR TITLE
docs(cli): update credential injection with bitwarden and custom keyring

### DIFF
--- a/docs/cli/features/credential-injection.mdx
+++ b/docs/cli/features/credential-injection.mdx
@@ -1,6 +1,6 @@
 ---
 title: Credential Injection
-description: Keep API keys out of the sandbox with proxy-based credential injection or environment variable injection from the system keystore, 1Password, or Apple Passwords
+description: Keep API keys out of the sandbox with proxy-based credential injection or environment variable injection from the system keystore, 1Password, Bitwarden, Apple Passwords, files, or environment variables
 ---
 
 nono provides two ways to keep credentials out of the sandboxed process:
@@ -33,7 +33,7 @@ Streaming responses (SSE for chat completions, MCP Streamable HTTP, A2A JSON-RPC
 
 ```bash
 # 1. Store credentials in the system keystore
-security add-generic-password -s "nono" -a "openai_api_key" -w "sk-..."  # macOS
+security add-generic-password -s "nono" -a "openai" -w "sk-..."  # macOS
 
 # 2. Run with credential injection
 nono run --allow-cwd --network-profile claude-code --credential openai -- my-agent
@@ -43,21 +43,28 @@ The proxy sets `OPENAI_BASE_URL=http://127.0.0.1:<port>/openai` in the child's e
 
 ## Storing Credentials
 
-Credentials are stored in the system keyring under the service name `nono`. The username/account corresponds to the `credential_key` defined in `network-policy.json`:
+Built-in credential routes load secrets from the source defined in `network-policy.json`. If a built-in route omits `credential_key`, the keyring username defaults to the service name under the keyring service `nono`.
 
-| CLI Service | Keyring Username | Keyring Service |
-|-------------|------------------|-----------------|
-| `openai` | `openai_api_key` | `nono` |
-| `anthropic` | `anthropic_api_key` | `nono` |
-| `gemini` | `gemini_api_key` | `nono` |
-| `google-ai` | `google_generative_ai_api_key` | `nono` |
+| CLI Service | Credential Source |
+|-------------|-------------------|
+| `openai` | keyring service `nono`, username `openai` |
+| `anthropic` | host environment variable `ANTHROPIC_API_KEY` via `env://ANTHROPIC_API_KEY` |
+| `gemini` | keyring service `nono`, username `gemini` |
+| `google-ai` | keyring service `nono`, username `google-ai` |
+| `github` | host environment variable `GITHUB_TOKEN` via `env://GITHUB_TOKEN` |
+| `gitlab` | host environment variable `GITLAB_TOKEN` via `env://GITLAB_TOKEN` |
 
 ### macOS
 
 ```bash
-security add-generic-password -s "nono" -a "openai_api_key" -w "sk-..."
-security add-generic-password -s "nono" -a "anthropic_api_key" -w "sk-ant-..."
-security add-generic-password -s "nono" -a "gemini_api_key" -w "your-gemini-key"
+security add-generic-password -s "nono" -a "openai" -w "sk-..."
+security add-generic-password -s "nono" -a "gemini" -w "your-gemini-key"
+security add-generic-password -s "nono" -a "google-ai" -w "your-google-ai-key"
+
+# Built-in Anthropic, GitHub, and GitLab routes read from host env vars.
+export ANTHROPIC_API_KEY="sk-ant-..."
+export GITHUB_TOKEN="ghp_..."
+export GITLAB_TOKEN="glpat-..."
 ```
 
 ### Linux
@@ -65,17 +72,17 @@ security add-generic-password -s "nono" -a "gemini_api_key" -w "your-gemini-key"
 The `keyring` crate uses `service`, `username`, and `target` attributes. You must use these exact attribute names:
 
 ```bash
-echo -n "sk-..." | secret-tool store --label="nono: openai_api_key" \
-    service nono username openai_api_key target default
+echo -n "sk-..." | secret-tool store --label="nono: openai" \
+    service nono username openai target default
 
-echo -n "sk-ant-..." | secret-tool store --label="nono: anthropic_api_key" \
-    service nono username anthropic_api_key target default
+echo -n "your-gemini-key" | secret-tool store --label="nono: gemini" \
+    service nono username gemini target default
 
-echo -n "your-gemini-key" | secret-tool store --label="nono: gemini_api_key" \
-    service nono username gemini_api_key target default
+echo -n "your-google-ai-key" | secret-tool store --label="nono: google-ai" \
+    service nono username google-ai target default
 ```
 
-**Important:** Use `username` (not `account`) as the attribute name. The `target default` attribute is required for the keyring crate to find the entry.
+**Important:** Use `username` (not `account`) as the attribute name. The `target default` attribute is required for the keyring crate to find the entry. Built-in Anthropic, GitHub, and GitLab routes read from host environment variables instead of the keyring.
 
 ## 1Password Integration
 
@@ -269,6 +276,48 @@ credential reference and destination variable are unambiguous.
 
 ---
 
+## Bitwarden Integration
+
+nono supports Bitwarden entries via `bw://` URIs in both `--env-credential-map` and profile credential fields (`env_credentials`, `custom_credentials.credential_key`). The Bitwarden CLI (`bw`) must be installed and authenticated.
+
+URI format:
+
+```text
+bw://<item-id>
+bw://<item-id>/<field>
+```
+
+For proxy credentials, set `env_var` explicitly when `credential_key` uses `bw://`:
+
+```json
+{
+  "network": {
+    "custom_credentials": {
+      "openai": {
+        "upstream": "https://api.openai.com/v1",
+        "credential_key": "bw://12345678-1234-1234-1234-123456789abc/api-key",
+        "env_var": "OPENAI_API_KEY",
+        "inject_header": "Authorization",
+        "credential_format": "Bearer {}"
+      }
+    },
+    "credentials": ["openai"]
+  }
+}
+```
+
+## Custom Keyring Service
+
+Use `keyring://<service>/<account>` when a credential lives in the system keyring under a service name other than `nono`:
+
+```json
+{
+  "env_credentials": {
+    "keyring://my-service/openai_api_key": "OPENAI_API_KEY"
+  }
+}
+```
+
 ## Environment Variables
 
 When credential routes are configured, the proxy sets SDK-specific base URL environment variables:
@@ -291,6 +340,7 @@ The built-in `network-policy.json` defines default credential routes:
 | gemini | https://generativelanguage.googleapis.com | x-goog-api-key | {} |
 | google-ai | https://generativelanguage.googleapis.com | x-goog-api-key | {} |
 | github | https://api.github.com | Authorization | token {} |
+| gitlab | https://gitlab.com/api | Authorization | Bearer {} |
 
 All services in this table can be used directly with `--credential <service>` (e.g. `--credential github`, `--credential anthropic`) without any custom credential definition in your profile.
 
@@ -338,7 +388,7 @@ For APIs not covered by the built-in services, you can define custom credentials
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `upstream` | Yes | - | Upstream URL to proxy requests to (must be HTTPS, or HTTP for localhost only) |
-| `credential_key` | Yes | - | Keystore account name (alphanumeric and underscores only), `op://` URI for [1Password](#1password-integration), `apple-password://` URI for [Apple Passwords](#apple-passwords-integration-macos), `file://` URI for file-backed secrets, or `env://` URI for host environment variables (e.g., `env://MY_TOKEN`) |
+| `credential_key` | Yes | - | Keystore account name (alphanumeric and underscores only), `op://` URI for [1Password](#1password-integration), `bw://` URI for [Bitwarden](#bitwarden-integration), `apple-password://` URI for [Apple Passwords](#apple-passwords-integration-macos), `keyring://` URI for a custom keyring service, `file://` URI for file-backed secrets, or `env://` URI for host environment variables (e.g., `env://MY_TOKEN`) |
 | `inject_mode` | No | `header` | Credential injection mode: `header`, `url_path`, `query_param`, or `basic_auth` |
 | `inject_header` | No | `Authorization` | HTTP header to inject the credential into (used with `header` and `basic_auth` modes) |
 | `credential_format` | No | `Bearer {}` | Format string for the credential value (`{}` is replaced with the credential) |
@@ -346,7 +396,7 @@ For APIs not covered by the built-in services, you can define custom credentials
 | `path_replacement` | No | - | Optional replacement pattern for `url_path` mode (e.g., `/v2/bot{}/`) |
 | `query_param_name` | Conditional | - | Required for `query_param` mode. Query parameter name for credential injection (e.g., `key` or `api_key`) |
 | `proxy` | No | - | Optional proxy overrides for phantom token parsing. Omitted fields inherit from top-level values. See [Proxy-Side Overrides](#proxy-side-overrides). |
-| `env_var` | Conditional | - | Explicit environment variable name for the phantom token. Required when `credential_key` is `op://`, `apple-password://`, or `file://`. Optional for `env://` (derived from the URI) |
+| `env_var` | Conditional | - | Explicit environment variable name for the phantom token. Required when `credential_key` is `op://`, `bw://`, `apple-password://`, or `file://`. Optional for `env://` (derived from the URI) |
 
 **Important:** Use underscores, not hyphens, in credential names (the keys in `custom_credentials`). The credential name is used to generate environment variables like `TELEGRAM_BASE_URL`. Shell variable names cannot contain hyphens, so `my-api` would create `MY-API_BASE_URL` which cannot be referenced as `$MY-API_BASE_URL` in shell scripts. Use `my_api` instead.
 
@@ -539,13 +589,17 @@ Custom credentials can also override built-in services. For example, to route Op
 Custom credentials are validated at startup:
 
 - **Upstream URL must be HTTPS** (HTTP is only allowed for `localhost`, `127.0.0.1`, or `::1`)
-- **Credential key must be alphanumeric** (letters, numbers, and underscores only)
+- **Credential key must be alphanumeric** (letters, numbers, and underscores only) unless it uses a supported URI scheme such as `op://`, `bw://`, `apple-password://`, `keyring://`, `file://`, or `env://`
 
 Invalid configurations will fail with a clear error message before the sandbox is applied.
 
 ## Session Token Authentication
 
-Reverse proxy requests are authenticated using an `X-Nono-Token` header containing the session token. The proxy generates a unique 256-bit token per session and passes it to the child via the `NONO_PROXY_TOKEN` environment variable. Every request to a credential route must include this header — requests without a valid token are rejected with `407 Proxy Authentication Required`.
+Reverse proxy requests are authenticated using the session token. The proxy generates a unique 256-bit token per session and passes it to the child via the `NONO_PROXY_TOKEN` environment variable.
+
+For credential routes, the sandboxed client must present that token in the configured inbound credential location: the configured header, URL path placeholder, or query parameter. With the default header mode, this is the credential header itself, such as `Authorization` for OpenAI or `x-api-key` for Anthropic. Requests without a valid phantom token are rejected with `401 Unauthorized`.
+
+For no-credential reverse proxy routes, authentication uses proxy auth and invalid or missing credentials are rejected with `407 Proxy Authentication Required`.
 
 This prevents other localhost processes from accessing the credential injection routes.
 
@@ -564,11 +618,11 @@ To opt in to proxy mode without network enforcement, set `wsl2_proxy_policy: "in
 ## Security Properties
 
 - **Credentials never enter the sandbox** - The agent process has no access to API keys, even through environment variables or memory
-- **Session token isolation** - Reverse proxy routes require `X-Nono-Token` authentication; CONNECT tunnels use `Proxy-Authorization`
-- **Keystore-backed storage** - Credentials are loaded from the OS keyring (Keychain on macOS, Secret Service on Linux), not from plaintext files
+- **Session token isolation** - Credential reverse proxy routes validate the phantom token in the configured header, path, or query parameter; no-credential reverse routes and CONNECT tunnels use proxy auth
+- **Managed secret sources** - Credentials can be loaded from the OS keyring, 1Password, Bitwarden, Apple Passwords, explicit files, or host environment variables
 - **Zeroized in memory** - Credential values are stored in `Zeroizing<String>` and wiped from memory on drop
 - **Session-scoped** - Credentials are loaded once at proxy startup and never written to disk or logged
-- **Header stripping** - The proxy strips any `Authorization` or `x-api-key` headers from the agent's request before injecting the real credential, preventing the agent from overriding the injected value
+- **Header stripping** - Credential routes strip the configured credential header before injecting the real credential, along with hop-by-hop headers. No-credential reverse routes pass application headers such as `Authorization` through.
 
 ## Audit Logging
 


### PR DESCRIPTION
Did a sweep through the cred inj docs as been working there a bit and found a few fixes / polishes

- add support for bitwarden (`bw://`) and custom keyring (`keyring://`) credential sources
- clarify built-in anthropic, github, and gitlab services read from host environment variables
- simplify keyring usernames in macOS and linux examples
- update descriptions of `credential_key` and `env_var` fields
- improve explanation of session token authentication and header stripping behavior

