### PR TITLE
fix(cli): ensure Profile has corresponding CLI flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2178,6 +2178,7 @@ dependencies = [
  "shlex 2.0.1",
  "sigstore-sign",
  "similar",
+ "syn",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/nono-cli/Cargo.toml
+++ b/crates/nono-cli/Cargo.toml
@@ -110,6 +110,7 @@ serde.workspace = true
 [dev-dependencies]
 jsonschema = "0.46"
 proptest = "1"
+syn = { version = "2", features = ["full"] }
 
 [lints]
 workspace = true

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -624,6 +624,21 @@ impl CapabilitySetExt for CapabilitySet {
             caps.add_blocked_command(cmd);
         }
 
+        let signal_mode = args
+            .signal_mode
+            .map(nono::SignalMode::from)
+            .unwrap_or_default();
+        caps = caps.set_signal_mode(signal_mode);
+
+        let process_info_mode = args
+            .process_info_mode
+            .map(nono::ProcessInfoMode::from)
+            .unwrap_or_default();
+        caps.set_process_info_mode_mut(process_info_mode);
+
+        let ipc_mode = args.ipc_mode.map(nono::IpcMode::from).unwrap_or_default();
+        caps.set_ipc_mode_mut(ipc_mode);
+
         finalize_caps(&mut caps, &mut resolved, &loaded_policy, args, &[])?;
 
         Ok(PreparedCaps {
@@ -1008,26 +1023,24 @@ impl CapabilitySetExt for CapabilitySet {
             caps.add_allowed_command(cmd.as_str());
         }
 
-        // Apply signal mode from profile (None defaults to Isolated)
-        let mode = profile
-            .security
+        // CLI overrides profile; profile None falls through to enum default.
+        let mode = args
             .signal_mode
+            .or(profile.security.signal_mode)
             .map(nono::SignalMode::from)
             .unwrap_or_default();
         caps = caps.set_signal_mode(mode);
 
-        // Apply process inspection mode from profile (None defaults to Isolated)
-        let process_info_mode = profile
-            .security
+        let process_info_mode = args
             .process_info_mode
+            .or(profile.security.process_info_mode)
             .map(nono::ProcessInfoMode::from)
             .unwrap_or_default();
         caps.set_process_info_mode_mut(process_info_mode);
 
-        // Apply IPC mode from profile (None defaults to SharedMemoryOnly)
-        let ipc_mode = profile
-            .security
+        let ipc_mode = args
             .ipc_mode
+            .or(profile.security.ipc_mode)
             .map(nono::IpcMode::from)
             .unwrap_or_default();
         caps.set_ipc_mode_mut(ipc_mode);
@@ -3138,5 +3151,130 @@ mod tests {
         assert_eq!(socks.len(), 1);
         assert_eq!(socks[0].mode, UnixSocketMode::ConnectBind);
         assert_eq!(socks[0].scope, SocketScope::DirSubtree);
+    }
+
+    // ---------------------------------------------------------------------
+    // Security mode merging: --signal-mode / --process-info-mode / --ipc-mode
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn test_from_args_signal_mode_defaults_to_isolated() {
+        let (caps, _) = from_args_locked(&sandbox_args()).expect("build caps");
+        assert_eq!(caps.signal_mode(), nono::SignalMode::Isolated);
+    }
+
+    #[test]
+    fn test_from_args_signal_mode_flag_takes_effect() {
+        let args = SandboxArgs {
+            signal_mode: Some(crate::profile::ProfileSignalMode::AllowAll),
+            ..sandbox_args()
+        };
+        let (caps, _) = from_args_locked(&args).expect("build caps");
+        assert_eq!(caps.signal_mode(), nono::SignalMode::AllowAll);
+    }
+
+    #[test]
+    fn test_from_args_process_info_mode_defaults_to_isolated() {
+        let (caps, _) = from_args_locked(&sandbox_args()).expect("build caps");
+        assert_eq!(caps.process_info_mode(), nono::ProcessInfoMode::Isolated);
+    }
+
+    #[test]
+    fn test_from_args_process_info_mode_flag_takes_effect() {
+        let args = SandboxArgs {
+            process_info_mode: Some(crate::profile::ProfileProcessInfoMode::AllowSameSandbox),
+            ..sandbox_args()
+        };
+        let (caps, _) = from_args_locked(&args).expect("build caps");
+        assert_eq!(
+            caps.process_info_mode(),
+            nono::ProcessInfoMode::AllowSameSandbox
+        );
+    }
+
+    #[test]
+    fn test_from_args_ipc_mode_defaults_to_shared_memory_only() {
+        let (caps, _) = from_args_locked(&sandbox_args()).expect("build caps");
+        assert_eq!(caps.ipc_mode(), nono::IpcMode::SharedMemoryOnly);
+    }
+
+    #[test]
+    fn test_from_args_ipc_mode_flag_takes_effect() {
+        let args = SandboxArgs {
+            ipc_mode: Some(crate::profile::ProfileIpcMode::Full),
+            ..sandbox_args()
+        };
+        let (caps, _) = from_args_locked(&args).expect("build caps");
+        assert_eq!(caps.ipc_mode(), nono::IpcMode::Full);
+    }
+
+    #[test]
+    fn test_from_profile_cli_signal_mode_overrides_profile() {
+        let dir = tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("signal-profile.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "signal-profile" },
+                "security": { "signal_mode": "isolated" }
+            }"#,
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+
+        let workdir = tempdir().expect("workdir");
+        let args = SandboxArgs {
+            signal_mode: Some(crate::profile::ProfileSignalMode::AllowAll),
+            ..sandbox_args()
+        };
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
+        assert_eq!(
+            caps.signal_mode(),
+            nono::SignalMode::AllowAll,
+            "CLI --signal-mode must override the profile value"
+        );
+    }
+
+    #[test]
+    fn test_from_profile_signal_mode_falls_back_to_profile_when_flag_absent() {
+        let dir = tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("signal-profile.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "signal-profile" },
+                "security": { "signal_mode": "allow_same_sandbox" }
+            }"#,
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+
+        let workdir = tempdir().expect("workdir");
+        let args = sandbox_args();
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
+        assert_eq!(caps.signal_mode(), nono::SignalMode::AllowSameSandbox);
+    }
+
+    #[test]
+    fn test_from_profile_ipc_mode_cli_overrides_profile() {
+        let dir = tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("ipc-profile.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "ipc-profile" },
+                "security": { "ipc_mode": "shared_memory_only" }
+            }"#,
+        )
+        .expect("write profile");
+        let profile = crate::profile::load_profile_from_path(&profile_path).expect("load profile");
+
+        let workdir = tempdir().expect("workdir");
+        let args = SandboxArgs {
+            ipc_mode: Some(crate::profile::ProfileIpcMode::Full),
+            ..sandbox_args()
+        };
+        let (caps, _) = from_profile_locked(&profile, workdir.path(), &args).expect("build caps");
+        assert_eq!(caps.ipc_mode(), nono::IpcMode::Full);
     }
 }

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1341,6 +1341,44 @@ pub struct SandboxArgs {
     #[arg(long, help_heading = "OPTIONS")]
     pub allow_gpu: bool,
 
+    // ── Security ─────────────────────────────────────────────────────────
+    /// Signal isolation mode. Overrides the profile's security.signal_mode.
+    #[arg(long, value_name = "MODE", help_heading = "SECURITY")]
+    pub signal_mode: Option<crate::profile::ProfileSignalMode>,
+
+    /// Process inspection mode. Overrides the profile's security.process_info_mode.
+    #[arg(long, value_name = "MODE", help_heading = "SECURITY")]
+    pub process_info_mode: Option<crate::profile::ProfileProcessInfoMode>,
+
+    /// IPC mode. Overrides the profile's security.ipc_mode.
+    #[arg(long, value_name = "MODE", help_heading = "SECURITY")]
+    pub ipc_mode: Option<crate::profile::ProfileIpcMode>,
+
+    /// WSL2 fallback policy when ProxyOnly cannot be kernel-enforced.
+    /// Overrides the profile's security.wsl2_proxy_policy. Linux-only.
+    #[cfg(target_os = "linux")]
+    #[arg(long, value_name = "POLICY", help_heading = "SECURITY")]
+    pub wsl2_proxy_policy: Option<crate::profile::Wsl2ProxyPolicy>,
+
+    // ── Environment ──────────────────────────────────────────────────────
+    /// Allow an env var (or `PREFIX_*` pattern) into the sandbox. Repeatable.
+    /// Extends the profile's environment.allow_vars.
+    #[arg(
+        long = "allow-env-var",
+        value_name = "NAME",
+        help_heading = "ENVIRONMENT"
+    )]
+    pub allow_env_var: Vec<String>,
+
+    /// Strip an env var (or `PREFIX_*` pattern) from the sandbox. Repeatable.
+    /// Extends the profile's environment.deny_vars.
+    #[arg(
+        long = "deny-env-var",
+        value_name = "NAME",
+        help_heading = "ENVIRONMENT"
+    )]
+    pub deny_env_var: Vec<String>,
+
     /// Capability manifest file (JSON). A fully-resolved sandbox specification —
     /// mutually exclusive with all other sandbox configuration flags.
     #[arg(
@@ -1357,6 +1395,8 @@ pub struct SandboxArgs {
             "allow_bind", "allow_port", "allow_connect_port", "external_proxy", "proxy_port",
             "proxy_credential", "allow_endpoint", "env_credential", "env_credential_map",
             "allow_command", "block_command", "allow_launch_services", "allow_gpu",
+            "signal_mode", "process_info_mode", "ipc_mode",
+            "allow_env_var", "deny_env_var",
         ],
         help_heading = "OPTIONS"
     )]
@@ -1638,6 +1678,13 @@ impl From<WrapSandboxArgs> for SandboxArgs {
             profile: args.profile,
             allow_launch_services: args.allow_launch_services,
             allow_gpu: args.allow_gpu,
+            signal_mode: None,
+            process_info_mode: None,
+            ipc_mode: None,
+            #[cfg(target_os = "linux")]
+            wsl2_proxy_policy: None,
+            allow_env_var: Vec::new(),
+            deny_env_var: Vec::new(),
             config: args.config,
             verbose: args.verbose,
             dry_run: args.dry_run,
@@ -1684,6 +1731,11 @@ pub struct RunArgs {
     /// Exclude from snapshots. Globs match filenames; plain names match path components
     #[arg(long, value_name = "PATTERN", help_heading = "ROLLBACK")]
     pub rollback_exclude: Vec<String>,
+
+    /// Exclude files from snapshots by glob pattern matched against the filename
+    /// (e.g. `*.log`, `target/*`). Repeatable.
+    #[arg(long, value_name = "GLOB", help_heading = "ROLLBACK")]
+    pub rollback_exclude_glob: Vec<String>,
 
     /// Force-include an auto-excluded directory (name only, not full path)
     #[arg(long, value_name = "DIR_NAME", help_heading = "ROLLBACK")]

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -231,6 +231,7 @@ pub(crate) fn prepare_run_launch_plan(
     let proxy = prepare_proxy_launch_options(&args, &prepared, silent)?;
     let rollback_options = prepare_rollback_launch_options(
         &run_args.rollback_exclude,
+        &run_args.rollback_exclude_glob,
         run_args.rollback_all,
         &run_args.skip_dir,
         &run_args.rollback_include,
@@ -373,22 +374,45 @@ fn prepare_trust_launch_options(
     })
 }
 
+/// Merge profile-side rollback excludes with CLI-side ones. Entries from the
+/// legacy `--rollback-exclude` flag are auto-partitioned by shape (anything
+/// containing `*`, `?`, or `[` is a glob); `--rollback-exclude-glob` entries
+/// are always treated as globs.
+fn merge_rollback_excludes(
+    profile_patterns: &[String],
+    profile_globs: &[String],
+    cli_exclude: &[String],
+    cli_exclude_glob: &[String],
+) -> (Vec<String>, Vec<String>) {
+    let (cli_exclude_globs, cli_exclude_patterns): (Vec<_>, Vec<_>) = cli_exclude
+        .iter()
+        .cloned()
+        .partition(|v| v.contains('*') || v.contains('?') || v.contains('['));
+
+    let mut exclude_patterns = profile_patterns.to_vec();
+    exclude_patterns.extend(cli_exclude_patterns);
+
+    let mut exclude_globs = profile_globs.to_vec();
+    exclude_globs.extend(cli_exclude_globs);
+    exclude_globs.extend(cli_exclude_glob.iter().cloned());
+
+    (exclude_patterns, exclude_globs)
+}
+
 fn prepare_rollback_launch_options(
     rollback_exclude: &[String],
+    rollback_exclude_glob: &[String],
     rollback_all: bool,
     skip_dirs: &[String],
     rollback_include: &[String],
     prepared: &PreparedSandbox,
 ) -> RollbackLaunchOptions {
-    let is_glob = |v: &String| v.contains('*') || v.contains('?') || v.contains('[');
-    let (cli_exclude_globs, cli_exclude_patterns): (Vec<_>, Vec<_>) =
-        rollback_exclude.iter().cloned().partition(is_glob);
-
-    let mut exclude_patterns = prepared.rollback_exclude_patterns.clone();
-    exclude_patterns.extend(cli_exclude_patterns);
-
-    let mut exclude_globs = prepared.rollback_exclude_globs.clone();
-    exclude_globs.extend(cli_exclude_globs);
+    let (exclude_patterns, exclude_globs) = merge_rollback_excludes(
+        &prepared.rollback_exclude_patterns,
+        &prepared.rollback_exclude_globs,
+        rollback_exclude,
+        rollback_exclude_glob,
+    );
 
     RollbackLaunchOptions {
         track_all: rollback_all,
@@ -478,5 +502,59 @@ pub(crate) fn select_threading_context(
         exec_strategy::ThreadingContext::KeyringExpected
     } else {
         exec_strategy::ThreadingContext::Strict
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(v: &str) -> String {
+        v.to_string()
+    }
+
+    #[test]
+    fn merge_rollback_excludes_returns_only_profile_when_cli_empty() {
+        let (patterns, globs) = merge_rollback_excludes(&[s("target")], &[s("*.log")], &[], &[]);
+        assert_eq!(patterns, vec![s("target")]);
+        assert_eq!(globs, vec![s("*.log")]);
+    }
+
+    #[test]
+    fn merge_rollback_excludes_partitions_legacy_flag_by_shape() {
+        let (patterns, globs) = merge_rollback_excludes(
+            &[],
+            &[],
+            &[s("node_modules"), s("*.tmp"), s("dist"), s("[Bb]uild")],
+            &[],
+        );
+        assert_eq!(patterns, vec![s("node_modules"), s("dist")]);
+        assert_eq!(globs, vec![s("*.tmp"), s("[Bb]uild")]);
+    }
+
+    #[test]
+    fn merge_rollback_excludes_glob_flag_always_appended_to_globs() {
+        let (patterns, globs) =
+            merge_rollback_excludes(&[], &[], &[], &[s("plain-name-but-glob-flagged")]);
+        assert_eq!(patterns, Vec::<String>::new());
+        assert_eq!(globs, vec![s("plain-name-but-glob-flagged")]);
+    }
+
+    #[test]
+    fn merge_rollback_excludes_combines_all_four_sources() {
+        let (patterns, globs) = merge_rollback_excludes(
+            &[s("target")],
+            &[s("*.log")],
+            &[s("node_modules"), s("*.tmp")],
+            &[s("dist/**")],
+        );
+        assert_eq!(patterns, vec![s("target"), s("node_modules")]);
+        assert_eq!(globs, vec![s("*.log"), s("*.tmp"), s("dist/**")]);
+    }
+
+    #[test]
+    fn merge_rollback_excludes_preserves_profile_order_then_cli() {
+        let (patterns, _) = merge_rollback_excludes(&[s("a"), s("b")], &[], &[s("c"), s("d")], &[]);
+        assert_eq!(patterns, vec![s("a"), s("b"), s("c"), s("d")]);
     }
 }

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -384,16 +384,16 @@ fn merge_rollback_excludes(
     cli_exclude: &[String],
     cli_exclude_glob: &[String],
 ) -> (Vec<String>, Vec<String>) {
-    let (cli_exclude_globs, cli_exclude_patterns): (Vec<_>, Vec<_>) = cli_exclude
-        .iter()
-        .cloned()
-        .partition(|v| v.contains('*') || v.contains('?') || v.contains('['));
-
     let mut exclude_patterns = profile_patterns.to_vec();
-    exclude_patterns.extend(cli_exclude_patterns);
-
     let mut exclude_globs = profile_globs.to_vec();
-    exclude_globs.extend(cli_exclude_globs);
+
+    for entry in cli_exclude {
+        if entry.contains('*') || entry.contains('?') || entry.contains('[') {
+            exclude_globs.push(entry.clone());
+        } else {
+            exclude_patterns.push(entry.clone());
+        }
+    }
     exclude_globs.extend(cli_exclude_glob.iter().cloned());
 
     (exclude_patterns, exclude_globs)

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1235,8 +1235,9 @@ pub struct SessionHooks {
 /// Signal isolation mode as specified in a profile.
 ///
 /// Maps to `nono::SignalMode` when building the `CapabilitySet`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "snake_case")]
+#[clap(rename_all = "snake_case")]
 pub enum ProfileSignalMode {
     /// Signals restricted to the current process only
     Isolated,
@@ -1259,8 +1260,9 @@ impl From<ProfileSignalMode> for nono::SignalMode {
 /// Process inspection mode as specified in a profile.
 ///
 /// Maps to `nono::ProcessInfoMode` when building the `CapabilitySet`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "snake_case")]
+#[clap(rename_all = "snake_case")]
 pub enum ProfileProcessInfoMode {
     /// Inspection restricted to self only (default)
     Isolated,
@@ -1283,8 +1285,9 @@ impl From<ProfileProcessInfoMode> for nono::ProcessInfoMode {
 /// IPC mode as specified in a profile.
 ///
 /// Maps to `nono::IpcMode` when building the `CapabilitySet`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "snake_case")]
+#[clap(rename_all = "snake_case")]
 pub enum ProfileIpcMode {
     /// POSIX shared memory only (default). Semaphores denied.
     SharedMemoryOnly,
@@ -1309,8 +1312,9 @@ impl From<ProfileIpcMode> for nono::IpcMode {
 /// networking. On WSL2, that enforcement is unavailable.
 ///
 /// Default: `Error` — refuse to run rather than silently losing enforcement.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "snake_case")]
+#[clap(rename_all = "snake_case")]
 pub enum Wsl2ProxyPolicy {
     /// Refuse to run if ProxyOnly cannot be kernel-enforced on WSL2.
     /// This is the secure default.
@@ -1551,7 +1555,14 @@ where
     })
 }
 
-/// A complete profile definition
+/// A complete profile definition.
+///
+/// New fields on this struct (and on any `*Config` struct transitively
+/// reachable through it) require a categorization in
+/// `crates/nono-cli/tests/schema_cli_parity.rs::mapping_table()`. Valid
+/// categories: `Flag("<long-name>")`, `ProfileOnly("reason")`,
+/// `Deprecated("reason")`. The parity test fails CI on uncategorized
+/// fields.
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct Profile {
     /// Optional base profile(s) to inherit from (by name).

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -43,6 +43,31 @@ struct PrepareProfileOptions {
     hook_output_silent: bool,
 }
 
+/// Combine profile env-var patterns with CLI-supplied ones. Returns `None`
+/// (the "no list, everything passes" sentinel) only when both sources are
+/// empty AND the profile didn't explicitly opt into an empty list — matching
+/// the prior behavior where the field was untouched if neither side spoke.
+fn merge_env_var_patterns(
+    profile_patterns: &[String],
+    cli_patterns: &[String],
+    field_name: &str,
+) -> Option<Vec<String>> {
+    if profile_patterns.is_empty() && cli_patterns.is_empty() {
+        return None;
+    }
+    let mut combined = Vec::with_capacity(profile_patterns.len() + cli_patterns.len());
+    combined.extend_from_slice(profile_patterns);
+    for cli in cli_patterns {
+        if !combined.contains(cli) {
+            combined.push(cli.clone());
+        }
+    }
+    if let Some(err) = crate::exec_strategy::validate_env_var_patterns(&combined, field_name) {
+        eprintln!("Warning: {}", err);
+    }
+    Some(combined)
+}
+
 fn install_profile_hooks(_profile_name: Option<&str>, profile: &profile::Profile, silent: bool) {
     // In-binary hook installation was removed in v0.44.0 alongside
     // the hooks.rs module. Profiles that ship a `hooks.<target>`
@@ -590,9 +615,13 @@ fn prepare_profile_with_options(
             .and_then(|profile| profile.security.capability_elevation)
             .unwrap_or(false),
         #[cfg(target_os = "linux")]
-        wsl2_proxy_policy: loaded_profile
-            .as_ref()
-            .and_then(|profile| profile.security.wsl2_proxy_policy)
+        wsl2_proxy_policy: args
+            .wsl2_proxy_policy
+            .or_else(|| {
+                loaded_profile
+                    .as_ref()
+                    .and_then(|profile| profile.security.wsl2_proxy_policy)
+            })
             .unwrap_or_default(),
         #[cfg(target_os = "linux")]
         af_unix_mediation: loaded_profile
@@ -675,31 +704,24 @@ fn prepare_profile_with_options(
             .as_ref()
             .map(|profile| profile.diagnostics.suppress_system_services.clone())
             .unwrap_or_default(),
-        allowed_env_vars: loaded_profile.as_ref().and_then(|profile| {
-            profile.environment.as_ref().map(|env_config| {
-                if let Some(err) = crate::exec_strategy::validate_env_var_patterns(
-                    &env_config.allow_vars,
-                    "allow_vars",
-                ) {
-                    eprintln!("Warning: {}", err);
-                }
-                env_config.allow_vars.clone()
-            })
-        }),
-        denied_env_vars: loaded_profile.as_ref().and_then(|profile| {
-            profile.environment.as_ref().and_then(|env_config| {
-                if env_config.deny_vars.is_empty() {
-                    return None;
-                }
-                if let Some(err) = crate::exec_strategy::validate_env_var_patterns(
-                    &env_config.deny_vars,
-                    "deny_vars",
-                ) {
-                    eprintln!("Warning: {}", err);
-                }
-                Some(env_config.deny_vars.clone())
-            })
-        }),
+        allowed_env_vars: merge_env_var_patterns(
+            loaded_profile
+                .as_ref()
+                .and_then(|profile| profile.environment.as_ref())
+                .map(|env_config| env_config.allow_vars.as_slice())
+                .unwrap_or(&[]),
+            &args.allow_env_var,
+            "allow_vars",
+        ),
+        denied_env_vars: merge_env_var_patterns(
+            loaded_profile
+                .as_ref()
+                .and_then(|profile| profile.environment.as_ref())
+                .map(|env_config| env_config.deny_vars.as_slice())
+                .unwrap_or(&[]),
+            &args.deny_env_var,
+            "deny_vars",
+        ),
         set_vars: expand_profile_set_vars(loaded_profile.as_ref(), workdir)?,
         loaded_profile,
     })
@@ -1342,6 +1364,189 @@ mod tests {
                     profile.filesystem.allow.clone(),
                 )
             })
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // merge_env_var_patterns: profile + CLI source combinations
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn merge_env_var_patterns_returns_none_when_both_sources_empty() {
+        assert_eq!(merge_env_var_patterns(&[], &[], "allow_vars"), None);
+    }
+
+    #[test]
+    fn merge_env_var_patterns_uses_profile_only_when_cli_empty() {
+        let profile = vec!["PATH".to_string(), "HOME".to_string()];
+        let merged = merge_env_var_patterns(&profile, &[], "allow_vars");
+        assert_eq!(merged, Some(profile));
+    }
+
+    #[test]
+    fn merge_env_var_patterns_uses_cli_only_when_profile_empty() {
+        let cli = vec!["AWS_REGION".to_string()];
+        let merged = merge_env_var_patterns(&[], &cli, "allow_vars");
+        assert_eq!(merged, Some(cli));
+    }
+
+    #[test]
+    fn merge_env_var_patterns_concatenates_profile_then_cli() {
+        let profile = vec!["PATH".to_string()];
+        let cli = vec!["AWS_REGION".to_string()];
+        let merged = merge_env_var_patterns(&profile, &cli, "allow_vars");
+        assert_eq!(
+            merged,
+            Some(vec!["PATH".to_string(), "AWS_REGION".to_string()])
+        );
+    }
+
+    #[test]
+    fn merge_env_var_patterns_dedupes_cli_against_profile() {
+        let profile = vec!["PATH".to_string(), "HOME".to_string()];
+        let cli = vec!["HOME".to_string(), "AWS_REGION".to_string()];
+        let merged = merge_env_var_patterns(&profile, &cli, "allow_vars");
+        assert_eq!(
+            merged,
+            Some(vec![
+                "PATH".to_string(),
+                "HOME".to_string(),
+                "AWS_REGION".to_string(),
+            ])
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // prepare_profile integration: env var flags and (Linux) wsl2 flag
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn prepare_profile_extends_allow_env_var_with_cli_flag() {
+        let workdir = tempdir().expect("tempdir");
+        let profile_path = workdir.path().join("env-allow-profile.json");
+        fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "env-allow-profile" },
+                "environment": { "allow_vars": ["PATH"] }
+            }"#,
+        )
+        .expect("write profile");
+
+        let args = SandboxArgs {
+            profile: Some(profile_path.to_string_lossy().into_owned()),
+            allow_env_var: vec!["AWS_REGION".to_string()],
+            ..SandboxArgs::default()
+        };
+        let prepared =
+            prepare_profile_for_preflight(&args, workdir.path()).expect("prepare profile");
+        assert_eq!(
+            prepared.allowed_env_vars,
+            Some(vec!["PATH".to_string(), "AWS_REGION".to_string()])
+        );
+    }
+
+    #[test]
+    fn prepare_profile_extends_deny_env_var_with_cli_flag() {
+        let workdir = tempdir().expect("tempdir");
+        let profile_path = workdir.path().join("env-deny-profile.json");
+        fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "env-deny-profile" },
+                "environment": { "deny_vars": ["GH_TOKEN"] }
+            }"#,
+        )
+        .expect("write profile");
+
+        let args = SandboxArgs {
+            profile: Some(profile_path.to_string_lossy().into_owned()),
+            deny_env_var: vec!["AWS_SECRET_ACCESS_KEY".to_string()],
+            ..SandboxArgs::default()
+        };
+        let prepared =
+            prepare_profile_for_preflight(&args, workdir.path()).expect("prepare profile");
+        assert_eq!(
+            prepared.denied_env_vars,
+            Some(vec![
+                "GH_TOKEN".to_string(),
+                "AWS_SECRET_ACCESS_KEY".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn prepare_profile_env_vars_cli_only_with_no_profile_section() {
+        let workdir = tempdir().expect("tempdir");
+        let profile_path = workdir.path().join("env-empty-profile.json");
+        fs::write(
+            &profile_path,
+            r#"{ "meta": { "name": "env-empty-profile" } }"#,
+        )
+        .expect("write profile");
+
+        let args = SandboxArgs {
+            profile: Some(profile_path.to_string_lossy().into_owned()),
+            allow_env_var: vec!["PATH".to_string()],
+            deny_env_var: vec!["GH_TOKEN".to_string()],
+            ..SandboxArgs::default()
+        };
+        let prepared =
+            prepare_profile_for_preflight(&args, workdir.path()).expect("prepare profile");
+        assert_eq!(prepared.allowed_env_vars, Some(vec!["PATH".to_string()]));
+        assert_eq!(prepared.denied_env_vars, Some(vec!["GH_TOKEN".to_string()]));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn prepare_profile_wsl2_proxy_policy_cli_overrides_profile() {
+        let workdir = tempdir().expect("tempdir");
+        let profile_path = workdir.path().join("wsl2-profile.json");
+        fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "wsl2-profile" },
+                "security": { "wsl2_proxy_policy": "error" }
+            }"#,
+        )
+        .expect("write profile");
+
+        let args = SandboxArgs {
+            profile: Some(profile_path.to_string_lossy().into_owned()),
+            wsl2_proxy_policy: Some(profile::Wsl2ProxyPolicy::InsecureProxy),
+            ..SandboxArgs::default()
+        };
+        let prepared =
+            prepare_profile_for_preflight(&args, workdir.path()).expect("prepare profile");
+        assert_eq!(
+            prepared.wsl2_proxy_policy,
+            profile::Wsl2ProxyPolicy::InsecureProxy
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn prepare_profile_wsl2_proxy_policy_falls_back_to_profile_when_flag_absent() {
+        let workdir = tempdir().expect("tempdir");
+        let profile_path = workdir.path().join("wsl2-profile.json");
+        fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "wsl2-profile" },
+                "security": { "wsl2_proxy_policy": "insecure_proxy" }
+            }"#,
+        )
+        .expect("write profile");
+
+        let args = SandboxArgs {
+            profile: Some(profile_path.to_string_lossy().into_owned()),
+            ..SandboxArgs::default()
+        };
+        let prepared =
+            prepare_profile_for_preflight(&args, workdir.path()).expect("prepare profile");
+        assert_eq!(
+            prepared.wsl2_proxy_policy,
+            profile::Wsl2ProxyPolicy::InsecureProxy
         );
     }
 }

--- a/crates/nono-cli/tests/schema_cli_parity.rs
+++ b/crates/nono-cli/tests/schema_cli_parity.rs
@@ -453,10 +453,13 @@ fn schema_fields_are_categorized() {
     let table = mapping_table();
     let opaque: BTreeSet<&str> = opaque_structs().iter().copied().collect();
 
+    // Type-graph traversal: every struct reachable from `Profile` must have
+    // its fields categorized. Order doesn't matter (visit-once via `reachable`),
+    // so a stack via `Vec::pop` is sufficient — avoids a `VecDeque` import.
     let known_structs: BTreeSet<&str> = parsed.keys().map(String::as_str).collect();
     let mut reachable: BTreeSet<String> = BTreeSet::new();
-    let mut queue: Vec<String> = vec!["Profile".to_string()];
-    while let Some(s) = queue.pop() {
+    let mut stack: Vec<String> = vec!["Profile".to_string()];
+    while let Some(s) = stack.pop() {
         if !reachable.insert(s.clone()) {
             continue;
         }
@@ -469,7 +472,7 @@ fn schema_fields_are_categorized() {
         for f in fields {
             for ident in &f.type_idents {
                 if known_structs.contains(ident.as_str()) && !reachable.contains(ident) {
-                    queue.push(ident.clone());
+                    stack.push(ident.clone());
                 }
             }
         }
@@ -662,8 +665,8 @@ struct SecretLeaf {
 
     let known: BTreeSet<&str> = parsed.keys().map(String::as_str).collect();
     let mut reachable: BTreeSet<String> = BTreeSet::new();
-    let mut queue = vec!["Profile".to_string()];
-    while let Some(s) = queue.pop() {
+    let mut stack = vec!["Profile".to_string()];
+    while let Some(s) = stack.pop() {
         if !reachable.insert(s.clone()) {
             continue;
         }
@@ -673,7 +676,7 @@ struct SecretLeaf {
         for f in fields {
             for ident in &f.type_idents {
                 if known.contains(ident.as_str()) && !reachable.contains(ident) {
-                    queue.push(ident.clone());
+                    stack.push(ident.clone());
                 }
             }
         }

--- a/crates/nono-cli/tests/schema_cli_parity.rs
+++ b/crates/nono-cli/tests/schema_cli_parity.rs
@@ -6,13 +6,12 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
-use std::process::Command;
 
 /// Categorize a new `Profile` field by adding a `mapping_table()` entry:
 /// `Flag("<long-name>")` if backed by a CLI flag, `ProfileOnly("reason")`
-/// if deliberately profile-only, `Deprecated("reason")` if a back-compat
-/// alias. The reason strings are documentation for reviewers, not used
-/// programmatically.
+/// if deliberately profile-only forever, `Deprecated("reason")` if a
+/// back-compat alias. The reason strings are documentation for reviewers,
+/// not used programmatically.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 enum Category {
@@ -104,21 +103,13 @@ fn mapping_table() -> Vec<(&'static str, &'static str, Category)> {
             "unsafe_macos_seatbelt_rules",
             ProfileOnly("deliberately unsafe expert escape hatch; profile-only by design"),
         ),
-        (
-            "SecurityConfig",
-            "signal_mode",
-            ProfileOnly("isolation mode selection; backsweep candidate (#1027 PR 2)"),
-        ),
+        ("SecurityConfig", "signal_mode", Flag("signal-mode")),
         (
             "SecurityConfig",
             "process_info_mode",
-            ProfileOnly("isolation mode selection; backsweep candidate (#1027 PR 2)"),
+            Flag("process-info-mode"),
         ),
-        (
-            "SecurityConfig",
-            "ipc_mode",
-            ProfileOnly("isolation mode selection; backsweep candidate (#1027 PR 2)"),
-        ),
+        ("SecurityConfig", "ipc_mode", Flag("ipc-mode")),
         (
             "SecurityConfig",
             "capability_elevation",
@@ -127,7 +118,7 @@ fn mapping_table() -> Vec<(&'static str, &'static str, Category)> {
         (
             "SecurityConfig",
             "wsl2_proxy_policy",
-            ProfileOnly("WSL2-specific fallback knob; backsweep candidate (#1027 PR 2)"),
+            Flag("wsl2-proxy-policy"),
         ),
         (
             "GroupsConfig",
@@ -228,7 +219,14 @@ fn mapping_table() -> Vec<(&'static str, &'static str, Category)> {
             "af_unix_mediation",
             ProfileOnly("opt-in Linux pathname AF_UNIX mediation mode; profile-only by design"),
         ),
-        ("WorkdirConfig", "access", Flag("allow-cwd")),
+        (
+            "WorkdirConfig",
+            "access",
+            ProfileOnly(
+                "the access level (None/Read/Write/ReadWrite) is profile-set; \
+                 --allow-cwd only suppresses the prompt, it does not set a level",
+            ),
+        ),
         (
             "RollbackConfig",
             "exclude_patterns",
@@ -237,18 +235,10 @@ fn mapping_table() -> Vec<(&'static str, &'static str, Category)> {
         (
             "RollbackConfig",
             "exclude_globs",
-            ProfileOnly("glob excludes are profile-only today; backsweep candidate (#1027 PR 2)"),
+            Flag("rollback-exclude-glob"),
         ),
-        (
-            "EnvironmentConfig",
-            "allow_vars",
-            ProfileOnly("env var allow-list; backsweep candidate (#1027 PR 2)"),
-        ),
-        (
-            "EnvironmentConfig",
-            "deny_vars",
-            ProfileOnly("env var deny-list; backsweep candidate (#1027 PR 2)"),
-        ),
+        ("EnvironmentConfig", "allow_vars", Flag("allow-env-var")),
+        ("EnvironmentConfig", "deny_vars", Flag("deny-env-var")),
         (
             "OpenUrlConfig",
             "allow_origins",
@@ -327,9 +317,9 @@ struct FieldInfo {
 
 /// Parse `profile/mod.rs` as the source of truth for the policy surface.
 /// We don't use `nono-profile.schema.json` because it's hand-maintained and
-/// drifts (e.g. `connect_port` exists in the struct but not the schema -
-/// itself a #1027-class drift). `syn` understands multi-line types, raw
-/// idents, attributes, etc. - anything `cargo check` accepts.
+/// drifts from the Rust struct (e.g. `connect_port` exists in the struct but
+/// not the schema). `syn` understands multi-line types, raw idents,
+/// attributes, etc. - anything `cargo check` accepts.
 fn parse_struct_fields(source: &str) -> BTreeMap<String, Vec<FieldInfo>> {
     let file: syn::File = syn::parse_file(source).expect("failed to parse profile/mod.rs as Rust");
     let mut out: BTreeMap<String, Vec<FieldInfo>> = BTreeMap::new();
@@ -390,50 +380,70 @@ fn collect_type_idents(ty: &syn::Type, out: &mut Vec<String>) {
     }
 }
 
-/// Scrape `--flag` long forms out of `nono run --help`. We shell out because
-/// `nono-cli` is `[[bin]]`-only - no library target - so tests can't import
-/// `Cli` to enumerate flags directly.
-fn parse_cli_flags() -> BTreeSet<String> {
-    let output = Command::new(env!("CARGO_BIN_EXE_nono"))
-        .args(["run", "--help"])
-        .output()
-        .expect("failed to invoke `nono run --help`");
-    assert!(
-        output.status.success(),
-        "`nono run --help` exited non-zero: {:?}\nstderr: {}",
-        output.status,
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let help = String::from_utf8_lossy(&output.stdout);
+fn cli_source() -> String {
+    let path = workspace_root()
+        .join("crates")
+        .join("nono-cli")
+        .join("src")
+        .join("cli.rs");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()))
+}
 
+/// Parse `cli.rs` and collect every clap long-flag declared via `#[arg(long)]`
+/// or `#[arg(long = "name")]`. Source-based (not `--help`-scraping) so
+/// `cfg(target_os = "...")`-gated flags are included on every platform — the
+/// previous shell-out approach lost macOS-only flags on Linux and vice versa.
+fn parse_cli_flags(source: &str) -> BTreeSet<String> {
+    let file: syn::File = syn::parse_file(source).expect("failed to parse cli.rs as Rust");
     let mut flags = BTreeSet::new();
-    for line in help.lines() {
-        let mut rest = line;
-        while let Some(idx) = rest.find("--") {
-            // Only count `--` preceded by start-of-line or a separator -
-            // skips matches inside descriptive text like ALIAS(canonical="--foo")
-            // and (default: --foo).
-            let before_ok = idx == 0
-                || matches!(
-                    line.as_bytes().get(idx.wrapping_sub(1)),
-                    Some(b' ') | Some(b',') | Some(b'\t')
-                );
-            let after = &rest[idx + 2..];
-            if !before_ok {
-                rest = after;
+    for item in &file.items {
+        let syn::Item::Struct(item_struct) = item else {
+            continue;
+        };
+        let syn::Fields::Named(named) = &item_struct.fields else {
+            continue;
+        };
+        for field in &named.named {
+            let Some(field_name) = &field.ident else {
                 continue;
+            };
+            for attr in &field.attrs {
+                if !attr.path().is_ident("arg") {
+                    continue;
+                }
+                if let Some(name) = extract_long_flag(attr, &field_name.to_string()) {
+                    flags.insert(name);
+                }
             }
-            let name: String = after
-                .chars()
-                .take_while(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
-                .collect();
-            if !name.is_empty() {
-                flags.insert(name);
-            }
-            rest = after;
         }
     }
     flags
+}
+
+/// Inspect a single `#[arg(...)]` attribute. Returns the long-flag name if the
+/// attribute opts into one, either via bare `long` (auto-derived from the field
+/// name as kebab-case) or via `long = "explicit-name"`. Returns `None` if no
+/// `long` token is present (i.e. positional or short-only args).
+fn extract_long_flag(attr: &syn::Attribute, field_name: &str) -> Option<String> {
+    let mut has_long = false;
+    let mut explicit_long: Option<String> = None;
+    let _ = attr.parse_nested_meta(|meta| {
+        if !meta.path.is_ident("long") {
+            return Ok(());
+        }
+        has_long = true;
+        if let Ok(value) = meta.value()
+            && let Ok(lit_str) = value.parse::<syn::LitStr>()
+        {
+            explicit_long = Some(lit_str.value());
+        }
+        Ok(())
+    });
+    if !has_long {
+        return None;
+    }
+    Some(explicit_long.unwrap_or_else(|| field_name.replace('_', "-")))
 }
 
 #[test]
@@ -514,7 +524,7 @@ fn schema_fields_are_categorized() {
             errors.push(format!(
                 "uncategorized policy field: {struct_name}.{field_name} - \
                  add a Flag/Deprecated/ProfileOnly entry to mapping_table() \
-                 in crates/nono-cli/tests/schema_cli_parity.rs (issue #1027)"
+                 in crates/nono-cli/tests/schema_cli_parity.rs"
             ));
         }
     }
@@ -535,7 +545,7 @@ fn schema_fields_are_categorized() {
 /// We don't check the inverse (every CLI flag maps to a policy field).
 #[test]
 fn flag_backed_fields_have_real_cli_flags() {
-    let cli_flags = parse_cli_flags();
+    let cli_flags = parse_cli_flags(&cli_source());
     let table = mapping_table();
     let mut errors: Vec<String> = Vec::new();
 
@@ -544,9 +554,9 @@ fn flag_backed_fields_have_real_cli_flags() {
             && !cli_flags.contains(*name)
         {
             errors.push(format!(
-                "mapping says {s}.{f} → --{name}, but `nono run --help` \
-                 does not list --{name} (renamed flag? typo? \
-                 macOS-conditional flag absent on this build?)"
+                "mapping says {s}.{f} → --{name}, but no `#[arg(...)]` in \
+                 crates/nono-cli/src/cli.rs declares --{name} (flag missing? \
+                 typo? renamed?)"
             ));
         }
     }

--- a/crates/nono-cli/tests/schema_cli_parity.rs
+++ b/crates/nono-cli/tests/schema_cli_parity.rs
@@ -240,6 +240,14 @@ fn mapping_table() -> Vec<(&'static str, &'static str, Category)> {
         ("EnvironmentConfig", "allow_vars", Flag("allow-env-var")),
         ("EnvironmentConfig", "deny_vars", Flag("deny-env-var")),
         (
+            "EnvironmentConfig",
+            "set_vars",
+            ProfileOnly(
+                "static env injection (HashMap key=value); profile-authored auditable decision \
+                 with shell-style expansion - not exposed as a flag",
+            ),
+        ),
+        (
             "OpenUrlConfig",
             "allow_origins",
             ProfileOnly("URL origin allowlist for OAuth flows; profile-authored"),

--- a/crates/nono-cli/tests/schema_cli_parity.rs
+++ b/crates/nono-cli/tests/schema_cli_parity.rs
@@ -1,0 +1,694 @@
+//! Parity check: every policy field on `Profile` (transitively)
+//! must be categorized in `mapping_table()` as flag-backed, deprecated, or
+//! deliberately profile-only. New fields with no entry fail CI.
+
+#![allow(clippy::expect_used)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Categorize a new `Profile` field by adding a `mapping_table()` entry:
+/// `Flag("<long-name>")` if backed by a CLI flag, `ProfileOnly("reason")`
+/// if deliberately profile-only, `Deprecated("reason")` if a back-compat
+/// alias. The reason strings are documentation for reviewers, not used
+/// programmatically.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+enum Category {
+    /// Long-flag name, without leading `--`.
+    Flag(&'static str),
+    Deprecated(&'static str),
+    ProfileOnly(&'static str),
+    NestedRecurse,
+}
+
+#[allow(clippy::type_complexity)]
+fn mapping_table() -> Vec<(&'static str, &'static str, Category)> {
+    use Category::*;
+    vec![
+        (
+            "Profile",
+            "extends",
+            ProfileOnly("profile inheritance is structural; set at authoring time, not per-run"),
+        ),
+        (
+            "Profile",
+            "meta",
+            ProfileOnly(
+                "profile metadata block (name/version/description/author); not a runtime knob",
+            ),
+        ),
+        ("Profile", "security", NestedRecurse),
+        ("Profile", "groups", NestedRecurse),
+        ("Profile", "commands", NestedRecurse),
+        ("Profile", "filesystem", NestedRecurse),
+        ("Profile", "network", NestedRecurse),
+        ("Profile", "diagnostics", NestedRecurse),
+        ("Profile", "linux", NestedRecurse),
+        ("Profile", "env_credentials", Flag("env-credential")),
+        ("Profile", "environment", NestedRecurse),
+        ("Profile", "workdir", NestedRecurse),
+        (
+            "Profile",
+            "hooks",
+            ProfileOnly(
+                "event-driven application hooks; profile-authored multi-key map, not a flag",
+            ),
+        ),
+        (
+            "Profile",
+            "session_hooks",
+            ProfileOnly("lifecycle hooks run with host privileges; profile-only by design"),
+        ),
+        ("Profile", "rollback", NestedRecurse),
+        ("Profile", "open_urls", NestedRecurse),
+        (
+            "Profile",
+            "allow_launch_services",
+            Flag("allow-launch-services"),
+        ),
+        ("Profile", "allow_gpu", Flag("allow-gpu")),
+        (
+            "Profile",
+            "allow_parent_of_protected",
+            ProfileOnly("opt-in macOS-only escape hatch; deliberately not exposed as a flag"),
+        ),
+        (
+            "Profile",
+            "interactive",
+            Deprecated(
+                "parsed for backward compatibility but ignored; supervised mode preserves TTY by default",
+            ),
+        ),
+        ("Profile", "skipdirs", Flag("skip-dir")),
+        (
+            "Profile",
+            "packs",
+            ProfileOnly(
+                "pack dependencies are part of the profile contract, not per-run overrides",
+            ),
+        ),
+        (
+            "Profile",
+            "binary",
+            ProfileOnly("default binary fallback when no `-- <cmd>` is given; profile-authored"),
+        ),
+        (
+            "Profile",
+            "command_args",
+            ProfileOnly("default args appended to the child command; profile-authored, not a flag"),
+        ),
+        (
+            "Profile",
+            "unsafe_macos_seatbelt_rules",
+            ProfileOnly("deliberately unsafe expert escape hatch; profile-only by design"),
+        ),
+        (
+            "SecurityConfig",
+            "signal_mode",
+            ProfileOnly("isolation mode selection; backsweep candidate (#1027 PR 2)"),
+        ),
+        (
+            "SecurityConfig",
+            "process_info_mode",
+            ProfileOnly("isolation mode selection; backsweep candidate (#1027 PR 2)"),
+        ),
+        (
+            "SecurityConfig",
+            "ipc_mode",
+            ProfileOnly("isolation mode selection; backsweep candidate (#1027 PR 2)"),
+        ),
+        (
+            "SecurityConfig",
+            "capability_elevation",
+            Flag("capability-elevation"),
+        ),
+        (
+            "SecurityConfig",
+            "wsl2_proxy_policy",
+            ProfileOnly("WSL2-specific fallback knob; backsweep candidate (#1027 PR 2)"),
+        ),
+        (
+            "GroupsConfig",
+            "include",
+            ProfileOnly(
+                "policy group composition is part of the profile contract, not a runtime override",
+            ),
+        ),
+        (
+            "GroupsConfig",
+            "exclude",
+            ProfileOnly(
+                "policy group composition is part of the profile contract, not a runtime override",
+            ),
+        ),
+        (
+            "CommandsConfig",
+            "allow",
+            Deprecated("v0.33.0 startup-only allow list; --allow-command kept for compat"),
+        ),
+        (
+            "CommandsConfig",
+            "deny",
+            Deprecated("v0.33.0 startup-only deny list; --block-command kept for compat"),
+        ),
+        ("FilesystemConfig", "allow", Flag("allow")),
+        ("FilesystemConfig", "read", Flag("read")),
+        ("FilesystemConfig", "write", Flag("write")),
+        ("FilesystemConfig", "allow_file", Flag("allow-file")),
+        ("FilesystemConfig", "read_file", Flag("read-file")),
+        ("FilesystemConfig", "write_file", Flag("write-file")),
+        ("FilesystemConfig", "unix_socket", Flag("allow-unix-socket")),
+        (
+            "FilesystemConfig",
+            "unix_socket_bind",
+            Flag("allow-unix-socket-bind"),
+        ),
+        (
+            "FilesystemConfig",
+            "unix_socket_dir",
+            Flag("allow-unix-socket-dir"),
+        ),
+        (
+            "FilesystemConfig",
+            "unix_socket_dir_bind",
+            Flag("allow-unix-socket-dir-bind"),
+        ),
+        (
+            "FilesystemConfig",
+            "unix_socket_subtree",
+            Flag("allow-unix-socket-subtree"),
+        ),
+        (
+            "FilesystemConfig",
+            "unix_socket_subtree_bind",
+            Flag("allow-unix-socket-subtree-bind"),
+        ),
+        (
+            "FilesystemConfig",
+            "deny",
+            ProfileOnly(
+                "deny rules are policy-level; per-run extensions go through bypass_protection instead",
+            ),
+        ),
+        (
+            "FilesystemConfig",
+            "bypass_protection",
+            Flag("bypass-protection"),
+        ),
+        (
+            "FilesystemConfig",
+            "suppress_save_prompt",
+            Flag("suppress-save-prompt"),
+        ),
+        ("NetworkConfig", "block", Flag("block-net")),
+        ("NetworkConfig", "network_profile", Flag("network-profile")),
+        ("NetworkConfig", "allow_domain", Flag("allow-domain")),
+        ("NetworkConfig", "credentials", Flag("credential")),
+        ("NetworkConfig", "open_port", Flag("open-port")),
+        ("NetworkConfig", "listen_port", Flag("listen-port")),
+        ("NetworkConfig", "connect_port", Flag("allow-connect-port")),
+        (
+            "NetworkConfig",
+            "custom_credentials",
+            ProfileOnly(
+                "custom credential service definitions are complex per-service maps; profile-only",
+            ),
+        ),
+        ("NetworkConfig", "upstream_proxy", Flag("upstream-proxy")),
+        ("NetworkConfig", "upstream_bypass", Flag("upstream-bypass")),
+        (
+            "DiagnosticsConfig",
+            "suppress_system_services",
+            ProfileOnly("diagnostic UX filter; not enforcement, profile-only by design"),
+        ),
+        (
+            "LinuxConfig",
+            "af_unix_mediation",
+            ProfileOnly("opt-in Linux pathname AF_UNIX mediation mode; profile-only by design"),
+        ),
+        ("WorkdirConfig", "access", Flag("allow-cwd")),
+        (
+            "RollbackConfig",
+            "exclude_patterns",
+            Flag("rollback-exclude"),
+        ),
+        (
+            "RollbackConfig",
+            "exclude_globs",
+            ProfileOnly("glob excludes are profile-only today; backsweep candidate (#1027 PR 2)"),
+        ),
+        (
+            "EnvironmentConfig",
+            "allow_vars",
+            ProfileOnly("env var allow-list; backsweep candidate (#1027 PR 2)"),
+        ),
+        (
+            "EnvironmentConfig",
+            "deny_vars",
+            ProfileOnly("env var deny-list; backsweep candidate (#1027 PR 2)"),
+        ),
+        (
+            "OpenUrlConfig",
+            "allow_origins",
+            ProfileOnly("URL origin allowlist for OAuth flows; profile-authored"),
+        ),
+        (
+            "OpenUrlConfig",
+            "allow_localhost",
+            ProfileOnly("OAuth localhost callback toggle; profile-authored"),
+        ),
+        (
+            "ProfileMeta",
+            "name",
+            ProfileOnly("profile metadata, not policy enforcement"),
+        ),
+        (
+            "ProfileMeta",
+            "version",
+            ProfileOnly("profile metadata, not policy enforcement"),
+        ),
+        (
+            "ProfileMeta",
+            "description",
+            ProfileOnly("profile metadata, not policy enforcement"),
+        ),
+        (
+            "ProfileMeta",
+            "author",
+            ProfileOnly("profile metadata, not policy enforcement"),
+        ),
+    ]
+}
+
+/// Structs the BFS treats as leaves: no fixed field set (`#[serde(flatten)]`
+/// over a HashMap) or already covered by their parent's mapping entry.
+fn opaque_structs() -> &'static [&'static str] {
+    &[
+        "HooksConfig",         // serde(flatten) HashMap<String, HookConfig>
+        "HookConfig",          // per-application hook spec; profile-authored
+        "SessionHooks",        // before/after session hooks; profile-authored
+        "SessionHook",         // single hook spec; profile-authored
+        "SecretsConfig",       // serde(flatten) HashMap<String, String>
+        "ProfileDeserialize",  // private deserialization helper
+        "CustomCredentialDef", // per-service credential def; profile-only via custom_credentials map
+    ]
+}
+
+fn workspace_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .map(PathBuf::from)
+        .unwrap_or(manifest_dir)
+}
+
+fn profile_source() -> String {
+    let path = workspace_root()
+        .join("crates")
+        .join("nono-cli")
+        .join("src")
+        .join("profile")
+        .join("mod.rs");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()))
+}
+
+#[derive(Debug)]
+struct FieldInfo {
+    name: String,
+    /// Identifiers from the field's type expression. Filtered downstream
+    /// against parsed struct names - stdlib generics, enums, primitives,
+    /// and types from other crates fall through as leaves.
+    type_idents: Vec<String>,
+}
+
+/// Parse `profile/mod.rs` as the source of truth for the policy surface.
+/// We don't use `nono-profile.schema.json` because it's hand-maintained and
+/// drifts (e.g. `connect_port` exists in the struct but not the schema -
+/// itself a #1027-class drift). `syn` understands multi-line types, raw
+/// idents, attributes, etc. - anything `cargo check` accepts.
+fn parse_struct_fields(source: &str) -> BTreeMap<String, Vec<FieldInfo>> {
+    let file: syn::File = syn::parse_file(source).expect("failed to parse profile/mod.rs as Rust");
+    let mut out: BTreeMap<String, Vec<FieldInfo>> = BTreeMap::new();
+    for item in &file.items {
+        let syn::Item::Struct(item_struct) = item else {
+            continue;
+        };
+        if !matches!(item_struct.vis, syn::Visibility::Public(_)) {
+            continue;
+        }
+        let syn::Fields::Named(named) = &item_struct.fields else {
+            continue;
+        };
+        let struct_name = item_struct.ident.to_string();
+        let mut fields: Vec<FieldInfo> = Vec::new();
+        for field in &named.named {
+            let Some(ident) = &field.ident else { continue };
+            if !matches!(field.vis, syn::Visibility::Public(_)) {
+                continue;
+            }
+            let mut idents = Vec::new();
+            collect_type_idents(&field.ty, &mut idents);
+            fields.push(FieldInfo {
+                name: ident.to_string(),
+                type_idents: idents,
+            });
+        }
+        out.insert(struct_name, fields);
+    }
+    out
+}
+
+fn collect_type_idents(ty: &syn::Type, out: &mut Vec<String>) {
+    match ty {
+        syn::Type::Path(type_path) => {
+            for segment in &type_path.path.segments {
+                out.push(segment.ident.to_string());
+                if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                    for arg in &args.args {
+                        if let syn::GenericArgument::Type(inner) = arg {
+                            collect_type_idents(inner, out);
+                        }
+                    }
+                }
+            }
+        }
+        syn::Type::Reference(r) => collect_type_idents(&r.elem, out),
+        syn::Type::Array(a) => collect_type_idents(&a.elem, out),
+        syn::Type::Slice(s) => collect_type_idents(&s.elem, out),
+        syn::Type::Tuple(t) => {
+            for elem in &t.elems {
+                collect_type_idents(elem, out);
+            }
+        }
+        syn::Type::Group(g) => collect_type_idents(&g.elem, out),
+        syn::Type::Paren(p) => collect_type_idents(&p.elem, out),
+        _ => {}
+    }
+}
+
+/// Scrape `--flag` long forms out of `nono run --help`. We shell out because
+/// `nono-cli` is `[[bin]]`-only - no library target - so tests can't import
+/// `Cli` to enumerate flags directly.
+fn parse_cli_flags() -> BTreeSet<String> {
+    let output = Command::new(env!("CARGO_BIN_EXE_nono"))
+        .args(["run", "--help"])
+        .output()
+        .expect("failed to invoke `nono run --help`");
+    assert!(
+        output.status.success(),
+        "`nono run --help` exited non-zero: {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let help = String::from_utf8_lossy(&output.stdout);
+
+    let mut flags = BTreeSet::new();
+    for line in help.lines() {
+        let mut rest = line;
+        while let Some(idx) = rest.find("--") {
+            // Only count `--` preceded by start-of-line or a separator -
+            // skips matches inside descriptive text like ALIAS(canonical="--foo")
+            // and (default: --foo).
+            let before_ok = idx == 0
+                || matches!(
+                    line.as_bytes().get(idx.wrapping_sub(1)),
+                    Some(b' ') | Some(b',') | Some(b'\t')
+                );
+            let after = &rest[idx + 2..];
+            if !before_ok {
+                rest = after;
+                continue;
+            }
+            let name: String = after
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+                .collect();
+            if !name.is_empty() {
+                flags.insert(name);
+            }
+            rest = after;
+        }
+    }
+    flags
+}
+
+#[test]
+fn schema_fields_are_categorized() {
+    let source = profile_source();
+    let parsed = parse_struct_fields(&source);
+    let table = mapping_table();
+    let opaque: BTreeSet<&str> = opaque_structs().iter().copied().collect();
+
+    let known_structs: BTreeSet<&str> = parsed.keys().map(String::as_str).collect();
+    let mut reachable: BTreeSet<String> = BTreeSet::new();
+    let mut queue: Vec<String> = vec!["Profile".to_string()];
+    while let Some(s) = queue.pop() {
+        if !reachable.insert(s.clone()) {
+            continue;
+        }
+        if opaque.contains(s.as_str()) {
+            continue;
+        }
+        let Some(fields) = parsed.get(&s) else {
+            continue;
+        };
+        for f in fields {
+            for ident in &f.type_idents {
+                if known_structs.contains(ident.as_str()) && !reachable.contains(ident) {
+                    queue.push(ident.clone());
+                }
+            }
+        }
+    }
+    assert!(
+        reachable.contains("Profile"),
+        "Profile struct not found in {}/crates/nono-cli/src/profile/mod.rs - \
+         did the file move or the parser break?",
+        workspace_root().display()
+    );
+
+    let mut schema_fields: BTreeSet<(String, String)> = BTreeSet::new();
+    for struct_name in &reachable {
+        if opaque.contains(struct_name.as_str()) {
+            continue;
+        }
+        let Some(fields) = parsed.get(struct_name) else {
+            continue;
+        };
+        for f in fields {
+            schema_fields.insert((struct_name.clone(), f.name.clone()));
+        }
+    }
+
+    let mut errors: Vec<String> = Vec::new();
+
+    let mut table_keys: BTreeMap<(String, String), usize> = BTreeMap::new();
+    for (s, f, _) in &table {
+        *table_keys
+            .entry((s.to_string(), f.to_string()))
+            .or_insert(0) += 1;
+    }
+    for (key, count) in &table_keys {
+        if *count > 1 {
+            errors.push(format!(
+                "duplicate mapping entry: {}.{} appears {} times",
+                key.0, key.1, count
+            ));
+        }
+        if !schema_fields.contains(key) {
+            errors.push(format!(
+                "stale mapping entry: {}.{} is in the parity table but not in \
+                 crates/nono-cli/src/profile/mod.rs (struct removed, field \
+                 renamed, or struct now in opaque_structs?)",
+                key.0, key.1
+            ));
+        }
+    }
+
+    for (struct_name, field_name) in &schema_fields {
+        if !table_keys.contains_key(&(struct_name.clone(), field_name.clone())) {
+            errors.push(format!(
+                "uncategorized policy field: {struct_name}.{field_name} - \
+                 add a Flag/Deprecated/ProfileOnly entry to mapping_table() \
+                 in crates/nono-cli/tests/schema_cli_parity.rs (issue #1027)"
+            ));
+        }
+    }
+
+    if !errors.is_empty() {
+        let n = errors.len();
+        panic!(
+            "schema↔CLI parity check failed ({} error{}):\n  - {}\n\nSee \
+             crates/nono-cli/tests/schema_cli_parity.rs for context.",
+            n,
+            if n == 1 { "" } else { "s" },
+            errors.join("\n  - ")
+        );
+    }
+}
+
+/// Forward direction only: `Flag(name)` mappings must point at real flags.
+/// We don't check the inverse (every CLI flag maps to a policy field).
+#[test]
+fn flag_backed_fields_have_real_cli_flags() {
+    let cli_flags = parse_cli_flags();
+    let table = mapping_table();
+    let mut errors: Vec<String> = Vec::new();
+
+    for (s, f, cat) in &table {
+        if let Category::Flag(name) = cat
+            && !cli_flags.contains(*name)
+        {
+            errors.push(format!(
+                "mapping says {s}.{f} → --{name}, but `nono run --help` \
+                 does not list --{name} (renamed flag? typo? \
+                 macOS-conditional flag absent on this build?)"
+            ));
+        }
+    }
+
+    if !errors.is_empty() {
+        let n = errors.len();
+        panic!(
+            "flag-existence check failed ({} error{}):\n  - {}",
+            n,
+            if n == 1 { "" } else { "s" },
+            errors.join("\n  - ")
+        );
+    }
+}
+
+/// Synthetic-fixture test for the parser + BFS. Real-source coverage lives
+/// in `schema_fields_are_categorized`; this one's just the unit-level guard.
+#[test]
+fn bfs_descends_into_unknown_sub_structs() {
+    let synthetic = r#"
+#[derive(Debug)]
+pub struct Profile {
+    pub gpu: Option<GpuConfig>,
+    pub credentials: std::collections::HashMap<
+        String,
+        CredentialEntry,
+    >,
+    pub deeply_nested: Vec<Option<Vec<DeepLeaf>>>,
+    secret: SecretLeaf,
+}
+
+pub struct GpuConfig {
+    pub mode: String,
+    pub vendor: Option<GpuVendor>,
+}
+
+pub struct GpuVendor {
+    pub name: String,
+}
+
+pub struct CredentialEntry {
+    pub key: String,
+}
+
+pub struct DeepLeaf {
+    pub n: u32,
+}
+
+pub struct OpaqueWrapper(pub String);
+
+struct SecretLeaf {
+    pub leaked: bool,
+}
+"#;
+    let parsed = parse_struct_fields(synthetic);
+
+    assert!(parsed.contains_key("Profile"));
+    assert!(parsed.contains_key("GpuConfig"));
+    assert!(parsed.contains_key("CredentialEntry"));
+    assert!(parsed.contains_key("DeepLeaf"));
+    assert!(
+        !parsed.contains_key("SecretLeaf"),
+        "private struct must not be parsed (visibility filter)"
+    );
+    assert!(
+        !parsed.contains_key("OpaqueWrapper"),
+        "tuple struct must not be parsed (no named fields)"
+    );
+
+    let profile_fields = parsed.get("Profile").expect("Profile present");
+    let field_names: Vec<&str> = profile_fields.iter().map(|f| f.name.as_str()).collect();
+    assert_eq!(
+        field_names,
+        vec!["gpu", "credentials", "deeply_nested"],
+        "private `secret` field must be filtered out"
+    );
+
+    let credentials_idents: BTreeSet<&str> = profile_fields
+        .iter()
+        .find(|f| f.name == "credentials")
+        .expect("credentials field")
+        .type_idents
+        .iter()
+        .map(String::as_str)
+        .collect();
+    assert!(
+        credentials_idents.contains("CredentialEntry"),
+        "multi-line generic type lost CredentialEntry: got {credentials_idents:?}"
+    );
+
+    let deeply_idents: BTreeSet<&str> = profile_fields
+        .iter()
+        .find(|f| f.name == "deeply_nested")
+        .expect("deeply_nested field")
+        .type_idents
+        .iter()
+        .map(String::as_str)
+        .collect();
+    assert!(
+        deeply_idents.contains("DeepLeaf"),
+        "deeply nested generics lost DeepLeaf: got {deeply_idents:?}"
+    );
+
+    let known: BTreeSet<&str> = parsed.keys().map(String::as_str).collect();
+    let mut reachable: BTreeSet<String> = BTreeSet::new();
+    let mut queue = vec!["Profile".to_string()];
+    while let Some(s) = queue.pop() {
+        if !reachable.insert(s.clone()) {
+            continue;
+        }
+        let Some(fields) = parsed.get(&s) else {
+            continue;
+        };
+        for f in fields {
+            for ident in &f.type_idents {
+                if known.contains(ident.as_str()) && !reachable.contains(ident) {
+                    queue.push(ident.clone());
+                }
+            }
+        }
+    }
+
+    assert!(reachable.contains("Profile"));
+    assert!(
+        reachable.contains("GpuConfig"),
+        "BFS failed to follow Profile.gpu: Option<GpuConfig> into GpuConfig"
+    );
+    assert!(
+        reachable.contains("GpuVendor"),
+        "BFS failed to follow GpuConfig.vendor: Option<GpuVendor> into GpuVendor - \
+         transitive descent is broken, sub-sub-structs would slip through"
+    );
+    assert!(
+        reachable.contains("CredentialEntry"),
+        "BFS failed to descend through multi-line HashMap into CredentialEntry"
+    );
+    assert!(
+        reachable.contains("DeepLeaf"),
+        "BFS failed to descend through Vec<Option<Vec<...>>> into DeepLeaf"
+    );
+    assert!(
+        !reachable.contains("SecretLeaf"),
+        "private struct must not be reachable"
+    );
+}

--- a/docs/cli/development/index.mdx
+++ b/docs/cli/development/index.mdx
@@ -65,5 +65,6 @@ RUST_LOG=debug cargo run -- run --allow-cwd -- echo "test"
 - **Unwrap Policy**: Never use `.unwrap()` or `.expect()` - enforced by clippy
 - **Unsafe Code**: Restricted to FFI; must include `// SAFETY:` documentation
 - **Path Security**: All paths must be validated and canonicalized
+- **Adding a policy field**: New fields on `Profile` (and on any nested `*Config` struct) require an explicit entry in `crates/nono-cli/tests/schema_cli_parity.rs::mapping_table()`, categorized as `Flag(...)`, `ProfileOnly(...)`, or `Deprecated(...)`. The parity test fails CI on uncategorized fields. See the doc-comment on `Profile` in `crates/nono-cli/src/profile/mod.rs` for details.
 
 See [CLAUDE.md](https://github.com/always-further/nono/blob/main/CLAUDE.md) for complete coding standards.


### PR DESCRIPTION
## Linked Issue

Closes #1027

## Summary

- Adds a CI parity check that fails if a new policy field on `Profile` (or any nested `*Config` struct) is added without an explicit categorization.
- Completes the backsweep so the existing schema-vs-flag drift is closed.

The parity check (`crates/nono-cli/tests/schema_cli_parity.rs`) parses `crates/nono-cli/src/profile/mod.rs` with `syn`, walks `Profile`'s type graph by BFS, and requires every reachable field to have one entry in `mapping_table()` tagged as `Flag("<long-name>")`, `ProfileOnly("reason")`, or `Deprecated("reason")`. Uncategorized fields fail CI as `uncategorized policy field: Foo.bar`. The CLI side is also `syn`-parsed (out of `cli.rs`'s `#[arg(...)]` attributes) so platform-conditional flags don't produce false negatives.

The backsweep adds 7 CLI flags so previously profile-only knobs are reachable per-run:

- `--signal-mode`, `--process-info-mode`, `--ipc-mode` - security isolation modes (clap `ValueEnum`-derived from the existing profile enums).
- `--wsl2-proxy-policy` - Linux-only; mirrors `security.wsl2_proxy_policy`.
- `--rollback-exclude-glob` - explicit glob-only counterpart to the legacy `--rollback-exclude` (which auto-routes by shape).
- `--allow-env-var`, `--deny-env-var` - extend `environment.allow_vars` / `environment.deny_vars`.

CLI values override profile values for the mode enums; list-typed flags (env vars, rollback globs) extend rather than replace, with dedup.

Documents the convention on the `Profile` struct doc-comment and `docs/cli/development/index.mdx` so contributors see it before hitting CI.

## Agent Disclosure

Most code in this PR is generated by Claude. Human review is done by myself.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed - not added now (should we?)

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion.
- [x] I described my intent and approach in the issue discussion.
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (no external code reused or adapted)
- [x] I did not use forbidden patterns such as unwrap/expect (clippy `unwrap_used` clean; `expect()` appears only in test code, which is gated by `#![allow(clippy::expect_used)]` on the parity test file with a justification comment)
- [x] I used NonoError where required (no new error paths introduced; existing `Result` propagation preserved)
- [x] I validated and canonicalized all relevant paths (no new path-handling code; existing canonicalization preserved)
- [x] This PR matches the approved or disclosed issue scope.