### PR TITLE
feat(environment): add set_vars for static env injection

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -738,6 +738,11 @@
           "type": "array",
           "items": { "type": "string", "pattern": "^([^*]+\\*?|\\*)$" },
           "description": "Deny-list of environment variable names stripped from the sandboxed process. Supports exact names (\"GH_TOKEN\") and prefix patterns ending with * (\"GITHUB_*\"). Denied vars are stripped even if they also appear in allow_vars."
+        },
+        "set_vars": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Static environment variables injected after environment filtering and before credential injection. PATH and NONO_* are reserved. Values support variable expansion ($HOME, $WORKDIR, $TMPDIR, $XDG_*, $NONO_PACKAGES)."
         }
       }
     },

--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -213,12 +213,14 @@ Supported key formats:
 
 ### environment
 
-Controls which environment variables are passed to the sandboxed process. When `allow_vars` is set, only the listed variables (and nono-injected credentials) are passed through.
+Controls which environment variables are passed to the sandboxed process. When `allow_vars` is set, only the listed variables (and nono-injected credentials) are passed through. `set_vars` injects explicit values regardless of filtering.
 
 ```json
 {
   "environment": {
-    "allow_vars": ["PATH", "HOME", "TERM", "AWS_*"]
+    "allow_vars": ["PATH", "HOME", "TERM", "AWS_*"],
+    "deny_vars": ["GH_TOKEN"],
+    "set_vars": { "RUST_LOG": "debug", "XDG_CONFIG_HOME": "$HOME/.config" }
   }
 }
 ```
@@ -226,8 +228,10 @@ Controls which environment variables are passed to the sandboxed process. When `
 | Field         | Type            | Default | Description |
 |---------------|-----------------|---------|-------------|
 | `allow_vars`  | array of string | `[]`    | Allow-list of environment variable names. Supports exact names (`"PATH"`) and prefix patterns ending with `*` (`"AWS_*"` matches `AWS_REGION`, `AWS_SECRET_ACCESS_KEY`, etc.). The `*` wildcard is only valid as a trailing suffix. When the `environment` section is omitted entirely, all variables are allowed. When present with an empty array, no inherited variables are passed (only nono-injected credentials). Nono-injected credentials always bypass this list. |
+| `deny_vars`   | array of string | `[]`    | Deny-list of environment variable names stripped from the child. Same pattern syntax as `allow_vars` (exact names and trailing `*`). Denied vars are stripped even if they also match `allow_vars`. |
+| `set_vars`    | object (string→string) | `{}` | Static environment variables injected after allow/deny filtering and before credential injection (injected credentials win on conflict). Values support the same expansion as profile paths (`$HOME`, `~`, `$WORKDIR`, `$TMPDIR`, `$XDG_*`, `$NONO_PACKAGES`); keys are not expanded. `PATH` and any `NONO_*` key are reserved and rejected at load time. Unlike inherited host vars, keys here are NOT subject to the dangerous-variable blocklist (`LD_PRELOAD`, `NODE_OPTIONS`, …) — setting one is an explicit operator decision. |
 
-Inheritance: child `allow_vars` are appended to base values and deduplicated.
+Inheritance: child `allow_vars` and `deny_vars` are appended to base values and deduplicated; `set_vars` merges as a map, with the child's value winning on key conflict.
 
 ### hooks
 
@@ -529,7 +533,7 @@ nono profile diff <a> <b>         # Compare two profiles
 
 ## 6. Variable Expansion
 
-The following variables are expanded in all path fields (`filesystem.*`, including `filesystem.allow`, `filesystem.read`, `filesystem.write`, `filesystem.deny`, `filesystem.bypass_protection`, and `filesystem.suppress_save_prompt`).
+The following variables are expanded in all path fields (`filesystem.*`, including `filesystem.allow`, `filesystem.read`, `filesystem.write`, `filesystem.deny`, `filesystem.bypass_protection`, and `filesystem.suppress_save_prompt`), in `command_args`, and in the values of `environment.set_vars`.
 
 | Variable           | Expands to |
 |--------------------|------------|

--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -213,6 +213,7 @@ pub(crate) fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
             suppressed_system_service_operations: prepared.suppressed_system_service_operations,
             allowed_env_vars: prepared.allowed_env_vars,
             denied_env_vars: prepared.denied_env_vars,
+            set_vars: prepared.set_vars,
             startup_timeout_secs: args.startup_timeout_secs,
             proxy,
             redaction_policy: load_configured_redaction_policy()?,
@@ -297,6 +298,7 @@ pub(crate) fn run_wrap(wrap_args: WrapArgs, silent: bool) -> Result<()> {
             suppressed_system_service_operations: prepared.suppressed_system_service_operations,
             allowed_env_vars: prepared.allowed_env_vars,
             denied_env_vars: prepared.denied_env_vars,
+            set_vars: prepared.set_vars,
             ..ExecutionFlags::defaults(silent)?
         },
     })

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -421,6 +421,43 @@ pub fn execute_direct(config: &ExecConfig<'_>) -> Result<()> {
 /// parent can capture terminal output for diagnostics while the child still sees
 /// a TTY. Otherwise the child inherits the parent's terminal directly.
 /// The parent prints diagnostics and rollback UI after the child exits.
+///
+/// Append `set_vars` to a raw `execve` environment vector, deduplicating by key.
+///
+/// `env_c` is a raw `KEY=VALUE` vector passed straight to `execve` — unlike
+/// [`std::process::Command::env`] it does not collapse duplicate keys, so we
+/// must dedupe by hand. Passing duplicate keys to `execve` is
+/// platform-dependent and a potential dynamic-linker-bypass vector.
+///
+/// Precedence matches `execute_direct`: credentials (`env_vars`) win over
+/// `set_vars`, which win over inherited host vars. A `set_vars` key already
+/// destined to be set by `env_vars` is skipped; any earlier entry (e.g. an
+/// inherited host var) with the same key is removed before the new value is
+/// pushed.
+fn push_set_vars(
+    env_c: &mut Vec<CString>,
+    set_vars: &[(String, String)],
+    env_vars: &[(&str, &str)],
+) {
+    for (key, value) in set_vars {
+        if env_vars.iter().any(|(ek, _)| ek == key) {
+            continue;
+        }
+        let mut prefix = Vec::with_capacity(key.len() + 1);
+        prefix.extend_from_slice(key.as_bytes());
+        prefix.push(b'=');
+        env_c.retain(|cstr| !cstr.as_bytes().starts_with(&prefix));
+
+        let mut kv = Vec::with_capacity(key.len() + 1 + value.len() + 1);
+        kv.extend_from_slice(key.as_bytes());
+        kv.push(b'=');
+        kv.extend_from_slice(value.as_bytes());
+        if let Ok(cstr) = CString::new(kv) {
+            env_c.push(cstr);
+        }
+    }
+}
+
 pub fn execute_supervised(
     config: &ExecConfig<'_>,
     supervisor: Option<&SupervisorConfig<'_>>,
@@ -522,15 +559,7 @@ pub fn execute_supervised(
 
     // Static profile vars (set_vars): after host filtering, before credentials
     // so injected credentials win on conflict.
-    for (key, value) in &config.set_vars {
-        let mut kv = Vec::with_capacity(key.len() + 1 + value.len() + 1);
-        kv.extend_from_slice(key.as_bytes());
-        kv.push(b'=');
-        kv.extend_from_slice(value.as_bytes());
-        if let Ok(cstr) = CString::new(kv) {
-            env_c.push(cstr);
-        }
-    }
+    push_set_vars(&mut env_c, &config.set_vars, &config.env_vars);
 
     // Add user-specified environment variables (secrets, etc.)
     for (key, value) in &config.env_vars {
@@ -3561,6 +3590,75 @@ mod tests {
     use nix::sys::termios::{
         ControlFlags, InputFlags, LocalFlags, OutputFlags, SpecialCharacterIndices,
     };
+
+    fn env_strings(env_c: &[CString]) -> Vec<String> {
+        env_c
+            .iter()
+            .map(|c| c.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn push_set_vars_appends_new_keys() {
+        let mut env_c = vec![CString::new("HOME=/home/x").expect("cstring")];
+        let set_vars = vec![("RUST_LOG".to_string(), "debug".to_string())];
+        push_set_vars(&mut env_c, &set_vars, &[]);
+        assert_eq!(env_strings(&env_c), vec!["HOME=/home/x", "RUST_LOG=debug"]);
+    }
+
+    #[test]
+    fn push_set_vars_overrides_inherited_host_var_without_duplicating() {
+        // An inherited host var with the same key must be replaced, not duplicated.
+        let mut env_c = vec![
+            CString::new("PRE=1").expect("cstring"),
+            CString::new("RUST_LOG=info").expect("cstring"),
+            CString::new("POST=2").expect("cstring"),
+        ];
+        let set_vars = vec![("RUST_LOG".to_string(), "debug".to_string())];
+        push_set_vars(&mut env_c, &set_vars, &[]);
+        // Exactly one RUST_LOG entry, carrying the set_vars value.
+        let entries = env_strings(&env_c);
+        assert_eq!(
+            entries
+                .iter()
+                .filter(|e| e.starts_with("RUST_LOG="))
+                .count(),
+            1
+        );
+        assert!(entries.contains(&"RUST_LOG=debug".to_string()));
+        assert!(entries.contains(&"PRE=1".to_string()));
+        assert!(entries.contains(&"POST=2".to_string()));
+    }
+
+    #[test]
+    fn push_set_vars_skips_keys_overridden_by_env_vars() {
+        // A key also set via env_vars (credentials) is skipped entirely, so
+        // env_vars wins and there is no duplicate. The inherited host entry is
+        // left for env_vars (appended later) to override.
+        let mut env_c = vec![CString::new("TOKEN=host").expect("cstring")];
+        let set_vars = vec![("TOKEN".to_string(), "from_set_vars".to_string())];
+        let env_vars = vec![("TOKEN", "from_credentials")];
+        push_set_vars(&mut env_c, &set_vars, &env_vars);
+        // set_vars did not push its value...
+        let entries = env_strings(&env_c);
+        assert!(!entries.contains(&"TOKEN=from_set_vars".to_string()));
+        // ...and did not duplicate the key.
+        assert_eq!(
+            entries.iter().filter(|e| e.starts_with("TOKEN=")).count(),
+            1
+        );
+    }
+
+    #[test]
+    fn push_set_vars_does_not_substring_match_other_keys() {
+        // PATH must not be removed when set_vars sets PA (prefix-collision guard).
+        let mut env_c = vec![CString::new("PATH=/usr/bin").expect("cstring")];
+        let set_vars = vec![("PA".to_string(), "x".to_string())];
+        push_set_vars(&mut env_c, &set_vars, &[]);
+        let entries = env_strings(&env_c);
+        assert!(entries.contains(&"PATH=/usr/bin".to_string()));
+        assert!(entries.contains(&"PA=x".to_string()));
+    }
 
     #[cfg(target_os = "linux")]
     #[test]

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -41,6 +41,7 @@ use tracing::{debug, info, warn};
 pub(crate) use env_sanitization::is_dangerous_env_var;
 use env_sanitization::should_skip_env_var;
 pub(crate) use env_sanitization::validate_env_var_patterns;
+pub(crate) use env_sanitization::validate_set_vars;
 
 /// Resolve a program name to its absolute path.
 ///
@@ -244,6 +245,10 @@ pub struct ExecConfig<'a> {
     /// name or prefix pattern (e.g. `"GITHUB_*"`) are stripped even if they
     /// also appear in `allowed_env_vars`. Nono-injected credentials bypass this.
     pub denied_env_vars: Option<Vec<String>>,
+    /// Static environment variables (`environment.set_vars`) injected after host
+    /// env filtering and before `env_vars` (credentials/proxy/hooks). Values are
+    /// already variable-expanded. Bypasses allow/deny filtering by design.
+    pub set_vars: Vec<(String, String)>,
 }
 
 #[derive(Clone, Copy)]
@@ -365,6 +370,12 @@ pub fn execute_direct(config: &ExecConfig<'_>) -> Result<()> {
     }
 
     cmd.args(cmd_args).env("NONO_CAP_FILE", config.cap_file);
+
+    // Static profile vars (set_vars): after host filtering, before credentials
+    // so injected credentials win on conflict.
+    for (key, value) in &config.set_vars {
+        cmd.env(key, value);
+    }
 
     for (key, value) in &config.env_vars {
         cmd.env(key, value);
@@ -507,6 +518,18 @@ pub fn execute_supervised(
         && let Ok(cstr) = CString::new(format!("NONO_CAP_FILE={}", cap_file_str))
     {
         env_c.push(cstr);
+    }
+
+    // Static profile vars (set_vars): after host filtering, before credentials
+    // so injected credentials win on conflict.
+    for (key, value) in &config.set_vars {
+        let mut kv = Vec::with_capacity(key.len() + 1 + value.len() + 1);
+        kv.extend_from_slice(key.as_bytes());
+        kv.push(b'=');
+        kv.extend_from_slice(value.as_bytes());
+        if let Ok(cstr) = CString::new(kv) {
+            env_c.push(cstr);
+        }
     }
 
     // Add user-specified environment variables (secrets, etc.)

--- a/crates/nono-cli/src/exec_strategy/env_sanitization.rs
+++ b/crates/nono-cli/src/exec_strategy/env_sanitization.rs
@@ -112,6 +112,57 @@ pub(crate) fn validate_env_var_patterns(patterns: &[String], field_name: &str) -
     None
 }
 
+/// Returns true if `name` is a valid POSIX environment variable name:
+/// a non-empty `[A-Za-z_][A-Za-z0-9_]*` with no `=` or NUL.
+fn is_valid_env_var_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Validates `environment.set_vars` keys before they are injected into the
+/// sandboxed child. Returns an error message describing the first invalid key,
+/// or `None` if all keys are acceptable.
+///
+/// Rejected keys:
+/// - `PATH` (reserved; controlled via allow/deny filtering, not injection)
+/// - any `NONO_*` key (reserved for nono's own injected variables)
+/// - empty or syntactically invalid names (must match `[A-Za-z_][A-Za-z0-9_]*`)
+///
+/// The dangerous-variable blocklist (`LD_PRELOAD`, `NODE_OPTIONS`, …) is
+/// intentionally NOT applied here: that defense targets injection from an
+/// untrusted parent shell, whereas `set_vars` is explicit operator intent.
+pub(crate) fn validate_set_vars(
+    set_vars: &std::collections::HashMap<String, String>,
+) -> Option<String> {
+    for key in set_vars.keys() {
+        if key == "PATH" {
+            return Some(
+                "Invalid set_vars key 'PATH': PATH is reserved; use allow_vars/deny_vars to \
+                 control it"
+                    .to_string(),
+            );
+        }
+        if key.starts_with("NONO_") {
+            return Some(format!(
+                "Invalid set_vars key '{}': the NONO_* prefix is reserved",
+                key
+            ));
+        }
+        if !is_valid_env_var_name(key) {
+            return Some(format!(
+                "Invalid set_vars key '{}': environment variable names must match \
+                 [A-Za-z_][A-Za-z0-9_]*",
+                key
+            ));
+        }
+    }
+    None
+}
+
 /// Decide whether an inherited env var should be dropped for sandbox execution.
 pub(super) fn should_skip_env_var(
     key: &str,
@@ -342,5 +393,65 @@ mod tests {
         assert!(is_env_var_denied("GH_TOKEN", &denied));
         assert!(is_env_var_allowed("GH_TOKEN", &allowed));
         // In exec path, deny is checked before allow, so GH_TOKEN is stripped
+    }
+
+    // ============================================================================
+    // set_vars validation
+    // ============================================================================
+
+    fn set_vars_from(pairs: &[(&str, &str)]) -> std::collections::HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn test_set_vars_accepts_normal_keys() {
+        let set_vars = set_vars_from(&[("RUST_LOG", "debug"), ("MY_VAR", "value")]);
+        assert_eq!(validate_set_vars(&set_vars), None);
+    }
+
+    #[test]
+    fn test_set_vars_accepts_dangerous_keys() {
+        // set_vars is explicit operator intent: dangerous keys are NOT blocked.
+        let set_vars = set_vars_from(&[("LD_PRELOAD", "/tmp/x.so")]);
+        assert_eq!(validate_set_vars(&set_vars), None);
+        let set_vars = set_vars_from(&[("NODE_OPTIONS", "--max-old-space-size=4096")]);
+        assert_eq!(validate_set_vars(&set_vars), None);
+        let set_vars = set_vars_from(&[("DYLD_INSERT_LIBRARIES", "/tmp/x.dylib")]);
+        assert_eq!(validate_set_vars(&set_vars), None);
+    }
+
+    #[test]
+    fn test_set_vars_rejects_path() {
+        let set_vars = set_vars_from(&[("PATH", "/usr/bin")]);
+        assert!(validate_set_vars(&set_vars).is_some());
+    }
+
+    #[test]
+    fn test_set_vars_rejects_nono_prefix() {
+        let set_vars = set_vars_from(&[("NONO_FOO", "bar")]);
+        assert!(validate_set_vars(&set_vars).is_some());
+        let set_vars = set_vars_from(&[("NONO_CAP_FILE", "/tmp/cap")]);
+        assert!(validate_set_vars(&set_vars).is_some());
+    }
+
+    #[test]
+    fn test_set_vars_rejects_invalid_names() {
+        // empty name
+        assert!(validate_set_vars(&set_vars_from(&[("", "v")])).is_some());
+        // leading digit
+        assert!(validate_set_vars(&set_vars_from(&[("1FOO", "v")])).is_some());
+        // contains '='
+        assert!(validate_set_vars(&set_vars_from(&[("A=B", "v")])).is_some());
+        // contains a dash
+        assert!(validate_set_vars(&set_vars_from(&[("MY-VAR", "v")])).is_some());
+    }
+
+    #[test]
+    fn test_set_vars_empty_is_ok() {
+        let set_vars: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        assert_eq!(validate_set_vars(&set_vars), None);
     }
 }

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -400,6 +400,7 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
         af_unix_mediation: flags.af_unix_mediation,
         allowed_env_vars: flags.allowed_env_vars,
         denied_env_vars: flags.denied_env_vars,
+        set_vars: flags.set_vars.unwrap_or_default(),
     };
 
     match strategy {

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -115,6 +115,8 @@ pub(crate) struct ExecutionFlags {
     pub(crate) session_hooks: profile::SessionHooks,
     pub(crate) allowed_env_vars: Option<Vec<String>>,
     pub(crate) denied_env_vars: Option<Vec<String>>,
+    /// Expanded `environment.set_vars` (key, expanded-value), `None` if absent.
+    pub(crate) set_vars: Option<Vec<(String, String)>>,
     pub(crate) startup_timeout_secs: Option<u64>,
 }
 
@@ -146,6 +148,7 @@ impl ExecutionFlags {
             session_hooks: profile::SessionHooks::default(),
             allowed_env_vars: None,
             denied_env_vars: None,
+            set_vars: None,
             startup_timeout_secs: None,
         })
     }
@@ -283,6 +286,7 @@ pub(crate) fn prepare_run_launch_plan(
             session_hooks: prepared.session_hooks,
             allowed_env_vars: prepared.allowed_env_vars,
             denied_env_vars: prepared.denied_env_vars,
+            set_vars: prepared.set_vars,
             startup_timeout_secs,
         },
     })

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -287,6 +287,7 @@ mod tests {
             suppressed_system_service_operations: Vec::new(),
             allowed_env_vars: None,
             denied_env_vars: None,
+            set_vars: None,
             network_block_requested: false,
         };
 
@@ -339,6 +340,7 @@ mod tests {
             suppressed_system_service_operations: Vec::new(),
             allowed_env_vars: None,
             denied_env_vars: None,
+            set_vars: None,
             network_block_requested: false,
         };
 

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1474,6 +1474,20 @@ pub struct EnvironmentConfig {
     /// Use this to strip specific secrets while keeping everything else inherited.
     #[serde(default)]
     pub deny_vars: Vec<String>,
+
+    /// Static environment variables injected into the sandboxed process.
+    ///
+    /// Maps variable names to values, set after allow/deny filtering and before
+    /// credential injection (so injected credentials win on conflict). Values
+    /// support the same expansion as profile paths (`$HOME`, `~`, `$WORKDIR`,
+    /// `$TMPDIR`, `$XDG_*`, `$NONO_PACKAGES`).
+    ///
+    /// `PATH` and any `NONO_*` key are reserved and rejected at parse time.
+    /// Unlike inherited host variables, keys here are NOT subject to the
+    /// dangerous-variable blocklist: setting one explicitly is a deliberate,
+    /// auditable operator decision.
+    #[serde(default)]
+    pub set_vars: std::collections::HashMap<String, String>,
 }
 
 /// Configuration for supervisor-delegated URL opening.
@@ -2296,6 +2310,14 @@ pub(crate) fn parse_profile_bytes(content: &[u8]) -> Result<Profile> {
     // Validate env_credentials keys (URI entries need structural validation)
     validate_env_credential_keys(&profile)?;
 
+    // Validate environment.set_vars keys (reserved/invalid keys are fatal)
+    if let Some(env_config) = profile.environment.as_ref()
+        && !env_config.set_vars.is_empty()
+        && let Some(err) = crate::exec_strategy::validate_set_vars(&env_config.set_vars)
+    {
+        return Err(NonoError::ProfileParse(err));
+    }
+
     Ok(profile)
 }
 
@@ -2655,6 +2677,11 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
             (Some(base_env), Some(child_env)) => Some(EnvironmentConfig {
                 allow_vars: dedup_append(&base_env.allow_vars, &child_env.allow_vars),
                 deny_vars: dedup_append(&base_env.deny_vars, &child_env.deny_vars),
+                set_vars: {
+                    let mut merged = base_env.set_vars.clone();
+                    merged.extend(child_env.set_vars.clone());
+                    merged
+                },
             }),
         },
         // NOTE: WorkdirAccess::None serves as both "not specified" and "explicitly no access".
@@ -3494,6 +3521,7 @@ mod tests {
             environment: Some(EnvironmentConfig {
                 allow_vars: vec![],
                 deny_vars: vec!["GH_TOKEN".into()],
+                set_vars: Default::default(),
             }),
             ..Default::default()
         };
@@ -3501,6 +3529,7 @@ mod tests {
             environment: Some(EnvironmentConfig {
                 allow_vars: vec![],
                 deny_vars: vec!["ANTHROPIC_API_KEY".into()],
+                set_vars: Default::default(),
             }),
             ..Default::default()
         };
@@ -3517,6 +3546,7 @@ mod tests {
             environment: Some(EnvironmentConfig {
                 allow_vars: vec![],
                 deny_vars: vec!["GH_TOKEN".into(), "ANTHROPIC_API_KEY".into()],
+                set_vars: Default::default(),
             }),
             ..Default::default()
         };
@@ -3524,6 +3554,7 @@ mod tests {
             environment: Some(EnvironmentConfig {
                 allow_vars: vec![],
                 deny_vars: vec!["ANTHROPIC_API_KEY".into()],
+                set_vars: Default::default(),
             }),
             ..Default::default()
         };
@@ -6909,6 +6940,40 @@ mod tests {
             err.to_string().contains("unknown field"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn set_vars_parses_valid_keys() {
+        let json = br#"{
+            "meta": { "name": "set-vars-valid" },
+            "environment": {
+                "set_vars": { "RUST_LOG": "debug", "FOO": "$HOME/.config" }
+            }
+        }"#;
+        let profile = parse_profile_bytes(json).expect("valid set_vars should parse");
+        let env = profile.environment.expect("environment present");
+        assert_eq!(env.set_vars.get("RUST_LOG"), Some(&"debug".to_string()));
+        assert_eq!(env.set_vars.get("FOO"), Some(&"$HOME/.config".to_string()));
+    }
+
+    #[test]
+    fn set_vars_rejects_reserved_path_key() {
+        let json = br#"{
+            "meta": { "name": "set-vars-path" },
+            "environment": { "set_vars": { "PATH": "/usr/bin" } }
+        }"#;
+        let err = parse_profile_bytes(json).expect_err("PATH in set_vars must be rejected");
+        assert!(err.to_string().contains("PATH"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn set_vars_rejects_reserved_nono_prefix() {
+        let json = br#"{
+            "meta": { "name": "set-vars-nono" },
+            "environment": { "set_vars": { "NONO_FOO": "bar" } }
+        }"#;
+        let err = parse_profile_bytes(json).expect_err("NONO_* in set_vars must be rejected");
+        assert!(err.to_string().contains("NONO_"), "unexpected error: {err}");
     }
 
     #[test]

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -31,6 +31,10 @@ pub(crate) struct PreparedProfile {
     pub(crate) suppressed_system_service_operations: Vec<String>,
     pub(crate) allowed_env_vars: Option<Vec<String>>,
     pub(crate) denied_env_vars: Option<Vec<String>>,
+    /// Expanded `environment.set_vars` entries (key, expanded-value). `None`
+    /// when the profile has no `set_vars`. Values are expanded with
+    /// [`profile::expand_vars`] at prepare time.
+    pub(crate) set_vars: Option<Vec<(String, String)>>,
 }
 
 #[derive(Clone, Copy)]
@@ -388,6 +392,39 @@ fn expand_ignored_denial_path(path: &Path, workdir: &Path) -> PathBuf {
     nono::try_canonicalize(&expanded)
 }
 
+/// Expand the values of `environment.set_vars` using the same variable
+/// substitution as profile paths (`$HOME`, `~`, `$WORKDIR`, `$TMPDIR`,
+/// `$XDG_*`, `$NONO_PACKAGES`). Keys are preserved verbatim. Returns `None`
+/// when the profile has no `set_vars`. Expansion errors are fatal so a
+/// misconfigured value never silently reaches the child.
+fn expand_profile_set_vars(
+    loaded_profile: Option<&profile::Profile>,
+    workdir: &Path,
+) -> crate::Result<Option<Vec<(String, String)>>> {
+    let Some(env_config) = loaded_profile.and_then(|profile| profile.environment.as_ref()) else {
+        return Ok(None);
+    };
+    if env_config.set_vars.is_empty() {
+        return Ok(None);
+    }
+
+    // Sort keys for deterministic ordering (HashMap iteration order is random).
+    let mut keys: Vec<&String> = env_config.set_vars.keys().collect();
+    keys.sort();
+
+    let mut expanded = Vec::with_capacity(keys.len());
+    for key in keys {
+        let Some(value) = env_config.set_vars.get(key) else {
+            continue;
+        };
+        let expanded_value = profile::expand_vars(value, workdir)?
+            .to_string_lossy()
+            .into_owned();
+        expanded.push((key.clone(), expanded_value));
+    }
+    Ok(Some(expanded))
+}
+
 fn collect_ignored_denial_paths(
     loaded_profile: Option<&profile::Profile>,
     cli_ignored_denials: &[PathBuf],
@@ -615,6 +652,7 @@ fn prepare_profile_with_options(
                 Some(env_config.deny_vars.clone())
             })
         }),
+        set_vars: expand_profile_set_vars(loaded_profile.as_ref(), workdir)?,
         loaded_profile,
     })
 }
@@ -676,6 +714,47 @@ mod tests {
         };
         let _env = crate::test_env::EnvVarGuard::set_all(&[("XDG_CONFIG_HOME", config_str)]);
         f(&config_dir)
+    }
+
+    #[test]
+    fn expand_profile_set_vars_expands_home() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let _env = crate::test_env::EnvVarGuard::set_all(&[("HOME", "/home/tester")]);
+
+        let mut profile = profile::Profile::default();
+        let mut set_vars = std::collections::HashMap::new();
+        set_vars.insert("RUST_LOG".to_string(), "debug".to_string());
+        set_vars.insert("CFG".to_string(), "$HOME/.config".to_string());
+        profile.environment = Some(profile::EnvironmentConfig {
+            allow_vars: vec![],
+            deny_vars: vec![],
+            set_vars,
+        });
+
+        let workdir = Path::new("/tmp/work");
+        let expanded = expand_profile_set_vars(Some(&profile), workdir)
+            .expect("expansion should succeed")
+            .expect("set_vars should be present");
+
+        // Keys are sorted for determinism: CFG before RUST_LOG.
+        assert_eq!(
+            expanded,
+            vec![
+                ("CFG".to_string(), "/home/tester/.config".to_string()),
+                ("RUST_LOG".to_string(), "debug".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn expand_profile_set_vars_none_when_absent() {
+        let profile = profile::Profile::default();
+        let result = expand_profile_set_vars(Some(&profile), Path::new("/tmp/work"))
+            .expect("expansion should succeed");
+        assert!(result.is_none());
     }
 
     fn create_pack_dir(config_dir: &Path, namespace: &str, name: &str) -> PathBuf {

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -441,6 +441,8 @@ pub(crate) struct PreparedSandbox {
     pub(crate) suppressed_system_service_operations: Vec<String>,
     pub(crate) allowed_env_vars: Option<Vec<String>>,
     pub(crate) denied_env_vars: Option<Vec<String>>,
+    /// Expanded `environment.set_vars` (key, expanded-value), `None` if absent.
+    pub(crate) set_vars: Option<Vec<(String, String)>>,
     /// True when the profile or CLI requested `network.block`. Carried
     /// through because a CLI proxy flag (e.g. `--credential`) may later
     /// override `caps` to `ProxyOnly`, losing the original intent.
@@ -1074,6 +1076,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
                 suppressed_system_service_operations: Vec::new(),
                 allowed_env_vars: None,
                 denied_env_vars: None,
+                set_vars: None,
                 network_block_requested: args.block_net,
             },
             args,
@@ -1109,6 +1112,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         suppressed_system_service_operations,
         allowed_env_vars: profile_allowed_env_vars,
         denied_env_vars: profile_denied_env_vars,
+        set_vars: profile_set_vars,
     } = prepared_profile;
 
     let session_hooks = loaded_profile
@@ -1385,6 +1389,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
             suppressed_system_service_operations,
             allowed_env_vars: profile_allowed_env_vars,
             denied_env_vars: profile_denied_env_vars,
+            set_vars: profile_set_vars,
             network_block_requested,
         },
         args,

--- a/docs/cli/features/environment.mdx
+++ b/docs/cli/features/environment.mdx
@@ -127,6 +127,33 @@ This strips `GITHUB_TOKEN`, `GITHUB_ACTIONS`, any var starting with `ANTHROPIC_`
 
 **Inheritance:** like `allow_vars`, `deny_vars` is additive across profile inheritance — a child profile appends to the base's list, and duplicates are removed.
 
+## Setting static variables
+
+Use `set_vars` to inject environment variables with specific values into the sandboxed process. This is the inverse of filtering: instead of controlling which inherited variables pass through, you define explicit values.
+
+```json
+{
+  "environment": {
+    "set_vars": {
+      "RUST_LOG": "debug",
+      "XDG_CONFIG_HOME": "$HOME/.config"
+    }
+  }
+}
+```
+
+**Ordering:** `set_vars` is applied **after** allow/deny filtering and **before** credential injection. If a key in `set_vars` collides with a variable injected via `env_credentials`, the injected credential wins. A `set_vars` value overrides any inherited value with the same name.
+
+**Variable expansion:** values support the same expansion as profile paths — `$HOME`, `~`, `$WORKDIR`, `$TMPDIR`, `$UID`, `$XDG_CONFIG_HOME`, `$XDG_DATA_HOME`, `$XDG_STATE_HOME`, `$XDG_CACHE_HOME`, `$XDG_RUNTIME_DIR`, and `$NONO_PACKAGES`. For example, `"$HOME/.config"` expands to the user's config directory. Keys are never expanded.
+
+**Reserved keys:** `PATH` and any key starting with `NONO_` are reserved and rejected at profile load time (`PATH` is controlled via `allow_vars`/`deny_vars`; the `NONO_*` prefix is reserved for nono's own injected variables). Keys must be valid environment variable names (`[A-Za-z_][A-Za-z0-9_]*`).
+
+<Note>
+  Unlike inherited host variables, `set_vars` keys are **not** subject to the built-in dangerous-variable blocklist. Setting `LD_PRELOAD`, `NODE_OPTIONS`, or similar via `set_vars` is allowed — it is an explicit, auditable operator decision in the profile, not injection from an untrusted parent shell. Use this deliberately.
+</Note>
+
+**Inheritance:** `set_vars` merges across profile inheritance like a map — a child profile's entries are added to the base's, and on key conflict the child's value wins.
+
 ## Interaction with the Built-in Deny-List
 
 nono maintains a built-in deny-list of dangerous environment variables (e.g., `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `PYTHONPATH`, `NODE_OPTIONS`). These variables are **always blocked**, even if they appear in `allow_vars`. This prevents a compromised profile from disabling sandbox protections.
@@ -147,6 +174,7 @@ nono maintains a built-in deny-list of dangerous environment variables (e.g., `L
 - **Empty allow-list restricts all**: `"allow_vars": []` passes zero inherited variables — only nono-injected credentials reach the child
 - **Explicit allow-list**: When `allow_vars` has entries, only matching variables reach the child process
 - **Operator deny-list**: `deny_vars` strips named variables even when `allow_vars` would otherwise pass them through
+- **Static values via `set_vars`**: explicit variables injected after filtering and before credentials; `PATH` and `NONO_*` are reserved, but the dangerous-variable blocklist does not apply (explicit operator intent)
 - **Injected credentials bypass both lists**: `env_credentials` variables always pass through, regardless of `allow_vars` or `deny_vars`
 - **Built-in deny-list is non-overridable**: Dangerous variables like `LD_PRELOAD` are always blocked and cannot be re-allowed
 - **Precedence**: built-in blocklist > `deny_vars` > `allow_vars`

--- a/docs/cli/features/profile-authoring.mdx
+++ b/docs/cli/features/profile-authoring.mdx
@@ -129,7 +129,9 @@ With `--full`, additional sections are included as empty stubs for all additive 
   },
   "env_credentials": {},
   "environment": {
-    "allow_vars": []
+    "allow_vars": [],
+    "deny_vars": [],
+    "set_vars": {}
   },
   "hooks": {},
   "rollback": {


### PR DESCRIPTION
## Linked Issue

Closes #1133

## Summary

Adds `environment.set_vars`, a `string → string` map in a profile's
`environment` section that injects static environment variables into the
sandboxed child.

- **Pipeline placement:** injected after host-environment allow/deny filtering
  and before credential injection, so nono-injected credentials win on conflict
  and a `set_vars` value overrides any inherited value of the same name.
- **Variable expansion:** values are expanded with the existing
  `profile::expand_vars` (`$HOME`, `~`, `$WORKDIR`, `$TMPDIR`, `$UID`,
  `$XDG_*`, `$NONO_PACKAGES`), so a value like `"$HOME/.config"` is portable.
  Keys are never expanded.
- **Reserved keys:** `PATH` and any `NONO_*` key are rejected at parse time
  (hard error). Keys must be valid environment variable names
  (`[A-Za-z_][A-Za-z0-9_]*`).
- **Dangerous keys allowed by design:** the built-in dangerous-variable
  blocklist (`LD_PRELOAD`, `NODE_OPTIONS`, …) is intentionally *not* applied to
  `set_vars`. That blocklist defends against injection from an untrusted parent
  shell; `set_vars` is an explicit, auditable operator decision. The host
  inheritance path still strips dangerous variables as before.
- **Inheritance:** merges as a map across `extends`, child wins on key conflict.

## Agent Disclosure (if applicable)

- This PR was generated by an AI agent (Claude Code).

## Test Plan

- New tests:
  - `env_sanitization`: `validate_set_vars` rejects `PATH`, `NONO_*`, and
    invalid names; accepts normal keys **and** dangerous keys like `LD_PRELOAD`
    (asserting they are not blocked).
  - `profile`: `parse_profile_bytes` parses valid `set_vars` and rejects
    reserved `PATH` / `NONO_*` keys.
  - `profile_runtime`: `$HOME/.config` expands to the resolved home path;
    absent `set_vars` yields `None`.
- CLI manual verification: `nono profile validate` accepts a profile with
  `set_vars` and rejects `set_vars.PATH` with a clear error.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

## Agent Compliance Check (Required for AI/Automated PRs)

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope
