### PR TITLE
fix(proxy): deny-by-default when network.block is set

### DIFF
--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -87,6 +87,10 @@ pub(crate) struct ProxyLaunchOptions {
     #[cfg(target_os = "macos")]
     pub(crate) trust_proxy_ca: bool,
     pub(crate) proxy_ca_validity: Option<std::time::Duration>,
+    /// True when the user requested `network.block` or `--block-net`.
+    /// Propagated to `ProxyConfig.strict_filter` so the filter denies
+    /// unlisted hosts instead of falling back to allow-all.
+    pub(crate) network_block: bool,
 }
 
 #[derive(Clone)]

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -287,6 +287,7 @@ mod tests {
             suppressed_system_service_operations: Vec::new(),
             allowed_env_vars: None,
             denied_env_vars: None,
+            network_block_requested: false,
         };
 
         let effective = resolve_effective_proxy_settings(&args, &prepared);
@@ -338,6 +339,7 @@ mod tests {
             suppressed_system_service_operations: Vec::new(),
             allowed_env_vars: None,
             denied_env_vars: None,
+            network_block_requested: false,
         };
 
         let effective = resolve_effective_proxy_settings(&args, &prepared);

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -97,6 +97,7 @@ pub(crate) fn prepare_proxy_launch_options(
         proxy_ca_validity: args
             .proxy_ca_validity
             .map(|days| std::time::Duration::from_secs(u64::from(days) * 24 * 60 * 60)),
+        network_block: prepared.network_block_requested,
     })
 }
 
@@ -208,6 +209,7 @@ pub(crate) fn build_proxy_config_from_flags(
     resolved.routes = routes;
 
     let mut proxy_config = network_policy::build_proxy_config(&resolved, &plain_hosts);
+    proxy_config.strict_filter = proxy.network_block;
 
     if let Some(ref addr) = proxy.upstream_proxy {
         proxy_config.external_proxy = Some(nono_proxy::config::ExternalProxyConfig {
@@ -530,5 +532,34 @@ mod tests {
             }
             _ => panic!("expected WithEndpoints"),
         }
+    }
+
+    /// `network_block: true` must set `strict_filter` on the generated `ProxyConfig`.
+    #[test]
+    fn test_build_proxy_config_propagates_network_block_to_strict_filter() {
+        let proxy = ProxyLaunchOptions {
+            active: true,
+            network_block: true,
+            ..ProxyLaunchOptions::default()
+        };
+        let config = build_proxy_config_from_flags(&proxy).expect("build_proxy_config_from_flags");
+        assert!(
+            config.strict_filter,
+            "network_block: true must set strict_filter on ProxyConfig"
+        );
+    }
+
+    #[test]
+    fn test_build_proxy_config_strict_filter_off_when_no_block() {
+        let proxy = ProxyLaunchOptions {
+            active: true,
+            network_block: false,
+            ..ProxyLaunchOptions::default()
+        };
+        let config = build_proxy_config_from_flags(&proxy).expect("build_proxy_config_from_flags");
+        assert!(
+            !config.strict_filter,
+            "strict_filter must default off when network_block is false"
+        );
     }
 }

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -441,6 +441,10 @@ pub(crate) struct PreparedSandbox {
     pub(crate) suppressed_system_service_operations: Vec<String>,
     pub(crate) allowed_env_vars: Option<Vec<String>>,
     pub(crate) denied_env_vars: Option<Vec<String>>,
+    /// True when the profile or CLI requested `network.block`. Carried
+    /// through because a CLI proxy flag (e.g. `--credential`) may later
+    /// override `caps` to `ProxyOnly`, losing the original intent.
+    pub(crate) network_block_requested: bool,
 }
 
 fn resolved_workdir(args: &SandboxArgs) -> PathBuf {
@@ -1070,6 +1074,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
                 suppressed_system_service_operations: Vec::new(),
                 allowed_env_vars: None,
                 denied_env_vars: None,
+                network_block_requested: args.block_net,
             },
             args,
             silent,
@@ -1339,6 +1344,14 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         return Err(NonoError::NoCapabilities);
     }
 
+    // Capture the profile's `network.block` intent before `loaded_profile`
+    // is consumed below.
+    let profile_network_block = loaded_profile
+        .as_ref()
+        .map(|p| p.network.block)
+        .unwrap_or(false);
+    let network_block_requested = args.block_net || profile_network_block;
+
     let profile_secrets = loaded_profile
         .map(|profile| profile.env_credentials.mappings)
         .unwrap_or_default();
@@ -1372,6 +1385,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
             suppressed_system_service_operations,
             allowed_env_vars: profile_allowed_env_vars,
             denied_env_vars: profile_denied_env_vars,
+            network_block_requested,
         },
         args,
         silent,

--- a/crates/nono-proxy/src/config.rs
+++ b/crates/nono-proxy/src/config.rs
@@ -36,9 +36,15 @@ pub struct ProxyConfig {
     pub bind_port: u16,
 
     /// Allowed hosts for CONNECT mode (exact match + wildcards).
-    /// Empty = allow all hosts (except deny list).
+    /// Empty = allow all hosts (except deny list), unless `strict_filter`
+    /// is `true`.
     #[serde(default)]
     pub allowed_hosts: Vec<String>,
+
+    /// When `true`, an empty `allowed_hosts` denies every host instead of
+    /// falling back to allow-all.
+    #[serde(default)]
+    pub strict_filter: bool,
 
     /// Reverse proxy credential routes.
     #[serde(default)]
@@ -144,6 +150,7 @@ impl Default for ProxyConfig {
             bind_addr: default_bind_addr(),
             bind_port: 0,
             allowed_hosts: Vec::new(),
+            strict_filter: false,
             routes: Vec::new(),
             external_proxy: None,
             direct_connect_ports: Vec::new(),

--- a/crates/nono-proxy/src/filter.rs
+++ b/crates/nono-proxy/src/filter.rs
@@ -36,6 +36,14 @@ impl ProxyFilter {
         }
     }
 
+    /// Create a strict proxy filter: an empty allowlist denies every host.
+    #[must_use]
+    pub fn new_strict(allowed_hosts: &[String]) -> Self {
+        Self {
+            inner: HostFilter::new_strict(allowed_hosts),
+        }
+    }
+
     /// Create a filter that allows all hosts (except cloud metadata).
     #[must_use]
     pub fn allow_all() -> Self {

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -401,8 +401,10 @@ pub async fn start(config: ProxyConfig) -> Result<ProxyHandle> {
     };
     let loaded_routes = credential_store.loaded_prefixes();
 
-    // Build filter
-    let filter = if config.allowed_hosts.is_empty() {
+    // Build filter. Strict mode treats an empty allowlist as deny-all.
+    let filter = if config.strict_filter {
+        ProxyFilter::new_strict(&config.allowed_hosts)
+    } else if config.allowed_hosts.is_empty() {
         ProxyFilter::allow_all()
     } else {
         ProxyFilter::new(&config.allowed_hosts)
@@ -1642,6 +1644,49 @@ mod tests {
         assert!(
             !no_proxy.1.contains("server.internal"),
             "host on port 4222 should NOT be in NO_PROXY when only 443 is allowed"
+        );
+
+        handle.shutdown();
+    }
+
+    /// Regression test: when `strict_filter` is true and `allowed_hosts` is
+    /// empty, the proxy must deny CONNECT instead of falling back to allow-all.
+    #[tokio::test]
+    async fn test_strict_filter_with_empty_allowlist_denies_connect() {
+        use tokio::io::AsyncReadExt;
+        use tokio::net::TcpStream;
+
+        let config = ProxyConfig {
+            strict_filter: true,
+            allowed_hosts: Vec::new(),
+            ..ProxyConfig::default()
+        };
+        let handle = start(config).await.unwrap();
+        let addr = format!("127.0.0.1:{}", handle.port);
+
+        let mut stream = TcpStream::connect(&addr).await.unwrap();
+        let request = b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n";
+        tokio::io::AsyncWriteExt::write_all(&mut stream, request)
+            .await
+            .unwrap();
+
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.unwrap();
+        let response_str = String::from_utf8_lossy(&response);
+        assert!(
+            response_str.starts_with("HTTP/1.1 403"),
+            "strict filter with empty allowlist must deny CONNECT, got: {}",
+            response_str
+        );
+
+        let events = handle.drain_audit_events();
+        assert!(
+            events
+                .iter()
+                .any(|e| e.decision == nono::undo::NetworkAuditDecision::Deny
+                    && e.target == "example.com"),
+            "expected a Deny audit event for example.com, got: {:?}",
+            events
         );
 
         handle.shutdown();

--- a/crates/nono/src/net_filter.rs
+++ b/crates/nono/src/net_filter.rs
@@ -116,6 +116,8 @@ pub struct HostFilter {
     allowed_suffixes: Vec<String>,
     /// Hostnames that are always denied
     deny_hosts: Vec<String>,
+    /// When true, an empty allowlist denies instead of allowing.
+    strict: bool,
 }
 
 impl HostFilter {
@@ -144,7 +146,16 @@ impl HostFilter {
             allowed_hosts: exact,
             allowed_suffixes: suffixes,
             deny_hosts: DENY_HOSTS.iter().map(|s| s.to_lowercase()).collect(),
+            strict: false,
         }
+    }
+
+    /// Create a strict host filter: empty allowlist denies everything.
+    #[must_use]
+    pub fn new_strict(allowed_hosts: &[String]) -> Self {
+        let mut filter = Self::new(allowed_hosts);
+        filter.strict = true;
+        filter
     }
 
     /// Create a host filter that allows everything (no filtering).
@@ -156,6 +167,7 @@ impl HostFilter {
             allowed_hosts: Vec::new(),
             allowed_suffixes: Vec::new(),
             deny_hosts: DENY_HOSTS.iter().map(|s| s.to_lowercase()).collect(),
+            strict: false,
         }
     }
 
@@ -190,8 +202,13 @@ impl HostFilter {
             }
         }
 
-        // 3. If no allowlist is configured (allow_all mode), allow
+        // 3. Empty allowlist: deny when strict, allow otherwise.
         if self.allowed_hosts.is_empty() && self.allowed_suffixes.is_empty() {
+            if self.strict {
+                return FilterResult::DenyNotAllowed {
+                    host: host.to_string(),
+                };
+            }
             return FilterResult::Allow;
         }
 
@@ -433,5 +450,29 @@ mod tests {
             ip: IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254)),
         };
         assert!(link_local.reason().contains("link-local"));
+    }
+
+    #[test]
+    fn test_strict_filter_empty_allowlist_denies() {
+        let filter = HostFilter::new_strict(&[]);
+        let result = filter.check_host("example.com", &public_ip());
+        assert!(matches!(result, FilterResult::DenyNotAllowed { .. }));
+    }
+
+    #[test]
+    fn test_strict_filter_respects_explicit_allowlist() {
+        let filter = HostFilter::new_strict(&["api.openai.com".to_string()]);
+        let allowed = filter.check_host("api.openai.com", &public_ip());
+        assert!(matches!(allowed, FilterResult::Allow));
+
+        let denied = filter.check_host("evil.com", &public_ip());
+        assert!(matches!(denied, FilterResult::DenyNotAllowed { .. }));
+    }
+
+    #[test]
+    fn test_non_strict_empty_allowlist_allows() {
+        let filter = HostFilter::new(&[]);
+        let result = filter.check_host("example.com", &public_ip());
+        assert!(matches!(result, FilterResult::Allow));
     }
 }


### PR DESCRIPTION
## Linked Issue

Closes #1080

## Summary

With `network.block: true` plus a `custom_credentials` route (or any CLI flag that activates the proxy, e.g. `--credential`), HTTPS to arbitrary hosts like `example.com` was being allowed through. The user asked to block everything except the credential route, but unrelated hosts went through.

Two things were happening:

1. CLI proxy flags like `--credential` override `caps` to `NetworkMode::ProxyOnly`, masking the original `block: true` intent at the capability layer.
2. The proxy's host filter treats an empty `allowed_hosts` as **allow-all** (`net_filter.rs:194`). With no `allow_domain`/`network_profile` populating it, every CONNECT is allowed.

This PR addresses (2). The user's block intent is captured early on `PreparedSandbox` and threaded through `ProxyLaunchOptions` to a new `strict_filter: bool` on `ProxyConfig`. When strict, an empty allowlist denies instead of allowing.

(1) is intentionally out of scope -- this fix makes the proxy honor the user's intent regardless of whether the capability mode was overridden.

## Disclosure

Implementation done with AI agent assistance (interactive design + code generation). Final code, tests, and manual verification reviewed by me.

## Test Plan

- Library unit (`crates/nono/src/net_filter.rs`):
  - `test_strict_filter_empty_allowlist_denies`
  - `test_strict_filter_respects_explicit_allowlist`
  - `test_non_strict_empty_allowlist_allows` (backward-compat guard)
- Proxy integration (`crates/nono-proxy/src/server.rs`):
  - `test_strict_filter_with_empty_allowlist_denies_connect` -- starts proxy with `strict_filter=true`, empty allowlist, sends CONNECT, asserts 403 + audit deny.
- CLI plumbing (`crates/nono-cli/src/proxy_runtime.rs`):
  - `test_build_proxy_config_propagates_network_block_to_strict_filter`
  - `test_build_proxy_config_strict_filter_off_when_no_block`
- Manual repro from the issue (profile + command from #1080):
  ```
  HTTPS example.com -> CONNECT tunnel failed, response 403 (before: 200)
  Network Events: 1
    deny connect example.com:443 (reason=host example.com is not in the allowlist)
  ```
- `cargo clippy -p nono -p nono-cli -p nono-proxy --all-targets -- -D warnings -D clippy::unwrap_used`: clean
- `cargo fmt --check`: clean

## Backward compatibility

- `HostFilter::new()` unchanged. New `HostFilter::new_strict()` is opt-in.
- `ProxyConfig::strict_filter` defaults to `false`. Existing CLI invocations and external proxy callers see no behavior change.

## Design alternative considered

`ProxyConfig.allowed_hosts: Option<Vec<String>>` where `None` = deny-all, `Some([])` = allow-all would be more elegant but is a breaking serde change. The `strict_filter: bool` add is the non-breaking option. Happy to switch if preferred.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using DCO
- [x] All new code follows the project's coding standards (CLAUDE.md) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates (N/A -- internal behavior fix)
- [ ] Release note has been added to CHANGELOG.md if needed
