### PR TITLE
docs: add copr installation instructions

### DIFF
--- a/docs/cli/getting_started/installation.mdx
+++ b/docs/cli/getting_started/installation.mdx
@@ -22,7 +22,17 @@ wget https://github.com/always-further/nono/releases/download/v${VERSION}/nono-c
 sudo dpkg -i nono-cli_${VERSION}_${ARCH}.deb
 ```
 
-### Fedora/RHEL/openSUSE
+### Fedora (COPR)
+
+nono is available from the official [COPR repository](https://copr.fedorainfracloud.org/coprs/always-further/nono/):
+
+```bash
+sudo dnf install 'dnf-command(copr)'
+sudo dnf copr enable always-further/nono
+sudo dnf install nono-cli
+```
+
+### Manual RPM (RHEL/openSUSE and fallback)
 
 Download the `.rpm` package from [GitHub Releases](https://github.com/always-further/nono/releases):
 


### PR DESCRIPTION
## Linked Issue

Related to always-further/nono#1074 and always-further/nono#1103.

## Summary

Update the nono installation documentation in this repository to mention the official Fedora COPR repository.

Fedora users can now install nono with:

```bash
sudo dnf install 'dnf-command(copr)'
sudo dnf copr enable always-further/nono
sudo dnf install nono-cli
```

The existing Debian/Ubuntu and macOS installation hints are unchanged.

## Agent Disclosure

This PR was prepared with assistance from an AI coding agent.

Relevant files and sections consulted:
- `README.md`
- upstream nono COPR packaging issues: always-further/nono#1074 and always-further/nono#1103

This change is documentation-only and does not modify runtime behaviour.

## Test Plan

```bash
git diff --check
```

Manually reviewed the rendered Markdown diff for the updated installation section.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [x] Release note has been added to `CHANGELOG.md` if needed

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope

Notes:
- No Rust code or `NonoError` paths were changed; this is documentation-only.
- No path handling logic was added.
- No `CHANGELOG.md` update is needed for this documentation-only change.
