### PR TITLE
fix(diagnostic): replace deprecated nono learn with nono run

### DIFF
--- a/crates/nono-cli/src/diagnostic/formatter.rs
+++ b/crates/nono-cli/src/diagnostic/formatter.rs
@@ -6,7 +6,7 @@
 //!
 //! The structured, policy-free denial records live in the core
 //! `nono::diagnostic` module; everything here is CLI/product UX: footer
-//! rendering, CLI flag suggestions, `nono why`/`nono learn` guidance, policy
+//! rendering, CLI flag suggestions, `nono why`/`nono run` guidance, policy
 //! explanations, and stderr heuristics.
 //!
 //! # Design Principles
@@ -1268,11 +1268,13 @@ impl<'a> DiagnosticFormatter<'a> {
         lines.push("[nono] Next steps:".to_string());
         if let Some(command) = self.format_command_for_learn() {
             lines.push(format!(
-                "[nono]   Discover paths: nono learn -- {}",
+                "[nono]   Add permissions: nono run --allow <path> -- {}",
                 command
             ));
         } else {
-            lines.push("[nono]   Discover paths: nono learn -- <your command>".to_string());
+            lines.push(
+                "[nono]   Add permissions: nono run --allow <path> -- <your command>".to_string(),
+            );
         }
         lines.push(
             "[nono]   Query policy: nono why --path <path> --op <read|write|readwrite>".to_string(),
@@ -2882,7 +2884,7 @@ mod tests {
         assert!(output.contains("Sandbox denial:"));
         assert!(output.contains(&format!("Try: --read-file {}", denied.display())));
         assert!(output.contains("No path denials were observed during this session."));
-        assert!(output.contains("Discover paths: nono learn -- <your command>"));
+        assert!(output.contains("Add permissions: nono run --allow <path> -- <your command>"));
         assert!(!output.contains("Sandbox policy:"));
     }
 
@@ -2912,7 +2914,7 @@ mod tests {
         ));
         assert!(output.contains("Sandbox denial:"));
         assert!(output.contains(&denied.display().to_string()));
-        assert!(output.contains("Discover paths: nono learn -- <your command>"));
+        assert!(output.contains("Add permissions: nono run --allow <path> -- <your command>"));
     }
 
     #[test]
@@ -2966,7 +2968,7 @@ mod tests {
         assert!(output.contains("Application error:"));
         assert!(output.contains("EEXIST: file already exists"));
         assert!(output.contains("To grant additional access, re-run with:"));
-        assert!(output.contains("Discover paths: nono learn -- <your command>"));
+        assert!(output.contains("Add permissions: nono run --allow <path> -- <your command>"));
     }
 
     #[test]


### PR DESCRIPTION
Diagnostic footer suggests `nono learn` which was deprecated in v0.50.1. Users following the suggestion hit a dead end. Replaced with `nono run --allow <path>` so the guidance points to an
   actual next action.