### PR TITLE
fix(docs): fix broken profiles link in quickstart

### DIFF
--- a/docs/cli/getting_started/quickstart.mdx
+++ b/docs/cli/getting_started/quickstart.mdx
@@ -37,7 +37,7 @@ nono run --profile always-further/pi -- pi
 ```
 
 <Note> 
-  If the agent you want to use cannot be found, create an [issue](https://github.com/always-further/nono/issues) to request consideration for adding it to the registry, or better yet, fork an existing profile and submit a PR with the new agent profile! See [Profiles & Groups](/cli/features/package-publishing) for details on how to create your own profiles.
+  If the agent you want to use cannot be found, create an [issue](https://github.com/always-further/nono/issues) to request consideration for adding it to the registry, or better yet, fork an existing profile and submit a PR with the new agent profile! See [Profiles & Groups](/cli/features/profiles-groups) for details on how to create your own profiles.
 </Note>
 
 ### Build your own profile


### PR DESCRIPTION
The "See Profiles & Groups" note linked to `/cli/features/package-publishing` instead of `/cli/features/profiles-groups`.