### PR TITLE
fix(policy): remove npm from dangerous_commands deny list

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -556,7 +556,6 @@
           "su",
           "doas",
           "pip",
-          "npm",
           "kill",
           "killall",
           "pkill",


### PR DESCRIPTION
Closes #1042

**What:** Removes `npm` from the `dangerous_commands` group `deny.commands` in `crates/nono-cli/data/policy.json`.

**Why:** Command blocking was deprecated in v0.33.0 — it is startup-only gating, not kernel-enforced, and child processes bypass it. The `node-dev` profile extends `default` which includes `dangerous_commands`, so `npm` was blocked at startup despite the profile being designed for Node.js development.

**Security:** The real security for `node-dev` is already provided by filesystem deny paths (credentials, keychains, shell history), scoped allow grants (node_runtime group), and OS-level sandboxing (Seatbelt/Landlock). Command blocking was never effective against child processes and removing this stale entry does not degrade actual protection.

**Attribution:** `npm` was originally added to `dangerous_commands` in commit 4b572ee (Luke Hinds, Mar 14), prior to the deprecation of command blocking in commit 0ca641b (Apr 12).

### Checklist
- [x] Issue exists (#1042)
- [x] Change discussed in issue before implementation
- [x] All tests pass (1102 passed)
- [x] Clippy clean
- [x] DCO sign-off included