### PR TITLE
fix: report the actual blocked operation instead of the readable target path in sandbox denial diagnostics

### DIFF
--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -398,7 +398,7 @@ pub(super) fn handle_seccomp_notification(
         record_denial(
             denials,
             DenialRecord {
-                path: path.clone(),
+                path: canonicalized.clone(),
                 access,
                 reason: DenialReason::RateLimited,
             },
@@ -433,7 +433,7 @@ pub(super) fn handle_seccomp_notification(
                 record_denial(
                     denials,
                     DenialRecord {
-                        path: path.clone(),
+                        path: canonicalized.clone(),
                         access,
                         reason: DenialReason::PolicyBlocked,
                     },
@@ -462,7 +462,7 @@ pub(super) fn handle_seccomp_notification(
                 record_denial(
                     denials,
                     DenialRecord {
-                        path: path.clone(),
+                        path: canonicalized.clone(),
                         access,
                         reason: DenialReason::UserDenied,
                     },
@@ -475,7 +475,7 @@ pub(super) fn handle_seccomp_notification(
             record_denial(
                 denials,
                 DenialRecord {
-                    path: path.clone(),
+                    path: canonicalized.clone(),
                     access,
                     reason: DenialReason::BackendError,
                 },

--- a/crates/nono-cli/src/sandbox_log.rs
+++ b/crates/nono-cli/src/sandbox_log.rs
@@ -297,24 +297,6 @@ fn parse_violation_line(filter: &ViolationFilter, line: &str) -> Option<SandboxV
 
 #[cfg(target_os = "macos")]
 fn parse_violation_value(filter: &ViolationFilter, value: &Value) -> Option<SandboxViolation> {
-    if let Some(message) = value.get("eventMessage").and_then(Value::as_str)
-        && let Some(violation) = parse_event_message(filter, message)
-    {
-        return Some(violation);
-    }
-
-    let metadata = value.get("eventMessage").and_then(|event_message| {
-        event_message
-            .as_str()
-            .and_then(|text| serde_json::from_str::<Value>(text).ok())
-    });
-    if let Some(violation) = metadata
-        .as_ref()
-        .and_then(|metadata| parse_metadata_violation(filter, metadata))
-    {
-        return Some(violation);
-    }
-
     let metadata = value
         .get("metadata")
         .or_else(|| value.get("MetaData"))
@@ -329,9 +311,49 @@ fn parse_violation_value(filter: &ViolationFilter, value: &Value) -> Option<Sand
             }
         });
 
-    metadata
+    let metadata_violation = metadata
         .as_ref()
-        .and_then(|metadata| parse_metadata_violation(filter, metadata))
+        .and_then(|metadata| parse_metadata_violation(filter, metadata));
+    if metadata_violation
+        .as_ref()
+        .is_some_and(|violation| violation.target.is_some())
+    {
+        return metadata_violation;
+    }
+
+    let event_metadata = value.get("eventMessage").and_then(|event_message| {
+        event_message
+            .as_str()
+            .and_then(|text| serde_json::from_str::<Value>(text).ok())
+    });
+    let event_metadata_violation = event_metadata
+        .as_ref()
+        .and_then(|metadata| parse_metadata_violation(filter, metadata));
+    if event_metadata_violation
+        .as_ref()
+        .is_some_and(|violation| violation.target.is_some())
+    {
+        return event_metadata_violation;
+    }
+
+    let event_violation = value
+        .get("eventMessage")
+        .and_then(Value::as_str)
+        .and_then(|message| parse_event_message(filter, message));
+
+    // None of the candidates exposed a structured target above. Prefer any
+    // remaining candidate that still carries a target (e.g. an `eventMessage`
+    // that names the denied path) over a target-less metadata record, so a
+    // file denial is never downgraded to a non-filesystem violation and lose
+    // its actionable path.
+    [
+        metadata_violation,
+        event_metadata_violation,
+        event_violation,
+    ]
+    .into_iter()
+    .flatten()
+    .min_by_key(|violation| violation.target.is_none())
 }
 
 #[cfg(target_os = "macos")]
@@ -445,6 +467,36 @@ mod tests {
     fn parses_ndjson_metadata_violation() {
         let line = r#"{"eventMessage":"Sandbox: cat(1234) deny(1) file-read-data /Users/test/.ssh/id_rsa","subsystem":"com.apple.sandbox.reporting","category":"violation","MetaData":{"operation":"file-read-data","pid":1234,"target":"/Users/test/.ssh/id_rsa"}}"#;
         let violation = parse_violation_line(&pid_filter(1234), line).expect("violation");
+        assert_eq!(violation.operation, "file-read-data");
+        assert_eq!(violation.target.as_deref(), Some("/Users/test/.ssh/id_rsa"));
+    }
+
+    #[test]
+    fn prefers_structured_metadata_over_event_message() {
+        let line = r#"{"eventMessage":"Sandbox: nl(1234) deny(1) file-read-data /Users/test/workspace/readable.rs","subsystem":"com.apple.sandbox.reporting","category":"violation","MetaData":{"operation":"file-write-create","pid":1234,"target":"/Users/test/Library/Caches/nl/state"}}"#;
+        let violation = match parse_violation_line(&pid_filter(1234), line) {
+            Some(violation) => violation,
+            None => panic!("metadata violation should parse"),
+        };
+
+        assert_eq!(violation.operation, "file-write-create");
+        assert_eq!(
+            violation.target.as_deref(),
+            Some("/Users/test/Library/Caches/nl/state")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_event_message_target_when_metadata_has_no_target() {
+        // Metadata matches the pid/operation but carries no target; the
+        // eventMessage names the denied path. The path must survive so the
+        // denial stays an actionable filesystem violation.
+        let line = r#"{"eventMessage":"Sandbox: cat(1234) deny(1) file-read-data /Users/test/.ssh/id_rsa","subsystem":"com.apple.sandbox.reporting","category":"violation","MetaData":{"operation":"file-read-data","pid":1234}}"#;
+        let violation = match parse_violation_line(&pid_filter(1234), line) {
+            Some(violation) => violation,
+            None => panic!("event message violation should parse"),
+        };
+
         assert_eq!(violation.operation, "file-read-data");
         assert_eq!(violation.target.as_deref(), Some("/Users/test/.ssh/id_rsa"));
     }

--- a/crates/nono/src/diagnostic.rs
+++ b/crates/nono/src/diagnostic.rs
@@ -3151,6 +3151,74 @@ mod tests {
     }
 
     #[test]
+    fn test_violation_denial_keeps_file_read_target() {
+        let requested = PathBuf::from("/Users/alice/workspace/readable.rs");
+        let violations = vec![SandboxViolation {
+            operation: "file-read-data".to_string(),
+            target: Some(requested.display().to_string()),
+        }];
+
+        let (denials, non_fs) = violations_to_denials(&violations);
+
+        assert!(non_fs.is_empty());
+        assert_eq!(denials.len(), 1);
+        assert_eq!(denials[0].path, requested);
+        assert_eq!(denials[0].access, AccessMode::Read);
+    }
+
+    #[test]
+    fn test_logged_violation_target_wins_over_observed_requested_path() {
+        let caps = make_test_caps();
+        let requested = PathBuf::from("/Users/alice/workspace/readable.rs");
+        let actual = PathBuf::from("/Users/alice/Library/Caches/nl/state");
+        let violations = vec![SandboxViolation {
+            operation: "file-write-create".to_string(),
+            target: Some(actual.display().to_string()),
+        }];
+        let formatter = DiagnosticFormatter::new(&caps)
+            .with_mode(DiagnosticMode::Supervised)
+            .with_sandbox_violations(&violations)
+            .with_error_observation(ErrorObservation {
+                primary_verdict: Some(ErrorVerdict::LikelySandbox(ObservedPathHint {
+                    path: requested.clone(),
+                    access: AccessMode::Read,
+                })),
+                blocked_protected_file: None,
+                path_hints: vec![ObservedPathHint {
+                    path: requested.clone(),
+                    access: AccessMode::Read,
+                }],
+                missing_paths: Vec::new(),
+                non_sandbox_failure: None,
+            });
+
+        let output = formatter.format_footer(1);
+
+        assert!(output.contains(&format!("{} (write)", actual.display())));
+        assert!(!output.contains(&requested.display().to_string()));
+    }
+
+    #[test]
+    fn test_sandbox_violation_preserves_workspace_prefix() {
+        let caps = make_test_caps();
+        let actual = PathBuf::from(
+            "/Users/alice/workspace/flutter_photo_manager/lib/src/internal/plugin.dart",
+        );
+        let violations = vec![SandboxViolation {
+            operation: "file-read-data".to_string(),
+            target: Some(actual.display().to_string()),
+        }];
+        let formatter = DiagnosticFormatter::new(&caps)
+            .with_mode(DiagnosticMode::Supervised)
+            .with_sandbox_violations(&violations);
+
+        let output = formatter.format_footer(1);
+
+        assert!(output.contains(&format!("{} (read)", actual.display())));
+        assert!(!output.contains("[nono]   /src/internal/plugin.dart (read)"));
+    }
+
+    #[test]
     fn test_supervised_merges_mkdir_error_hint_with_logged_read_denial() {
         let temp = tempdir().expect("tempdir should be created");
         let pkg = temp.path().join("Library/Caches/copilot/pkg");


### PR DESCRIPTION
## Linked Issue

Closes #942

## Summary

The sandbox denial diagnostic could name a readable file as "blocked" when the captured violation was actually for a different operation/target. Two reported symptoms are addressed:

- macOS: a full-output `nl -ba <path>` reported `<path>` as a file-read denial even though `<path>` is readable (it succeeds with redirected/truncated stdout). The macOS log parser preferred the human-readable `eventMessage` line, which can name the readable target, over the structured `MetaData` record that carries the actual denied operation and target.
- Linux: an allowed repo-relative file was reported with its workspace prefix dropped (an absolute-looking `/src/...` fragment), because several seccomp denial records were built from the raw notification path instead of the already-canonicalized path used elsewhere in the same handler.

Changes:

- `crates/nono-cli/src/sandbox_log.rs` (`parse_violation_value`): prefer the structured `MetaData` operation/target when it carries a target, then fall back through the metadata embedded in `eventMessage`, then the parsed `eventMessage` line. The final fallback now keeps whichever candidate still carries a target so a file denial is never downgraded to a target-less (non-filesystem) violation.
- `crates/nono-cli/src/exec_strategy/supervisor_linux.rs` (`handle_seccomp_notification`): the rate-limited, policy-blocked, user-denied, and backend-error denial records now use the same canonicalized path already used by the rest of the handler, so the workspace prefix is preserved.
- `crates/nono/src/diagnostic.rs`: regression tests for the happy path, actual-target-wins-over-observed-requested-path, and workspace-prefix preservation.

The happy-path output for genuine `file-read-data` denials on the requested path is unchanged.

## Agent Disclosure (if applicable)

AI was used for assistance. This contribution was prepared by an AI agent. Intent and approach were disclosed in the issue discussion (#942) before changes were made. Source areas consulted: `crates/nono-cli/src/sandbox_log.rs`, `crates/nono-cli/src/exec_strategy/supervisor_linux.rs`, and `crates/nono/src/diagnostic.rs`. All new logic is newly written; no external code was adapted. The change complies with the repository coding and security requirements in CLAUDE.md.

## Test Plan

- `cargo test -p nono` (diagnostic regression tests) passes.
- `cargo test -p nono-cli sandbox_log` passes (11 tests, including the new metadata-precedence and event-message-fallback cases).
- `cargo fmt --all -- --check` and `cargo clippy -p nono-cli --bins` are clean.
- One pre-existing integration test (`url_open_integration::test_open_url_helper_binary_succeeds_with_valid_supervisor`) fails only because this checkout's path makes the supervisor Unix socket path exceed macOS `SUN_LEN`; it is unrelated to this change and not touched by the diff.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

## Agent Compliance Check (Required for AI/Automated PRs)

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope
