### PR TITLE
build: add copr source rpm packaging

### DIFF
--- a/packaging/rpm/README.md
+++ b/packaging/rpm/README.md
@@ -1,0 +1,47 @@
+# RPM source packaging
+
+This directory contains the RPM source package template used to build `nono-cli`
+from source for Fedora COPR.
+
+The GitHub Release RPM workflow uses `scripts/build-rpm.sh`, which packages an
+already-built release binary. COPR should instead build from a source RPM, using
+the helper below.
+
+## Build an SRPM
+
+```bash
+scripts/build-srpm.sh
+```
+
+To build an SRPM for a specific version or tag value:
+
+```bash
+scripts/build-srpm.sh 0.61.1
+scripts/build-srpm.sh v0.61.1
+```
+
+The generated SRPM is written under:
+
+```text
+target/rpm/copr/SRPMS/
+```
+
+The helper vendors Cargo dependencies into the source tarball and writes a local
+Cargo source override, so COPR can build with `cargo --offline`.
+
+## Submit to COPR
+
+After creating the COPR project, submit the generated SRPM:
+
+```bash
+copr-cli build always-further/nono target/rpm/copr/SRPMS/*.src.rpm
+```
+
+Replace `always-further/nono` with the actual COPR owner/project name if the
+official project uses a COPR group namespace.
+
+## Build requirements
+
+The spec expects chroots with Rust and Cargo 1.95 or newer, matching the
+workspace `rust-version`. It also requires the native C/C++ toolchain and CMake
+for vendored Rust dependencies that compile native code.

--- a/packaging/rpm/nono-cli.spec.in
+++ b/packaging/rpm/nono-cli.spec.in
@@ -1,0 +1,38 @@
+Name:           nono-cli
+Version:        @RPM_VERSION@
+Release:        @RPM_RELEASE@
+Summary:        CLI for nono capability-based sandbox
+
+License:        Apache-2.0
+URL:            https://github.com/always-further/nono
+Source0:        nono-%{version}.tar.gz
+
+# This spec has no changelog; avoid distro macros trying to derive
+# SOURCE_DATE_EPOCH from one.
+%global source_date_epoch_from_changelog 0
+
+BuildRequires:  cargo >= 1.95
+BuildRequires:  rust >= 1.95
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
+BuildRequires:  cmake
+BuildRequires:  make
+BuildRequires:  perl
+
+%description
+nono is a capability-based sandboxing system for running untrusted AI agents
+with OS-enforced isolation.
+
+%prep
+%autosetup -n nono-%{version}
+
+%build
+cargo build --release --locked --offline -p nono-cli
+
+%install
+install -Dm0755 target/release/nono %{buildroot}%{_bindir}/nono
+
+%files
+%{_bindir}/nono
+%doc README.md
+%license LICENSE

--- a/scripts/build-srpm.sh
+++ b/scripts/build-srpm.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Build a source RPM suitable for Fedora COPR.
+# Usage: scripts/build-srpm.sh [version]
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 [version]" >&2
+}
+
+if [[ $# -gt 1 ]]; then
+    usage
+    exit 2
+fi
+
+for tool in cargo git rpmbuild tar; do
+    if ! command -v "${tool}" >/dev/null 2>&1; then
+        echo "Error: ${tool} is required to build the source RPM" >&2
+        exit 1
+    fi
+done
+
+ROOT="$(git rev-parse --show-toplevel)"
+if ! git -C "${ROOT}" diff-index --quiet HEAD --; then
+    echo "Warning: You have uncommitted changes. 'git archive' will only package committed changes from HEAD." >&2
+fi
+PACKAGE_NAME="nono-cli"
+VERSION="${1:-$(sed -n 's/^version = "\([^"]*\)"/\1/p' "${ROOT}/crates/nono-cli/Cargo.toml" | head -n 1)}"
+VERSION="${VERSION#v}"
+
+if [[ -z "${VERSION}" ]]; then
+    echo "Error: could not determine nono-cli version" >&2
+    exit 1
+fi
+
+RPM_VERSION="${VERSION}"
+RPM_RELEASE="1%{?dist}"
+if [[ "${VERSION}" == *-* ]]; then
+    RPM_VERSION="${VERSION%%-*}"
+    RPM_PRERELEASE="${VERSION#*-}"
+    RPM_PRERELEASE="${RPM_PRERELEASE//[^[:alnum:].]/.}"
+    RPM_RELEASE="0.${RPM_PRERELEASE}%{?dist}"
+fi
+
+WORKDIR="${ROOT}/target/rpm/copr"
+SOURCES_DIR="${WORKDIR}/SOURCES"
+SPECS_DIR="${WORKDIR}/SPECS"
+SOURCE_PARENT="${WORKDIR}/source"
+SOURCE_NAME="nono-${RPM_VERSION}"
+SOURCE_ROOT="${SOURCE_PARENT}/${SOURCE_NAME}"
+SPEC_TEMPLATE="${ROOT}/packaging/rpm/${PACKAGE_NAME}.spec.in"
+SPEC_FILE="${SPECS_DIR}/${PACKAGE_NAME}.spec"
+
+if [[ ! -f "${SPEC_TEMPLATE}" ]]; then
+    echo "Error: spec template not found: ${SPEC_TEMPLATE}" >&2
+    exit 1
+fi
+
+rm -rf "${WORKDIR}"
+mkdir -p "${SOURCES_DIR}" "${SPECS_DIR}" "${SOURCE_PARENT}"
+
+git -C "${ROOT}" archive --format=tar --prefix="${SOURCE_NAME}/" HEAD | tar -C "${SOURCE_PARENT}" -xf -
+
+mkdir -p "${SOURCE_ROOT}/.cargo"
+(
+    cd "${SOURCE_ROOT}"
+    cargo vendor --quiet --locked --versioned-dirs vendor >> .cargo/config.toml
+)
+
+sed \
+    -e "s|@RPM_VERSION@|${RPM_VERSION}|g" \
+    -e "s|@RPM_RELEASE@|${RPM_RELEASE}|g" \
+    "${SPEC_TEMPLATE}" > "${SPEC_FILE}"
+
+tar -C "${SOURCE_PARENT}" -czf "${SOURCES_DIR}/${SOURCE_NAME}.tar.gz" "${SOURCE_NAME}"
+
+rpmbuild \
+    --define "_topdir ${WORKDIR}" \
+    --define "dist %{nil}" \
+    -bs "${SPEC_FILE}"
+
+find "${WORKDIR}/SRPMS" -name '*.src.rpm' -print


### PR DESCRIPTION
## Linked Issue

Closes #1074

## Summary

Add source RPM packaging support for Fedora COPR. This adds an RPM spec template and a helper script that builds an SRPM from the current repository contents, vendors Cargo dependencies, and configures Cargo to build offline inside COPR.

This is intentionally separate from the existing GitHub Release RPM flow:
- `scripts/build-rpm.sh` packages an already-built release binary for GitHub Releases.
- `scripts/build-srpm.sh` creates a source RPM suitable for COPR, where COPR builds the binary from source.

## Creating the official COPR project

A maintainer with the desired COPR namespace can create the project with something like:

```bash
sudo dnf install copr-cli
copr-cli create always-further/nono \
  --chroot fedora-rawhide-x86_64 \
  --chroot fedora-rawhide-aarch64 \
  --chroot fedora-44-x86_64 \
  --chroot fedora-44-aarch64 \
  --description "RPM packages for nono" \
  --instructions "sudo dnf copr enable always-further/nono && sudo dnf install nono-cli"
```

If COPR uses a group namespace for the project, replace `always-further/nono` with the actual COPR owner/project name.

Then submit an SRPM:

```bash
scripts/build-srpm.sh
copr-cli build always-further/nono target/rpm/copr/SRPMS/*.src.rpm
```

## Test Plan

```bash
bash -n scripts/build-srpm.sh
bash -n scripts/build-rpm.sh
git diff --check
```

If local Rust/Cargo is new enough for this workspace, also run:

```bash
scripts/build-srpm.sh
rpm -qpi target/rpm/copr/SRPMS/*.src.rpm
```

## Notes

This PR does not add automatic COPR publishing or secrets. Once the official COPR project exists and the manual SRPM flow is validated, a follow-up can wire release automation with `copr-cli` and a repository secret.