### PR TITLE
refactor(networking): typed NetworkIntent, decouple --credential from OS isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ The library is a **pure sandbox primitive**. It applies ONLY what clients explic
 | `QueryContext` | All output and UX |
 | `keystore` | `learn` mode |
 | `undo` module (ObjectStore, SnapshotManager, MerkleTree, ExclusionFilter) | Rollback lifecycle, exclusion policy, rollback UI |
+| `NetworkMode` (enforcement detail — requires a bound port) | `NetworkIntent` (policy intent — resolved from flags and profile before proxy starts) |
 
 ## Build & Test
 
@@ -75,6 +76,8 @@ make fmt             # Auto-format
 3. **Capability resolution**: All paths are canonicalized at grant time to prevent symlink escapes.
 
 4. **Library is policy-free**: The library applies ONLY what's in `CapabilitySet`. No built-in sensitive paths, dangerous commands, or system paths. Clients define all policy.
+
+5. **Credential injection is not traffic isolation**: `--credential` injects headers transparently without setting `NetworkMode::ProxyOnly`. OS-level traffic isolation requires an explicit domain filter (`--allow-domain`, `--network-profile`). Do not couple credential features to `has_proxy_flags()` or `NetworkMode` changes.
 
 ## Platform-Specific Notes
 

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -970,18 +970,8 @@ impl CapabilitySetExt for CapabilitySet {
             caps.add_blocked_command(cmd);
         }
 
-        // Network blocking or proxy mode from profile
         if profile.network.block {
             caps.set_network_blocked(true);
-        } else if profile.network.has_proxy_flags() {
-            let bind_ports =
-                crate::merge_dedup_ports(&profile.network.listen_port, &args.allow_bind);
-            // Profile requests proxy mode; port 0 is a placeholder.
-            // bind_ports come from profile listen_port plus CLI --listen-port.
-            caps = caps.set_network_mode(nono::NetworkMode::ProxyOnly {
-                port: 0,
-                bind_ports,
-            });
         }
 
         // Localhost IPC ports from profile
@@ -1136,13 +1126,6 @@ fn apply_cli_network_mode(caps: &mut CapabilitySet, args: &SandboxArgs) {
         caps.set_network_blocked(true);
     } else if args.allow_net {
         caps.set_network_mode_mut(nono::NetworkMode::AllowAll);
-    } else if args.has_proxy_flags() {
-        // Proxy mode: port 0 is a placeholder, updated when proxy starts.
-        // bind_ports are passed through allow_bind CLI flag.
-        caps.set_network_mode_mut(nono::NetworkMode::ProxyOnly {
-            port: 0,
-            bind_ports: args.allow_bind.clone(),
-        });
     }
 }
 

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1366,11 +1366,11 @@ pub struct SandboxArgs {
 }
 
 impl SandboxArgs {
-    /// Whether any CLI flag requires proxy mode activation.
+    /// Whether any CLI flag activates proxy/domain-filter mode.
+    /// `--credential` is excluded — it injects headers without OS-level isolation.
     pub fn has_proxy_flags(&self) -> bool {
         self.network_profile.is_some()
             || !self.allow_proxy.is_empty()
-            || !self.proxy_credential.is_empty()
             || self.external_proxy.is_some()
     }
 }

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -1,5 +1,6 @@
 use crate::cli::RunArgs;
 use crate::config;
+use crate::network_intent::NetworkIntent;
 use crate::proxy_runtime::prepare_proxy_launch_options;
 use crate::sandbox_prepare::{
     PreparedSandbox, prepare_sandbox, print_allow_gpu_warning, print_allow_launch_services_warning,
@@ -91,6 +92,7 @@ pub(crate) struct ProxyLaunchOptions {
     /// Propagated to `ProxyConfig.strict_filter` so the filter denies
     /// unlisted hosts instead of falling back to allow-all.
     pub(crate) network_block: bool,
+    pub(crate) network_intent: NetworkIntent,
 }
 
 #[derive(Clone)]

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -33,6 +33,7 @@ mod legacy_cleanup;
 #[cfg(target_os = "macos")]
 mod macos_trust;
 mod migration;
+mod network_intent;
 mod network_policy;
 mod open_url_runtime;
 mod output;
@@ -97,7 +98,6 @@ const DETACHED_CWD_PROMPT_RESPONSE_ENV: &str = "NONO_DETACHED_CWD_PROMPT_RESPONS
 const DETACHED_SESSION_ID_ENV: &str = "NONO_DETACHED_SESSION_ID";
 
 pub(crate) use launch_runtime::rollback_base_exclusions;
-pub(crate) use proxy_runtime::merge_dedup_ports;
 
 fn main() {
     let legacy_network_warnings = collect_legacy_network_warnings();
@@ -287,7 +287,7 @@ mod tests {
             suppressed_system_service_operations: Vec::new(),
             allowed_env_vars: None,
             denied_env_vars: None,
-            network_block_requested: false,
+            network_intent: crate::network_intent::NetworkIntent::Unrestricted,
         };
 
         let effective = resolve_effective_proxy_settings(&args, &prepared);
@@ -339,7 +339,7 @@ mod tests {
             suppressed_system_service_operations: Vec::new(),
             allowed_env_vars: None,
             denied_env_vars: None,
-            network_block_requested: false,
+            network_intent: crate::network_intent::NetworkIntent::Unrestricted,
         };
 
         let effective = resolve_effective_proxy_settings(&args, &prepared);

--- a/crates/nono-cli/src/network_intent.rs
+++ b/crates/nono-cli/src/network_intent.rs
@@ -1,0 +1,112 @@
+/// Resolved network intent from CLI flags and profile config, before the proxy
+/// starts. Separates policy intent from `NetworkMode` enforcement details.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) enum NetworkIntent {
+    #[default]
+    /// No network restrictions.
+    Unrestricted,
+    /// All network blocked at OS level (`--block-net` / `network.block`).
+    BlockAll,
+    /// Traffic filtered through a local proxy (domain filter or network profile).
+    /// Credentials alone do not produce this variant — they inject headers
+    /// without imposing OS-level isolation.
+    ProxyFiltered {
+        /// When true the proxy denies unlisted hosts; when false it is a
+        /// transparent pass-through for credential injection only.
+        strict_filter: bool,
+    },
+}
+
+/// Resolve network intent from CLI flags and profile config. Block flags take
+/// precedence; `allow_net` (deprecated explicit-unrestricted flag) overrides
+/// profile proxy settings; proxy-activating flags (domain filter, upstream
+/// proxy, network profile) produce `ProxyFiltered`. Credentials alone yield
+/// `Unrestricted`.
+pub(crate) fn resolve_network_intent(
+    block_net: bool,
+    allow_net: bool,
+    has_proxy_flags: bool,
+    profile_block: bool,
+    profile_has_proxy: bool,
+) -> NetworkIntent {
+    if block_net || profile_block {
+        NetworkIntent::BlockAll
+    } else if allow_net {
+        // Deprecated flag: explicitly forces unrestricted even if the profile
+        // has proxy settings.
+        NetworkIntent::Unrestricted
+    } else if has_proxy_flags || profile_has_proxy {
+        NetworkIntent::ProxyFiltered {
+            strict_filter: false,
+        }
+    } else {
+        NetworkIntent::Unrestricted
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unrestricted_by_default() {
+        assert_eq!(
+            resolve_network_intent(false, false, false, false, false),
+            NetworkIntent::Unrestricted
+        );
+    }
+
+    #[test]
+    fn block_net_flag_wins() {
+        assert_eq!(
+            resolve_network_intent(true, false, false, false, false),
+            NetworkIntent::BlockAll
+        );
+    }
+
+    #[test]
+    fn profile_block_wins() {
+        assert_eq!(
+            resolve_network_intent(false, false, false, true, false),
+            NetworkIntent::BlockAll
+        );
+    }
+
+    #[test]
+    fn block_net_wins_over_proxy_flags() {
+        assert_eq!(
+            resolve_network_intent(true, false, true, false, false),
+            NetworkIntent::BlockAll
+        );
+    }
+
+    #[test]
+    fn proxy_flags_set_proxy_filtered() {
+        assert_eq!(
+            resolve_network_intent(false, false, true, false, false),
+            NetworkIntent::ProxyFiltered {
+                strict_filter: false
+            }
+        );
+    }
+
+    #[test]
+    fn profile_proxy_flags_set_proxy_filtered() {
+        assert_eq!(
+            resolve_network_intent(false, false, false, false, true),
+            NetworkIntent::ProxyFiltered {
+                strict_filter: false
+            }
+        );
+    }
+
+    #[test]
+    fn allow_net_overrides_profile_proxy() {
+        // --allow-net (deprecated) forces unrestricted even when the profile
+        // has proxy settings.
+        assert_eq!(
+            resolve_network_intent(false, true, false, false, true),
+            NetworkIntent::Unrestricted
+        );
+    }
+}

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -3,6 +3,7 @@
 //! All colors are drawn from the active theme via `theme::current()`.
 
 use crate::command_display::format_command_line;
+use crate::network_intent::NetworkIntent;
 use crate::theme::{self, Rgb, badge, fg};
 use colored::Colorize;
 use nono::{AccessMode, CapabilitySet, NetworkMode, NonoError, Result};
@@ -52,7 +53,12 @@ pub fn print_banner(silent: bool) {
 /// When `verbose` is 0, only user-specified capabilities are shown (CLI flags
 /// and profile filesystem entries). System paths and group-resolved paths are
 /// hidden to reduce noise. Use `-v` to show all capabilities.
-pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
+pub fn print_capabilities(
+    caps: &CapabilitySet,
+    network_intent: &NetworkIntent,
+    verbose: u8,
+    silent: bool,
+) {
     if silent {
         return;
     }
@@ -191,11 +197,19 @@ pub fn print_capabilities(caps: &CapabilitySet, verbose: u8, silent: bool) {
             }
         }
         NetworkMode::AllowAll => {
-            eprintln!(
-                "  {} {}",
-                theme::badge(" net ", t.green, BADGE_FG_DARK),
-                theme::fg("outbound allowed", t.subtext),
-            );
+            if matches!(network_intent, NetworkIntent::ProxyFiltered { .. }) {
+                eprintln!(
+                    "  {} {}",
+                    theme::badge(" net ", t.yellow, BADGE_FG_DARK),
+                    theme::fg("domain filtered", t.subtext),
+                );
+            } else {
+                eprintln!(
+                    "  {} {}",
+                    theme::badge(" net ", t.green, BADGE_FG_DARK),
+                    theme::fg("outbound allowed", t.subtext),
+                );
+            }
         }
     }
     if !caps.localhost_ports().is_empty() {
@@ -917,6 +931,7 @@ mod tests {
         dry_run_command_line, format_unix_socket_mode_badge, print_capabilities,
         print_profile_hint, render_diagnostic_footer, render_terminal_block_for_tty,
     };
+    use crate::network_intent::NetworkIntent;
     use nono::{CapabilitySet, UnixSocketMode};
     use std::ffi::{OsStr, OsString};
     use tempfile::tempdir;
@@ -1018,7 +1033,7 @@ mod tests {
             .allow_unix_socket_dir(dir.path(), UnixSocketMode::ConnectBind)
             .expect("bind dir grant");
 
-        print_capabilities(&caps, 0, true);
-        print_capabilities(&caps, 1, true);
+        print_capabilities(&caps, &NetworkIntent::Unrestricted, 0, true);
+        print_capabilities(&caps, &NetworkIntent::Unrestricted, 1, true);
     }
 }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1083,11 +1083,11 @@ impl NetworkConfig {
         self.credentials.as_deref().unwrap_or(&[])
     }
 
-    /// Whether any profile setting requires proxy mode activation.
+    /// Whether any profile setting activates proxy/domain-filter mode.
+    /// `credentials` is excluded — it injects headers without OS-level isolation.
     pub fn has_proxy_flags(&self) -> bool {
         self.resolved_network_profile().is_some()
             || !self.allow_domain.is_empty()
-            || !self.resolved_credentials().is_empty()
             || self.upstream_proxy.is_some()
     }
 }
@@ -5697,13 +5697,16 @@ mod tests {
     }
 
     #[test]
-    fn test_credentials_none_does_not_activate_proxy() {
+    fn test_credentials_do_not_activate_proxy_mode() {
+        // Credentials inject headers but do not impose OS-level ProxyOnly
+        // isolation. has_proxy_flags() must return false for credential-only
+        // configs so that network_intent stays Unrestricted.
         let mut config = NetworkConfig::default();
         assert!(!config.has_proxy_flags()); // None = no proxy
         config.credentials = Some(Vec::new());
         assert!(!config.has_proxy_flags()); // Some([]) = no proxy
         config.credentials = Some(vec!["openai".to_string()]);
-        assert!(config.has_proxy_flags()); // Some(["openai"]) = proxy
+        assert!(!config.has_proxy_flags()); // credentials alone = no ProxyOnly mode
     }
 
     #[test]

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -1,5 +1,6 @@
 use crate::cli::SandboxArgs;
 use crate::launch_runtime::ProxyLaunchOptions;
+use crate::network_intent::NetworkIntent;
 use crate::network_policy;
 use crate::sandbox_prepare::{PreparedSandbox, validate_external_proxy_bypass};
 #[cfg(not(target_os = "macos"))]
@@ -70,10 +71,7 @@ pub(crate) fn prepare_proxy_launch_options(
         }
         false
     } else {
-        matches!(
-            prepared.caps.network_mode(),
-            nono::NetworkMode::ProxyOnly { .. }
-        ) || !credentials.is_empty()
+        !credentials.is_empty()
             || network_profile.is_some()
             || !allow_domain.is_empty()
             || upstream_proxy.is_some()
@@ -97,7 +95,8 @@ pub(crate) fn prepare_proxy_launch_options(
         proxy_ca_validity: args
             .proxy_ca_validity
             .map(|days| std::time::Duration::from_secs(u64::from(days) * 24 * 60 * 60)),
-        network_block: prepared.network_block_requested,
+        network_block: matches!(prepared.network_intent, NetworkIntent::BlockAll),
+        network_intent: prepared.network_intent.clone(),
     })
 }
 
@@ -303,10 +302,14 @@ pub(crate) fn start_proxy_runtime(
             );
         }
     }
-    caps.set_network_mode_mut(nono::NetworkMode::ProxyOnly {
-        port,
-        bind_ports: proxy.allow_bind_ports.clone(),
-    });
+    // Credentials alone inject headers without OS-level isolation;
+    // only domain-filter/network-profile intent triggers ProxyOnly.
+    if matches!(proxy.network_intent, NetworkIntent::ProxyFiltered { .. }) {
+        caps.set_network_mode_mut(nono::NetworkMode::ProxyOnly {
+            port,
+            bind_ports: proxy.allow_bind_ports.clone(),
+        });
+    }
 
     // Grant the sandboxed child a read capability on the ephemeral
     // trust bundle so `SSL_CERT_FILE` etc. are actually openable after

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -4,6 +4,7 @@ use crate::command_blocking_deprecation;
 #[cfg(unix)]
 use crate::config;
 use crate::credential_runtime::load_env_credentials;
+use crate::network_intent::{NetworkIntent, resolve_network_intent};
 use crate::network_policy;
 use crate::output;
 use crate::profile;
@@ -441,10 +442,7 @@ pub(crate) struct PreparedSandbox {
     pub(crate) suppressed_system_service_operations: Vec<String>,
     pub(crate) allowed_env_vars: Option<Vec<String>>,
     pub(crate) denied_env_vars: Option<Vec<String>>,
-    /// True when the profile or CLI requested `network.block`. Carried
-    /// through because a CLI proxy flag (e.g. `--credential`) may later
-    /// override `caps` to `ProxyOnly`, losing the original intent.
-    pub(crate) network_block_requested: bool,
+    pub(crate) network_intent: NetworkIntent,
 }
 
 fn resolved_workdir(args: &SandboxArgs) -> PathBuf {
@@ -573,7 +571,12 @@ fn finalize_prepared_sandbox(
     silent: bool,
 ) -> Result<PreparedSandbox> {
     output::print_skipped_requested_paths(&collect_missing_cli_requested_paths(args), silent);
-    output::print_capabilities(&prepared.caps, args.verbose, silent);
+    output::print_capabilities(
+        &prepared.caps,
+        &prepared.network_intent,
+        args.verbose,
+        silent,
+    );
 
     if let Some(ref profile_name) = args.profile {
         crate::pack_update_hint::show_pack_update_hints(profile_name, silent);
@@ -1074,7 +1077,13 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
                 suppressed_system_service_operations: Vec::new(),
                 allowed_env_vars: None,
                 denied_env_vars: None,
-                network_block_requested: args.block_net,
+                network_intent: resolve_network_intent(
+                    args.block_net,
+                    args.allow_net,
+                    false,
+                    false,
+                    false,
+                ),
             },
             args,
             silent,
@@ -1344,13 +1353,22 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         return Err(NonoError::NoCapabilities);
     }
 
-    // Capture the profile's `network.block` intent before `loaded_profile`
-    // is consumed below.
+    // Capture before `loaded_profile` is moved into the struct below.
     let profile_network_block = loaded_profile
         .as_ref()
         .map(|p| p.network.block)
         .unwrap_or(false);
-    let network_block_requested = args.block_net || profile_network_block;
+    let profile_has_proxy = loaded_profile
+        .as_ref()
+        .map(|p| p.network.has_proxy_flags())
+        .unwrap_or(false);
+    let network_intent = resolve_network_intent(
+        args.block_net,
+        args.allow_net,
+        args.has_proxy_flags(),
+        profile_network_block,
+        profile_has_proxy,
+    );
 
     let profile_secrets = loaded_profile
         .map(|profile| profile.env_credentials.mappings)
@@ -1385,7 +1403,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
             suppressed_system_service_operations,
             allowed_env_vars: profile_allowed_env_vars,
             denied_env_vars: profile_denied_env_vars,
-            network_block_requested,
+            network_intent,
         },
         args,
         silent,


### PR DESCRIPTION
## Summary

Introduce NetworkIntent (Unrestricted / BlockAll / ProxyFiltered) to replace the network_block_requested: bool side channel in PreparedSandbox. Network intent is now resolved once from CLI flags and profile config and carried through to start_proxy_runtime, eliminating the ProxyOnly { port: 0 } placeholder pattern from capability_ext.rs.

--credential no longer activates OS-level ProxyOnly enforcement. Credentials inject headers transparently without restricting outbound traffic. Pair with --allow-domain or --network-profile to also enforce host-level filtering.

A small PR to start off the networking refactor

## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Fixes #1031
Ref #1098
Ref #1099


<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
