### PR TITLE
fix: replace stale nono.dev schema domains with nono.sh

### DIFF
--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -6062,7 +6062,7 @@ mod tests {
     fn test_top_level_schema_field_allowed_in_profile() {
         let profile: Profile = serde_json::from_str(
             r#"{
-                "$schema": "https://nono.dev/schemas/nono-profile.schema.json",
+                "$schema": "https://nono.sh/schemas/nono-profile.schema.json",
                 "meta": { "name": "schema-ok" }
             }"#,
         )

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -3154,7 +3154,7 @@ fn resolve_to_manifest(
 
     Ok(manifest::CapabilityManifest {
         version,
-        schema: Some("https://nono.dev/schemas/capability-manifest.schema.json".to_string()),
+        schema: Some("https://nono.sh/schemas/capability-manifest.schema.json".to_string()),
         filesystem,
         network,
         process,

--- a/crates/nono/schema/capability-manifest.schema.json
+++ b/crates/nono/schema/capability-manifest.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://nono.dev/schemas/capability-manifest.schema.json",
+  "$id": "https://nono.sh/schemas/capability-manifest.schema.json",
   "title": "nono Capability Manifest",
   "description": "A fully-resolved, portable capability manifest describing what a nono sandbox enforces. Manifests are the machine-consumable contract for sandbox configuration — they contain no inheritance, no legacy aliases, and no composition. Profiles compile down to manifests. NOTE: additionalProperties is true during schema development to allow forward-compatible evolution without breaking existing consumers. Switch to false once the schema stabilizes (post-1.0).",
   "type": "object",


### PR DESCRIPTION
## Linked Issue

Closes #1084

## Summary

Replaces the stale `nono.dev` schema domain with `nono.sh` in the capability manifest schema `$id` and the two CLI references to it, exactly as prescribed in #1084. Three lines across three files; no behavior change beyond the corrected URLs.

## Agent Disclosure (if applicable)

This PR was prepared by an AI agent on the contributor's behalf. Files consulted: `crates/nono/schema/capability-manifest.schema.json`, `crates/nono-cli/src/profile/mod.rs`, `crates/nono-cli/src/profile_cmd.rs`, `CLAUDE.md`, and the #1084 thread (including why the prior attempt #1085 was closed: missing DCO and an oversized diff). The diff is the minimal three-line change matching the issue's stated scope, and the commit is DCO signed off.

## Test Plan

`cargo fmt --check` is clean, and a repo-wide grep confirms no `nono.dev` references remain under `crates/`. String-only change, no code paths touched.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests (string-only change, no new code paths)
- [x] Public-facing changes are paired with documentation updates (the schema URL is the documentation surface)
- [ ] Release note has been added to `CHANGELOG.md` if needed (none needed for a URL correction; happy to add one if preferred)

## Agent Compliance Check (Required for AI/Automated PRs)

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion (disclosed here in the PR instead; happy to add an issue comment if preferred)
- [ ] I described my intent and approach in the issue discussion (described here in the PR instead)
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (none reused)
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required (no error paths touched)
- [x] I validated and canonicalized all relevant paths (no path handling touched)
- [x] This PR matches the approved or disclosed issue scope
