### PR TITLE
feat: [aws] implement aws_auth config

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -486,24 +486,31 @@
         }
       }
     },
-    "CustomCredentialDef": {
-      "type": "object",
-      "description": "Custom credential route definition for the reverse proxy. Defines how to route requests and inject credentials for a service. Must have either credential_key or auth (mutually exclusive).",
-      "additionalProperties": false,
-      "required": ["upstream"],
-      "properties": {
-        "upstream": {
-          "type": "string",
-          "description": "Upstream URL to proxy requests to (e.g., \"https://api.telegram.org\"). Must use HTTPS, or HTTP only for loopback addresses."
-        },
-        "credential_key": {
-          "type": "string",
-          "description": "Keystore account name for the credential (e.g., \"telegram_bot_token\"), or a 1Password op:// URI, Bitwarden bw:// URI, apple-password:// URI, file:// URI, or env:// URI (e.g., \"env://MY_TOKEN\"). Mutually exclusive with auth."
-        },
-        "auth": {
-          "$ref": "#/$defs/OAuth2Config",
-          "description": "OAuth2 client_credentials configuration. When present, the proxy handles token exchange automatically. Mutually exclusive with credential_key."
-        },
+     "CustomCredentialDef": {
+       "type": "object",
+       "description": "Custom credential route definition for the reverse proxy. Defines how to route requests and inject credentials for a service. Must have exactly one of: credential_key, auth, or aws_auth (mutually exclusive).",
+       "additionalProperties": false,
+       "required": ["upstream"],
+       "properties": {
+         "upstream": {
+           "type": "string",
+           "description": "Upstream URL to proxy requests to (e.g., \"https://api.telegram.org\"). Must use HTTPS, or HTTP only for loopback addresses."
+         },
+         "credential_key": {
+           "type": "string",
+           "description": "Keystore account name for the credential (e.g., \"telegram_bot_token\"), or a 1Password op:// URI, Bitwarden bw:// URI, apple-password:// URI, file:// URI, or env:// URI (e.g., \"env://MY_TOKEN\"). Mutually exclusive with auth and aws_auth."
+         },
+         "auth": {
+           "$ref": "#/$defs/OAuth2Config",
+           "description": "OAuth2 client_credentials configuration. When present, the proxy handles token exchange automatically. Mutually exclusive with credential_key and aws_auth."
+         },
+         "aws_auth": {
+           "oneOf": [
+             { "$ref": "#/$defs/AwsAuthConfig" },
+             { "type": "null" }
+           ],
+           "description": "AWS SigV4 signing configuration. When present, the proxy signs outbound requests with AWS credentials. Mutually exclusive with credential_key and auth."
+         },
         "inject_mode": {
           "$ref": "#/$defs/InjectMode",
           "description": "Credential injection mode. Determines how the credential is inserted into outbound requests.",
@@ -676,30 +683,58 @@
       }
     },
     "OAuth2Config": {
-      "type": "object",
-      "description": "OAuth2 client_credentials configuration for automatic token exchange. The proxy exchanges client_id + client_secret for an access_token, caches it, and refreshes automatically before expiry.",
-      "additionalProperties": false,
-      "required": ["token_url", "client_id", "client_secret"],
-      "properties": {
-        "token_url": {
-          "type": "string",
-          "description": "Token endpoint URL (e.g., \"https://auth.example.com/oauth/token\"). Must use HTTPS, or HTTP only for loopback addresses."
-        },
-        "client_id": {
-          "type": "string",
-          "description": "Client ID — plain value or credential reference (env://, file://, op://)."
-        },
-        "client_secret": {
-          "type": "string",
-          "description": "Client secret — credential reference (env://, file://, op://)."
-        },
-        "scope": {
-          "type": "string",
-          "description": "OAuth2 scopes (space-separated). Empty or omitted means no scope parameter is sent.",
-          "default": ""
-        }
-      }
-    },
+       "type": "object",
+       "description": "OAuth2 client_credentials configuration for automatic token exchange. The proxy exchanges client_id + client_secret for an access_token, caches it, and refreshes automatically before expiry.",
+       "additionalProperties": false,
+       "required": ["token_url", "client_id", "client_secret"],
+       "properties": {
+         "token_url": {
+           "type": "string",
+           "description": "Token endpoint URL (e.g., \"https://auth.example.com/oauth/token\"). Must use HTTPS, or HTTP only for loopback addresses."
+         },
+         "client_id": {
+           "type": "string",
+           "description": "Client ID — plain value or credential reference (env://, file://, op://)."
+         },
+         "client_secret": {
+           "type": "string",
+           "description": "Client secret — credential reference (env://, file://, op://)."
+         },
+         "scope": {
+           "type": "string",
+           "description": "OAuth2 scopes (space-separated). Empty or omitted means no scope parameter is sent.",
+           "default": ""
+         }
+       }
+     },
+     "AwsAuthConfig": {
+       "type": "object",
+       "description": "AWS SigV4 signing configuration for a credential route. All fields are optional: an empty {} block uses the default credential chain with region and service auto-detected from the upstream URL.",
+       "additionalProperties": false,
+       "properties": {
+         "profile": {
+           "oneOf": [
+             { "type": "string" },
+             { "type": "null" }
+           ],
+           "description": "AWS profile name to use for credentials. If omitted, the default credential chain is used (environment variables → AWS_PROFILE → default profile → instance metadata). Must be non-empty if set."
+         },
+         "region": {
+           "oneOf": [
+             { "type": "string" },
+             { "type": "null" }
+           ],
+           "description": "Explicit SigV4 signing region (e.g., \"us-east-1\"). If omitted, auto-detected from the upstream URL. Must be non-empty and contain no whitespace if set."
+         },
+         "service": {
+           "oneOf": [
+             { "type": "string" },
+             { "type": "null" }
+           ],
+           "description": "Explicit SigV4 service name (e.g., \"bedrock\", \"s3\"). If omitted, auto-detected from the upstream URL. Must be non-empty and contain no whitespace if set."
+         }
+       }
+     },
     "SecretsConfig": {
       "type": "object",
       "description": "Maps keystore account names (or op://, bw://, apple-password://, env:// URIs) to environment variable names. Secrets are loaded from the system keystore under the service name \"nono\".",

--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -257,6 +257,7 @@ pub fn resolve_credentials(
                     })
                     .transpose()?,
                 oauth2,
+                aws_auth: cred.aws_auth.clone(),
             });
         } else if let Some(cred) = policy.credentials.get(name) {
             // Validate env_var against dangerous variable blocklist
@@ -288,6 +289,7 @@ pub fn resolve_credentials(
                 tls_client_cert: None,
                 tls_client_key: None,
                 oauth2: None,
+                aws_auth: None,
             });
         }
         // We already validated existence above, so this else branch won't be hit
@@ -414,6 +416,7 @@ pub fn partition_allow_domain(
                         tls_client_cert: None,
                         tls_client_key: None,
                         oauth2: None,
+                        aws_auth: None,
                     });
                 }
             }
@@ -567,6 +570,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                aws_auth: None,
             },
         );
 
@@ -607,6 +611,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                aws_auth: None,
             },
         );
 
@@ -643,6 +648,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                aws_auth: None,
             },
         );
 
@@ -689,6 +695,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                aws_auth: None,
             },
         );
 
@@ -775,6 +782,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                aws_auth: None,
             },
         );
 
@@ -808,6 +816,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                aws_auth: None,
             },
         );
 
@@ -841,6 +850,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                aws_auth: None,
             },
         );
 
@@ -879,6 +889,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                aws_auth: None,
             },
         );
 
@@ -1011,6 +1022,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                aws_auth: None,
             },
         );
 
@@ -1099,6 +1111,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                aws_auth: None,
             },
         );
 
@@ -1147,6 +1160,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                aws_auth: None,
             },
         );
 

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -340,6 +340,14 @@ pub struct CustomCredentialDef {
     /// to the certificate in `tls_client_cert`.
     #[serde(default)]
     pub tls_client_key: Option<String>,
+
+    /// Optional AWS SigV4 signing configuration.
+    ///
+    /// When present, the proxy will sign outbound requests with AWS SigV4
+    /// credentials resolved from the configured profile (or the default
+    /// credential chain). Mutually exclusive with `credential_key` and `auth`.
+    #[serde(default)]
+    pub aws_auth: Option<nono_proxy::config::AwsAuthConfig>,
 }
 
 fn default_inject_header() -> String {
@@ -446,6 +454,15 @@ fn validate_credential_key(context_name: &str, key: &str) -> Result<()> {
 ///   - `query_param`: query_param_name required, valid query param name
 ///   - `basic_auth`: no additional required fields
 fn validate_custom_credential(name: &str, cred: &CustomCredentialDef) -> Result<()> {
+    // Mutual exclusion: aws_auth is incompatible with credential_key and auth.
+    if cred.aws_auth.is_some() && (cred.credential_key.is_some() || cred.auth.is_some()) {
+        return Err(NonoError::ProfileParse(format!(
+            "custom credential '{}' has 'aws_auth' set together with 'credential_key' or 'auth'; \
+             aws_auth is mutually exclusive with both — remove the other auth field",
+            name
+        )));
+    }
+
     // Mutual exclusion: credential_key and auth cannot both be set
     if cred.credential_key.is_some() && cred.auth.is_some() {
         return Err(NonoError::ProfileParse(format!(
@@ -455,10 +472,10 @@ fn validate_custom_credential(name: &str, cred: &CustomCredentialDef) -> Result<
         )));
     }
 
-    // At least one of credential_key or auth must be set
-    if cred.credential_key.is_none() && cred.auth.is_none() {
+    // At least one of credential_key, auth, or aws_auth must be set
+    if cred.credential_key.is_none() && cred.auth.is_none() && cred.aws_auth.is_none() {
         return Err(NonoError::ProfileParse(format!(
-            "custom credential '{}' must have either 'credential_key' or 'auth' set",
+            "custom credential '{}' must have either 'credential_key', 'auth', or 'aws_auth' set",
             name
         )));
     }
@@ -466,6 +483,11 @@ fn validate_custom_credential(name: &str, cred: &CustomCredentialDef) -> Result<
     // Validate OAuth2 auth if present
     if let Some(ref auth) = cred.auth {
         validate_oauth2_auth(name, auth)?;
+    }
+
+    // Validate aws_auth if present
+    if let Some(ref aws) = cred.aws_auth {
+        validate_aws_auth(name, aws)?;
     }
 
     // Validate credential_key if present
@@ -680,6 +702,46 @@ fn validate_oauth2_auth(name: &str, auth: &OAuth2Config) -> Result<()> {
     if auth.client_secret.is_empty() {
         return Err(NonoError::ProfileParse(format!(
             "auth.client_secret for custom credential '{}' cannot be empty",
+            name
+        )));
+    }
+
+    Ok(())
+}
+
+/// Validate AWS SigV4 signing configuration subfields.
+///
+/// Checks:
+/// - `profile`: if set, must be a non-empty string
+/// - `region`: if set, must be a non-empty string with no whitespace
+/// - `service`: if set, must be a non-empty string with no whitespace
+fn validate_aws_auth(name: &str, aws: &nono_proxy::config::AwsAuthConfig) -> Result<()> {
+    if let Some(ref profile) = aws.profile
+        && profile.is_empty()
+    {
+        return Err(NonoError::ProfileParse(format!(
+            "aws_auth.profile for custom credential '{}' must not be empty; \
+             omit the field to use the default credential chain",
+            name
+        )));
+    }
+
+    if let Some(ref region) = aws.region
+        && (region.is_empty() || region.contains(char::is_whitespace))
+    {
+        return Err(NonoError::ProfileParse(format!(
+            "aws_auth.region for custom credential '{}' must be a non-empty string \
+             with no whitespace (e.g., \"us-east-1\")",
+            name
+        )));
+    }
+
+    if let Some(ref service) = aws.service
+        && (service.is_empty() || service.contains(char::is_whitespace))
+    {
+        return Err(NonoError::ProfileParse(format!(
+            "aws_auth.service for custom credential '{}' must be a non-empty string \
+             with no whitespace (e.g., \"bedrock\", \"s3\")",
             name
         )));
     }
@@ -3998,6 +4060,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            aws_auth: None,
         }
     }
 
@@ -4162,6 +4225,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            aws_auth: None,
         };
         assert!(validate_custom_credential("telegram", &cred).is_ok());
     }
@@ -4184,6 +4248,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            aws_auth: None,
         };
         let result = validate_custom_credential("telegram", &cred);
         let err = result.expect_err("missing path_pattern should be rejected");
@@ -4208,6 +4273,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            aws_auth: None,
         };
         let result = validate_custom_credential("telegram", &cred);
         let err = result.expect_err("pattern without {} should be rejected");
@@ -4232,6 +4298,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            aws_auth: None,
         };
         assert!(validate_custom_credential("telegram", &cred).is_ok());
     }
@@ -4254,6 +4321,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            aws_auth: None,
         };
         let result = validate_custom_credential("telegram", &cred);
         let err = result.expect_err("replacement without {} should be rejected");
@@ -4278,6 +4346,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            aws_auth: None,
         };
         assert!(validate_custom_credential("google_maps", &cred).is_ok());
     }
@@ -4300,6 +4369,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            aws_auth: None,
         };
         let result = validate_custom_credential("google_maps", &cred);
         let err = result.expect_err("missing query_param_name should be rejected");
@@ -4324,6 +4394,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            aws_auth: None,
         };
         let result = validate_custom_credential("google_maps", &cred);
         let err = result.expect_err("empty query_param_name should be rejected");
@@ -4348,6 +4419,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            aws_auth: None,
         };
         // BasicAuth mode doesn't require additional fields
         // Credential value is expected to be "username:password" format
@@ -4549,6 +4621,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            aws_auth: None,
         }
     }
 
@@ -5113,6 +5186,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                aws_auth: None,
             },
         );
 
@@ -5135,6 +5209,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                aws_auth: None,
             },
         );
 
@@ -5275,6 +5350,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                aws_auth: None,
             },
         );
 
@@ -5297,6 +5373,7 @@ mod tests {
                 tls_ca: None,
                 tls_client_cert: None,
                 tls_client_key: None,
+                aws_auth: None,
             },
         );
 
@@ -6762,6 +6839,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            aws_auth: None,
         };
         assert!(
             validate_custom_credential("example", &cred).is_ok(),
@@ -6787,6 +6865,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            aws_auth: None,
         };
         let result = validate_custom_credential("example", &cred);
         let err = result.expect_err("file:// URI without env_var should be rejected");
@@ -6815,6 +6894,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            aws_auth: None,
         };
         let result = validate_custom_credential("example", &cred);
         let err = result.expect_err("file:// URI with relative path should be rejected");
@@ -6843,6 +6923,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            aws_auth: None,
         };
         let result = validate_custom_credential("example", &cred);
         assert!(
@@ -6903,6 +6984,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            aws_auth: None,
         };
         assert!(validate_custom_credential("example", &cred).is_ok());
     }
@@ -6925,6 +7007,7 @@ mod tests {
             tls_ca: None,
             tls_client_cert: None,
             tls_client_key: None,
+            aws_auth: None,
         };
         let result = validate_custom_credential("example", &cred);
         assert!(result.is_err(), "env://LD_PRELOAD should be rejected");
@@ -7690,5 +7773,248 @@ mod tests {
             Some("/usr/bin/inherited"),
             "child without binary should inherit from base"
         );
+    }
+
+    // ========================================================================
+    // aws_auth validation tests
+    // ========================================================================
+
+    fn aws_auth_cred_builder() -> CustomCredentialDef {
+        CustomCredentialDef {
+            upstream: "https://bedrock-runtime.us-east-1.amazonaws.com".to_string(),
+            credential_key: None,
+            auth: None,
+            aws_auth: Some(nono_proxy::config::AwsAuthConfig {
+                profile: None,
+                region: None,
+                service: None,
+            }),
+            inject_mode: InjectMode::Header,
+            inject_header: "Authorization".to_string(),
+            credential_format: None,
+            path_pattern: None,
+            path_replacement: None,
+            query_param_name: None,
+            proxy: None,
+            env_var: None,
+            endpoint_rules: vec![],
+            tls_ca: None,
+            tls_client_cert: None,
+            tls_client_key: None,
+        }
+    }
+
+    #[test]
+    fn test_aws_auth_minimal_valid() {
+        let cred = aws_auth_cred_builder();
+        assert!(validate_custom_credential("bedrock", &cred).is_ok());
+    }
+
+    #[test]
+    fn test_aws_auth_all_fields_valid() {
+        let cred = CustomCredentialDef {
+            aws_auth: Some(nono_proxy::config::AwsAuthConfig {
+                profile: Some("my-aws-profile".to_string()),
+                region: Some("us-east-1".to_string()),
+                service: Some("bedrock".to_string()),
+            }),
+            ..aws_auth_cred_builder()
+        };
+        assert!(validate_custom_credential("bedrock", &cred).is_ok());
+    }
+
+    #[test]
+    fn test_aws_auth_with_http_upstream_rejected() {
+        // AWS routes require HTTPS just like any other credential type.
+        let cred = CustomCredentialDef {
+            upstream: "http://bedrock-runtime.us-east-1.amazonaws.com".to_string(),
+            ..aws_auth_cred_builder()
+        };
+        let result = validate_custom_credential("bedrock", &cred);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("https") || msg.contains("HTTPS"),
+            "error should mention https requirement, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_aws_auth_mutually_exclusive_with_credential_key() {
+        let cred = CustomCredentialDef {
+            credential_key: Some("my_aws_key".to_string()),
+            ..aws_auth_cred_builder()
+        };
+        let result = validate_custom_credential("bedrock", &cred);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("aws_auth"),
+            "error should mention aws_auth, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_aws_auth_mutually_exclusive_with_auth_oauth2() {
+        let cred = CustomCredentialDef {
+            auth: Some(OAuth2Config {
+                token_url: "https://auth.example.com/token".to_string(),
+                client_id: "cid".to_string(),
+                client_secret: "env://SECRET".to_string(),
+                scope: String::new(),
+            }),
+            ..aws_auth_cred_builder()
+        };
+        let result = validate_custom_credential("bedrock", &cred);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("aws_auth"),
+            "error should mention aws_auth, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_aws_auth_none_of_three_rejected() {
+        let cred = CustomCredentialDef {
+            credential_key: None,
+            auth: None,
+            aws_auth: None,
+            ..aws_auth_cred_builder()
+        };
+        let result = validate_custom_credential("bedrock", &cred);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("credential_key") || msg.contains("auth") || msg.contains("aws_auth"),
+            "error should mention the missing auth fields, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_aws_auth_empty_profile_rejected() {
+        let cred = CustomCredentialDef {
+            aws_auth: Some(nono_proxy::config::AwsAuthConfig {
+                profile: Some(String::new()),
+                region: None,
+                service: None,
+            }),
+            ..aws_auth_cred_builder()
+        };
+        let result = validate_custom_credential("bedrock", &cred);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("profile"),
+            "error should mention profile, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_aws_auth_empty_region_rejected() {
+        let cred = CustomCredentialDef {
+            aws_auth: Some(nono_proxy::config::AwsAuthConfig {
+                profile: None,
+                region: Some(String::new()),
+                service: None,
+            }),
+            ..aws_auth_cred_builder()
+        };
+        let result = validate_custom_credential("bedrock", &cred);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("region"),
+            "error should mention region, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_aws_auth_empty_service_rejected() {
+        let cred = CustomCredentialDef {
+            aws_auth: Some(nono_proxy::config::AwsAuthConfig {
+                profile: None,
+                region: None,
+                service: Some(String::new()),
+            }),
+            ..aws_auth_cred_builder()
+        };
+        let result = validate_custom_credential("bedrock", &cred);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("service"),
+            "error should mention service, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_aws_auth_region_with_whitespace_rejected() {
+        let cred = CustomCredentialDef {
+            aws_auth: Some(nono_proxy::config::AwsAuthConfig {
+                profile: None,
+                region: Some("us east-1".to_string()),
+                service: None,
+            }),
+            ..aws_auth_cred_builder()
+        };
+        let result = validate_custom_credential("bedrock", &cred);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("region"),
+            "error should mention region, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_aws_auth_service_with_whitespace_rejected() {
+        let cred = CustomCredentialDef {
+            aws_auth: Some(nono_proxy::config::AwsAuthConfig {
+                profile: None,
+                region: None,
+                service: Some("bed rock".to_string()),
+            }),
+            ..aws_auth_cred_builder()
+        };
+        let result = validate_custom_credential("bedrock", &cred);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("service"),
+            "error should mention service, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_aws_auth_serde_roundtrip_in_custom_cred_def() {
+        let json = r#"{
+            "upstream": "https://bedrock-runtime.us-east-1.amazonaws.com",
+            "aws_auth": {
+                "profile": "my-aws-profile",
+                "region": "us-east-1",
+                "service": "bedrock"
+            }
+        }"#;
+        let cred: CustomCredentialDef = serde_json::from_str(json).unwrap();
+        let aws = cred.aws_auth.as_ref().unwrap();
+        assert_eq!(aws.profile.as_deref(), Some("my-aws-profile"));
+        assert_eq!(aws.region.as_deref(), Some("us-east-1"));
+        assert_eq!(aws.service.as_deref(), Some("bedrock"));
+
+        // Roundtrip
+        let serialized = serde_json::to_string(&cred).unwrap();
+        let deserialized: CustomCredentialDef = serde_json::from_str(&serialized).unwrap();
+        let aws2 = deserialized.aws_auth.unwrap();
+        assert_eq!(aws2.profile.as_deref(), Some("my-aws-profile"));
     }
 }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -711,37 +711,42 @@ fn validate_oauth2_auth(name: &str, auth: &OAuth2Config) -> Result<()> {
 
 /// Validate AWS SigV4 signing configuration subfields.
 ///
-/// Checks:
-/// - `profile`: if set, must be a non-empty string
-/// - `region`: if set, must be a non-empty string with no whitespace
-/// - `service`: if set, must be a non-empty string with no whitespace
+/// - `profile`: non-empty, no whitespace (whitespace breaks the AWS INI config
+///   parser; see aws/aws-cli#2806). Mixed case is allowed — profile names are
+///   case-sensitive.
+/// - `region` / `service`: non-empty, lowercase, no whitespace. The SigV4
+///   credential scope requires lowercase region and service codes.
 fn validate_aws_auth(name: &str, aws: &nono_proxy::config::AwsAuthConfig) -> Result<()> {
     if let Some(ref profile) = aws.profile
-        && profile.is_empty()
+        && (profile.is_empty() || profile.contains(char::is_whitespace))
     {
         return Err(NonoError::ProfileParse(format!(
-            "aws_auth.profile for custom credential '{}' must not be empty; \
-             omit the field to use the default credential chain",
+            "aws_auth.profile for custom credential '{}' must be a non-empty string \
+             with no whitespace; omit the field to use the default credential chain",
             name
         )));
     }
 
     if let Some(ref region) = aws.region
-        && (region.is_empty() || region.contains(char::is_whitespace))
+        && (region.is_empty()
+            || region.contains(char::is_whitespace)
+            || region.chars().any(|c| c.is_uppercase()))
     {
         return Err(NonoError::ProfileParse(format!(
-            "aws_auth.region for custom credential '{}' must be a non-empty string \
-             with no whitespace (e.g., \"us-east-1\")",
+            "aws_auth.region for custom credential '{}' must be a non-empty, \
+             lowercase string with no whitespace (e.g., \"us-east-1\")",
             name
         )));
     }
 
     if let Some(ref service) = aws.service
-        && (service.is_empty() || service.contains(char::is_whitespace))
+        && (service.is_empty()
+            || service.contains(char::is_whitespace)
+            || service.chars().any(|c| c.is_uppercase()))
     {
         return Err(NonoError::ProfileParse(format!(
-            "aws_auth.service for custom credential '{}' must be a non-empty string \
-             with no whitespace (e.g., \"bedrock\", \"s3\")",
+            "aws_auth.service for custom credential '{}' must be a non-empty, \
+             lowercase string with no whitespace (e.g., \"bedrock\", \"s3\")",
             name
         )));
     }
@@ -8016,5 +8021,170 @@ mod tests {
         let deserialized: CustomCredentialDef = serde_json::from_str(&serialized).unwrap();
         let aws2 = deserialized.aws_auth.unwrap();
         assert_eq!(aws2.profile.as_deref(), Some("my-aws-profile"));
+    }
+
+    // --- profile whitespace rejection ---
+
+    #[test]
+    fn test_aws_auth_profile_with_space_rejected() {
+        let cred = CustomCredentialDef {
+            aws_auth: Some(nono_proxy::config::AwsAuthConfig {
+                profile: Some("my profile".to_string()),
+                region: None,
+                service: None,
+            }),
+            ..aws_auth_cred_builder()
+        };
+        let result = validate_custom_credential("bedrock", &cred);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("profile"),
+            "error should mention profile, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_aws_auth_profile_with_tab_rejected() {
+        let cred = CustomCredentialDef {
+            aws_auth: Some(nono_proxy::config::AwsAuthConfig {
+                profile: Some("my\tprofile".to_string()),
+                region: None,
+                service: None,
+            }),
+            ..aws_auth_cred_builder()
+        };
+        let result = validate_custom_credential("bedrock", &cred);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("profile"),
+            "error should mention profile, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_aws_auth_profile_mixed_case_valid() {
+        let cred = CustomCredentialDef {
+            aws_auth: Some(nono_proxy::config::AwsAuthConfig {
+                profile: Some("MyCompany-Prod".to_string()),
+                region: None,
+                service: None,
+            }),
+            ..aws_auth_cred_builder()
+        };
+        assert!(validate_custom_credential("bedrock", &cred).is_ok());
+    }
+
+    // --- region lowercase enforcement ---
+
+    #[test]
+    fn test_aws_auth_region_uppercase_rejected() {
+        let cred = CustomCredentialDef {
+            aws_auth: Some(nono_proxy::config::AwsAuthConfig {
+                profile: None,
+                region: Some("US-EAST-1".to_string()),
+                service: None,
+            }),
+            ..aws_auth_cred_builder()
+        };
+        let result = validate_custom_credential("bedrock", &cred);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("region"),
+            "error should mention region, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_aws_auth_region_mixed_case_rejected() {
+        let cred = CustomCredentialDef {
+            aws_auth: Some(nono_proxy::config::AwsAuthConfig {
+                profile: None,
+                region: Some("Us-East-1".to_string()),
+                service: None,
+            }),
+            ..aws_auth_cred_builder()
+        };
+        let result = validate_custom_credential("bedrock", &cred);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("region"),
+            "error should mention region, got: {}",
+            msg
+        );
+    }
+
+    // --- service lowercase enforcement ---
+
+    #[test]
+    fn test_aws_auth_service_uppercase_rejected() {
+        let cred = CustomCredentialDef {
+            aws_auth: Some(nono_proxy::config::AwsAuthConfig {
+                profile: None,
+                region: None,
+                service: Some("Bedrock".to_string()),
+            }),
+            ..aws_auth_cred_builder()
+        };
+        let result = validate_custom_credential("bedrock", &cred);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("service"),
+            "error should mention service, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_aws_auth_service_all_caps_rejected() {
+        let cred = CustomCredentialDef {
+            aws_auth: Some(nono_proxy::config::AwsAuthConfig {
+                profile: None,
+                region: None,
+                service: Some("S3".to_string()),
+            }),
+            ..aws_auth_cred_builder()
+        };
+        let result = validate_custom_credential("bedrock", &cred);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("service"),
+            "error should mention service, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_aws_auth_service_with_hyphen_valid() {
+        let cred = CustomCredentialDef {
+            aws_auth: Some(nono_proxy::config::AwsAuthConfig {
+                profile: None,
+                region: None,
+                service: Some("workers-ai".to_string()),
+            }),
+            ..aws_auth_cred_builder()
+        };
+        assert!(validate_custom_credential("cf", &cred).is_ok());
+    }
+
+    #[test]
+    fn test_aws_auth_execute_api_service_valid() {
+        let cred = CustomCredentialDef {
+            aws_auth: Some(nono_proxy::config::AwsAuthConfig {
+                profile: None,
+                region: Some("ap-southeast-2".to_string()),
+                service: Some("execute-api".to_string()),
+            }),
+            ..aws_auth_cred_builder()
+        };
+        assert!(validate_custom_credential("apigw", &cred).is_ok());
     }
 }

--- a/crates/nono-proxy/src/config.rs
+++ b/crates/nono-proxy/src/config.rs
@@ -520,20 +520,23 @@ pub struct OAuth2Config {
 #[serde(deny_unknown_fields)]
 pub struct AwsAuthConfig {
     /// AWS profile name to use for credentials.
-    /// If omitted, the default credential chain is used
-    /// (environment variables → AWS_PROFILE → default profile → instance metadata).
+    /// If omitted, the default credential chain is used.
+    /// Must be non-empty with no whitespace if provided (whitespace breaks the
+    /// AWS INI config parser; profile names are case-sensitive).
     #[serde(default)]
     pub profile: Option<String>,
 
     /// Explicit SigV4 signing region (e.g., `"us-east-1"`).
     /// If omitted, auto-detected from the upstream URL.
-    /// Must be non-empty and contain no whitespace if provided.
+    /// Must be non-empty and lowercase if provided (SigV4 credential scope
+    /// requires lowercase region codes).
     #[serde(default)]
     pub region: Option<String>,
 
-    /// Explicit SigV4 service name (e.g., `"bedrock"`, `"s3"`).
+    /// Explicit SigV4 service name (e.g., `"bedrock"`, `"s3"`, `"execute-api"`).
     /// If omitted, auto-detected from the upstream URL.
-    /// Must be non-empty and contain no whitespace if provided.
+    /// Must be non-empty and lowercase if provided (SigV4 credential scope
+    /// requires lowercase service codes).
     #[serde(default)]
     pub service: Option<String>,
 }

--- a/crates/nono-proxy/src/config.rs
+++ b/crates/nono-proxy/src/config.rs
@@ -274,6 +274,13 @@ pub struct RouteConfig {
     /// Mutually exclusive with `credential_key` — use one or the other.
     #[serde(default)]
     pub oauth2: Option<OAuth2Config>,
+
+    /// Optional AWS SigV4 signing configuration.
+    ///
+    /// When present, the proxy will sign outbound requests with AWS SigV4
+    /// credentials. Mutually exclusive with `credential_key` and `oauth2`.
+    #[serde(default)]
+    pub aws_auth: Option<AwsAuthConfig>,
 }
 
 /// Optional proxy-side overrides for credential injection shape.
@@ -499,6 +506,36 @@ pub struct OAuth2Config {
     /// OAuth2 scopes (space-separated). Empty = no scope parameter sent.
     #[serde(default)]
     pub scope: String,
+}
+
+/// AWS SigV4 signing configuration for a credential route.
+///
+/// When present on a route, the proxy will sign outbound requests using AWS
+/// SigV4. All fields are optional: an empty `aws_auth: {}` block is valid and
+/// uses the default credential chain with region and service auto-detected from
+/// the upstream URL.
+///
+/// Mutually exclusive with `credential_key` and `oauth2`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct AwsAuthConfig {
+    /// AWS profile name to use for credentials.
+    /// If omitted, the default credential chain is used
+    /// (environment variables → AWS_PROFILE → default profile → instance metadata).
+    #[serde(default)]
+    pub profile: Option<String>,
+
+    /// Explicit SigV4 signing region (e.g., `"us-east-1"`).
+    /// If omitted, auto-detected from the upstream URL.
+    /// Must be non-empty and contain no whitespace if provided.
+    #[serde(default)]
+    pub region: Option<String>,
+
+    /// Explicit SigV4 service name (e.g., `"bedrock"`, `"s3"`).
+    /// If omitted, auto-detected from the upstream URL.
+    /// Must be non-empty and contain no whitespace if provided.
+    #[serde(default)]
+    pub service: Option<String>,
 }
 
 #[cfg(test)]
@@ -934,5 +971,97 @@ mod tests {
                 "omitted format: Authorization header name is matched case-insensitively for Bearer default"
             );
         }
+    }
+
+    // ========================================================================
+    // AwsAuthConfig tests
+    // ========================================================================
+
+    #[test]
+    fn test_aws_auth_config_minimal_deserializes() {
+        let json = r#"{}"#;
+        let aws: AwsAuthConfig = serde_json::from_str(json).unwrap();
+        assert!(aws.profile.is_none());
+        assert!(aws.region.is_none());
+        assert!(aws.service.is_none());
+    }
+
+    #[test]
+    fn test_aws_auth_config_all_fields_roundtrip() {
+        let original = AwsAuthConfig {
+            profile: Some("my-aws-profile".to_string()),
+            region: Some("us-east-1".to_string()),
+            service: Some("bedrock".to_string()),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: AwsAuthConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.profile.as_deref(), Some("my-aws-profile"));
+        assert_eq!(deserialized.region.as_deref(), Some("us-east-1"));
+        assert_eq!(deserialized.service.as_deref(), Some("bedrock"));
+    }
+
+    #[test]
+    fn test_aws_auth_field_absent_is_none() {
+        let json = r#"{"prefix": "bedrock", "upstream": "https://bedrock-runtime.us-east-1.amazonaws.com"}"#;
+        let route: RouteConfig = serde_json::from_str(json).unwrap();
+        assert!(route.aws_auth.is_none());
+    }
+
+    #[test]
+    fn test_aws_auth_config_unknown_field_rejected() {
+        let json = r#"{"profile": "foo", "unknown_field": "bar"}"#;
+        let result: std::result::Result<AwsAuthConfig, _> = serde_json::from_str(json);
+        assert!(
+            result.is_err(),
+            "unknown fields must be rejected by deny_unknown_fields"
+        );
+    }
+
+    #[test]
+    fn test_route_config_with_aws_auth_deserializes() {
+        let json = r#"{
+            "prefix": "bedrock",
+            "upstream": "https://bedrock-runtime.us-east-1.amazonaws.com",
+            "aws_auth": {
+                "profile": "my-aws-profile"
+            }
+        }"#;
+        let route: RouteConfig = serde_json::from_str(json).unwrap();
+        let aws = route.aws_auth.unwrap();
+        assert_eq!(aws.profile.as_deref(), Some("my-aws-profile"));
+        assert!(aws.region.is_none());
+        assert!(aws.service.is_none());
+    }
+
+    #[test]
+    fn test_route_config_with_full_aws_auth_deserializes() {
+        let json = r#"{
+            "prefix": "bedrock",
+            "upstream": "https://bedrock-runtime.us-east-1.amazonaws.com",
+            "aws_auth": {
+                "profile": "my-aws-profile",
+                "region": "us-west-2",
+                "service": "bedrock"
+            }
+        }"#;
+        let route: RouteConfig = serde_json::from_str(json).unwrap();
+        let aws = route.aws_auth.unwrap();
+        assert_eq!(aws.profile.as_deref(), Some("my-aws-profile"));
+        assert_eq!(aws.region.as_deref(), Some("us-west-2"));
+        assert_eq!(aws.service.as_deref(), Some("bedrock"));
+    }
+
+    #[test]
+    fn test_aws_auth_empty_object_sets_all_none() {
+        let json = r#"{
+            "prefix": "bedrock",
+            "upstream": "https://bedrock-runtime.us-east-1.amazonaws.com",
+            "aws_auth": {}
+        }"#;
+        let route: RouteConfig = serde_json::from_str(json).unwrap();
+        let aws = route.aws_auth.unwrap();
+        assert!(aws.profile.is_none());
+        assert!(aws.region.is_none());
+        assert!(aws.service.is_none());
     }
 }

--- a/crates/nono-proxy/src/credential.rs
+++ b/crates/nono-proxy/src/credential.rs
@@ -90,6 +90,10 @@ pub struct CredentialStore {
     credentials: HashMap<String, LoadedCredential>,
     /// Map from route prefix to OAuth2 route (token cache + upstream)
     oauth2_routes: HashMap<String, OAuth2Route>,
+    /// Map from route prefix to AWS SigV4 route (placeholder until full
+    /// SigV4 signing is implemented; value is () because no runtime state
+    /// is needed yet).
+    aws_routes: HashMap<String, ()>,
 }
 
 impl CredentialStore {
@@ -113,6 +117,7 @@ impl CredentialStore {
     pub fn load(routes: &[RouteConfig], tls_connector: &TlsConnector) -> Result<Self> {
         let mut credentials = HashMap::new();
         let mut oauth2_routes = HashMap::new();
+        let mut aws_routes = HashMap::new();
 
         for route in routes {
             // Normalize prefix: strip leading/trailing slashes so it matches
@@ -271,12 +276,20 @@ impl CredentialStore {
                         continue;
                     }
                 }
+            } else if route.aws_auth.is_some() {
+                // AWS SigV4 path — no credentials to load yet. Register the
+                // prefix so get_aws() returns true and the proxy can return
+                // 501 Not Implemented. The () value is a placeholder; the
+                // real AwsRoute struct will replace it when SigV4 signing is
+                // implemented.
+                aws_routes.insert(normalized_prefix.clone(), ());
             }
         }
 
         Ok(Self {
             credentials,
             oauth2_routes,
+            aws_routes,
         })
     }
 
@@ -286,6 +299,7 @@ impl CredentialStore {
         Self {
             credentials: HashMap::new(),
             oauth2_routes: HashMap::new(),
+            aws_routes: HashMap::new(),
         }
     }
 
@@ -301,25 +315,35 @@ impl CredentialStore {
         self.oauth2_routes.get(prefix)
     }
 
-    /// Check if any credentials (static or OAuth2) are loaded.
+    /// Returns `Some(())` if an AWS SigV4 route is configured for the given
+    /// prefix, `None` otherwise. The `Option<&()>` return mirrors `get_oauth2`
+    /// so call sites can use `.is_some()` uniformly. The value will become
+    /// `Option<&AwsRoute>` when SigV4 signing is implemented.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.credentials.is_empty() && self.oauth2_routes.is_empty()
+    pub fn get_aws(&self, prefix: &str) -> Option<&()> {
+        self.aws_routes.get(prefix)
     }
 
-    /// Number of loaded credentials (static + OAuth2).
+    /// Check if any credentials (static, OAuth2, or AWS) are loaded.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.credentials.is_empty() && self.oauth2_routes.is_empty() && self.aws_routes.is_empty()
+    }
+
+    /// Number of loaded credentials (static + OAuth2 + AWS).
     #[must_use]
     pub fn len(&self) -> usize {
-        self.credentials.len() + self.oauth2_routes.len()
+        self.credentials.len() + self.oauth2_routes.len() + self.aws_routes.len()
     }
 
     /// Returns the set of route prefixes that have loaded credentials
-    /// (both static keystore and OAuth2 routes).
+    /// (static keystore, OAuth2, and AWS routes).
     #[must_use]
     pub fn loaded_prefixes(&self) -> std::collections::HashSet<String> {
         self.credentials
             .keys()
             .chain(self.oauth2_routes.keys())
+            .chain(self.aws_routes.keys())
             .cloned()
             .collect()
     }
@@ -575,6 +599,7 @@ mod tests {
             tls_client_cert: None,
             tls_client_key: None,
             oauth2: None,
+            aws_auth: None,
         }];
         let store = CredentialStore::load(&routes, &tls);
         assert!(store.is_ok());
@@ -609,6 +634,7 @@ mod tests {
         let store = CredentialStore {
             credentials: HashMap::new(),
             oauth2_routes,
+            aws_routes: HashMap::new(),
         };
 
         assert!(
@@ -637,6 +663,7 @@ mod tests {
         let store = CredentialStore {
             credentials: HashMap::new(),
             oauth2_routes,
+            aws_routes: HashMap::new(),
         };
 
         let prefixes = store.loaded_prefixes();
@@ -665,6 +692,7 @@ mod tests {
             tls_client_cert: None,
             tls_client_key: None,
             oauth2: None,
+            aws_auth: None,
         }];
         let store = CredentialStore::load(&routes, &tls).expect("credential load");
         let cred = store.get("litellm").expect("route should be loaded");
@@ -694,6 +722,7 @@ mod tests {
             tls_client_cert: None,
             tls_client_key: None,
             oauth2: None,
+            aws_auth: None,
         }];
         let store = CredentialStore::load(&routes, &tls).expect("credential load");
         let cred = store.get("api").expect("route should be loaded");
@@ -734,6 +763,7 @@ mod tests {
                 client_secret: "env://TEST_OAUTH2_CLIENT_SECRET".to_string(),
                 scope: String::new(),
             }),
+            aws_auth: None,
         }];
 
         let store = CredentialStore::load(&routes, &tls);

--- a/crates/nono-proxy/src/reverse.rs
+++ b/crates/nono-proxy/src/reverse.rs
@@ -130,6 +130,7 @@ pub async fn handle_reverse_proxy(
         })?;
     let static_cred = ctx.credential_store.get(&service);
     let oauth2_route = ctx.credential_store.get_oauth2(&service);
+    let aws_route = ctx.credential_store.get_aws(&service);
     let managed_ctx = static_cred.map(|cred| {
         managed_credential_event_ctx(
             &service,
@@ -153,7 +154,11 @@ pub async fn handle_reverse_proxy(
             ..audit::EventContext::default()
         });
 
-    if route.missing_managed_credential(static_cred.is_some(), oauth2_route.is_some()) {
+    if route.missing_managed_credential(
+        static_cred.is_some(),
+        oauth2_route.is_some(),
+        aws_route.is_some(),
+    ) {
         let reason = format!(
             "managed credential unavailable for service '{}': route is configured for proxy-supplied auth",
             service
@@ -219,6 +224,14 @@ pub async fn handle_reverse_proxy(
             ctx,
         )
         .await;
+    }
+
+    // AWS SigV4 signing is not yet implemented. Return 501 so the caller
+    // knows the route exists but is not functional. This branch will be
+    // replaced with real SigV4 signing in a follow-up.
+    if aws_route.is_some() {
+        send_error(stream, 501, "Not Implemented").await?;
+        return Ok(());
     }
 
     let cred = static_cred;

--- a/crates/nono-proxy/src/route.rs
+++ b/crates/nono-proxy/src/route.rs
@@ -88,6 +88,11 @@ fn auth_mechanism_for_route(route: &RouteConfig) -> Option<NetworkAuditAuthMecha
         return Some(NetworkAuditAuthMechanism::PhantomHeader);
     }
 
+    if route.aws_auth.is_some() {
+        // SigV4 signs via the Authorization header — same phantom token shape.
+        return Some(NetworkAuditAuthMechanism::PhantomHeader);
+    }
+
     if route.credential_key.is_some() {
         let proxy_mode = route
             .proxy
@@ -109,6 +114,11 @@ fn auth_mechanism_for_route(route: &RouteConfig) -> Option<NetworkAuditAuthMecha
 fn injection_mode_for_route(route: &RouteConfig) -> Option<NetworkAuditInjectionMode> {
     if route.oauth2.is_some() {
         return Some(NetworkAuditInjectionMode::OAuth2);
+    }
+
+    if route.aws_auth.is_some() {
+        // SigV4 injects via the Authorization header.
+        return Some(NetworkAuditInjectionMode::Header);
     }
 
     if route.credential_key.is_some() {
@@ -183,8 +193,9 @@ impl RouteStore {
             // they exist to provide a `*_BASE_URL` env var or appear in
             // `route_upstream_hosts()` — and CONNECT to those still gets
             // blocked with 403 (the "force SDK cooperation" path).
-            let requires_managed_credential =
-                route.credential_key.is_some() || route.oauth2.is_some();
+            let requires_managed_credential = route.credential_key.is_some()
+                || route.oauth2.is_some()
+                || route.aws_auth.is_some();
             let requires_intercept =
                 requires_managed_credential || !route.endpoint_rules.is_empty();
             let managed_auth_mechanism = auth_mechanism_for_route(route);
@@ -410,8 +421,9 @@ impl LoadedRoute {
         &self,
         has_static_credential: bool,
         has_oauth2: bool,
+        has_aws: bool,
     ) -> bool {
-        self.requires_managed_credential && !has_static_credential && !has_oauth2
+        self.requires_managed_credential && !has_static_credential && !has_oauth2 && !has_aws
     }
 }
 
@@ -653,6 +665,7 @@ mod tests {
             tls_client_cert: None,
             tls_client_key: None,
             oauth2: None,
+            aws_auth: None,
         }];
 
         let store = RouteStore::load(&routes).unwrap();
@@ -692,6 +705,7 @@ mod tests {
             tls_client_cert: None,
             tls_client_key: None,
             oauth2: None,
+            aws_auth: None,
         }];
 
         let store = RouteStore::load(&routes).unwrap();
@@ -718,6 +732,7 @@ mod tests {
             tls_client_cert: None,
             tls_client_key: None,
             oauth2: None,
+            aws_auth: None,
         }];
 
         let store = RouteStore::load(&routes).unwrap();
@@ -745,6 +760,7 @@ mod tests {
                 tls_client_cert: None,
                 tls_client_key: None,
                 oauth2: None,
+                aws_auth: None,
             },
             RouteConfig {
                 prefix: "anthropic".to_string(),
@@ -763,6 +779,7 @@ mod tests {
                 tls_client_cert: None,
                 tls_client_key: None,
                 oauth2: None,
+                aws_auth: None,
             },
         ];
 
@@ -845,6 +862,7 @@ mod tests {
             tls_client_cert: None,
             tls_client_key: None,
             oauth2: None,
+            aws_auth: None,
         }];
         let store = RouteStore::load(&routes).unwrap();
         let hit = store.lookup_by_upstream("api.openai.com:443").unwrap();
@@ -885,6 +903,7 @@ mod tests {
             tls_client_cert: None,
             tls_client_key: None,
             oauth2: None,
+            aws_auth: None,
         }];
         let store = RouteStore::load(&routes).unwrap();
         let hit = store
@@ -915,6 +934,7 @@ mod tests {
             tls_client_cert: None,
             tls_client_key: None,
             oauth2: None,
+            aws_auth: None,
         }];
         let store = RouteStore::load(&routes).unwrap();
         assert!(store.is_route_upstream("aliased.example.com:443"));
@@ -933,9 +953,10 @@ mod tests {
             managed_auth_mechanism: Some(NetworkAuditAuthMechanism::PhantomHeader),
             managed_injection_mode: Some(NetworkAuditInjectionMode::Header),
         };
-        assert!(managed.missing_managed_credential(false, false));
-        assert!(!managed.missing_managed_credential(true, false));
-        assert!(!managed.missing_managed_credential(false, true));
+        assert!(managed.missing_managed_credential(false, false, false));
+        assert!(!managed.missing_managed_credential(true, false, false));
+        assert!(!managed.missing_managed_credential(false, true, false));
+        assert!(!managed.missing_managed_credential(false, false, true));
 
         let l7_only = LoadedRoute {
             upstream: "https://internal.example.com".to_string(),
@@ -947,7 +968,7 @@ mod tests {
             managed_auth_mechanism: None,
             managed_injection_mode: None,
         };
-        assert!(!l7_only.missing_managed_credential(false, false));
+        assert!(!l7_only.missing_managed_credential(false, false, false));
     }
 
     #[test]
@@ -969,6 +990,7 @@ mod tests {
             tls_client_cert: None,
             tls_client_key: None,
             oauth2: None,
+            aws_auth: None,
         }];
         let store = RouteStore::load(&routes).unwrap();
         let hit = store.lookup_by_upstream("api.openai.com:443").unwrap();
@@ -1001,6 +1023,7 @@ mod tests {
                 tls_client_cert: None,
                 tls_client_key: None,
                 oauth2: None,
+                aws_auth: None,
             },
             RouteConfig {
                 prefix: "github_org_b".to_string(),
@@ -1022,6 +1045,7 @@ mod tests {
                 tls_client_cert: None,
                 tls_client_key: None,
                 oauth2: None,
+                aws_auth: None,
             },
         ];
         let store = RouteStore::load(&routes).unwrap();
@@ -1097,6 +1121,7 @@ mod tests {
                 tls_client_cert: None,
                 tls_client_key: None,
                 oauth2: None,
+                aws_auth: None,
             }
         }
 
@@ -1509,6 +1534,7 @@ h56ZLEEqHfVWFhJWIKRSabtxYPV/VJyMv+lo3L0QwSKsouHs3dtF1zVQ
             tls_client_cert: Some(cert_path.to_str().unwrap().to_string()),
             tls_client_key: Some(key_path.to_str().unwrap().to_string()),
             oauth2: None,
+            aws_auth: None,
         }];
 
         let store = RouteStore::load(&routes).expect("should load mTLS route");

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -1084,6 +1084,7 @@ mod tests {
                     tls_client_cert: None,
                     tls_client_key: None,
                     oauth2: None,
+                    aws_auth: None,
                 }],
                 intercept_ca_dir: Some(dir.path().to_path_buf()),
                 ..Default::default()
@@ -1148,6 +1149,7 @@ mod tests {
                 tls_client_cert: None,
                 tls_client_key: None,
                 oauth2: None,
+                aws_auth: None,
             }],
             intercept_ca_dir: Some(dir.path().to_path_buf()),
             ..Default::default()
@@ -1194,6 +1196,7 @@ mod tests {
                 tls_client_cert: None,
                 tls_client_key: None,
                 oauth2: None,
+                aws_auth: None,
             }],
             intercept_ca_dir: Some(missing_dir),
             ..Default::default()
@@ -1240,6 +1243,7 @@ mod tests {
                     tls_client_cert: None,
                     tls_client_key: None,
                     oauth2: None,
+                    aws_auth: None,
                 },
                 crate::config::RouteConfig {
                     prefix: "alias".to_string(),
@@ -1258,6 +1262,7 @@ mod tests {
                     tls_client_cert: None,
                     tls_client_key: None,
                     oauth2: None,
+                    aws_auth: None,
                 },
             ],
             intercept_ca_dir: Some(dir.path().to_path_buf()),
@@ -1331,6 +1336,7 @@ mod tests {
                 tls_client_cert: None,
                 tls_client_key: None,
                 oauth2: None,
+                aws_auth: None,
             }],
             ..Default::default()
         };
@@ -1377,6 +1383,7 @@ mod tests {
                 tls_client_cert: None,
                 tls_client_key: None,
                 oauth2: None,
+                aws_auth: None,
             }],
             ..Default::default()
         };
@@ -1432,6 +1439,7 @@ mod tests {
                 tls_client_cert: None,
                 tls_client_key: None,
                 oauth2: None,
+                aws_auth: None,
             }],
             ..Default::default()
         };
@@ -1493,6 +1501,7 @@ mod tests {
                     tls_client_cert: None,
                     tls_client_key: None,
                     oauth2: None,
+                    aws_auth: None,
                 },
                 crate::config::RouteConfig {
                     prefix: "github".to_string(),
@@ -1511,6 +1520,7 @@ mod tests {
                     tls_client_cert: None,
                     tls_client_key: None,
                     oauth2: None,
+                    aws_auth: None,
                 },
             ],
             ..Default::default()
@@ -1574,6 +1584,7 @@ mod tests {
                 tls_client_cert: None,
                 tls_client_key: None,
                 oauth2: None,
+                aws_auth: None,
             }],
             ..Default::default()
         };
@@ -1608,6 +1619,7 @@ mod tests {
                 tls_client_cert: None,
                 tls_client_key: None,
                 oauth2: None,
+                aws_auth: None,
             }],
             ..Default::default()
         };
@@ -1660,6 +1672,7 @@ mod tests {
                 tls_client_cert: None,
                 tls_client_key: None,
                 oauth2: None,
+                aws_auth: None,
             }],
             ..Default::default()
         };
@@ -1701,6 +1714,7 @@ mod tests {
                 tls_client_cert: None,
                 tls_client_key: None,
                 oauth2: None,
+                aws_auth: None,
             }],
             ..Default::default()
         };
@@ -1888,6 +1902,7 @@ mod tests {
                 tls_client_cert: None,
                 tls_client_key: None,
                 oauth2: None,
+                aws_auth: None,
             }],
             intercept_ca_dir: Some(dir.path().to_path_buf()),
             ..Default::default()

--- a/crates/nono-proxy/src/tls_intercept/handle.rs
+++ b/crates/nono-proxy/src/tls_intercept/handle.rs
@@ -279,9 +279,14 @@ where
 
     let cred = service.and_then(|s| ctx.credential_store.get(s));
     let oauth2_route = service.and_then(|s| ctx.credential_store.get_oauth2(s));
+    let aws_route = service.and_then(|s| ctx.credential_store.get_aws(s));
 
     if let Some(rt) = route
-        && rt.missing_managed_credential(cred.is_some(), oauth2_route.is_some())
+        && rt.missing_managed_credential(
+            cred.is_some(),
+            oauth2_route.is_some(),
+            aws_route.is_some(),
+        )
     {
         let svc = service.unwrap_or("unknown");
         let reason = format!(
@@ -307,6 +312,14 @@ where
             &reason,
         );
         reverse::send_error_generic(tls_stream, 503, "Service Unavailable").await?;
+        return Ok(());
+    }
+
+    // AWS SigV4 signing is not yet implemented. Return 501 so the caller
+    // knows the route exists but is not functional. This branch will be
+    // replaced with real SigV4 signing in a follow-up.
+    if aws_route.is_some() {
+        reverse::send_error_generic(tls_stream, 501, "Not Implemented").await?;
         return Ok(());
     }
 


### PR DESCRIPTION
This adds the aws_auth struct to customCredentials, with optional subkeys: profile, region, and service. If the aws_auth subkey is present at all, the route will be signed with AWS credentials in the future

The subkey is mutually exclusive with credential_key and auth.

The routes with aws_auth are wired through to the proxy, where a 501 not implemented is returned for any route using the config

## Linked Issue


Closes #1165

## Summary
This begins to add support to sigv4 (AWS) credentials for the nono proxy. This first PR is about wiring up the aws config in the customCredentials

Example profile:
```json
"custom_credentials": {
      "bedrock": {
        "upstream": "https://bedrock-runtime.us-east-1.amazonaws.com",
        "aws_auth": {
          "profile": "my-aws-profile"
        }
      }
    }
```

## Agent Disclosure (if applicable)
The code was generated by claude sonnet, in direct response to prompts, and following the earlier aws spike prototype


## Test Plan
TBD

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

