### PR TITLE
fix: write cargo vendor config for copr srpms

### DIFF
--- a/scripts/build-srpm.sh
+++ b/scripts/build-srpm.sh
@@ -64,8 +64,15 @@ git -C "${ROOT}" archive --format=tar --prefix="${SOURCE_NAME}/" HEAD | tar -C "
 mkdir -p "${SOURCE_ROOT}/.cargo"
 (
     cd "${SOURCE_ROOT}"
-    cargo vendor --quiet --locked --versioned-dirs vendor >> .cargo/config.toml
+    cargo vendor --quiet --locked --versioned-dirs vendor >/dev/null
 )
+cat > "${SOURCE_ROOT}/.cargo/config.toml" <<'EOF'
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"
+EOF
 
 sed \
     -e "s|@RPM_VERSION@|${RPM_VERSION}|g" \


### PR DESCRIPTION
## Linked Issue

Closes #1103

## Summary

Write the Cargo source replacement config explicitly after vendoring COPR SRPM dependencies.

With `cargo vendor --quiet`, Cargo does not emit the config snippet to stdout, which left `.cargo/config.toml` empty in the generated SRPM. COPR then built with `cargo --offline` but without the vendored source override, causing dependency resolution failures such as:

```text
error: no matching package named `der` found
```

This keeps the existing vendoring behavior, but writes the expected Cargo source override directly.

## Agent Disclosure

This PR was prepared with assistance from an AI coding agent.

Relevant files and sections consulted:
- `AGENTS.md` / `CLAUDE.md` repository contribution requirements
- `scripts/build-srpm.sh`
- COPR build logs linked from #1103
- Cargo vendor behavior for `--quiet`

The change is scoped to #1103 and only updates SRPM packaging helper behavior.

## Test Plan

```bash
bash -n scripts/build-srpm.sh
git diff --check
scripts/build-srpm.sh
```

Verified the generated source tarball contains both the vendor config and the missing vendored crate:

```bash
tar -xzf target/rpm/copr/SOURCES/nono-0.62.0.tar.gz nono-0.62.0/.cargo/config.toml -O
tar -tzf target/rpm/copr/SOURCES/nono-0.62.0.tar.gz | grep '^nono-0.62.0/vendor/der-0.7.10/' | head
```

Also verified offline dependency resolution from the generated tarball:

```bash
rm -rf /tmp/nono-srpm-offline-check
mkdir -p /tmp/nono-srpm-offline-check
tar -xzf target/rpm/copr/SOURCES/nono-0.62.0.tar.gz -C /tmp/nono-srpm-offline-check
cd /tmp/nono-srpm-offline-check/nono-0.62.0
cargo fetch --locked --offline
```

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope

Notes:
- No Rust code or `NonoError` paths were changed; this only updates a Bash packaging helper.
- The script writes fixed relative Cargo vendor configuration inside the generated SRPM source tree; no new path canonicalization logic was introduced.
- If the agent disclosure has also been added to issue #1103, the issue-discussion disclosure item above can be checked before submission.
