### PR TITLE
fix(aur): skip ssh-keyscan banner lines in host key check

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -111,14 +111,23 @@ jobs:
             exit 1
           fi
 
-          while IFS= read -r hostkey; do
-            fp="$(printf '%s\n' "$hostkey" | ssh-keygen -lf - | awk '{print $2}')"
+          # ssh-keyscan (OpenSSH 10+) writes an informational "# host SSH-2.0-..."
+          # banner line to stdout for each scanned key. Feeding the whole file to
+          # ssh-keygen -lf (rather than each line to stdin) lets ssh-keygen skip
+          # those comments natively and emit one fingerprint per host key.
+          fingerprints="$(ssh-keygen -lf /home/builder/.ssh/scanned | awk '{print $2}')"
+          if [ -z "$fingerprints" ]; then
+            echo "::error::ssh-keygen produced no fingerprints for aur.archlinux.org"
+            exit 1
+          fi
+
+          while IFS= read -r fp; do
             if [[ " $expected " != *" $fp "* ]]; then
               echo "::error::Unexpected SSH host key fingerprint for aur.archlinux.org: $fp"
               exit 1
             fi
             echo "Verified host key: $fp"
-          done < /home/builder/.ssh/scanned
+          done <<< "$fingerprints"
 
           mv /home/builder/.ssh/scanned /home/builder/.ssh/known_hosts
 


### PR DESCRIPTION
Fixes #1092

## Summary

The **Publish to AUR** job fails because `ssh-keyscan` (OpenSSH 10+) writes a `# host SSH-2.0-...` banner line to stdout for each key. The verification step piped every line individually to `ssh-keygen -lf -`, so a banner line failed with `(stdin) is not a public key file.` and the job exited 255.

This passes the whole scanned file to `ssh-keygen -lf` instead, which natively skips comment and blank lines and emits one fingerprint per host key. The pinned-fingerprint allow-list check (fail-secure, no trust-on-first-use) is unchanged, and a guard still aborts if no fingerprints are produced.

  ## Approach

  - Replaced the per-line `ssh-keygen -lf -` stdin loop with a single `ssh-keygen -lf <file>` over the scanned file.
  - Kept the pinned `expected` fingerprint allow-list and the fail-secure behavior.

  ## Testing

  Verified in an `archlinux:latest` container (OpenSSH 10.3p1, `/bin/sh` → bash):
  - correct pinned keys pass (exit 0),
  - rotated/unexpected keys are rejected,
  - a comment-only scan is rejected.

  ## Files consulted

  - `.github/workflows/aur-publish.yml` (the only file changed)
  - `packaging/aur/README.md` (host key verification documentation)

  This contribution is made by an AI coding agent (Claude Code) on behalf of the maintainer.

  ## Agent Compliance Check

  - [x] I am not prohibited from contributing under this policy
  - [x] An issue already exists (#1092)
  - [x] I described my intent and approach in the issue discussion
  - [x] I reviewed repository coding and security rules for the affected area
  - [x] I provided required attribution for reused or adapted code (N/A — no reused code)
  - [x] I did not use forbidden patterns such as unwrap/expect
  - [x] I used NonoError where required (N/A — CI workflow change, no Rust)
  - [x] I validated and canonicalized all relevant paths (N/A — no path handling)
  - [x] This PR matches the approved or disclosed issue scope