### PR TITLE
test(wsl2): fix has_landlock_network V4+ detection in test_wsl2.sh

### DIFF
--- a/tests/integration/test_wsl2.sh
+++ b/tests/integration/test_wsl2.sh
@@ -13,9 +13,15 @@ verify_nono_binary
 
 # Detect whether Landlock has native TCP filtering (V4+).
 # With V4+, per-port network filtering and proxy enforcement work natively.
-# Uses --dry-run to avoid sandbox application or forking.
+# Probes `setup --check-only`, which performs a real TCP-rule support probe
+# without applying a sandbox or forking. The `nono run` banner does not print
+# the feature list, so grepping it misclassifies V4+ kernels as pre-V4.
+# Output is captured first (not piped into `grep -q`): under `set -o pipefail`
+# grep's early exit would SIGPIPE nono and make the pipeline fail spuriously.
 has_landlock_network() {
-    "$NONO_BIN" run --dry-run --allow /tmp -- true </dev/null 2>&1 | grep -q "TCP network filtering"
+    local _setup_out
+    _setup_out="$("$NONO_BIN" setup --check-only 2>&1)"
+    grep -q "TCP network rule support verified" <<<"$_setup_out"
 }
 
 echo ""


### PR DESCRIPTION
Closes #1111

## Summary

`tests/integration/test_wsl2.sh` misclassifies Landlock **V4+** kernels as **pre-V4**, causing 3 spurious failures in the "WSL2 Proxy Policy" section on machines with native TCP filtering (e.g. WSL2 with a V6 kernel). The binary behaves correctly throughout — only the test's detection helper is wrong. This PR fixes the helper. Test-only change; no library or CLI behavior is modified.

## Problem

`has_landlock_network()` selects between the pre-V4 fail-secure and V4+ native-enforcement branches of the proxy-policy assertions:

```bash
has_landlock_network() {
    "$NONO_BIN" run --dry-run --allow /tmp -- true </dev/null 2>&1 | grep -q "TCP network filtering"
}
```

Two independent bugs make this a false negative on a V4+/V6 box:

1. **Wrong source string.** The feature string `"TCP network filtering"` is printed by `nono setup --check-only`, not by the `nono run` banner, so the grep never matches and the test takes the obsolete pre-V4 fail-secure branch (which asserts ProxyOnly is *rejected*). On V4+ nono enforces the proxy natively and runs, so those assertions fail.
2. **`pipefail` + SIGPIPE.** Even pointed at a command that emits the string, piping into `grep -q` is unsafe under `set -o pipefail` (set in `tests/lib/test_helpers.sh`): `grep -q` closes the pipe on first match, `nono` is killed by SIGPIPE, and `pipefail` propagates the failure. Manifests under `bash` (harness shell), not `zsh`.

### Observed (before)
WSL2 / Ubuntu 24.04 / kernel 6.19 / Landlock V6, `nono` 0.59.0: **21 tests, 18 passed, 3 failed** — all 3 in "WSL2 Proxy Policy", while the same run's banner reports `kernel Landlock V6` (internally contradictory).

## Fix

```bash
has_landlock_network() {
    local _setup_out
    _setup_out="$("$NONO_BIN" setup --check-only 2>&1)"
    grep -q "TCP network rule support verified" <<<"$_setup_out"
}
```

- Probes `nono setup --check-only`, whose runtime check emits `"TCP network rule support verified"` only when native TCP rule support is actually verified — authoritative, and it neither applies a sandbox nor forks.
- **Captures output first**, then greps via a here-string, so there is no upstream process for `grep -q` to SIGPIPE — safe under `set -euo pipefail`.

## Testing

- Fixed helper returns true under harness conditions (`bash -c 'set -euo pipefail; …'`) → V4+ branch selected.
- `setup --check-only` on the test machine reports `Landlock V6`, `Per-port network filtering: available (Landlock V4+)`, `TCP network rule support verified`.
- Run outside a nono sandbox (inner `nono run` needs to write `~/.nono/audit`): `NONO_BIN=./target/debug/nono bash tests/integration/test_wsl2.sh`.

## Notes

Prepared with AI assistance (Claude Code); reviewed by me.

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists (#1111)
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (n/a — no reused code)
- [x] I did not use forbidden patterns such as unwrap/expect (n/a — shell test)
- [x] I used NonoError where required (n/a — shell test)
- [x] I validated and canonicalized all relevant paths (n/a — shell test)
- [x] This PR matches the approved or disclosed issue scope