### PR TITLE
fix(exec): settle-wait for transient threads before supervised fork

### DIFF
--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -597,50 +597,9 @@ pub fn execute_supervised(
         .chain(std::iter::once(std::ptr::null()))
         .collect();
 
-    // Validate threading before fork.
-    // Supervised mode applies sandbox in child (allocates), so threads holding
-    // allocator locks would cause deadlock. Both KeyringExpected and CryptoExpected
-    // threads are safe: keyring threads are idle XPC dispatch workers (macOS) or
-    // D-Bus workers (Linux) parked after the synchronous call completes; crypto
-    // threads are idle aws-lc-rs pool workers parked on condvars. Neither holds
-    // allocator locks.
-    let thread_count = get_thread_count()?;
-    match (config.threading, thread_count) {
-        (_, 1) => {}
-        (ThreadingContext::KeyringExpected, n) if n <= MAX_KEYRING_THREADS => {
-            debug!(
-                "Supervised fork with {} threads (keyring workers, idle after sync call)",
-                n
-            );
-        }
-        (ThreadingContext::CryptoExpected, n) if n <= MAX_CRYPTO_THREADS => {
-            debug!(
-                "Supervised fork with {} threads (crypto pool workers, idle on condvar)",
-                n
-            );
-        }
-        (ThreadingContext::Strict, n) => {
-            return Err(NonoError::SandboxInit(format!(
-                "Cannot fork in supervised mode: process has {} threads (expected 1). \
-                 This is a bug - fork() requires single-threaded execution.",
-                n
-            )));
-        }
-        (ThreadingContext::KeyringExpected, n) => {
-            return Err(NonoError::SandboxInit(format!(
-                "Cannot fork: process has {} threads (max {} with keyring). \
-                 Unexpected threading detected.",
-                n, MAX_KEYRING_THREADS
-            )));
-        }
-        (ThreadingContext::CryptoExpected, n) => {
-            return Err(NonoError::SandboxInit(format!(
-                "Cannot fork: process has {} threads (max {} with crypto pool). \
-                 Unexpected threading detected.",
-                n, MAX_CRYPTO_THREADS
-            )));
-        }
-    }
+    // Validate threading before fork. See `validate_fork_thread_count` for why
+    // a bounded settle window precedes the decision.
+    validate_fork_thread_count(config.threading)?;
 
     // NOTE: We do not set PR_SET_DUMPABLE(0) before fork because the parent may
     // need to inspect the child's memory for seccomp-notify requests. Instead,
@@ -1938,6 +1897,78 @@ impl Drop for SignalForwardingGuard {
 /// Used to verify single-threaded execution before fork().
 /// Returns an error if the count cannot be determined, since fork()
 /// safety depends on knowing the exact thread count.
+/// The fork-safe thread budget for a given threading context, or `None` if the
+/// context is open-ended (only the main thread is permitted).
+fn fork_thread_budget(threading: ThreadingContext) -> usize {
+    match threading {
+        ThreadingContext::Strict => 1,
+        ThreadingContext::KeyringExpected => MAX_KEYRING_THREADS,
+        ThreadingContext::CryptoExpected => MAX_CRYPTO_THREADS,
+    }
+}
+
+/// Validate that the process is safe to `fork()` in supervised mode.
+///
+/// Supervised mode applies the sandbox in the child (which allocates), so any
+/// parent thread holding an allocator lock at fork time would deadlock the
+/// child. We therefore cap the thread count at a context-specific budget. The
+/// permitted non-main threads are all known-idle: keyring workers are parked
+/// XPC/D-Bus dispatch threads after their synchronous call returns, and crypto
+/// workers are aws-lc-rs pool threads parked on condvars. Neither holds
+/// allocator locks.
+///
+/// The thread count can transiently exceed the budget: tokio's blocking pool
+/// spawns an on-demand worker for the first DNS lookup during proxy startup,
+/// and crypto verification spins up pool threads, both of which are reaped or
+/// parked shortly after. Rather than fail spuriously when the check lands in
+/// that window, we wait up to [`timeouts::FORK_THREAD_SETTLE_TIMEOUT`] for the
+/// count to settle into budget before deciding. This never relaxes the cap —
+/// if the count stays over budget for the whole window, we still refuse to
+/// fork.
+fn validate_fork_thread_count(threading: ThreadingContext) -> Result<()> {
+    let budget = fork_thread_budget(threading);
+
+    let start = Instant::now();
+    let mut thread_count = get_thread_count()?;
+    while thread_count > budget && start.elapsed() < timeouts::FORK_THREAD_SETTLE_TIMEOUT {
+        std::thread::sleep(timeouts::FORK_THREAD_SETTLE_POLL_INTERVAL);
+        thread_count = get_thread_count()?;
+    }
+
+    if thread_count <= budget {
+        match threading {
+            ThreadingContext::Strict => {}
+            ThreadingContext::KeyringExpected => debug!(
+                "Supervised fork with {} threads (keyring workers, idle after sync call)",
+                thread_count
+            ),
+            ThreadingContext::CryptoExpected => debug!(
+                "Supervised fork with {} threads (crypto pool workers, idle on condvar)",
+                thread_count
+            ),
+        }
+        return Ok(());
+    }
+
+    Err(match threading {
+        ThreadingContext::Strict => NonoError::SandboxInit(format!(
+            "Cannot fork in supervised mode: process has {} threads (expected 1). \
+             This is a bug - fork() requires single-threaded execution.",
+            thread_count
+        )),
+        ThreadingContext::KeyringExpected => NonoError::SandboxInit(format!(
+            "Cannot fork: process has {} threads (max {} with keyring). \
+             Unexpected threading detected.",
+            thread_count, MAX_KEYRING_THREADS
+        )),
+        ThreadingContext::CryptoExpected => NonoError::SandboxInit(format!(
+            "Cannot fork: process has {} threads (max {} with crypto pool). \
+             Unexpected threading detected.",
+            thread_count, MAX_CRYPTO_THREADS
+        )),
+    })
+}
+
 fn get_thread_count() -> Result<usize> {
     #[cfg(target_os = "linux")]
     {
@@ -3538,6 +3569,36 @@ mod tests {
     use nix::sys::termios::{
         ControlFlags, InputFlags, LocalFlags, OutputFlags, SpecialCharacterIndices,
     };
+
+    #[test]
+    fn test_fork_thread_budget_per_context() {
+        assert_eq!(fork_thread_budget(ThreadingContext::Strict), 1);
+        assert_eq!(
+            fork_thread_budget(ThreadingContext::KeyringExpected),
+            MAX_KEYRING_THREADS
+        );
+        assert_eq!(
+            fork_thread_budget(ThreadingContext::CryptoExpected),
+            MAX_CRYPTO_THREADS
+        );
+    }
+
+    #[test]
+    fn test_validate_fork_thread_count_returns_promptly_within_budget() {
+        // The crypto budget is large enough to cover the test runner's own
+        // worker threads, so validation should succeed without ever exhausting
+        // the settle window. This guards against the settle loop blocking for
+        // the full timeout when the count is already in budget.
+        let start = Instant::now();
+        let result = validate_fork_thread_count(ThreadingContext::CryptoExpected);
+        let elapsed = start.elapsed();
+        if result.is_ok() {
+            assert!(
+                elapsed < timeouts::FORK_THREAD_SETTLE_TIMEOUT,
+                "validation within budget should not consume the settle window (took {elapsed:?})"
+            );
+        }
+    }
 
     #[cfg(target_os = "linux")]
     #[test]

--- a/crates/nono-cli/src/timeouts.rs
+++ b/crates/nono-cli/src/timeouts.rs
@@ -15,6 +15,19 @@ pub const POST_EXIT_PTY_DRAIN_TIMEOUT: Duration = Duration::from_millis(100);
 /// Poll interval for the non-blocking `waitpid` loop.
 pub const CHILD_POLL_INTERVAL: Duration = Duration::from_millis(200);
 
+/// Maximum time to wait, before a supervised `fork()`, for transient worker
+/// threads (tokio blocking-pool DNS workers, aws-lc-rs crypto pool) to be
+/// reaped down to the fork-safe budget. These threads are spawned on demand
+/// during proxy startup / trust verification and parked or torn down shortly
+/// after, so a brief settle window turns the intermittent over-budget error
+/// into a reliable fork. The window is a ceiling: as soon as the count is
+/// within budget we proceed immediately.
+pub const FORK_THREAD_SETTLE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Poll interval while waiting for the thread count to settle before a
+/// supervised `fork()`.
+pub const FORK_THREAD_SETTLE_POLL_INTERVAL: Duration = Duration::from_millis(20);
+
 // pty_proxy
 
 /// Read timeout on the attach socket when reading the request-kind byte.


### PR DESCRIPTION
## Linked Issue

Closes #957

## Summary

`nono run` in supervised mode intermittently fails with:

```
nono: Sandbox initialization failed: Cannot fork: process has 8 threads (max 7 with crypto pool). Unexpected threading detected.
```

Supervised mode applies the sandbox in the forked child, which allocates. If a
parent thread held an allocator lock at `fork()` time, the child's
`Sandbox::apply()` would deadlock. To prevent that, `execute_supervised`
snapshots the thread count immediately before `fork()` and refuses if it
exceeds a context-specific budget (`MAX_CRYPTO_THREADS = 7` for the
`CryptoExpected` context selected whenever a proxy / `--allow-domain` /
trust scanning is active).

That budget assumes a **fixed** thread layout — `1 main + 2 tokio proxy
workers + 4 aws-lc-rs crypto workers` — but two of those contributors are
**transient**:

- tokio's blocking pool spawns an on-demand worker for the first DNS
  `getaddrinfo` during proxy startup, and
- crypto verification (aws-lc-rs ECDSA) spins up pool threads.

Both are reaped or parked shortly after, so whether the pre-fork check
observes 7 or 8 threads is a timing race — producing the intermittent error.
This is distinct from the pack-update-hint thread source described in #957,
which was already removed in #1005; setting `NONO_NO_UPDATE_CHECK=1` does
**not** suppress this remaining source.

### Change

Extract the inline threading `match` into `validate_fork_thread_count()`,
which polls the thread count for up to `FORK_THREAD_SETTLE_TIMEOUT` (500ms,
20ms interval), proceeding the **instant** it falls within budget. The cap
itself is never relaxed: if the count stays over budget for the whole window,
the fork is still refused with the original diagnostics.

This preserves the security invariant — fork only with known-idle parked
workers that hold no allocator locks — while turning a spurious, timing-
dependent failure into a reliable fork.

## Test Plan

- `cargo build -p nono-cli` — clean
- `cargo clippy -p nono-cli --all-targets` — no warnings (strict: `-D warnings -D clippy::unwrap_used`)
- `cargo fmt -p nono-cli -- --check` — clean
- New unit tests (run via `cargo test -p nono-cli --bin nono fork_thread`):
  - `test_fork_thread_budget_per_context` — verifies the per-context budget mapping (`Strict` = 1, `KeyringExpected` = `MAX_KEYRING_THREADS`, `CryptoExpected` = `MAX_CRYPTO_THREADS`).
  - `test_validate_fork_thread_count_returns_promptly_within_budget` — guards against the settle loop blocking for the full timeout when already within budget.

## Checklist

- [x] An issue exists and is linked above (#957)
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates — N/A (internal fork-safety behavior; no user-facing API or flag change)
- [ ] Release note has been added to `CHANGELOG.md` if needed — **pending** (bugfix worth a changelog entry; add if maintainers want one)

## Agent Disclosure

This PR was prepared by an AI agent (Claude Code).

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists (#957)
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (no external code reused; all newly written)
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths (N/A — no path handling in this change)
- [x] This PR matches the approved or disclosed issue scope
