### PR TITLE
build(rpm): add rpm release artifacts

### DIFF
--- a/.github/workflows/attest-release.yml
+++ b/.github/workflows/attest-release.yml
@@ -31,6 +31,7 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --pattern "*.tar.gz" \
             --pattern "*.deb" \
+            --pattern "*.rpm" \
             --dir artifacts
 
       - name: Attest build provenance
@@ -39,3 +40,4 @@ jobs:
           subject-path: |
             artifacts/*.tar.gz
             artifacts/*.deb
+            artifacts/*.rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,8 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
 
       - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux' && matrix.target != 'aarch64-unknown-linux-gnu'
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config rpm
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -100,6 +100,13 @@ jobs:
           cd crates/nono-cli
           cargo deb --target aarch64-unknown-linux-gnu --no-build --deb-version "$VERSION"
 
+      - name: Build .rpm
+        if: runner.os == 'Linux'
+        run: |
+          VERSION="${{ env.RELEASE_TAG }}"
+          VERSION="${VERSION#v}"
+          scripts/build-rpm.sh "$VERSION" "${{ matrix.target }}"
+
       - name: Prepare upload
         shell: bash
         run: |
@@ -110,6 +117,9 @@ jobs:
           fi
           if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ] && [ -d target/aarch64-unknown-linux-gnu/debian ]; then
             cp target/aarch64-unknown-linux-gnu/debian/*.deb artifact_staging/
+          fi
+          if [ -d "target/rpm/${{ matrix.target }}/RPMS" ]; then
+            find "target/rpm/${{ matrix.target }}/RPMS" -name "*.rpm" -exec cp {} artifact_staging/ \;
           fi
 
       - name: Upload artifact
@@ -139,6 +149,7 @@ jobs:
           subject-path: |
             artifacts/**/*.tar.gz
             artifacts/**/*.deb
+            artifacts/**/*.rpm
 
   release:
     name: Create Release
@@ -161,7 +172,8 @@ jobs:
           cd artifacts
           find . -name "*.tar.gz" -exec mv {} . \;
           find . -name "*.deb" -exec mv {} . \;
-          sha256sum *.tar.gz > SHA256SUMS.txt
+          find . -name "*.rpm" -exec mv {} . \;
+          sha256sum *.tar.gz *.deb *.rpm > SHA256SUMS.txt
           cat SHA256SUMS.txt
 
       - name: Create GitHub Release
@@ -173,6 +185,7 @@ jobs:
           files: |
             artifacts/*.tar.gz
             artifacts/*.deb
+            artifacts/*.rpm
             artifacts/SHA256SUMS.txt
 
   publish-crates:

--- a/docs/cli/getting_started/installation.mdx
+++ b/docs/cli/getting_started/installation.mdx
@@ -16,11 +16,24 @@ brew install nono
 Download the `.deb` package from [GitHub Releases](https://github.com/always-further/nono/releases):
 
 ```bash
-VERSION=$(curl -sI https://github.com/always-further/nono/releases/latest | grep -i location | grep -oP 'v\K[0-9.]+')
+VERSION=$(curl -sI https://github.com/always-further/nono/releases/latest | grep -i location | grep -oP 'v\K[0-9a-zA-Z.-]+')
 ARCH=$(dpkg --print-architecture)
 wget https://github.com/always-further/nono/releases/download/v${VERSION}/nono-cli_${VERSION}_${ARCH}.deb
 sudo dpkg -i nono-cli_${VERSION}_${ARCH}.deb
 ```
+
+### Fedora/RHEL/openSUSE
+
+Download the `.rpm` package from [GitHub Releases](https://github.com/always-further/nono/releases):
+
+```bash
+VERSION=$(curl -sI https://github.com/always-further/nono/releases/latest | grep -i location | grep -oP 'v\K[0-9a-zA-Z.-]+')
+ARCH=$(uname -m)
+wget https://github.com/always-further/nono/releases/download/v${VERSION}/nono-cli-${VERSION}-1.${ARCH}.rpm
+sudo dnf install ./nono-cli-${VERSION}-1.${ARCH}.rpm
+```
+
+For openSUSE, use `sudo zypper install ./nono-cli-${VERSION}-1.${ARCH}.rpm` instead.
 
 ### Nix
 

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Build an RPM for an already-built nono CLI binary.
+# Usage: scripts/build-rpm.sh <version> <target> [binary]
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <version> <target> [binary]" >&2
+    echo "Targets: x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu" >&2
+}
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+    usage
+    exit 2
+fi
+
+if ! command -v rpmbuild >/dev/null 2>&1; then
+    echo "Error: rpmbuild is required to build RPM packages" >&2
+    exit 1
+fi
+
+ROOT="$(git rev-parse --show-toplevel)"
+PACKAGE_NAME="nono-cli"
+VERSION="${1#v}"
+TARGET="$2"
+BINARY="${3:-${ROOT}/target/${TARGET}/release/nono}"
+
+case "${TARGET}" in
+    x86_64-unknown-linux-gnu)
+        RPM_ARCH="x86_64"
+        ;;
+    aarch64-unknown-linux-gnu)
+        RPM_ARCH="aarch64"
+        ;;
+    *)
+        echo "Error: unsupported RPM target: ${TARGET}" >&2
+        usage
+        exit 1
+        ;;
+esac
+
+if [[ ! -f "${BINARY}" ]]; then
+    echo "Error: binary not found: ${BINARY}" >&2
+    exit 1
+fi
+
+RPM_VERSION="${VERSION}"
+RPM_RELEASE="1%{?dist}"
+if [[ "${VERSION}" == *-* ]]; then
+    RPM_VERSION="${VERSION%%-*}"
+    RPM_PRERELEASE="${VERSION#*-}"
+    RPM_PRERELEASE="${RPM_PRERELEASE//[^[:alnum:].]/.}"
+    RPM_RELEASE="0.${RPM_PRERELEASE}%{?dist}"
+fi
+
+WORKDIR="${ROOT}/target/rpm/${TARGET}"
+SOURCES_DIR="${WORKDIR}/SOURCES"
+SPECS_DIR="${WORKDIR}/SPECS"
+SOURCE_PARENT="${WORKDIR}/source"
+SOURCE_ROOT="${SOURCE_PARENT}/${PACKAGE_NAME}-${RPM_VERSION}"
+SPEC_FILE="${SPECS_DIR}/${PACKAGE_NAME}.spec"
+
+rm -rf "${WORKDIR}"
+mkdir -p "${SOURCES_DIR}" "${SPECS_DIR}" "${SOURCE_ROOT}"
+
+install -m 0755 "${BINARY}" "${SOURCE_ROOT}/nono"
+install -m 0644 "${ROOT}/README.md" "${SOURCE_ROOT}/README.md"
+install -m 0644 "${ROOT}/LICENSE" "${SOURCE_ROOT}/LICENSE"
+
+tar -C "${SOURCE_PARENT}" -czf "${SOURCES_DIR}/${PACKAGE_NAME}-${RPM_VERSION}.tar.gz" "${PACKAGE_NAME}-${RPM_VERSION}"
+
+cat > "${SPEC_FILE}" <<EOF
+Name:           ${PACKAGE_NAME}
+Version:        ${RPM_VERSION}
+Release:        ${RPM_RELEASE}
+Summary:        CLI for nono capability-based sandbox
+
+License:        Apache-2.0
+URL:            https://github.com/always-further/nono
+Source0:        %{name}-%{version}.tar.gz
+
+# This spec has no changelog; avoid distro macros trying to derive
+# SOURCE_DATE_EPOCH from one.
+%global source_date_epoch_from_changelog 0
+
+# The release binary is already built by Cargo. Avoid host strip/debug steps,
+# which can fail when packaging cross-compiled Linux binaries.
+%global debug_package %{nil}
+%global __brp_strip /bin/true
+%global __brp_strip_lto /bin/true
+%global __brp_strip_comment_note /bin/true
+%global __brp_strip_static_archive /bin/true
+
+%description
+nono is a capability-based sandboxing system for running untrusted AI agents
+with OS-enforced isolation.
+
+%prep
+%setup -q
+
+%build
+
+%install
+install -Dm0755 nono %{buildroot}/usr/bin/nono
+
+%files
+/usr/bin/nono
+%doc README.md
+%license LICENSE
+EOF
+
+rpmbuild \
+    --target "${RPM_ARCH}" \
+    --define "_topdir ${WORKDIR}" \
+    --define "dist %{nil}" \
+    -bb "${SPEC_FILE}"
+
+find "${WORKDIR}/RPMS" -name '*.rpm' -print


### PR DESCRIPTION
## Linked Issue

Closes #1035

## Summary

Add RPM packaging for the nono CLI release flow. The release workflow now builds RPMs for Linux x86_64 and aarch64 targets, stages them with the other release artifacts, and includes them in checksums and provenance attestations.

This also documents installation for Fedora, RHEL, and openSUSE users.

## Agent Disclosure

This PR was prepared with assistance from an AI coding agent.

Relevant files and sections consulted:
- `AGENTS.md` / `CLAUDE.md` repository contribution and release requirements
- `.github/workflows/release.yml`
- `.github/workflows/attest-release.yml`
- `docs/cli/getting_started/installation.mdx`
- existing Debian release packaging metadata in `crates/nono-cli/Cargo.toml`

The change is scoped to issue #1035 and avoids modifying sandbox/runtime behavior.

## Test Plan

Tested locally on Fedora:

```bash
cargo build --release --target x86_64-unknown-linux-gnu -p nono-cli
scripts/build-rpm.sh 0.59.0 x86_64-unknown-linux-gnu
rpm -qpl ./target/rpm/x86_64-unknown-linux-gnu/RPMS/x86_64/nono-cli-0.59.0-1.x86_64.rpm
rpm -qpR ./target/rpm/x86_64-unknown-linux-gnu/RPMS/x86_64/nono-cli-0.59.0-1.x86_64.rpm
sudo dnf remove nono-cli
sudo dnf install ./target/rpm/x86_64-unknown-linux-gnu/RPMS/x86_64/nono-cli-0.59.0-1.x86_64.rpm
nono --version
nono run --allow-cwd --dry-run -- echo test
```

Also checked:

```bash
bash -n scripts/build-rpm.sh
git diff --check
```

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope

Notes:
- No Rust error-handling paths were added, so `NonoError` is not applicable beyond confirming no new Rust error handling was introduced.
- No path canonicalization logic was added; packaging only installs fixed release artifacts into RPM paths.
- The agent disclosure is included in this PR body. If disclosure was also added to issue #1035, the unchecked issue-discussion item above can be checked before submission.
