### PR TITLE
fix(sandbox/linux): allow open_port=0 to disable Landlock TCP in Prox…

### DIFF
--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -1066,8 +1066,16 @@ impl CapabilitySet {
     /// `127.0.0.1:port`. Works across all network modes.
     ///
     /// On macOS: outbound is per-port via Seatbelt; bind/inbound is blanket
-    /// (same tradeoff as `--allow-bind`).
-    /// On Linux: per-port ConnectTcp + BindTcp via Landlock.
+    /// (same tradeoff as `--allow-bind`). Port `0` generates a `localhost:*`
+    /// wildcard rule, allowing any localhost port.
+    ///
+    /// On Linux: per-port ConnectTcp + BindTcp via Landlock. Port `0` has no
+    /// wildcard semantics in Landlock — `ConnectTcp/0` only matches connects to
+    /// destination port 0, and `BindTcp/0` only permits `bind(port=0)` (OS ephemeral
+    /// assignment). Neither covers connecting to a random high port such as a
+    /// Testcontainers mapping. Instead, port `0` causes Landlock network handling to be
+    /// skipped entirely, leaving the proxy as the sole domain enforcer. This is only
+    /// permitted in `ProxyOnly` mode; `Blocked` mode rejects port `0` at sandbox init.
     #[must_use]
     pub fn allow_localhost_port(mut self, port: u16) -> Self {
         self.localhost_ports.push(port);

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -479,12 +479,47 @@ pub fn apply_with_abi(caps: &CapabilitySet, abi: &DetectedAbi) -> Result<Seccomp
     info!("Using Landlock ABI {:?}", target_abi);
     let scopes = requested_scopes(caps, abi)?;
 
-    if !matches!(caps.network_mode(), NetworkMode::AllowAll) && caps.localhost_ports().contains(&0)
-    {
+    // Port 0 in localhost_ports means "allow all TCP ports" (localhost wildcard).
+    //
+    // Landlock's network rules match on exact port number via a red-black tree lookup
+    // in security/landlock/net.c; there is no wildcard rule type and no IP filter.
+    // Port 0 has access-specific semantics:
+    //   - BindTcp/port 0: matches bind(port=0), allowing OS ephemeral port assignment
+    //     from ip_local_port_range. Useful, but only covers the bind side.
+    //   - ConnectTcp/port 0: matches connect() to destination port 0 only — not a
+    //     wildcard. connect(localhost:32768) still has no rule and is denied EACCES.
+    // There is also no way to express "allow 127.0.0.1:* but deny external:*" — rules
+    // carry no IP-address component.
+    //
+    // In Blocked mode there is no proxy to enforce host-level restrictions; reject here.
+    //
+    // In ProxyOnly mode the correct approach is to skip Landlock network handling entirely.
+    // Without handle_access(AccessNet) on the ruleset, the kernel imposes no TCP port
+    // restrictions. The proxy (injected via HTTPS_PROXY / HTTP_PROXY env vars) then acts
+    // as the sole domain enforcer. This matches macOS behaviour where Seatbelt expresses
+    // localhost:* as a true wildcard; Linux achieves the same result by not adding any
+    // Landlock TCP rules.
+    if matches!(caps.network_mode(), NetworkMode::Blocked) && caps.localhost_ports().contains(&0) {
         return Err(NonoError::SandboxInit(
-            "open_port 0 (localhost TCP wildcard) is macOS-only; on Linux use explicit ports or a network profile."
+            "open_port 0 (localhost TCP wildcard) requires ProxyOnly mode on Linux. \
+             Landlock cannot restrict TCP connects by destination IP, so port 0 must \
+             disable Landlock network enforcement; this is only safe when a proxy \
+             enforces domain restrictions. Use --proxy or --allow-domain."
                 .to_string(),
         ));
+    }
+
+    // When port 0 is in localhost_ports with ProxyOnly, skip all Landlock network handling.
+    // The proxy is the sole TCP enforcer; all kernel-level port restrictions are lifted.
+    let localhost_wildcard_proxy = matches!(caps.network_mode(), NetworkMode::ProxyOnly { .. })
+        && caps.localhost_ports().contains(&0);
+
+    if localhost_wildcard_proxy {
+        warn!(
+            "open_port 0 in ProxyOnly mode: Landlock TCP enforcement disabled. \
+             All ports are accessible at the kernel level; domain restrictions \
+             are enforced by the proxy only."
+        );
     }
 
     // Determine which access rights to handle based on ABI
@@ -502,16 +537,22 @@ pub fn apply_with_abi(caps: &CapabilitySet, abi: &DetectedAbi) -> Result<Seccomp
         .map_err(|e| NonoError::SandboxInit(format!("Failed to handle fs access: {}", e)))?
         .set_compatibility(CompatLevel::BestEffort);
 
-    // Determine if we need network handling (any mode besides AllowAll)
-    let needs_network_handling = !matches!(caps.network_mode(), NetworkMode::AllowAll)
-        || !caps.tcp_connect_ports().is_empty()
-        || !caps.tcp_bind_ports().is_empty();
+    // Skip all kernel-level TCP filtering when localhost_wildcard_proxy is set; the proxy
+    // is the enforcer. Also skip when AllowAll and no explicit port lists are requested.
+    let needs_network_handling = !localhost_wildcard_proxy
+        && (!matches!(caps.network_mode(), NetworkMode::AllowAll)
+            || !caps.tcp_connect_ports().is_empty()
+            || !caps.tcp_bind_ports().is_empty());
 
     let mut seccomp_net_fallback = SeccompNetFallback::None;
+    // True only when Landlock itself is configured to handle AccessNet (not seccomp fallback,
+    // and not skipped via localhost_wildcard_proxy). Only then can NetPort rules be added.
+    let mut network_handled_by_landlock = false;
 
     let ruleset_builder = if needs_network_handling {
         let handled_net = AccessNet::from_all(target_abi);
         if !handled_net.is_empty() {
+            network_handled_by_landlock = true;
             debug!("Handling network access: {:?}", handled_net);
             ruleset_builder
                 .set_compatibility(CompatLevel::HardRequirement)
@@ -594,10 +635,10 @@ pub fn apply_with_abi(caps: &CapabilitySet, abi: &DetectedAbi) -> Result<Seccomp
         .create()
         .map_err(|e| NonoError::SandboxInit(format!("Failed to create ruleset: {}", e)))?;
 
-    // Add Landlock network port rules ONLY when Landlock is handling networking.
-    // When a seccomp fallback is active (BlockAll or ProxyOnly), the ruleset was
-    // created without handle_access(AccessNet), so adding NetPort rules would fail.
-    if matches!(seccomp_net_fallback, SeccompNetFallback::None) {
+    // Add Landlock network port rules only when Landlock itself is handling networking.
+    // Skipped when seccomp fallback is active (ruleset has no AccessNet), or when
+    // localhost_wildcard_proxy disabled Landlock network handling entirely.
+    if network_handled_by_landlock {
         // Add per-port TCP connect rules (ProxyOnly port + explicit tcp_connect_ports)
         if let NetworkMode::ProxyOnly { port, bind_ports } = caps.network_mode() {
             debug!("Adding ProxyOnly TCP connect rule for port {}", port);
@@ -648,6 +689,8 @@ pub fn apply_with_abi(caps: &CapabilitySet, abi: &DetectedAbi) -> Result<Seccomp
         // Add localhost IPC port rules (connect + bind per port).
         // Only meaningful in Blocked/ProxyOnly modes. In AllowAll mode, all ports are
         // already reachable and adding Landlock network handling would restrict them.
+        // Port 0 (localhost wildcard in ProxyOnly mode) is handled above by skipping
+        // network handling entirely, so localhost_ports here never contains 0 in that path.
         if !matches!(caps.network_mode(), NetworkMode::AllowAll) {
             for port in caps.localhost_ports() {
                 debug!("Adding localhost TCP connect rule for port {}", port);
@@ -3219,9 +3262,9 @@ mod tests {
         );
     }
 
-    /// Rejects `open_port: [0]` on Linux for any restricted network mode (not Landlock-only).
+    /// Rejects `open_port: [0]` in Blocked mode — no proxy to enforce host-level restrictions.
     #[test]
-    fn test_reject_localhost_port_wildcard_zero_on_linux() {
+    fn test_reject_localhost_port_wildcard_zero_in_blocked_mode() {
         let Ok(detected) = detect_abi() else {
             return;
         };
@@ -3229,7 +3272,29 @@ mod tests {
         caps.add_localhost_port(0);
         let err = apply_with_abi(&caps, &detected).expect_err("port 0 wildcard must be rejected");
         let msg = format!("{err}");
-        assert!(msg.contains("macOS-only"), "unexpected error: {msg}");
+        assert!(
+            msg.contains("ProxyOnly mode"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    /// Accepts `open_port: [0]` in ProxyOnly mode on Linux (Landlock v4+) — the proxy
+    /// enforces domain restrictions; port 0 acts as a wildcard to allow localhost
+    /// connections on dynamically assigned ports (e.g. Testcontainers, Maven Surefire).
+    #[test]
+    fn test_accept_localhost_port_wildcard_zero_in_proxy_only_mode() {
+        let Ok(detected) = detect_abi() else {
+            return;
+        };
+        if !detected.has_network() {
+            // Landlock < v4: no TCP filtering; test not applicable.
+            return;
+        }
+        let mut caps = CapabilitySet::new().proxy_only(8080);
+        caps.add_localhost_port(0);
+        // Should not return an error; port 0 is the Landlock wildcard.
+        apply_with_abi(&caps, &detected)
+            .expect("port 0 in ProxyOnly mode must be accepted on Linux");
     }
 
     #[test]

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -3292,9 +3292,37 @@ mod tests {
         }
         let mut caps = CapabilitySet::new().proxy_only(8080);
         caps.add_localhost_port(0);
-        // Should not return an error; port 0 is the Landlock wildcard.
-        apply_with_abi(&caps, &detected)
-            .expect("port 0 in ProxyOnly mode must be accepted on Linux");
+
+        // Fork a child to isolate the irreversible sandbox application.
+        // apply_with_abi() calls restrict_self(), which permanently sandboxes the
+        // calling process. Running it in a child prevents corrupting the test runner.
+        // SAFETY: fork() is used in a test helper; the child exits via _exit without
+        // running parent process destructors after fork.
+        let child_pid = unsafe { libc::fork() };
+        assert!(child_pid >= 0, "fork() failed");
+
+        if child_pid == 0 {
+            let exit_code = match apply_with_abi(&caps, &detected) {
+                Ok(_) => 0,
+                Err(_) => 1,
+            };
+            // SAFETY: _exit terminates the child without running parent destructors.
+            unsafe { libc::_exit(exit_code) };
+        }
+
+        let mut child_status = 0;
+        // SAFETY: child_pid is the PID returned by fork() in the parent branch.
+        let waited = unsafe { libc::waitpid(child_pid, &mut child_status, 0) };
+        assert_eq!(waited, child_pid, "waitpid() failed");
+        assert!(
+            libc::WIFEXITED(child_status),
+            "child did not exit normally"
+        );
+        assert_eq!(
+            libc::WEXITSTATUS(child_status),
+            0,
+            "port 0 in ProxyOnly mode must be accepted on Linux"
+        );
     }
 
     #[test]

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -3272,10 +3272,7 @@ mod tests {
         caps.add_localhost_port(0);
         let err = apply_with_abi(&caps, &detected).expect_err("port 0 wildcard must be rejected");
         let msg = format!("{err}");
-        assert!(
-            msg.contains("ProxyOnly mode"),
-            "unexpected error: {msg}"
-        );
+        assert!(msg.contains("ProxyOnly mode"), "unexpected error: {msg}");
     }
 
     /// Accepts `open_port: [0]` in ProxyOnly mode on Linux (Landlock v4+) — the proxy
@@ -3314,10 +3311,7 @@ mod tests {
         // SAFETY: child_pid is the PID returned by fork() in the parent branch.
         let waited = unsafe { libc::waitpid(child_pid, &mut child_status, 0) };
         assert_eq!(waited, child_pid, "waitpid() failed");
-        assert!(
-            libc::WIFEXITED(child_status),
-            "child did not exit normally"
-        );
+        assert!(libc::WIFEXITED(child_status), "child did not exit normally");
         assert_eq!(
             libc::WEXITSTATUS(child_status),
             0,


### PR DESCRIPTION
# Allow `open_port = [0]` in ProxyOnly mode on Linux

**Closes #611**

---

## What this fixes

When domain filtering is active (`--allow-domain` / `--proxy`), nono enters ProxyOnly mode.
Landlock restricts outbound TCP to the proxy port only. This breaks Testcontainers and Maven
Surefire, both of which bind to dynamically assigned ports on localhost that cannot be known in
advance:

- Testcontainers maps Docker container ports to random ephemeral ports on `127.0.0.1`
- Maven Surefire binds to `127.0.0.1:0` (OS-assigned ephemeral port) for inter-process
  coordination

Before this change, users had to disable domain filtering entirely to run their test suite,
losing the protection they wanted.

---

## Approach

On macOS, `open_port = [0]` already works: Seatbelt generates
`(allow network-outbound (remote tcp "localhost:*"))`, a genuine IP-scoped wildcard that permits
any localhost port while external hosts remain restricted. Linux cannot do the same.

### Why Linux requires a different mechanism

Landlock network rules match on **exact port number** via a red-black tree lookup in
`security/landlock/net.c`. There is no wildcard rule type and no IP-address filter. Port 0 has
access-specific semantics but is not a general wildcard:

- **`BindTcp` + port 0**: meaningful — matches `bind(port=0)` calls, triggering OS ephemeral
  port assignment from `/proc/sys/net/ipv4/ip_local_port_range`. Covers Maven Surefire's bind
  side only.
- **`ConnectTcp` + port 0**: matches `connect()` to destination port 0 only. A Testcontainers
  `connect(localhost:32768)` has no matching rule and is denied `EACCES`.

There is no way to express "allow `127.0.0.1:*` but deny `*.*.*.*:*`" in Landlock — rules carry
no IP-address component.

The correct mechanism: when `open_port = [0]` is set in ProxyOnly mode, **skip
`handle_access(AccessNet)` on the Landlock ruleset entirely**. A ruleset with no `AccessNet`
handling imposes no kernel-level TCP restrictions. The proxy — already running, already injecting
`HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` — becomes the sole network enforcer.

This also applies to the seccomp fallback path (kernels without Landlock v4+): the seccomp TCP
filter is similarly skipped.

### Security scope of this change

Skipping `handle_access(AccessNet)` removes kernel-level TCP enforcement entirely, not just for
localhost. A process can make **direct raw TCP connections to remote hosts on any port**,
bypassing the proxy. This affects non-HTTP TCP clients such as `psql`, `redis-cli`, `nc`, or
custom socket code with a hardcoded IP — tools that do not read `HTTPS_PROXY`.

This is a deliberate and disclosed tradeoff: ProxyOnly mode is designed to constrain **HTTP/HTTPS
requests** to unauthorized domains, which standard HTTP libraries route through the proxy
automatically. The remaining sandbox layers (Landlock filesystem restrictions, command blocklists,
process isolation) continue to apply.

A complete fix for raw TCP bypass would require either:

- **Network namespace isolation**: confine the sandbox to a namespace with only loopback and a
  veth to the proxy, making external IPs unreachable by construction
- **cgroup BPF (`BPF_PROG_TYPE_CGROUP_SOCK_ADDR`)**: a BPF program that permits `127.0.0.1:*`
  and denies all other destinations

Both require capabilities outside nono's current architecture. This change is a pragmatic
improvement for the common case, with the limitation fully documented in code and in this PR.

`open_port = [0]` in `Blocked` mode (no proxy) continues to be rejected with an error directing
users to `--allow-domain`.

---

## Files changed

| File | Change |
|---|---|
| `crates/nono/src/sandbox/linux.rs` | Port 0 rejection narrowed to `Blocked` mode only; `localhost_wildcard_proxy` flag added; `needs_network_handling` skips when flag is set; `network_handled_by_landlock` gates the NetPort rule block (prevents adding port rules to a ruleset not configured for `AccessNet`); `warn!()` emitted at runtime |
| `crates/nono/src/capability.rs` | `allow_localhost_port` doc updated to explain port 0 semantics per platform and the Linux scope difference |

## Tests

- `test_reject_localhost_port_wildcard_zero_in_blocked_mode` — renamed and updated; verifies
  port 0 in `block_network` mode is still rejected with a message directing to ProxyOnly mode
- `test_accept_localhost_port_wildcard_zero_in_proxy_only_mode` — new; verifies `apply_with_abi`
  succeeds with `proxy_only(8080)` + `localhost_port(0)` on Landlock v4+ kernels; skips
  gracefully on older kernels

---

## Contributor notes

This PR was prepared by Claude (Anthropic), an AI coding assistant, at the request of a
maintainer. The implementation went through two iterations: the first attempt incorrectly assumed
`NetPort::new(0, ...)` was a Landlock wildcard (it is not); the second iteration skips network
handling entirely, which is the correct mechanism. The scope of the TCP relaxation — not just
localhost but all TCP — was identified and disclosed during implementation.

Files and sections consulted:

- `crates/nono/src/sandbox/linux.rs` — `apply_with_abi`, `SeccompNetFallback`,
  `seccomp_network_fallback_mode`, existing port 0 rejection guard
- `crates/nono/src/sandbox/macos.rs` — `push_localhost_tcp_outbound_seatbelt_rules`,
  port 0 → `localhost:*` wildcard handling
- `crates/nono/src/capability.rs` — `NetworkMode`, `CapabilitySet`, `allow_localhost_port`,
  `localhost_ports` field docs
- `crates/nono-cli/src/capability_ext.rs` — port flow from CLI/profile into `CapabilitySet`
- Linux kernel `security/landlock/net.c` — confirmed exact-port red-black tree matching;
  no wildcard rule exists; port 0 semantics per access type

---

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists (#611)
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (none reused; all new logic)
- [x] I did not use forbidden patterns such as `unwrap`/`expect`
- [x] I used `NonoError` where required
- [x] I validated and canonicalized all relevant paths (no path handling in this change)
- [x] This PR matches the approved or disclosed issue scope
- [ ] I described my intent and approach in the issue discussion before implementing

The final item is unchecked: implementation preceded issue discussion because this was a
maintainer-directed change. The security tradeoff (raw TCP beyond localhost) was identified during
implementation and is disclosed here rather than in the issue thread.