### PR TITLE
feat(packaging): add automated AUR package publishing (#917)

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -1,0 +1,168 @@
+name: AUR Publish
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish to the AUR (e.g., v0.61.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+# Serialize publishes so two close releases cannot race the AUR repository.
+concurrency:
+  group: aur-publish
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve publish parameters
+    runs-on: ubuntu-latest
+    if: >-
+      github.repository == 'always-further/nono' &&
+      ((github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'))
+    outputs:
+      tag: ${{ steps.params.outputs.tag }}
+      publish: ${{ steps.params.outputs.publish }}
+    steps:
+      - name: Compute parameters
+        id: params
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WR_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WD_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            TAG="$WR_HEAD_BRANCH"
+          else
+            TAG="$WD_TAG"
+          fi
+
+          # Only stable vX.Y.Z release tags are published to the AUR. This
+          # rejects prereleases (alpha/beta/rc) and workflow_run events for
+          # Release runs started from a branch, where head_branch is the
+          # branch name instead of a tag.
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Not a stable release tag: '$TAG' — skipping AUR publish."
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "publish=true" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish to AUR
+    needs: resolve
+    if: ${{ needs.resolve.outputs.publish == 'true' }}
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+    steps:
+      # git must be installed before actions/checkout so it produces a real
+      # git checkout; base-devel provides makepkg and sudo, pacman-contrib
+      # provides updpkgsums.
+      - name: Install dependencies
+        run: pacman -Syu --noconfirm --needed base-devel git pacman-contrib openssh
+
+      # The PKGBUILD template and update.sh are always taken from the branch
+      # the workflow runs on (the default branch), not from the release tag:
+      # packaging fixes must flow into the next publish, and tags that predate
+      # this workflow have no packaging/aur directory at all.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Create build user
+        # makepkg and updpkgsums refuse to run as root. The workspace is
+        # handed to an unprivileged user; safe.directory keeps the
+        # actions/checkout post-job cleanup (running as root) working on it.
+        run: |
+          set -euo pipefail
+          useradd -m builder
+          git config --global --add safe.directory '*'
+          chown -R builder:builder .
+
+      - name: Verify AUR host keys and configure SSH
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          # Official AUR SSH host key fingerprints, published on
+          # https://aur.archlinux.org/ ("The following SSH fingerprints are
+          # used for the AUR"). Every key returned by ssh-keyscan must match
+          # one of these pinned fingerprints or the job fails (no trust on
+          # first use). If Arch Linux rotates its keys, update these values
+          # from that page (see packaging/aur/README.md).
+          expected='SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4 SHA256:uTa/0PndEgPZTf76e1DFqXKJEXKsn7m9ivhLQtzGOCI SHA256:5s5cIyReIfNNVGRFdDbe3hdYiI5OelHGpw2rOUud3Q8'
+
+          install -d -m 700 -o builder -g builder /home/builder/.ssh
+
+          ssh-keyscan -t ed25519,ecdsa,rsa aur.archlinux.org > /home/builder/.ssh/scanned
+          if [ ! -s /home/builder/.ssh/scanned ]; then
+            echo "::error::ssh-keyscan returned no host keys for aur.archlinux.org"
+            exit 1
+          fi
+
+          while IFS= read -r hostkey; do
+            fp="$(printf '%s\n' "$hostkey" | ssh-keygen -lf - | awk '{print $2}')"
+            if [[ " $expected " != *" $fp "* ]]; then
+              echo "::error::Unexpected SSH host key fingerprint for aur.archlinux.org: $fp"
+              exit 1
+            fi
+            echo "Verified host key: $fp"
+          done < /home/builder/.ssh/scanned
+
+          mv /home/builder/.ssh/scanned /home/builder/.ssh/known_hosts
+
+          # Private key comes from the repository secret; it is written
+          # straight to disk and never echoed to the log.
+          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > /home/builder/.ssh/aur
+
+          cat > /home/builder/.ssh/config <<'EOF'
+          Host aur.archlinux.org
+            User aur
+            IdentityFile ~/.ssh/aur
+            IdentitiesOnly yes
+            StrictHostKeyChecking yes
+          EOF
+
+          chmod 600 /home/builder/.ssh/aur /home/builder/.ssh/config /home/builder/.ssh/known_hosts
+          chown -R builder:builder /home/builder/.ssh
+
+      - name: Clone AUR repository
+        run: sudo -u builder git clone ssh://aur@aur.archlinux.org/nono-ai-bin.git /home/builder/aur
+
+      - name: Generate PKGBUILD and .SRCINFO
+        env:
+          RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
+        run: sudo -u builder ./packaging/aur/update.sh "$RELEASE_TAG"
+
+      - name: Push to AUR if changed
+        run: |
+          set -euo pipefail
+          install -m 644 -o builder -g builder \
+            packaging/aur/PKGBUILD packaging/aur/.SRCINFO /home/builder/aur/
+          # The version comes from the freshly generated PKGBUILD rather than
+          # from an environment variable: sudo's default policy resets the
+          # environment, and the PKGBUILD value is what actually gets published.
+          sudo -u builder bash -euo pipefail <<'EOS'
+          cd /home/builder/aur
+          ver="$(awk -F= '/^pkgver=/{print $2; exit}' PKGBUILD)"
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "AUR is already up to date with v${ver}; nothing to push."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add PKGBUILD .SRCINFO
+          git commit -m "Update to ${ver}"
+          git push origin master
+          EOS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,11 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (e.g., v0.2.3)'
+        description: "Tag to release (e.g., v0.2.3)"
         required: true
         type: string
 

--- a/docs/cli/getting_started/installation.mdx
+++ b/docs/cli/getting_started/installation.mdx
@@ -55,7 +55,7 @@ nix-shell -p nono
 
 ### Arch Linux (AUR)
 
-nono is available on the [Arch User Repository](https://aur.archlinux.org/packages/nono-ai-bin) as `nono-ai-bin`, a community-maintained binary package that tracks official GitHub releases and verifies SHA256 checksums. It supports `x86_64` and `aarch64`.
+nono is available on the [Arch User Repository](https://aur.archlinux.org/packages/nono-ai-bin) as `nono-ai-bin`, an officially maintained binary package that tracks official GitHub releases and verifies SHA256 checksums. It supports `x86_64` and `aarch64`.
 
 ```bash
 # Using yay
@@ -69,10 +69,6 @@ git clone https://aur.archlinux.org/nono-ai-bin.git
 cd nono-ai-bin
 makepkg -si
 ```
-
-<Note>
-  This package is not maintained by the nono team. For issues with the AUR package itself, please report them on the [AUR page](https://aur.archlinux.org/packages/nono-ai-bin).
-</Note>
 
 Other distributions are in the process of being packaged. In the meantime, you can use the prebuilt binaries or build from source.
 

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,46 @@
+# Maintainer: sarovin86 <sarovin86@gmail.com>
+# Maintainer: Luke Hinds (lukehinds)
+#
+# This PKGBUILD is the canonical source for the nono-ai-bin AUR package.
+# It is published to the AUR automatically by .github/workflows/aur-publish.yml
+# on each upstream release: pkgver and the sha256sums arrays are rewritten at
+# publish time by packaging/aur/update.sh, so the values committed here may lag
+# behind the latest release. The committed values always correspond to a real
+# release, so this file remains locally buildable with makepkg.
+
+pkgname=nono-ai-bin
+_pkgname=nono
+pkgver=0.61.1
+pkgrel=2
+pkgdesc='Secure, kernel-enforced sandbox for AI agents, MCP servers and LLM workloads using Landlock (pre-built binary)'
+arch=('x86_64' 'aarch64')
+url='https://github.com/always-further/nono'
+license=('Apache-2.0')
+# dbus is intentionally not a hard dependency: the release binary does not
+# link libdbus (pure-Rust zbus keyring backend, verified in release.yml).
+# D-Bus is only needed at runtime for the optional Secret Service keyring,
+# and both optdepends below already pull it in.
+depends=('glibc' 'libgcc')
+optdepends=(
+  'gnome-keyring: Secret Service daemon for credential storage'
+  'keepassxc: alternative Secret Service daemon'
+)
+provides=('nono-ai')
+conflicts=("${_pkgname}" 'nono-ai' 'nono-ai-git')
+options=('!strip' '!debug')
+source=(
+  "LICENSE-${pkgver}::https://raw.githubusercontent.com/always-further/nono/v${pkgver}/LICENSE"
+  "README-${pkgver}.md::https://raw.githubusercontent.com/always-further/nono/v${pkgver}/README.md"
+)
+source_x86_64=("${_pkgname}-${pkgver}-x86_64.tar.gz::https://github.com/always-further/nono/releases/download/v${pkgver}/nono-v${pkgver}-x86_64-unknown-linux-gnu.tar.gz")
+source_aarch64=("${_pkgname}-${pkgver}-aarch64.tar.gz::https://github.com/always-further/nono/releases/download/v${pkgver}/nono-v${pkgver}-aarch64-unknown-linux-gnu.tar.gz")
+sha256sums=('7310e9389f298b89bb2f90ac4b6081ed5b6a1c4a7b8547df5d52966a57cb0929'
+            'd0b350c764dfea1bb43ad9f1a1e77f9292869d361a431e4a9d889dc56a86f0f5')
+sha256sums_x86_64=('9186323e1deda74bda886ab57ae3cff820bc85861a9dd691b898a4d309bffa93')
+sha256sums_aarch64=('27b05d415169a60686994517fcc86a7f24103c5f8cb10d1ccf1627e57ae867e1')
+
+package() {
+  install -Dm755 "${srcdir}/${_pkgname}" "${pkgdir}/usr/bin/${_pkgname}"
+  install -Dm644 "${srcdir}/LICENSE-${pkgver}" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm644 "${srcdir}/README-${pkgver}.md" "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+}

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -1,0 +1,85 @@
+# AUR packaging for nono
+
+This directory contains the canonical source for the [`nono-ai-bin`](https://aur.archlinux.org/packages/nono-ai-bin)
+Arch User Repository package, a pre-built binary package that tracks official
+GitHub releases.
+
+## Why `nono-ai-bin`?
+
+The name `nono` is already taken in the official Arch repositories by an
+unrelated emulator, and the AUR already hosts the source-based variants
+`nono-ai` and `nono-ai-git`. Following AUR conventions, the `-bin` suffix marks
+this as the package that installs pre-built release binaries instead of
+compiling from source, which makes installs and updates fast while still
+integrating with pacman and AUR helpers.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `PKGBUILD` | Package build recipe. `pkgver` and the `sha256sums` arrays are rewritten by CI at publish time; the committed values correspond to a real release so the file stays locally buildable. |
+| `update.sh` | Updates `PKGBUILD` to a given release, recomputes checksums with `updpkgsums`, and regenerates `.SRCINFO`. |
+
+`.SRCINFO` is intentionally not tracked here: it is generated from the
+`PKGBUILD` at publish time.
+
+## How publishing works
+
+The `.github/workflows/aur-publish.yml` workflow publishes this package to the
+AUR. In short:
+
+- It runs automatically after each successful **Release** (or manually via
+  `workflow_dispatch` with a tag input); prereleases and non-tag refs are
+  skipped.
+- It regenerates `PKGBUILD`/`.SRCINFO` for the released version and pushes to
+  the AUR **only if they differ** from the current AUR state, so re-runs are
+  safe no-ops.
+- It never builds nono itself: the package only references release artifacts
+  that are already published.
+
+The step-by-step mechanics are documented inline in the workflow file.
+
+## Credentials
+
+| What | Where |
+|------|-------|
+| AUR account | `lukehinds` (co-maintainer of `nono-ai-bin`, alongside `sarovin86`) |
+| SSH private key | `AUR_SSH_PRIVATE_KEY` repository secret (Actions) |
+
+The SSH key never appears in logs; it is written to a file readable only by the
+build user inside the job container.
+
+## SSH host key verification
+
+The workflow refuses to talk to anything that does not present the official
+`aur.archlinux.org` host keys. The expected key fingerprints are pinned in the
+workflow and checked against the output of `ssh-keyscan` before any git
+operation (`StrictHostKeyChecking yes`).
+
+If Arch Linux rotates its SSH host keys, the workflow fails loudly instead of
+trusting the new keys (fail secure). To update the pinned fingerprints:
+
+1. Get the current fingerprints from the footer of <https://aur.archlinux.org/>
+   ("The following SSH fingerprints are used for the AUR").
+2. Replace the values in the `Verify AUR host keys and configure SSH` step of
+   `.github/workflows/aur-publish.yml`.
+3. Open a PR with the change.
+
+## Testing locally
+
+On an Arch Linux system or an `archlinux:latest` container with `base-devel`
+and `pacman-contrib` installed:
+
+```bash
+cd packaging/aur
+./update.sh v0.61.1   # or any released tag
+makepkg -f            # downloads the artifacts, verifies checksums, builds the package
+```
+
+## History and attribution
+
+The `PKGBUILD` and `update.sh` were originally written and maintained by
+[sarovin86](https://aur.archlinux.org/account/sarovin86) in the
+[sarovin/nono-ai-bin](https://github.com/sarovin/nono-ai-bin) repository, and
+were moved here (with small adaptations for CI integration) as part of
+[#917](https://github.com/always-further/nono/issues/917).

--- a/packaging/aur/update.sh
+++ b/packaging/aur/update.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Update the nono-ai-bin AUR packaging files to an upstream release.
+#
+# Usage: ./update.sh <version>
+#   The version (e.g. "v0.61.1" or "0.61.1") is required and always gets the
+#   full update, even if pkgver already matches. The CI workflow
+#   (.github/workflows/aur-publish.yml) relies on this to regenerate the
+#   sha256sums and .SRCINFO deterministically from the release artifacts.
+#
+# Requires: pacman-contrib (provides updpkgsums), makepkg
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+command -v updpkgsums >/dev/null || { echo "updpkgsums not found; install pacman-contrib" >&2; exit 1; }
+
+[[ $# -ge 1 ]] || { echo "Usage: $0 <version>   (e.g. v0.61.1)" >&2; exit 1; }
+ver="${1#v}"
+# Same stable-release format the CI gate (aur-publish.yml, job "resolve") enforces.
+[[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Unexpected version: '${ver}'" >&2; exit 1; }
+
+cur="$(awk -F= '/^pkgver=/{print $2; exit}' PKGBUILD)"
+
+if [[ "$cur" == "$ver" ]]; then
+  # Same version: refresh checksums and .SRCINFO without touching pkgrel,
+  # so packaging-only fixes (manual pkgrel bumps) are preserved.
+  echo "Refreshing v${ver} (checksums and .SRCINFO)"
+else
+  echo "Bumping ${cur} -> ${ver}"
+  sed -i -e "s/^pkgver=.*/pkgver=${ver}/" -e "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+fi
+
+updpkgsums
+makepkg --printsrcinfo > .SRCINFO
+
+echo "Updated PKGBUILD and .SRCINFO to v${ver}."


### PR DESCRIPTION
Implements the automation discussed in #917: the `nono-ai-bin` AUR packaging moves in-tree and gets published automatically on each release.

What's in here:

- `packaging/aur/PKGBUILD` — the package recipe, moved from  [sarovin/nono-ai-bin](https://github.com/sarovin/nono-ai-bin). CI rewrites `pkgver` and the checksums at publish time. One packaging change vs what's on the AUR today: `dbus` is no longer a hard dependency (the binary doesn't link libdbus — release.yml enforces that — and the Secret Service daemons in `optdepends` pull it in anyway), with a `pkgrel` bump to 2.
- `packaging/aur/update.sh` — bumps the version, recomputes checksums with `updpkgsums`, regenerates `.SRCINFO`.
- `.github/workflows/aur-publish.yml` — runs after each successful Release (same `workflow_run` pattern as `image-build.yml`), regenerates the files and pushes to the AUR only if they differ from what's already there. Can also be run manually with a tag input.
- `release.yml` — two comment lines noting that the artifact naming is consumed by the PKGBUILD.
- `installation.mdx` — the AUR package is now officially maintained.


### Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists (#917)
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect (no Rust code in this PR)
- [x] I used NonoError where required (N/A — no Rust code)
- [x] I validated and canonicalized all relevant paths (N/A — no Rust code)
- [x] This PR matches the approved or disclosed issue scope