### PR TITLE
feat(cli): move runtime state to XDG state dirs

### DIFF
--- a/crates/nono-cli/src/audit_ledger.rs
+++ b/crates/nono-cli/src/audit_ledger.rs
@@ -1,4 +1,5 @@
 use crate::audit_session::audit_root;
+use crate::state_paths;
 use nix::fcntl::{Flock, FlockArg};
 use nono::audit::{
     LedgerRecord, LedgerVerificationResult, append_session_to_ledger_file,
@@ -9,7 +10,7 @@ use nono::undo::SessionMetadata;
 use nono::{NonoError, Result};
 use std::fs::OpenOptions;
 use std::io::BufReader;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const AUDIT_LEDGER_FILENAME: &str = "ledger.ndjson";
 const AUDIT_LEDGER_LOCK_FILENAME: &str = "ledger.lock";
@@ -18,6 +19,7 @@ pub(crate) fn append_session(metadata: &SessionMetadata) -> Result<LedgerRecord>
     validate_ledger_session_id(&metadata.session_id)?;
 
     let root = audit_root()?;
+    state_paths::maybe_migrate_legacy_audit_ledger()?;
     std::fs::create_dir_all(&root).map_err(|e| {
         NonoError::Snapshot(format!(
             "Failed to create audit root {}: {e}",
@@ -45,7 +47,29 @@ pub(crate) fn append_session(metadata: &SessionMetadata) -> Result<LedgerRecord>
 pub(crate) fn verify_session_in_ledger(
     metadata: &SessionMetadata,
 ) -> Result<LedgerVerificationResult> {
-    let root = audit_root()?;
+    let primary = audit_root()?;
+    let result = verify_session_in_ledger_at_root(&primary, metadata)?;
+    if result.session_found {
+        return Ok(result);
+    }
+
+    if let Ok(legacy) = state_paths::legacy_audit_root()
+        && legacy != primary
+    {
+        let legacy_ledger = legacy.join(AUDIT_LEDGER_FILENAME);
+        if legacy_ledger.exists() {
+            state_paths::warn_legacy_audit_path(&legacy);
+            return verify_session_in_ledger_at_root(&legacy, metadata);
+        }
+    }
+
+    Ok(result)
+}
+
+fn verify_session_in_ledger_at_root(
+    root: &Path,
+    metadata: &SessionMetadata,
+) -> Result<LedgerVerificationResult> {
     let path = root.join(AUDIT_LEDGER_FILENAME);
     if !path.exists() {
         return missing_ledger_verification_result(metadata);
@@ -125,8 +149,11 @@ mod tests {
     fn ledger_appends_and_verifies_session_digest() {
         let _env_lock = ENV_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir().unwrap();
+        let state = tmp.path().join("state");
+        std::fs::create_dir_all(&state).unwrap();
         let home = tmp.path().to_string_lossy().to_string();
-        let _env = EnvVarGuard::set_all(&[("HOME", &home)]);
+        let state_str = state.to_string_lossy().to_string();
+        let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
 
         let meta = sample_metadata("20260421-200000-11111");
         append_session(&meta).unwrap();
@@ -142,8 +169,11 @@ mod tests {
     fn ledger_rejects_malformed_session_id() {
         let _env_lock = ENV_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir().unwrap();
+        let state = tmp.path().join("state");
+        std::fs::create_dir_all(&state).unwrap();
         let home = tmp.path().to_string_lossy().to_string();
-        let _env = EnvVarGuard::set_all(&[("HOME", &home)]);
+        let state_str = state.to_string_lossy().to_string();
+        let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
 
         let meta = sample_metadata("real-token\\|real-key");
         let err = match append_session(&meta) {

--- a/crates/nono-cli/src/audit_ledger.rs
+++ b/crates/nono-cli/src/audit_ledger.rs
@@ -19,7 +19,6 @@ pub(crate) fn append_session(metadata: &SessionMetadata) -> Result<LedgerRecord>
     validate_ledger_session_id(&metadata.session_id)?;
 
     let root = audit_root()?;
-    state_paths::maybe_migrate_legacy_audit_ledger()?;
     std::fs::create_dir_all(&root).map_err(|e| {
         NonoError::Snapshot(format!(
             "Failed to create audit root {}: {e}",
@@ -29,6 +28,7 @@ pub(crate) fn append_session(metadata: &SessionMetadata) -> Result<LedgerRecord>
 
     let path = root.join(AUDIT_LEDGER_FILENAME);
     let _lock = LedgerLock::acquire(root.join(AUDIT_LEDGER_LOCK_FILENAME))?;
+    state_paths::maybe_migrate_legacy_audit_ledger()?;
     let mut file = OpenOptions::new()
         .create(true)
         .read(true)

--- a/crates/nono-cli/src/audit_session.rs
+++ b/crates/nono-cli/src/audit_session.rs
@@ -1,10 +1,12 @@
 //! Session discovery and management for the audit system.
 //!
-//! Audit sessions are stored in `~/.nono/audit/`. For backwards
-//! compatibility, the audit commands also read legacy audit metadata from
-//! `~/.nono/rollbacks/` when no migrated audit entry exists yet.
+//! Audit sessions are stored under `$XDG_STATE_HOME/nono/audit/` (default
+//! `~/.local/state/nono/audit/`). For backwards compatibility, reads also
+//! check `~/.nono/audit/` until v1.0.0, and legacy audit metadata under
+//! `~/.nono/rollbacks/` (or the canonical rollback root) when no migrated
+//! audit entry exists yet.
 
-use crate::rollback_session;
+use crate::state_paths;
 use nono::undo::{SessionMetadata, SnapshotManager};
 use nono::{NonoError, Result};
 use std::collections::BTreeSet;
@@ -27,10 +29,9 @@ pub struct SessionInfo {
     pub is_stale: bool,
 }
 
-/// Get the audit root directory (`~/.nono/audit/`)
+/// Get the canonical audit root directory (`$XDG_STATE_HOME/nono/audit/`).
 pub fn audit_root() -> Result<PathBuf> {
-    let home = dirs::home_dir().ok_or(NonoError::HomeNotFound)?;
-    Ok(home.join(".nono").join("audit"))
+    state_paths::audit_root()
 }
 
 /// Discover all audit sessions.
@@ -43,13 +44,10 @@ pub fn discover_sessions() -> Result<Vec<SessionInfo>> {
     let mut seen_ids = BTreeSet::new();
     let primary_root = audit_root()?;
 
-    for root in [
-        Some(primary_root.clone()),
-        rollback_session::rollback_root().ok(),
-    ] {
-        let Some(root) = root else {
-            continue;
-        };
+    let mut roots: Vec<PathBuf> = state_paths::audit_discovery_roots()?;
+    roots.extend(state_paths::rollback_discovery_roots()?);
+
+    for root in roots {
         if !root.exists() {
             continue;
         }
@@ -86,6 +84,7 @@ pub fn discover_sessions() -> Result<Vec<SessionInfo>> {
                 continue;
             }
 
+            state_paths::warn_if_legacy_audit_data_read(&dir);
             sessions.push(build_session_info(dir, metadata));
         }
     }
@@ -98,12 +97,10 @@ pub fn discover_sessions() -> Result<Vec<SessionInfo>> {
 pub fn load_session(session_id: &str) -> Result<SessionInfo> {
     validate_session_id(session_id)?;
     let primary_root = audit_root()?;
-    let roots = [
-        Some(primary_root.clone()),
-        rollback_session::rollback_root().ok(),
-    ];
+    let mut roots: Vec<PathBuf> = state_paths::audit_discovery_roots()?;
+    roots.extend(state_paths::rollback_discovery_roots()?);
 
-    for root in roots.into_iter().flatten() {
+    for root in roots {
         let dir = root.join(session_id);
         if !dir.exists() {
             continue;
@@ -129,6 +126,7 @@ pub fn load_session(session_id: &str) -> Result<SessionInfo> {
             continue;
         }
 
+        state_paths::warn_if_legacy_audit_data_read(&dir);
         return Ok(build_session_info(dir, metadata));
     }
 
@@ -242,8 +240,11 @@ mod tests {
     fn discover_sessions_excludes_rollback_backed_entries() {
         let _env_lock = ENV_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir().unwrap();
+        let state = tmp.path().join("state");
+        fs::create_dir_all(&state).unwrap();
         let home = tmp.path().to_string_lossy().to_string();
-        let _env = EnvVarGuard::set_all(&[("HOME", &home)]);
+        let state_str = state.to_string_lossy().to_string();
+        let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
 
         let audit_dir = audit_root().unwrap().join("20260421-111111-10001");
         fs::create_dir_all(&audit_dir).unwrap();
@@ -267,7 +268,7 @@ mod tests {
         )
         .unwrap();
 
-        let legacy_audit_dir = rollback_session::rollback_root()
+        let legacy_audit_dir = state_paths::legacy_rollback_root()
             .unwrap()
             .join("20260421-111111-10002");
         fs::create_dir_all(&legacy_audit_dir).unwrap();
@@ -291,7 +292,7 @@ mod tests {
         )
         .unwrap();
 
-        let rollback_dir = rollback_session::rollback_root()
+        let rollback_dir = state_paths::legacy_rollback_root()
             .unwrap()
             .join("20260421-111111-10003");
         fs::create_dir_all(&rollback_dir).unwrap();
@@ -324,5 +325,96 @@ mod tests {
         assert!(ids.contains(&"20260421-111111-10001"));
         assert!(ids.contains(&"20260421-111111-10002"));
         assert!(!ids.contains(&"20260421-111111-10003"));
+    }
+
+    #[test]
+    fn discover_sessions_reads_legacy_audit_root() {
+        let _env_lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let state = tmp.path().join("state");
+        fs::create_dir_all(&state).unwrap();
+        let home = tmp.path().to_string_lossy().to_string();
+        let state_str = state.to_string_lossy().to_string();
+        let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
+
+        let legacy_audit_dir = state_paths::legacy_audit_root()
+            .unwrap()
+            .join("20260421-111111-20001");
+        fs::create_dir_all(&legacy_audit_dir).unwrap();
+        SnapshotManager::write_session_metadata(
+            &legacy_audit_dir,
+            &SessionMetadata {
+                session_id: "20260421-111111-20001".to_string(),
+                started: "2026-04-21T11:11:11+01:00".to_string(),
+                ended: Some("2026-04-21T11:11:12+01:00".to_string()),
+                command: vec!["/bin/echo".to_string()],
+                executable_identity: None,
+                tracked_paths: vec![PathBuf::from("/tmp/work")],
+                snapshot_count: 0,
+                exit_code: Some(0),
+                merkle_roots: Vec::new(),
+                network_events: Vec::new(),
+                audit_event_count: 1,
+                audit_integrity: None,
+                audit_attestation: None,
+            },
+        )
+        .unwrap();
+
+        let sessions = discover_sessions().unwrap();
+        let ids: Vec<_> = sessions
+            .iter()
+            .map(|s| s.metadata.session_id.as_str())
+            .collect();
+        assert!(ids.contains(&"20260421-111111-20001"));
+        assert!(is_legacy_audit_only_session(
+            sessions
+                .iter()
+                .find(|s| s.metadata.session_id == "20260421-111111-20001")
+                .expect("legacy session")
+        ));
+    }
+
+    #[test]
+    fn discover_sessions_does_not_warn_when_legacy_audit_root_is_empty() {
+        let _env_lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let state = tmp.path().join("state");
+        fs::create_dir_all(&state).unwrap();
+        let home = tmp.path().to_string_lossy().to_string();
+        let state_str = state.to_string_lossy().to_string();
+        let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
+
+        let legacy_root = state_paths::legacy_audit_root().unwrap();
+        fs::create_dir_all(&legacy_root).unwrap();
+        fs::write(legacy_root.join("ledger.ndjson"), b"{}\n").unwrap();
+
+        let canonical_dir = state_paths::audit_root()
+            .unwrap()
+            .join("20260421-111111-30001");
+        fs::create_dir_all(&canonical_dir).unwrap();
+        SnapshotManager::write_session_metadata(
+            &canonical_dir,
+            &SessionMetadata {
+                session_id: "20260421-111111-30001".to_string(),
+                started: "2026-04-21T11:11:11+01:00".to_string(),
+                ended: Some("2026-04-21T11:11:12+01:00".to_string()),
+                command: vec!["/bin/echo".to_string()],
+                executable_identity: None,
+                tracked_paths: vec![PathBuf::from("/tmp/work")],
+                snapshot_count: 0,
+                exit_code: Some(0),
+                merkle_roots: Vec::new(),
+                network_events: Vec::new(),
+                audit_event_count: 1,
+                audit_integrity: None,
+                audit_attestation: None,
+            },
+        )
+        .unwrap();
+
+        let sessions = discover_sessions().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert!(is_primary_audit_session(&sessions[0].dir));
     }
 }

--- a/crates/nono-cli/src/audit_session.rs
+++ b/crates/nono-cli/src/audit_session.rs
@@ -43,6 +43,7 @@ pub fn discover_sessions() -> Result<Vec<SessionInfo>> {
     let mut sessions = Vec::new();
     let mut seen_ids = BTreeSet::new();
     let primary_root = audit_root()?;
+    let legacy_roots = state_paths::LegacyRootSet::resolve()?;
 
     let mut roots: Vec<PathBuf> = state_paths::audit_discovery_roots()?;
     roots.extend(state_paths::rollback_discovery_roots()?);
@@ -84,7 +85,7 @@ pub fn discover_sessions() -> Result<Vec<SessionInfo>> {
                 continue;
             }
 
-            state_paths::warn_if_legacy_audit_data_read(&dir);
+            legacy_roots.warn_if_legacy_audit_data_read(&dir);
             sessions.push(build_session_info(dir, metadata));
         }
     }
@@ -97,6 +98,7 @@ pub fn discover_sessions() -> Result<Vec<SessionInfo>> {
 pub fn load_session(session_id: &str) -> Result<SessionInfo> {
     validate_session_id(session_id)?;
     let primary_root = audit_root()?;
+    let legacy_roots = state_paths::LegacyRootSet::resolve()?;
     let mut roots: Vec<PathBuf> = state_paths::audit_discovery_roots()?;
     roots.extend(state_paths::rollback_discovery_roots()?);
 
@@ -126,7 +128,7 @@ pub fn load_session(session_id: &str) -> Result<SessionInfo> {
             continue;
         }
 
-        state_paths::warn_if_legacy_audit_data_read(&dir);
+        legacy_roots.warn_if_legacy_audit_data_read(&dir);
         return Ok(build_session_info(dir, metadata));
     }
 

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1699,7 +1699,7 @@ pub struct RunArgs {
     pub skip_dir: Vec<String>,
 
     /// Override the rollback snapshot destination directory.
-    /// By default, snapshots are stored in ~/.nono/rollbacks/.
+    /// By default, snapshots are stored in $XDG_STATE_HOME/nono/rollbacks/.
     /// The destination must be within a path already granted write access
     /// by --allow (or profile); nono will fail with a clear error if not.
     /// Useful for Docker volume mounts or shared storage paths.

--- a/crates/nono-cli/src/config/mod.rs
+++ b/crates/nono-cli/src/config/mod.rs
@@ -63,12 +63,9 @@ pub fn user_config_dir() -> Option<PathBuf> {
     dirs::config_dir().map(|p| p.join("nono"))
 }
 
-/// Get the user state directory path (for version tracking)
-#[allow(dead_code)]
+/// Get the user state directory path (for version tracking and runtime state)
 pub fn user_state_dir() -> Option<PathBuf> {
-    dirs::state_dir()
-        .or_else(dirs::data_local_dir)
-        .map(|p| p.join("nono"))
+    crate::state_paths::user_state_dir().ok()
 }
 
 // ============================================================================

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -432,7 +432,7 @@ fn validate_rollback_destination(
 
     Err(NonoError::ConfigParse(format!(
         "--rollback-dest '{}' is not covered by sandbox write permissions. \
-         Add --allow {} to grant access, or omit --rollback-dest to use the default path (~/.nono/rollbacks/).",
+         Add --allow {} to grant access, or omit --rollback-dest to use the default path ($XDG_STATE_HOME/nono/rollbacks/).",
         dest.display(),
         dest.display()
     )))

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -65,6 +65,7 @@ mod session_commands;
 mod setup;
 mod startup_prompt;
 mod startup_runtime;
+mod state_paths;
 mod supervised_runtime;
 mod terminal_approval;
 mod theme;

--- a/crates/nono-cli/src/protected_paths.rs
+++ b/crates/nono-cli/src/protected_paths.rs
@@ -1,7 +1,7 @@
 //! Protection for nono's own state paths.
 //!
 //! These checks enforce a hard fail if initial sandbox capabilities overlap
-//! with internal CLI state roots (currently `~/.nono`).
+//! with internal CLI state roots (`~/.nono` and `$XDG_STATE_HOME/nono`).
 
 use nono::{CapabilitySet, NonoError, Result, try_canonicalize};
 use std::path::{Path, PathBuf};
@@ -17,12 +17,11 @@ pub struct ProtectedRoots {
 impl ProtectedRoots {
     /// Build protected roots from current defaults.
     ///
-    /// Today this protects the full `~/.nono` subtree.
+    /// Protects both the legacy `~/.nono` tree and the canonical `$XDG_STATE_HOME/nono`
+    /// runtime state directory (audit, sessions, rollbacks).
     pub fn from_defaults() -> Result<Self> {
-        let home = dirs::home_dir().ok_or(NonoError::HomeNotFound)?;
-        let state_root = try_canonicalize(&home.join(".nono"));
         Ok(Self {
-            roots: vec![state_root],
+            roots: crate::state_paths::protected_state_roots()?,
         })
     }
 

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -369,20 +369,17 @@ pub(crate) fn start_proxy_runtime(
 }
 
 /// Choose the directory the proxy will write the TLS-intercept trust bundle
-/// into. Conventionally `~/.nono/sessions/<random>/`, kept owner-only.
+/// into. Conventionally `$XDG_STATE_HOME/nono/sessions/<random>/`, kept owner-only.
 ///
 /// Returns `Ok(None)` if no `HOME` is set (rare edge cases like CI). We log
 /// a warning rather than failing because TLS interception is opt-in: a
 /// missing directory just means CONNECTs to L7-bearing routes will get the
 /// usual 403, which is a coherent fallback rather than a hard error.
 fn prepare_intercept_ca_dir() -> Result<Option<PathBuf>> {
-    let home = match dirs::home_dir() {
-        Some(h) => h,
-        None => {
-            warn!(
-                "no $HOME found; skipping TLS-intercept setup (CONNECTs to L7-bearing routes \
-                 will be denied with 403)"
-            );
+    let dir = match crate::session::ensure_sessions_dir() {
+        Ok(base) => base,
+        Err(e) => {
+            warn!("cannot resolve session registry for TLS-intercept setup: {e}; skipping");
             return Ok(None);
         }
     };
@@ -396,10 +393,7 @@ fn prepare_intercept_ca_dir() -> Result<Option<PathBuf>> {
         .map(|d| d.subsec_nanos())
         .unwrap_or(0);
     let suffix = format!("{}-{:09}", pid, nanos);
-    let dir = home
-        .join(".nono")
-        .join("sessions")
-        .join(format!("intercept-{}", suffix));
+    let dir = dir.join(format!("intercept-{suffix}"));
     if let Err(e) = std::fs::create_dir_all(&dir) {
         warn!(
             "failed to create TLS-intercept dir '{}': {}; skipping interception",

--- a/crates/nono-cli/src/rollback_commands.rs
+++ b/crates/nono-cli/src/rollback_commands.rs
@@ -10,8 +10,9 @@ use crate::command_display::{format_command_line, truncate_chars};
 use crate::config::user::load_user_config;
 use crate::rollback_base_exclusions;
 use crate::rollback_session::{
-    SessionInfo, discover_sessions, format_bytes, load_session, remove_session, rollback_root,
+    SessionInfo, discover_sessions, format_bytes, load_session, remove_session,
 };
+use crate::state_paths;
 use crate::theme;
 use colored::Colorize;
 use nono::undo::{MerkleTree, ObjectStore, SnapshotManager};
@@ -921,8 +922,7 @@ fn cmd_cleanup(args: RollbackCleanupArgs) -> Result<()> {
 }
 
 fn cleanup_all(dry_run: bool) -> Result<()> {
-    let root = rollback_root()?;
-    if !root.exists() {
+    if !state_paths::any_rollback_root_exists()? {
         eprintln!("{} No rollback directory found.", prefix());
         return Ok(());
     }

--- a/crates/nono-cli/src/rollback_session.rs
+++ b/crates/nono-cli/src/rollback_session.rs
@@ -1,11 +1,13 @@
 //! Session discovery and management for the rollback system
 //!
-//! Provides functions to discover, load, and manage rollback sessions
-//! stored in `~/.nono/rollbacks/`. This is a CLI concern — the library
-//! provides primitives, the CLI provides session lifecycle management.
+//! Provides functions to discover, load, and manage rollback sessions stored
+//! under `$XDG_STATE_HOME/nono/rollbacks/` (default `~/.local/state/nono/rollbacks/`).
+//! Reads also check `~/.nono/rollbacks/` until v1.0.0.
 
+use crate::state_paths;
 use nono::undo::{SessionMetadata, SnapshotManager};
 use nono::{NonoError, Result};
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
@@ -25,66 +27,59 @@ pub struct SessionInfo {
     pub is_stale: bool,
 }
 
-/// Get the rollback root directory (`~/.nono/rollbacks/`)
+/// Get the canonical rollback root directory (`$XDG_STATE_HOME/nono/rollbacks/`).
 pub fn rollback_root() -> Result<PathBuf> {
-    let home = dirs::home_dir().ok_or(NonoError::HomeNotFound)?;
-    Ok(home.join(".nono").join("rollbacks"))
+    state_paths::rollback_root()
 }
 
-/// Discover all rollback sessions in `~/.nono/rollbacks/`.
+/// Discover all rollback sessions across canonical and legacy roots.
 ///
-/// Scans the rollback root directory, loads session metadata from each
+/// Scans rollback root directories, loads session metadata from each
 /// subdirectory, and enriches with derived data (disk size, alive status).
-/// Sessions with missing or corrupt metadata are skipped.
+/// Sessions with missing or corrupt metadata are skipped. When the same
+/// session ID exists in multiple roots, the canonical root wins.
 pub fn discover_sessions() -> Result<Vec<SessionInfo>> {
-    let root = rollback_root()?;
-    if !root.exists() {
-        return Ok(Vec::new());
-    }
-
     let mut sessions = Vec::new();
+    let mut seen_ids = BTreeSet::new();
 
-    let entries = fs::read_dir(&root).map_err(|e| {
-        NonoError::Snapshot(format!(
-            "Failed to read rollback directory {}: {e}",
-            root.display()
-        ))
-    })?;
-
-    for entry in entries {
-        let entry = match entry {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-
-        let dir = entry.path();
-        if !dir.is_dir() {
+    for root in state_paths::rollback_discovery_roots()? {
+        if !root.exists() {
             continue;
         }
 
-        // Try to load session metadata
-        let metadata = match SnapshotManager::load_session_metadata(&dir) {
-            Ok(m) => m,
-            Err(_) => continue, // Skip corrupt or incomplete sessions
-        };
+        let entries = fs::read_dir(&root).map_err(|e| {
+            NonoError::Snapshot(format!(
+                "Failed to read rollback directory {}: {e}",
+                root.display()
+            ))
+        })?;
 
-        let pid = parse_pid_from_session_id(&metadata.session_id);
-        let is_alive = pid.map(is_process_alive).unwrap_or(false);
-        let is_stale = metadata.ended.is_none() && !is_alive;
-        let disk_size = calculate_dir_size(&dir);
+        for entry in entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
 
-        sessions.push(SessionInfo {
-            metadata,
-            dir,
-            disk_size,
-            is_alive,
-            is_stale,
-        });
+            let dir = entry.path();
+            if !dir.is_dir() {
+                continue;
+            }
+
+            let metadata = match SnapshotManager::load_session_metadata(&dir) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+
+            if !seen_ids.insert(metadata.session_id.clone()) {
+                continue;
+            }
+
+            state_paths::warn_if_legacy_rollback_data_read(&dir);
+            sessions.push(build_session_info(dir, metadata));
+        }
     }
 
-    // Sort by start time, newest first
     sessions.sort_by(|a, b| b.metadata.started.cmp(&a.metadata.started));
-
     Ok(sessions)
 }
 
@@ -92,56 +87,49 @@ pub fn discover_sessions() -> Result<Vec<SessionInfo>> {
 ///
 /// The session_id is validated to prevent path traversal — it must not
 /// contain path separators or `..` components. The resolved path is
-/// verified to be within the rollback root directory.
+/// verified to be within a rollback root directory.
 pub fn load_session(session_id: &str) -> Result<SessionInfo> {
     validate_session_id(session_id)?;
-    let root = rollback_root()?;
-    let dir = root.join(session_id);
 
-    // Defense in depth: verify the resolved path is within rollback root.
-    // Both canonicalizations must succeed -- fail closed if either cannot
-    // be resolved (prevents bypassing the traversal check).
-    let canonical_root = root.canonicalize().map_err(|e| {
-        NonoError::SessionNotFound(format!(
-            "Cannot canonicalize rollback root {}: {}",
-            root.display(),
-            e
-        ))
-    })?;
-    let canonical_dir = dir.canonicalize().map_err(|_| {
-        // Don't leak path details in error -- session simply doesn't exist
-        NonoError::SessionNotFound(session_id.to_string())
-    })?;
-    if !canonical_dir.starts_with(&canonical_root) {
-        return Err(NonoError::SessionNotFound(session_id.to_string()));
+    for root in state_paths::rollback_discovery_roots()? {
+        let dir = root.join(session_id);
+        if !dir.exists() {
+            continue;
+        }
+
+        let canonical_root = root.canonicalize().map_err(|e| {
+            NonoError::SessionNotFound(format!(
+                "Cannot canonicalize rollback root {}: {}",
+                root.display(),
+                e
+            ))
+        })?;
+        let canonical_dir = dir
+            .canonicalize()
+            .map_err(|_| NonoError::SessionNotFound(session_id.to_string()))?;
+        if !canonical_dir.starts_with(&canonical_root) {
+            continue;
+        }
+
+        let metadata = SnapshotManager::load_session_metadata(&dir)?;
+        state_paths::warn_if_legacy_rollback_data_read(&dir);
+        return Ok(build_session_info(dir, metadata));
     }
 
-    if !dir.exists() {
-        return Err(NonoError::SessionNotFound(session_id.to_string()));
-    }
-
-    let metadata = SnapshotManager::load_session_metadata(&dir)?;
-    let pid = parse_pid_from_session_id(&metadata.session_id);
-    let is_alive = pid.map(is_process_alive).unwrap_or(false);
-    let is_stale = metadata.ended.is_none() && !is_alive;
-    let disk_size = calculate_dir_size(&dir);
-
-    Ok(SessionInfo {
-        metadata,
-        dir,
-        disk_size,
-        is_alive,
-        is_stale,
-    })
+    Err(NonoError::SessionNotFound(session_id.to_string()))
 }
 
-/// Calculate the total disk usage of all sessions.
+/// Calculate the total disk usage of all sessions across rollback roots.
 pub fn total_storage_bytes() -> Result<u64> {
-    let root = rollback_root()?;
-    if !root.exists() {
-        return Ok(0);
+    let mut total: u64 = 0;
+    let mut seen_roots = BTreeSet::new();
+    for root in state_paths::rollback_discovery_roots()? {
+        if !seen_roots.insert(root.clone()) || !root.exists() {
+            continue;
+        }
+        total = total.saturating_add(calculate_dir_size(&root));
     }
-    Ok(calculate_dir_size(&root))
+    Ok(total)
 }
 
 /// Remove a session directory.
@@ -152,6 +140,21 @@ pub fn remove_session(dir: &Path) -> Result<()> {
             dir.display()
         ))
     })
+}
+
+fn build_session_info(dir: PathBuf, metadata: SessionMetadata) -> SessionInfo {
+    let pid = parse_pid_from_session_id(&metadata.session_id);
+    let is_alive = pid.map(is_process_alive).unwrap_or(false);
+    let is_stale = metadata.ended.is_none() && !is_alive;
+    let disk_size = calculate_dir_size(&dir);
+
+    SessionInfo {
+        metadata,
+        dir,
+        disk_size,
+        is_alive,
+        is_stale,
+    }
 }
 
 /// Validate a session ID to prevent path traversal.
@@ -218,6 +221,7 @@ pub fn format_bytes(bytes: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env::{ENV_LOCK, EnvVarGuard};
 
     #[test]
     fn validate_session_id_rejects_traversal() {
@@ -260,7 +264,6 @@ mod tests {
     #[test]
     fn discover_sessions_empty_dir() {
         let dir = tempfile::TempDir::new().expect("tempdir");
-        // Override undo_root by testing calculate_dir_size directly
         let size = calculate_dir_size(dir.path());
         assert_eq!(size, 0);
     }
@@ -281,7 +284,48 @@ mod tests {
 
     #[test]
     fn dead_process_not_alive() {
-        // PID 99999999 is very unlikely to exist
         assert!(!is_process_alive(99_999_999));
+    }
+
+    #[test]
+    fn discover_sessions_reads_legacy_rollback_root() {
+        let _env_lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = tmp.path().join("state");
+        fs::create_dir_all(&state).expect("mkdir state");
+        let home = tmp.path().to_string_lossy().to_string();
+        let state_str = state.to_string_lossy().to_string();
+        let _env = EnvVarGuard::set_all(&[("HOME", &home), ("XDG_STATE_HOME", &state_str)]);
+
+        let legacy_dir = state_paths::legacy_rollback_root()
+            .expect("legacy rollback root")
+            .join("20260421-111111-30001");
+        fs::create_dir_all(&legacy_dir).expect("mkdir legacy rollback session");
+        SnapshotManager::write_session_metadata(
+            &legacy_dir,
+            &SessionMetadata {
+                session_id: "20260421-111111-30001".to_string(),
+                started: "2026-04-21T11:11:11+01:00".to_string(),
+                ended: Some("2026-04-21T11:11:12+01:00".to_string()),
+                command: vec!["/bin/true".to_string()],
+                executable_identity: None,
+                tracked_paths: vec![PathBuf::from("/tmp/work")],
+                snapshot_count: 2,
+                exit_code: Some(0),
+                merkle_roots: Vec::new(),
+                network_events: Vec::new(),
+                audit_event_count: 0,
+                audit_integrity: None,
+                audit_attestation: None,
+            },
+        )
+        .expect("write metadata");
+
+        let sessions = discover_sessions().expect("discover");
+        let ids: Vec<_> = sessions
+            .iter()
+            .map(|s| s.metadata.session_id.as_str())
+            .collect();
+        assert!(ids.contains(&"20260421-111111-30001"));
     }
 }

--- a/crates/nono-cli/src/rollback_session.rs
+++ b/crates/nono-cli/src/rollback_session.rs
@@ -41,6 +41,7 @@ pub fn rollback_root() -> Result<PathBuf> {
 pub fn discover_sessions() -> Result<Vec<SessionInfo>> {
     let mut sessions = Vec::new();
     let mut seen_ids = BTreeSet::new();
+    let legacy_roots = state_paths::LegacyRootSet::resolve()?;
 
     for root in state_paths::rollback_discovery_roots()? {
         if !root.exists() {
@@ -74,7 +75,7 @@ pub fn discover_sessions() -> Result<Vec<SessionInfo>> {
                 continue;
             }
 
-            state_paths::warn_if_legacy_rollback_data_read(&dir);
+            legacy_roots.warn_if_legacy_rollback_data_read(&dir);
             sessions.push(build_session_info(dir, metadata));
         }
     }
@@ -90,6 +91,7 @@ pub fn discover_sessions() -> Result<Vec<SessionInfo>> {
 /// verified to be within a rollback root directory.
 pub fn load_session(session_id: &str) -> Result<SessionInfo> {
     validate_session_id(session_id)?;
+    let legacy_roots = state_paths::LegacyRootSet::resolve()?;
 
     for root in state_paths::rollback_discovery_roots()? {
         let dir = root.join(session_id);
@@ -112,7 +114,7 @@ pub fn load_session(session_id: &str) -> Result<SessionInfo> {
         }
 
         let metadata = SnapshotManager::load_session_metadata(&dir)?;
-        state_paths::warn_if_legacy_rollback_data_read(&dir);
+        legacy_roots.warn_if_legacy_rollback_data_read(&dir);
         return Ok(build_session_info(dir, metadata));
     }
 

--- a/crates/nono-cli/src/session.rs
+++ b/crates/nono-cli/src/session.rs
@@ -225,15 +225,20 @@ fn ensure_private_dir(dir: &Path) -> Result<PathBuf> {
         validate_sessions_dir(dir)?;
         return Ok(dir.to_path_buf());
     }
-    std::fs::create_dir_all(dir).map_err(|e| NonoError::ConfigWrite {
-        path: dir.to_path_buf(),
-        source: e,
-    })?;
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o700);
-        std::fs::set_permissions(dir, perms).map_err(|e| NonoError::ConfigWrite {
+        use std::fs::DirBuilder;
+        use std::os::unix::fs::DirBuilderExt;
+        let mut builder = DirBuilder::new();
+        builder.recursive(true).mode(0o700);
+        builder.create(dir).map_err(|e| NonoError::ConfigWrite {
+            path: dir.to_path_buf(),
+            source: e,
+        })?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(dir).map_err(|e| NonoError::ConfigWrite {
             path: dir.to_path_buf(),
             source: e,
         })?;
@@ -318,6 +323,7 @@ pub fn generate_random_name() -> String {
 pub fn list_sessions() -> Result<Vec<SessionRecord>> {
     let mut sessions = Vec::new();
     let mut seen_ids = BTreeSet::new();
+    let legacy_roots = crate::state_paths::LegacyRootSet::resolve()?;
 
     for dir in crate::state_paths::session_registry_dirs_for_read()? {
         if !dir.exists() {
@@ -346,7 +352,7 @@ pub fn list_sessions() -> Result<Vec<SessionRecord>> {
             match load_reconciled_session_file(&path) {
                 Ok(record) => {
                     if seen_ids.insert(record.session_id.clone()) {
-                        crate::state_paths::warn_if_legacy_session_file_read(&path);
+                        legacy_roots.warn_if_legacy_session_file_read(&path);
                         sessions.push(record);
                     }
                 }
@@ -369,6 +375,7 @@ pub fn list_sessions() -> Result<Vec<SessionRecord>> {
 pub fn load_session(query: &str) -> Result<SessionRecord> {
     let mut id_matches = Vec::new();
     let mut name_matches = Vec::new();
+    let legacy_roots = crate::state_paths::LegacyRootSet::resolve()?;
 
     for dir in crate::state_paths::session_registry_dirs_for_read()? {
         if !dir.exists() {
@@ -400,7 +407,7 @@ pub fn load_session(query: &str) -> Result<SessionRecord> {
             if file_name.starts_with(query) {
                 match load_reconciled_session_file(&path) {
                     Ok(record) => {
-                        crate::state_paths::warn_if_legacy_session_file_read(&path);
+                        legacy_roots.warn_if_legacy_session_file_read(&path);
                         id_matches.push(record);
                     }
                     Err(e) => debug!("Skipping corrupt session file {}: {}", path.display(), e),
@@ -409,7 +416,7 @@ pub fn load_session(query: &str) -> Result<SessionRecord> {
                 match load_reconciled_session_file(&path) {
                     Ok(record) => {
                         if record.name.as_deref() == Some(query) {
-                            crate::state_paths::warn_if_legacy_session_file_read(&path);
+                            legacy_roots.warn_if_legacy_session_file_read(&path);
                             name_matches.push(record);
                         }
                     }

--- a/crates/nono-cli/src/session.rs
+++ b/crates/nono-cli/src/session.rs
@@ -1,11 +1,13 @@
 //! Session registry for the nono capability runtime.
 //!
 //! Each `nono run` or `nono shell` invocation in supervised mode creates a session
-//! file at `~/.nono/sessions/{session_id}.json`. This enables `nono ps`, `nono stop`,
+//! file at `$XDG_STATE_HOME/nono/sessions/{session_id}.json` (default
+//! `~/.local/state/nono/sessions/`). This enables `nono ps`, `nono stop`,
 //! `nono logs`, and `nono inspect` to discover and manage running sandboxes.
 
 use nono::{NonoError, Result};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -17,7 +19,7 @@ use std::os::unix::fs::OpenOptionsExt;
 #[cfg(unix)]
 use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 
-/// Session state persisted to `~/.nono/sessions/{session_id}.json`.
+/// Session state persisted to `$XDG_STATE_HOME/nono/sessions/{session_id}.json`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionRecord {
     pub session_id: String,
@@ -205,37 +207,38 @@ fn load_reconciled_session_file(path: &Path) -> Result<SessionRecord> {
     Ok(record)
 }
 
-/// Returns `~/.nono/sessions/` without creating it.
+/// Returns the canonical session registry without creating it.
 ///
 /// Use [`ensure_sessions_dir()`] when writing session files.
 pub fn sessions_dir() -> Result<PathBuf> {
-    let home = dirs::home_dir().ok_or_else(|| {
-        NonoError::ConfigParse("Cannot determine home directory for session registry".to_string())
-    })?;
-    Ok(home.join(".nono").join("sessions"))
+    crate::state_paths::sessions_dir()
 }
 
-/// Returns `~/.nono/sessions/`, creating with mode 0o700 if needed.
+/// Returns the canonical session registry, creating with mode 0o700 if needed.
 pub(crate) fn ensure_sessions_dir() -> Result<PathBuf> {
     let dir = sessions_dir()?;
+    ensure_private_dir(&dir)
+}
+
+fn ensure_private_dir(dir: &Path) -> Result<PathBuf> {
     if dir.exists() {
-        validate_sessions_dir(&dir)?;
-        return Ok(dir);
+        validate_sessions_dir(dir)?;
+        return Ok(dir.to_path_buf());
     }
-    std::fs::create_dir_all(&dir).map_err(|e| NonoError::ConfigWrite {
-        path: dir.clone(),
+    std::fs::create_dir_all(dir).map_err(|e| NonoError::ConfigWrite {
+        path: dir.to_path_buf(),
         source: e,
     })?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o700);
-        std::fs::set_permissions(&dir, perms).map_err(|e| NonoError::ConfigWrite {
-            path: dir.clone(),
+        std::fs::set_permissions(dir, perms).map_err(|e| NonoError::ConfigWrite {
+            path: dir.to_path_buf(),
             source: e,
         })?;
     }
-    Ok(dir)
+    Ok(dir.to_path_buf())
 }
 
 fn validate_sessions_dir(dir: &Path) -> Result<()> {
@@ -313,47 +316,47 @@ pub fn generate_random_name() -> String {
 ///
 /// Returns sessions sorted by start time (newest first).
 pub fn list_sessions() -> Result<Vec<SessionRecord>> {
-    let dir = match sessions_dir() {
-        Ok(d) => d,
-        Err(_) => return Ok(Vec::new()),
-    };
-
-    if !dir.exists() {
-        return Ok(Vec::new());
-    }
-    validate_sessions_dir(&dir)?;
-
     let mut sessions = Vec::new();
-    let entries = std::fs::read_dir(&dir).map_err(|e| NonoError::ConfigWrite {
-        path: dir.clone(),
-        source: e,
-    })?;
+    let mut seen_ids = BTreeSet::new();
 
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+    for dir in crate::state_paths::session_registry_dirs_for_read()? {
+        if !dir.exists() {
             continue;
         }
-        // Skip event log files
-        if path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .is_some_and(|n| n.ends_with(".events.json"))
-        {
-            continue;
-        }
+        validate_sessions_dir(&dir)?;
 
-        match load_reconciled_session_file(&path) {
-            Ok(record) => {
-                sessions.push(record);
+        let entries = std::fs::read_dir(&dir).map_err(|e| NonoError::ConfigWrite {
+            path: dir.clone(),
+            source: e,
+        })?;
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
             }
-            Err(e) => {
-                debug!("Skipping corrupt session file {}: {}", path.display(), e);
+            if path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with(".events.json"))
+            {
+                continue;
+            }
+
+            match load_reconciled_session_file(&path) {
+                Ok(record) => {
+                    if seen_ids.insert(record.session_id.clone()) {
+                        crate::state_paths::warn_if_legacy_session_file_read(&path);
+                        sessions.push(record);
+                    }
+                }
+                Err(e) => {
+                    debug!("Skipping corrupt session file {}: {}", path.display(), e);
+                }
             }
         }
     }
 
-    // Sort newest first
     sessions.sort_by(|a, b| b.started.cmp(&a.started));
     Ok(sessions)
 }
@@ -364,56 +367,64 @@ pub fn list_sessions() -> Result<Vec<SessionRecord>> {
 /// tries matching against session names. Returns an error if no match or
 /// multiple matches are found.
 pub fn load_session(query: &str) -> Result<SessionRecord> {
-    let dir = sessions_dir()?;
-    if !dir.exists() {
-        return Err(NonoError::SessionNotFound(query.to_string()));
-    }
-    validate_sessions_dir(&dir)?;
-    let entries = std::fs::read_dir(&dir).map_err(|e| NonoError::ConfigWrite {
-        path: dir.clone(),
-        source: e,
-    })?;
-
     let mut id_matches = Vec::new();
     let mut name_matches = Vec::new();
 
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+    for dir in crate::state_paths::session_registry_dirs_for_read()? {
+        if !dir.exists() {
             continue;
         }
-        // Skip event log files
-        if path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .is_some_and(|n| n.ends_with(".events.json"))
-        {
-            continue;
-        }
-        let file_name = match path.file_stem().and_then(|n| n.to_str()) {
-            Some(n) => n.to_string(),
-            None => continue,
-        };
+        validate_sessions_dir(&dir)?;
+        let entries = std::fs::read_dir(&dir).map_err(|e| NonoError::ConfigWrite {
+            path: dir.clone(),
+            source: e,
+        })?;
 
-        if file_name.starts_with(query) {
-            match load_reconciled_session_file(&path) {
-                Ok(record) => id_matches.push(record),
-                Err(e) => debug!("Skipping corrupt session file {}: {}", path.display(), e),
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
             }
-        } else {
-            // Try name match (only load file if ID didn't match)
-            match load_reconciled_session_file(&path) {
-                Ok(record) => {
-                    if record.name.as_deref() == Some(query) {
-                        name_matches.push(record);
+            if path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with(".events.json"))
+            {
+                continue;
+            }
+            let file_name = match path.file_stem().and_then(|n| n.to_str()) {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+
+            if file_name.starts_with(query) {
+                match load_reconciled_session_file(&path) {
+                    Ok(record) => {
+                        crate::state_paths::warn_if_legacy_session_file_read(&path);
+                        id_matches.push(record);
                     }
+                    Err(e) => debug!("Skipping corrupt session file {}: {}", path.display(), e),
                 }
-                Err(e) => debug!("Skipping corrupt session file {}: {}", path.display(), e),
+            } else {
+                match load_reconciled_session_file(&path) {
+                    Ok(record) => {
+                        if record.name.as_deref() == Some(query) {
+                            crate::state_paths::warn_if_legacy_session_file_read(&path);
+                            name_matches.push(record);
+                        }
+                    }
+                    Err(e) => debug!("Skipping corrupt session file {}: {}", path.display(), e),
+                }
             }
         }
     }
 
-    // Prefer ID matches over name matches
+    if id_matches.is_empty() && name_matches.is_empty() {
+        return Err(NonoError::SessionNotFound(query.to_string()));
+    }
+
+    // Prefer ID matches over name matches; canonical dir is scanned first so
+    // duplicates resolve to the XDG registry entry.
     let matches = if !id_matches.is_empty() {
         id_matches
     } else {

--- a/crates/nono-cli/src/state_paths.rs
+++ b/crates/nono-cli/src/state_paths.rs
@@ -35,7 +35,7 @@ fn resolve_xdg_state_base() -> Result<PathBuf> {
         );
     }
 
-    let home = dirs::home_dir().ok_or(NonoError::HomeNotFound)?;
+    let home = PathBuf::from(crate::config::validated_home()?);
     Ok(home.join(".local").join("state"))
 }
 
@@ -46,7 +46,7 @@ pub fn user_state_dir() -> Result<PathBuf> {
 
 /// Legacy `~/.nono` root (pre-XDG audit, session, and rollback data).
 pub fn legacy_home_state_root() -> Result<PathBuf> {
-    let home = dirs::home_dir().ok_or(NonoError::HomeNotFound)?;
+    let home = PathBuf::from(crate::config::validated_home()?);
     Ok(home.join(LEGACY_HOME_SUBDIR))
 }
 
@@ -175,69 +175,68 @@ fn warn_legacy_rollback_path(path: &Path) {
     });
 }
 
-/// Returns true when `path` is under the legacy rollback root (not the canonical one).
-pub fn is_legacy_rollback_path(path: &Path) -> bool {
-    let Ok(legacy) = legacy_rollback_root() else {
-        return false;
-    };
-    let Ok(primary) = rollback_root() else {
-        return false;
-    };
-    if legacy == primary {
-        return false;
-    }
-    path.starts_with(&legacy) && !path.starts_with(&primary)
+/// Pre-canonicalized primary and legacy roots for legacy-path detection.
+///
+/// Resolve once before iterating session directories to avoid repeated env lookups
+/// and to compare paths consistently on macOS (/Users vs /private/Users).
+pub struct LegacyRootSet {
+    primary_audit: PathBuf,
+    legacy_audit: PathBuf,
+    primary_rollback: PathBuf,
+    legacy_rollback: PathBuf,
+    primary_sessions: PathBuf,
+    legacy_sessions: PathBuf,
 }
 
-/// Warn once after successfully reading audit metadata from a legacy tree.
-pub(crate) fn warn_if_legacy_audit_data_read(session_dir: &Path) {
-    if is_legacy_audit_path(session_dir) {
-        let _ = legacy_audit_root().map(|root| warn_legacy_audit_path(&root));
-        return;
+impl LegacyRootSet {
+    pub fn resolve() -> Result<Self> {
+        Ok(Self {
+            primary_audit: try_canonicalize(&audit_root()?),
+            legacy_audit: try_canonicalize(&legacy_audit_root()?),
+            primary_rollback: try_canonicalize(&rollback_root()?),
+            legacy_rollback: try_canonicalize(&legacy_rollback_root()?),
+            primary_sessions: try_canonicalize(&sessions_dir()?),
+            legacy_sessions: try_canonicalize(&legacy_sessions_dir()?),
+        })
     }
-    if is_legacy_rollback_path(session_dir) {
-        let _ = legacy_rollback_root().map(|root| warn_legacy_rollback_path(&root));
-    }
-}
 
-/// Warn once after successfully reading rollback metadata from a legacy tree.
-pub(crate) fn warn_if_legacy_rollback_data_read(session_dir: &Path) {
-    if is_legacy_rollback_path(session_dir) {
-        let _ = legacy_rollback_root().map(|root| warn_legacy_rollback_path(&root));
+    fn is_under_legacy(path: &Path, legacy: &Path, primary: &Path) -> bool {
+        if legacy == primary {
+            return false;
+        }
+        let path = try_canonicalize(path);
+        path.starts_with(legacy) && !path.starts_with(primary)
     }
-}
 
-/// Warn once after successfully reading a session registry file from a legacy tree.
-pub(crate) fn warn_if_legacy_session_file_read(session_file: &Path) {
-    let Ok(legacy) = legacy_sessions_dir() else {
-        return;
-    };
-    let Ok(primary) = sessions_dir() else {
-        return;
-    };
-    if legacy == primary {
-        return;
+    /// Warn once after successfully reading audit metadata from a legacy tree.
+    pub fn warn_if_legacy_audit_data_read(&self, session_dir: &Path) {
+        if Self::is_under_legacy(session_dir, &self.legacy_audit, &self.primary_audit) {
+            warn_legacy_audit_path(&self.legacy_audit);
+            return;
+        }
+        if Self::is_under_legacy(session_dir, &self.legacy_rollback, &self.primary_rollback) {
+            warn_legacy_rollback_path(&self.legacy_rollback);
+        }
     }
-    if session_file.starts_with(&legacy) {
-        warn_legacy_sessions_path(&legacy);
-    }
-}
 
-/// Returns true when `path` is under the legacy audit root (not the canonical one).
-pub fn is_legacy_audit_path(path: &Path) -> bool {
-    let Ok(legacy) = legacy_audit_root() else {
-        return false;
-    };
-    let Ok(primary) = audit_root() else {
-        return false;
-    };
-    if legacy == primary {
-        return false;
+    /// Warn once after successfully reading rollback metadata from a legacy tree.
+    pub fn warn_if_legacy_rollback_data_read(&self, session_dir: &Path) {
+        if Self::is_under_legacy(session_dir, &self.legacy_rollback, &self.primary_rollback) {
+            warn_legacy_rollback_path(&self.legacy_rollback);
+        }
     }
-    path.starts_with(&legacy) && !path.starts_with(&primary)
+
+    /// Warn once after successfully reading a session registry file from a legacy tree.
+    pub fn warn_if_legacy_session_file_read(&self, session_file: &Path) {
+        if Self::is_under_legacy(session_file, &self.legacy_sessions, &self.primary_sessions) {
+            warn_legacy_sessions_path(&self.legacy_sessions);
+        }
+    }
 }
 
 /// Copy a legacy audit ledger into the canonical root on first write, if needed.
+///
+/// Caller must hold the audit ledger lock before calling this function.
 pub fn maybe_migrate_legacy_audit_ledger() -> Result<()> {
     let primary = audit_root()?;
     let legacy = legacy_audit_root()?;
@@ -262,10 +261,28 @@ pub fn maybe_migrate_legacy_audit_ledger() -> Result<()> {
         ))
     })?;
 
-    std::fs::copy(&legacy_ledger, &new_ledger).map_err(|e| {
+    let tmp_ledger = primary.join(format!("{AUDIT_LEDGER_FILENAME}.tmp"));
+    if tmp_ledger.exists() {
+        std::fs::remove_file(&tmp_ledger).map_err(|e| {
+            NonoError::Snapshot(format!(
+                "Failed to remove stale audit ledger migration temp file {}: {e}",
+                tmp_ledger.display()
+            ))
+        })?;
+    }
+
+    std::fs::copy(&legacy_ledger, &tmp_ledger).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp_ledger);
         NonoError::Snapshot(format!(
-            "Failed to migrate audit ledger from {} to {}: {e}",
-            legacy_ledger.display(),
+            "Failed to copy legacy audit ledger to temporary file {}: {e}",
+            tmp_ledger.display()
+        ))
+    })?;
+
+    std::fs::rename(&tmp_ledger, &new_ledger).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp_ledger);
+        NonoError::Snapshot(format!(
+            "Failed to rename temporary audit ledger to {}: {e}",
             new_ledger.display()
         ))
     })?;
@@ -376,5 +393,30 @@ mod tests {
         assert_eq!(roots.len(), 2);
         assert!(roots[0].ends_with("nono/rollbacks"));
         assert!(roots[1].ends_with(".nono/rollbacks"));
+    }
+
+    #[test]
+    fn maybe_migrate_legacy_audit_ledger_copies_via_temp_rename() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let (_env, home) = isolated_env(tmp.path());
+
+        let legacy_ledger = legacy_audit_root().unwrap().join(AUDIT_LEDGER_FILENAME);
+        fs::create_dir_all(legacy_ledger.parent().unwrap()).unwrap();
+        fs::write(&legacy_ledger, b"{\"sequence\":0}\n").unwrap();
+
+        maybe_migrate_legacy_audit_ledger().unwrap();
+
+        let migrated = audit_root().unwrap().join(AUDIT_LEDGER_FILENAME);
+        assert!(migrated.exists());
+        assert!(
+            !audit_root()
+                .unwrap()
+                .join(format!("{AUDIT_LEDGER_FILENAME}.tmp"))
+                .exists()
+        );
+        let content = fs::read_to_string(&migrated).unwrap();
+        assert_eq!(content, "{\"sequence\":0}\n");
+        let _ = home;
     }
 }

--- a/crates/nono-cli/src/state_paths.rs
+++ b/crates/nono-cli/src/state_paths.rs
@@ -1,0 +1,380 @@
+//! XDG-based paths for nono runtime state (audit trails, session registry, rollbacks).
+//!
+//! Canonical storage lives under `$XDG_STATE_HOME/nono/` (default
+//! `~/.local/state/nono/`). Until v1.0.0, reads also fall back to legacy
+//! `~/.nono/{audit,sessions,rollbacks}/` trees with a one-time deprecation warning.
+
+use nono::{NonoError, Result, try_canonicalize};
+use std::cell::Cell;
+use std::path::{Path, PathBuf};
+
+const LEGACY_HOME_SUBDIR: &str = ".nono";
+const LEGACY_REMOVE_BY: &str = "v1.0.0";
+const AUDIT_LEDGER_FILENAME: &str = "ledger.ndjson";
+
+thread_local! {
+    static LEGACY_AUDIT_WARNED: Cell<bool> = const { Cell::new(false) };
+    static LEGACY_SESSIONS_WARNED: Cell<bool> = const { Cell::new(false) };
+    static LEGACY_ROLLBACK_WARNED: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Resolve the XDG state base directory (`$XDG_STATE_HOME`, default `~/.local/state`).
+///
+/// When `$XDG_STATE_HOME` is unset, nono uses `$HOME/.local/state` on every platform
+/// (same convention as `gh`, Claude Code, and profile `$XDG_STATE_HOME` expansion),
+/// not macOS `~/Library/Application Support`.
+fn resolve_xdg_state_base() -> Result<PathBuf> {
+    if let Ok(raw) = std::env::var("XDG_STATE_HOME") {
+        let path = PathBuf::from(&raw);
+        if path.is_absolute() {
+            return Ok(path);
+        }
+        tracing::warn!(
+            "Ignoring invalid XDG_STATE_HOME='{}' (must be absolute), falling back to default state dir",
+            raw
+        );
+    }
+
+    let home = dirs::home_dir().ok_or(NonoError::HomeNotFound)?;
+    Ok(home.join(".local").join("state"))
+}
+
+/// Resolve `$XDG_STATE_HOME/nono` (default `~/.local/state/nono`).
+pub fn user_state_dir() -> Result<PathBuf> {
+    Ok(resolve_xdg_state_base()?.join("nono"))
+}
+
+/// Legacy `~/.nono` root (pre-XDG audit, session, and rollback data).
+pub fn legacy_home_state_root() -> Result<PathBuf> {
+    let home = dirs::home_dir().ok_or(NonoError::HomeNotFound)?;
+    Ok(home.join(LEGACY_HOME_SUBDIR))
+}
+
+/// Primary audit root: `$XDG_STATE_HOME/nono/audit/`.
+pub fn audit_root() -> Result<PathBuf> {
+    Ok(user_state_dir()?.join("audit"))
+}
+
+/// Legacy audit root: `~/.nono/audit/` (read fallback until v1.0.0).
+pub fn legacy_audit_root() -> Result<PathBuf> {
+    Ok(legacy_home_state_root()?.join("audit"))
+}
+
+/// Primary session registry: `$XDG_STATE_HOME/nono/sessions/`.
+pub fn sessions_dir() -> Result<PathBuf> {
+    Ok(user_state_dir()?.join("sessions"))
+}
+
+/// Legacy session registry: `~/.nono/sessions/` (read fallback until v1.0.0).
+pub fn legacy_sessions_dir() -> Result<PathBuf> {
+    Ok(legacy_home_state_root()?.join("sessions"))
+}
+
+/// Primary rollback root: `$XDG_STATE_HOME/nono/rollbacks/`.
+pub fn rollback_root() -> Result<PathBuf> {
+    Ok(user_state_dir()?.join("rollbacks"))
+}
+
+/// Legacy rollback root: `~/.nono/rollbacks/` (read fallback until v1.0.0).
+pub fn legacy_rollback_root() -> Result<PathBuf> {
+    Ok(legacy_home_state_root()?.join("rollbacks"))
+}
+
+/// Audit roots to scan when discovering or loading sessions (primary first).
+pub fn audit_discovery_roots() -> Result<Vec<PathBuf>> {
+    let primary = audit_root()?;
+    let mut roots = vec![primary.clone()];
+    if let Ok(legacy) = legacy_audit_root()
+        && legacy != primary
+    {
+        roots.push(legacy);
+    }
+    Ok(roots)
+}
+
+/// Session registry directories to scan when listing or loading (primary first).
+pub fn session_registry_dirs_for_read() -> Result<Vec<PathBuf>> {
+    let primary = sessions_dir()?;
+    let mut dirs = vec![primary.clone()];
+    if let Ok(legacy) = legacy_sessions_dir()
+        && legacy != primary
+    {
+        dirs.push(legacy);
+    }
+    Ok(dirs)
+}
+
+/// Rollback roots to scan when discovering or loading sessions (primary first).
+pub fn rollback_discovery_roots() -> Result<Vec<PathBuf>> {
+    let primary = rollback_root()?;
+    let mut roots = vec![primary.clone()];
+    if let Ok(legacy) = legacy_rollback_root()
+        && legacy != primary
+    {
+        roots.push(legacy);
+    }
+    Ok(roots)
+}
+
+/// Returns true when any rollback root directory exists.
+pub fn any_rollback_root_exists() -> Result<bool> {
+    Ok(rollback_discovery_roots()?.iter().any(|root| root.exists()))
+}
+
+/// Protected state roots that must not be grantable to sandboxed children.
+pub fn protected_state_roots() -> Result<Vec<PathBuf>> {
+    let mut roots = vec![
+        try_canonicalize(&legacy_home_state_root()?),
+        try_canonicalize(&user_state_dir()?),
+    ];
+    roots.sort();
+    roots.dedup();
+    Ok(roots)
+}
+
+/// Emit a one-time warning when legacy audit data is read.
+pub(crate) fn warn_legacy_audit_path(path: &Path) {
+    LEGACY_AUDIT_WARNED.with(|warned| {
+        if warned.get() {
+            return;
+        }
+        warned.set(true);
+        eprintln!(
+            "warning: reading audit data from deprecated path {} (will be removed in {LEGACY_REMOVE_BY}); \
+             new audit data is stored under $XDG_STATE_HOME/nono/audit/ (default ~/.local/state/nono/audit/)",
+            path.display(),
+        );
+    });
+}
+
+fn warn_legacy_sessions_path(path: &Path) {
+    LEGACY_SESSIONS_WARNED.with(|warned| {
+        if warned.get() {
+            return;
+        }
+        warned.set(true);
+        eprintln!(
+            "warning: reading session registry from deprecated path {} (will be removed in {LEGACY_REMOVE_BY}); \
+             new session files are stored under $XDG_STATE_HOME/nono/sessions/ (default ~/.local/state/nono/sessions/)",
+            path.display(),
+        );
+    });
+}
+
+fn warn_legacy_rollback_path(path: &Path) {
+    LEGACY_ROLLBACK_WARNED.with(|warned| {
+        if warned.get() {
+            return;
+        }
+        warned.set(true);
+        eprintln!(
+            "warning: reading rollback data from deprecated path {} (will be removed in {LEGACY_REMOVE_BY}); \
+             new rollback data is stored under $XDG_STATE_HOME/nono/rollbacks/ (default ~/.local/state/nono/rollbacks/)",
+            path.display(),
+        );
+    });
+}
+
+/// Returns true when `path` is under the legacy rollback root (not the canonical one).
+pub fn is_legacy_rollback_path(path: &Path) -> bool {
+    let Ok(legacy) = legacy_rollback_root() else {
+        return false;
+    };
+    let Ok(primary) = rollback_root() else {
+        return false;
+    };
+    if legacy == primary {
+        return false;
+    }
+    path.starts_with(&legacy) && !path.starts_with(&primary)
+}
+
+/// Warn once after successfully reading audit metadata from a legacy tree.
+pub(crate) fn warn_if_legacy_audit_data_read(session_dir: &Path) {
+    if is_legacy_audit_path(session_dir) {
+        let _ = legacy_audit_root().map(|root| warn_legacy_audit_path(&root));
+        return;
+    }
+    if is_legacy_rollback_path(session_dir) {
+        let _ = legacy_rollback_root().map(|root| warn_legacy_rollback_path(&root));
+    }
+}
+
+/// Warn once after successfully reading rollback metadata from a legacy tree.
+pub(crate) fn warn_if_legacy_rollback_data_read(session_dir: &Path) {
+    if is_legacy_rollback_path(session_dir) {
+        let _ = legacy_rollback_root().map(|root| warn_legacy_rollback_path(&root));
+    }
+}
+
+/// Warn once after successfully reading a session registry file from a legacy tree.
+pub(crate) fn warn_if_legacy_session_file_read(session_file: &Path) {
+    let Ok(legacy) = legacy_sessions_dir() else {
+        return;
+    };
+    let Ok(primary) = sessions_dir() else {
+        return;
+    };
+    if legacy == primary {
+        return;
+    }
+    if session_file.starts_with(&legacy) {
+        warn_legacy_sessions_path(&legacy);
+    }
+}
+
+/// Returns true when `path` is under the legacy audit root (not the canonical one).
+pub fn is_legacy_audit_path(path: &Path) -> bool {
+    let Ok(legacy) = legacy_audit_root() else {
+        return false;
+    };
+    let Ok(primary) = audit_root() else {
+        return false;
+    };
+    if legacy == primary {
+        return false;
+    }
+    path.starts_with(&legacy) && !path.starts_with(&primary)
+}
+
+/// Copy a legacy audit ledger into the canonical root on first write, if needed.
+pub fn maybe_migrate_legacy_audit_ledger() -> Result<()> {
+    let primary = audit_root()?;
+    let legacy = legacy_audit_root()?;
+    if primary == legacy {
+        return Ok(());
+    }
+
+    let new_ledger = primary.join(AUDIT_LEDGER_FILENAME);
+    if new_ledger.exists() {
+        return Ok(());
+    }
+
+    let legacy_ledger = legacy.join(AUDIT_LEDGER_FILENAME);
+    if !legacy_ledger.exists() {
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(&primary).map_err(|e| {
+        NonoError::Snapshot(format!(
+            "Failed to create audit root {}: {e}",
+            primary.display()
+        ))
+    })?;
+
+    std::fs::copy(&legacy_ledger, &new_ledger).map_err(|e| {
+        NonoError::Snapshot(format!(
+            "Failed to migrate audit ledger from {} to {}: {e}",
+            legacy_ledger.display(),
+            new_ledger.display()
+        ))
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::test_env::{ENV_LOCK, EnvVarGuard};
+    use std::fs;
+
+    fn isolated_env(base: &Path) -> (EnvVarGuard, PathBuf) {
+        let home = base.join("home");
+        let state = base.join("state");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&state).unwrap();
+        let home_str = home.to_string_lossy().to_string();
+        let state_str = state.to_string_lossy().to_string();
+        let guard = EnvVarGuard::set_all(&[("HOME", &home_str), ("XDG_STATE_HOME", &state_str)]);
+        (guard, home)
+    }
+
+    #[test]
+    fn default_state_base_uses_local_state_without_xdg_env() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        fs::create_dir_all(&home).unwrap();
+        let home_str = home.to_string_lossy().to_string();
+        let _env = EnvVarGuard::set_all(&[("HOME", &home_str)]);
+        assert_eq!(
+            user_state_dir().unwrap(),
+            home.join(".local").join("state").join("nono")
+        );
+    }
+
+    #[test]
+    fn canonical_paths_use_xdg_state_home() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let (_env, home) = isolated_env(tmp.path());
+
+        assert_eq!(
+            audit_root().unwrap(),
+            tmp.path().join("state").join("nono").join("audit")
+        );
+        assert_eq!(
+            sessions_dir().unwrap(),
+            tmp.path().join("state").join("nono").join("sessions")
+        );
+        assert_eq!(
+            legacy_audit_root().unwrap(),
+            home.join(".nono").join("audit")
+        );
+        assert_eq!(
+            legacy_sessions_dir().unwrap(),
+            home.join(".nono").join("sessions")
+        );
+        assert_eq!(
+            rollback_root().unwrap(),
+            tmp.path().join("state").join("nono").join("rollbacks")
+        );
+        assert_eq!(
+            legacy_rollback_root().unwrap(),
+            home.join(".nono").join("rollbacks")
+        );
+    }
+
+    #[test]
+    fn protected_roots_include_both_legacy_and_xdg() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let (_env, home) = isolated_env(tmp.path());
+
+        let roots = protected_state_roots().unwrap();
+        assert_eq!(roots.len(), 2);
+        assert!(roots.iter().any(|p| p.ends_with(".nono")));
+        assert!(
+            roots
+                .iter()
+                .any(|p| p.ends_with("nono") && !p.ends_with(".nono"))
+        );
+        let _ = home;
+    }
+
+    #[test]
+    fn audit_discovery_roots_lists_primary_before_legacy() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let (_env, _home) = isolated_env(tmp.path());
+
+        let roots = audit_discovery_roots().unwrap();
+        assert_eq!(roots.len(), 2);
+        assert!(roots[0].ends_with("nono/audit"));
+        assert!(roots[1].ends_with(".nono/audit"));
+    }
+
+    #[test]
+    fn rollback_discovery_roots_lists_primary_before_legacy() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let (_env, _home) = isolated_env(tmp.path());
+
+        let roots = rollback_discovery_roots().unwrap();
+        assert_eq!(roots.len(), 2);
+        assert!(roots[0].ends_with("nono/rollbacks"));
+        assert!(roots[1].ends_with(".nono/rollbacks"));
+    }
+}

--- a/crates/nono-cli/tests/audit_attestation.rs
+++ b/crates/nono-cli/tests/audit_attestation.rs
@@ -9,11 +9,12 @@ fn nono_bin() -> Command {
     Command::new(env!("CARGO_BIN_EXE_nono"))
 }
 
-fn run_nono(args: &[&str], home: &Path, cwd: &Path) -> Output {
+fn run_nono(args: &[&str], home: &Path, state: &Path, cwd: &Path) -> Output {
     nono_bin()
         .args(args)
         .env("HOME", home)
         .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("XDG_STATE_HOME", state)
         .current_dir(cwd)
         .output()
         .expect("failed to run nono")
@@ -28,7 +29,7 @@ fn assert_success(output: &Output) {
     );
 }
 
-fn setup_isolated_home() -> (tempfile::TempDir, PathBuf, PathBuf) {
+fn setup_isolated_home() -> (tempfile::TempDir, PathBuf, PathBuf, PathBuf) {
     let temp_root = std::env::current_dir()
         .expect("cwd")
         .join("target")
@@ -39,10 +40,16 @@ fn setup_isolated_home() -> (tempfile::TempDir, PathBuf, PathBuf) {
         .tempdir_in(&temp_root)
         .expect("tempdir");
     let home = tmp.path().join("home");
+    let state = tmp.path().join("state");
     let workspace = tmp.path().join("workspace");
     fs::create_dir_all(home.join(".config")).expect("create config dir");
+    fs::create_dir_all(&state).expect("create state dir");
     fs::create_dir_all(&workspace).expect("create workspace dir");
-    (tmp, home, workspace)
+    (tmp, home, state, workspace)
+}
+
+fn audit_root(state: &Path) -> PathBuf {
+    state.join("nono").join("audit")
 }
 
 fn key_path(home: &Path) -> PathBuf {
@@ -55,12 +62,13 @@ fn pub_key_path_for_file(private_key_path: &Path) -> PathBuf {
     PathBuf::from(pub_path)
 }
 
-fn generate_file_signing_key(home: &Path, cwd: &Path) -> PathBuf {
+fn generate_file_signing_key(home: &Path, state: &Path, cwd: &Path) -> PathBuf {
     let key_path = key_path(home);
     let keyref = format!("file://{}", key_path.display());
     let output = run_nono(
         &["trust", "keygen", "--force", "--keyref", &keyref],
         home,
+        state,
         cwd,
     );
     assert_success(&output);
@@ -72,8 +80,8 @@ fn generate_file_signing_key(home: &Path, cwd: &Path) -> PathBuf {
     key_path
 }
 
-fn only_audit_session_id(home: &Path) -> String {
-    let audit_root = home.join(".nono").join("audit");
+fn only_audit_session_id(state: &Path) -> String {
+    let audit_root = audit_root(state);
     let mut session_ids: Vec<String> = fs::read_dir(&audit_root)
         .expect("read audit root")
         .filter_map(|entry| entry.ok())
@@ -92,8 +100,8 @@ fn only_audit_session_id(home: &Path) -> String {
 
 #[test]
 fn audit_verify_reports_signed_attestation_with_pinned_public_key() {
-    let (_tmp, home, workspace) = setup_isolated_home();
-    let key_path = generate_file_signing_key(&home, &workspace);
+    let (_tmp, home, state, workspace) = setup_isolated_home();
+    let key_path = generate_file_signing_key(&home, &state, &workspace);
     let keyref = format!("file://{}", key_path.display());
 
     let run_output = run_nono(
@@ -106,11 +114,12 @@ fn audit_verify_reports_signed_attestation_with_pinned_public_key() {
             "/bin/pwd",
         ],
         &home,
+        &state,
         &workspace,
     );
     assert_success(&run_output);
 
-    let session_id = only_audit_session_id(&home);
+    let session_id = only_audit_session_id(&state);
     let pub_key_path = format!("{}", pub_key_path_for_file(&key_path).display());
     let verify_output = run_nono(
         &[
@@ -122,6 +131,7 @@ fn audit_verify_reports_signed_attestation_with_pinned_public_key() {
             "--json",
         ],
         &home,
+        &state,
         &workspace,
     );
     assert_success(&verify_output);
@@ -139,9 +149,9 @@ fn audit_verify_reports_signed_attestation_with_pinned_public_key() {
 
 #[test]
 fn rollback_signed_session_verifies_from_audit_dir_bundle() {
-    let (_tmp, home, workspace) = setup_isolated_home();
+    let (_tmp, home, state, workspace) = setup_isolated_home();
     fs::write(workspace.join("tracked.txt"), "before\n").expect("write tracked file");
-    let key_path = generate_file_signing_key(&home, &workspace);
+    let key_path = generate_file_signing_key(&home, &state, &workspace);
     let keyref = format!("file://{}", key_path.display());
 
     let run_output = run_nono(
@@ -156,13 +166,14 @@ fn rollback_signed_session_verifies_from_audit_dir_bundle() {
             "/bin/pwd",
         ],
         &home,
+        &state,
         &workspace,
     );
     assert_success(&run_output);
 
-    let session_id = only_audit_session_id(&home);
-    let audit_dir = home.join(".nono").join("audit").join(&session_id);
-    let rollback_dir = home.join(".nono").join("rollbacks").join(&session_id);
+    let session_id = only_audit_session_id(&state);
+    let audit_dir = audit_root(&state).join(&session_id);
+    let rollback_dir = state.join("nono").join("rollbacks").join(&session_id);
     assert!(
         audit_dir.join("audit-attestation.bundle").exists(),
         "bundle should live in audit dir"
@@ -175,6 +186,7 @@ fn rollback_signed_session_verifies_from_audit_dir_bundle() {
     let verify_output = run_nono(
         &["audit", "verify", &session_id, "--json"],
         &home,
+        &state,
         &workspace,
     );
     assert_success(&verify_output);

--- a/docs/cli/features/atomic-rollbacks.mdx
+++ b/docs/cli/features/atomic-rollbacks.mdx
@@ -22,7 +22,7 @@ nono run --rollback --profile always-further/claude -- claude
 ```
 
 <Note>
-`--rollback` automatically selects supervised execution because the parent process needs to remain unsandboxed to write snapshots to `~/.nono/rollbacks/`.
+`--rollback` automatically selects supervised execution because the parent process needs to remain unsandboxed to write snapshots to `$XDG_STATE_HOME/nono/rollbacks/` (default `~/.local/state/nono/rollbacks/`).
 </Note>
 
 ## Snapshot Architecture
@@ -41,10 +41,10 @@ Each snapshot builds a Merkle tree over all tracked files. The root hash provide
 
 ### Session Structure
 
-Sessions are stored in `~/.nono/rollbacks/` with the following layout:
+Sessions are stored in `$XDG_STATE_HOME/nono/rollbacks/` (default `~/.local/state/nono/rollbacks/`). Older installs may still have data under `~/.nono/rollbacks/`; nono reads that path with a deprecation warning until v1.0.0. Layout:
 
 ```
-~/.nono/rollbacks/
+$XDG_STATE_HOME/nono/rollbacks/
   <session-id>/
     manifest.json       # Session metadata, Merkle roots, timestamps
     objects/            # Content-addressable file store

--- a/docs/cli/features/audit.mdx
+++ b/docs/cli/features/audit.mdx
@@ -350,4 +350,4 @@ The audit trail is intentionally narrow in what it claims to prove.
 
 ## Storage
 
-Audit sessions are stored in `~/.nono/audit/`. Audit-only sessions are small (`session.json` and `audit-events.ndjson`). Signed sessions also include `audit-attestation.bundle`. Clean them up with `nono audit cleanup`.
+Audit sessions are stored in `$XDG_STATE_HOME/nono/audit/` (default `~/.local/state/nono/audit/`). Older installs may still have data under `~/.nono/audit/`; nono reads that path with a deprecation warning until v1.0.0. Audit-only sessions are small (`session.json` and `audit-events.ndjson`). Signed sessions also include `audit-attestation.bundle`. Clean them up with `nono audit cleanup`.

--- a/docs/cli/features/supervisor.mdx
+++ b/docs/cli/features/supervisor.mdx
@@ -67,7 +67,7 @@ On macOS, supervised mode provides rollback snapshots and the diagnostic footer,
 
 ## Protected State
 
-The supervisor always blocks access to nono's own protected state roots, such as `~/.nono`, before consulting the approval backend. This prevents dynamic grants from exposing rollback data, audit state, or other internal nono files.
+The supervisor always blocks access to nono's own protected state roots, such as `~/.nono` and `$XDG_STATE_HOME/nono`, before consulting the approval backend. This prevents dynamic grants from exposing rollback data, audit state, or other internal nono files.
 
 ## Audit Responsibilities
 

--- a/docs/cli/internals/security-model.mdx
+++ b/docs/cli/internals/security-model.mdx
@@ -99,7 +99,7 @@ nono's trust boundary is agent containment — restricting what the sandboxed ch
 
 ### Session metadata on disk
 
-Session JSON files in `~/.nono/sessions/` contain supervisor and child PIDs, the command line, profile name, working directory, and network mode. These files are protected by directory permissions (`0o700`) and file permissions (`0o600`), but are readable by any process running as the same user.
+Session JSON files in `$XDG_STATE_HOME/nono/sessions/` (default `~/.local/state/nono/sessions/`) contain supervisor and child PIDs, the command line, profile name, working directory, and network mode. These files are protected by directory permissions (`0o700`) and file permissions (`0o600`), but are readable by any process running as the same user.
 
 nono applies best-effort redaction before persisting command arguments in session metadata, audit records, rollback metadata, and audit attestations. It scrubs common secret-bearing forms such as `--token VALUE`, `--api-key=VALUE`, sensitive HTTP headers, URL userinfo, and sensitive query parameters.
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -926,7 +926,7 @@ nono run --no-rollback --allow . -- npm test
 
 #### `--no-audit`
 
-Disable the audit trail for this session. By default, every supervised execution records session metadata and audit events (command, timestamps, exit code, capability decisions, URL opens, network events) to `~/.nono/audit/`. Use this flag to suppress audit recording entirely.
+Disable the audit trail for this session. By default, every supervised execution records session metadata and audit events (command, timestamps, exit code, capability decisions, URL opens, network events) to `$XDG_STATE_HOME/nono/audit/` (default `~/.local/state/nono/audit/`). Use this flag to suppress audit recording entirely.
 
 ```bash
 nono run --no-audit --allow-cwd -- my-command

--- a/tests/integration/test_audit.sh
+++ b/tests/integration/test_audit.sh
@@ -21,9 +21,9 @@ fi
 TMPDIR=$(setup_test_dir)
 trap 'cleanup_test_dir "$TMPDIR"' EXIT
 
-# Use the real audit and rollback roots (same as nono uses via dirs::home_dir)
-AUDIT_ROOT="$HOME/.nono/audit"
-ROLLBACK_ROOT="$HOME/.nono/rollbacks"
+# Use the real audit and rollback roots (same as nono uses via XDG state + legacy rollback)
+AUDIT_ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/nono/audit"
+ROLLBACK_ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/nono/rollbacks"
 mkdir -p "$AUDIT_ROOT" "$ROLLBACK_ROOT"
 
 # Helper: find the session.json for a specific nono PID.

--- a/tests/integration/test_rollback_dest_edge_cases.sh
+++ b/tests/integration/test_rollback_dest_edge_cases.sh
@@ -136,7 +136,7 @@ run_test "session created under nonexistent dest after creation" 0 \
     bash -c "ls '$NONEXISTENT_DEST' | grep -qE '[0-9]{8}-[0-9]{6}-[0-9]+'"
 
 # =============================================================================
-# 6. Session is isolated to custom dest (not written to default ~/.nono/rollbacks)
+# 6. Session is isolated to custom dest (not written to default rollback root)
 # =============================================================================
 echo ""
 echo "--- Isolation: Custom Dest Does Not Pollute Default ---"
@@ -145,7 +145,7 @@ ISOLATED_DEST="$TMPDIR/isolated_rollbacks"
 mkdir -p "$ISOLATED_DEST"
 
 # Count sessions in default rollback root before
-default_root="$HOME/.nono/rollbacks"
+default_root="${XDG_STATE_HOME:-$HOME/.local/state}/nono/rollbacks"
 before_count=$(ls "$default_root" 2>/dev/null | grep -cE '[0-9]{8}-[0-9]{6}-[0-9]+' || true)
 
 expect_success "rollback with --rollback-dest runs successfully" \
@@ -157,7 +157,7 @@ expect_success "rollback with --rollback-dest runs successfully" \
 after_count=$(ls "$default_root" 2>/dev/null | grep -cE '[0-9]{8}-[0-9]{6}-[0-9]+' || true)
 
 if [ "$before_count" -eq "$after_count" ]; then
-    echo -e "  ${GREEN}PASS${NC}: default ~/.nono/rollbacks not polluted"
+    echo -e "  ${GREEN}PASS${NC}: default rollback root not polluted"
     TESTS_PASSED=$((TESTS_PASSED + 1))
 else
     echo -e "  ${RED}FAIL${NC}: unexpected new session in default rollback root"

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -76,14 +76,14 @@ export NONO_NO_MIGRATE=1
 export NONO_NO_SAVE_PROMPT=1
 
 # Audit is on by default, so every test invocation that does not pass
-# --no-audit writes a session under ~/.nono/audit/ (and ~/.nono/rollbacks/
-# for rollback tests), and appends to ~/.nono/audit/ledger.ndjson. There is
+# --no-audit writes a session under $XDG_STATE_HOME/nono/audit/ (and $XDG_STATE_HOME/nono/rollbacks/
+# for rollback tests), and appends to the audit ledger there. There is
 # no env-var override for the audit root, so snapshot the pre-run state and
 # restore it on exit. This removes only artefacts created during the run;
 # pre-existing user sessions and ledger entries are preserved.
 # Set NONO_TEST_KEEP_AUDIT=1 to skip cleanup for debugging.
-NONO_AUDIT_ROOT="$HOME/.nono/audit"
-NONO_ROLLBACK_ROOT="$HOME/.nono/rollbacks"
+NONO_AUDIT_ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/nono/audit"
+NONO_ROLLBACK_ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/nono/rollbacks"
 AUDIT_SNAPSHOT_DIR="$TEST_ENV_DIR/audit-snapshot"
 mkdir -p "$AUDIT_SNAPSHOT_DIR"
 


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1109 

## Summary

Store audit, session registry, and rollback data under /nono/ (default ~/.local/state/nono/) on all platforms. Keep read fallback and one-time deprecation warnings for ~/.nono/ until v1.0.0.

Pretty big runtime state change, would appreciate a good review just to verify all works. Tested locally and seems to be good.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
