### PR TITLE
fix: remove env_clear from the session_hook subprocess

### DIFF
--- a/crates/nono-cli/src/hook_runtime.rs
+++ b/crates/nono-cli/src/hook_runtime.rs
@@ -11,7 +11,7 @@
 //!
 //! - Script paths are validated before every execution
 //!   (absolute, canonical, regular file, executable, owned by user, not world-writable)
-//! - Hooks run as subprocesses with minimal environment
+//! - Hooks run as subprocesses
 //! - Process group isolation for timeout-based killing
 //! - NONO_ENV_FILE is used for env var export (not stdout parsing)
 //! - Dangerous env vars are filtered before injection
@@ -168,7 +168,6 @@ fn build_hook_command(
     kind: &HookKind<'_>,
 ) -> Command {
     let mut cmd = Command::new(script);
-    cmd.env_clear();
     cmd.env("NONO_SESSION_ID", session_id);
     cmd.env("NONO_WORKDIR", workdir);
     cmd.env("NONO_HOOK_TYPE", kind.type_env());


### PR DESCRIPTION
The session hooks already run on the host, outside of the sandbox. Therefore, there's no security boundary for restricting the environment, as the hook can source the same files (or just start a shell and export the vars)

Clearing the environment, however, makes it difficult to do proper operations without resorting to these workarounds, such as setting an environment variable derived from HOME, or using PATH etc.

The fix here is simply to remove env_clear, allowing the session hooks to easily have access to the same context that nono has

## Linked Issue

[session hooks need better environment support](https://github.com/always-further/nono/issues/1078)

Closes #1078 

## Summary
One-liner, just removes env_clear from the session_hook runtime. This allows the hook scripts to have access to $HOME, $PATH, $LANG and all the other important environment variables

## Test Plan
Run a hook, see that it can echo out $HOME

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
