### PR TITLE
fix(linux): skip rate limit for non-AF_UNIX seccomp passthrough

### DIFF
--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -818,13 +818,6 @@ pub(super) fn handle_network_notification(
 
     let notif = recv_notif(notify_fd)?;
 
-    // Rate limit to prevent flooding
-    if !rate_limiter.try_acquire() {
-        debug!("Rate limited network seccomp notification, denying");
-        let _ = deny_notif(notify_fd, notif.id);
-        return Ok(());
-    }
-
     // Read sockaddr from child's memory: args[1] = sockaddr*, args[2] = addrlen
     let sockaddr = match read_notif_sockaddr(notif.pid, notif.data.args[1], notif.data.args[2]) {
         Ok(info) => info,
@@ -838,6 +831,17 @@ pub(super) fn handle_network_notification(
     // TOCTOU check
     if !notif_id_valid(notify_fd, notif.id)? {
         debug!("Network seccomp notification expired (TOCTOU check)");
+        return Ok(());
+    }
+
+    // Rate-limit only notifications that do pathname AF_UNIX or proxy policy
+    // work. AF_UNIX-only mediation traps every connect()/bind(), but once we
+    // read the sockaddr, non-AF_UNIX traffic is resumed without further
+    // checks — that passthrough must not consume the supervisor token bucket
+    // shared with expansion prompts.
+    if network_notification_should_rate_limit(&sockaddr, config) && !rate_limiter.try_acquire() {
+        debug!("Rate limited network seccomp notification, denying");
+        let _ = deny_notif(notify_fd, notif.id);
         return Ok(());
     }
 
@@ -860,6 +864,28 @@ pub(super) fn handle_network_notification(
     }
 
     Ok(())
+}
+
+/// Whether a trapped connect/bind should consume the supervisor rate limiter.
+///
+/// The limiter caps expansion-prompt flooding, not routine network I/O.
+/// AF_UNIX-only mediation notifies on every connect/bind, but non-AF_UNIX
+/// syscalls are allowed as soon as the sockaddr family is known; only
+/// AF_UNIX pathname checks (and all proxy-mode notifications) count against
+/// the bucket.
+fn network_notification_should_rate_limit(
+    sockaddr: &nono::sandbox::SockaddrInfo,
+    config: &SupervisorConfig<'_>,
+) -> bool {
+    use crate::exec_strategy::LinuxNetworkNotifyMode;
+
+    if matches!(
+        config.linux_network_notify_mode,
+        LinuxNetworkNotifyMode::AfUnixOnly
+    ) {
+        return sockaddr.family == libc::AF_UNIX as u16;
+    }
+    true
 }
 
 fn record_af_unix_ipc_denial(
@@ -1640,6 +1666,41 @@ mod tests {
                 decide_network_notification(test_pid(), SYS_BIND, &inet_loopback(4000), &config),
                 NetworkDecision::Allow
             );
+        }
+
+        #[test]
+        fn af_unix_only_mode_skips_rate_limit_for_non_af_unix_passthrough() {
+            let backend = DenyAllBackend;
+            let config = make_af_unix_only_config(&backend, &[]);
+            assert!(
+                !super::network_notification_should_rate_limit(&inet_external(8080), &config),
+                "TCP passthrough must not consume the expansion rate limiter"
+            );
+            assert!(
+                !super::network_notification_should_rate_limit(&inet_loopback(4000), &config),
+                "loopback passthrough must not consume the expansion rate limiter"
+            );
+        }
+
+        #[test]
+        fn af_unix_only_mode_rate_limits_af_unix_notifications() {
+            let backend = DenyAllBackend;
+            let config = make_af_unix_only_config(&backend, &[]);
+            let dir = tempfile::tempdir().expect("tempdir");
+            assert!(super::network_notification_should_rate_limit(
+                &unix_pathname(&socket_path(&dir, "test.sock")),
+                &config
+            ));
+        }
+
+        #[test]
+        fn proxy_mode_rate_limits_all_notifications() {
+            let backend = DenyAllBackend;
+            let config = make_config(&backend, 8080, vec![], &[]);
+            assert!(super::network_notification_should_rate_limit(
+                &inet_external(8080),
+                &config
+            ));
         }
     }
 }


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1128

## Summary

AF_UNIX-only mediation traps every connect()/bind(), but TCP/UDP traffic is resumed once the sockaddr family is known. Do not charge those passthrough notifications against the expansion-prompt token bucket (burst 5), which was causing EPERM on routine outbound connects after a handful of syscalls.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
