### PR TITLE
fix(policy): allow go_runtime to readwrite go-build cache

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -410,6 +410,9 @@
         "read": [
           "~/go",
           "/usr/local/go"
+        ],
+        "readwrite": [
+          "~/.cache/go-build"
         ]
       }
     },

--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -412,7 +412,8 @@
           "/usr/local/go"
         ],
         "readwrite": [
-          "~/.cache/go-build"
+          "~/.cache/go-build",
+          "~/Library/Caches/go-build"
         ]
       }
     },

--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -410,9 +410,23 @@
         "read": [
           "~/go",
           "/usr/local/go"
-        ],
+        ]
+      }
+    },
+    "go_runtime_linux": {
+      "description": "Go build cache on Linux",
+      "platform": "linux",
+      "allow": {
         "readwrite": [
-          "~/.cache/go-build",
+          "~/.cache/go-build"
+        ]
+      }
+    },
+    "go_runtime_macos": {
+      "description": "Go build cache on macOS",
+      "platform": "macos",
+      "allow": {
+        "readwrite": [
           "~/Library/Caches/go-build"
         ]
       }
@@ -748,7 +762,7 @@
         "author": "always-further"
       },
       "groups": {
-        "include": ["go_runtime"]
+        "include": ["go_runtime", "go_runtime_linux", "go_runtime_macos"]
       },
       "security": {
         "signal_mode": "isolated"


### PR DESCRIPTION
## Linked Issue

Closes #1172

## Summary

Allow read-write access to the go-build cache for the go-dev profile.

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

I tested it by adding the following to a custom profile:
```json
  "filesystem": {
    "allow": [
      "~/.cache/go-build"
    ]
  }
  ```

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
