### PR TITLE
docs(credential-injection): fix broken Proxy Overrides anchor

### DIFF
--- a/docs/cli/features/credential-injection.mdx
+++ b/docs/cli/features/credential-injection.mdx
@@ -395,7 +395,7 @@ For APIs not covered by the built-in services, you can define custom credentials
 | `path_pattern` | Conditional | - | Required for `url_path` mode. URL path pattern with `{}` placeholder (e.g., `/bot{}/`) |
 | `path_replacement` | No | - | Optional replacement pattern for `url_path` mode (e.g., `/v2/bot{}/`) |
 | `query_param_name` | Conditional | - | Required for `query_param` mode. Query parameter name for credential injection (e.g., `key` or `api_key`) |
-| `proxy` | No | - | Optional proxy overrides for phantom token parsing. Omitted fields inherit from top-level values. See [Proxy-Side Overrides](#proxy-side-overrides). |
+| `proxy` | No | - | Optional proxy overrides for phantom token parsing. Omitted fields inherit from top-level values. See [Proxy Overrides](#proxy-overrides). |
 | `env_var` | Conditional | - | Explicit environment variable name for the phantom token. Required when `credential_key` is `op://`, `bw://`, `apple-password://`, or `file://`. Optional for `env://` (derived from the URI) |
 
 **Important:** Use underscores, not hyphens, in credential names (the keys in `custom_credentials`). The credential name is used to generate environment variables like `TELEGRAM_BASE_URL`. Shell variable names cannot contain hyphens, so `my-api` would create `MY-API_BASE_URL` which cannot be referenced as `$MY-API_BASE_URL` in shell scripts. Use `my_api` instead.


### PR DESCRIPTION
Fix the dead proxy link in the custom-credentials schema table — it pointed at #proxy-side-overrides, but the heading is "Proxy Overrides" (#proxy-overrides), so it scrolled nowhere.