### PR TITLE
fix(cli): use XDG config paths consistently

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -122,7 +122,7 @@
     "command_args": {
       "type": "array",
       "items": { "type": "string" },
-      "description": "Extra arguments appended to the child command at launch. Supports variable expansion (e.g. $NONO_PACKAGES)."
+      "description": "Extra arguments appended to the child command at launch. Supports variable expansion (e.g. $NONO_CONFIG, $NONO_PACKAGES)."
     },
     "unsafe_macos_seatbelt_rules": {
       "type": "array",
@@ -742,7 +742,7 @@
         "set_vars": {
           "type": "object",
           "additionalProperties": { "type": "string" },
-          "description": "Static environment variables injected after environment filtering and before credential injection. PATH and NONO_* are reserved. Values support variable expansion ($HOME, $WORKDIR, $TMPDIR, $XDG_*, $NONO_PACKAGES)."
+          "description": "Static environment variables injected after environment filtering and before credential injection. PATH and NONO_* are reserved. Values support variable expansion ($HOME, $WORKDIR, $TMPDIR, $XDG_*, $NONO_CONFIG, $NONO_PACKAGES)."
         }
       }
     },

--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -4,7 +4,10 @@ This guide is designed for LLM agents helping users create custom nono profiles.
 
 ## 1. Profile File Location
 
-User profiles live at `~/.config/nono/profiles/<name>.json`.
+User profiles live at **`~/.config/nono/profiles/<name>.json`** by default. If
+`XDG_CONFIG_HOME` is set, nono uses **`$XDG_CONFIG_HOME/nono/profiles/<name>.json`**
+instead. In profile JSON path grants, prefer `$XDG_CONFIG_HOME`, `$NONO_CONFIG`, or
+`$NONO_PACKAGES` over hardcoded `$HOME/.config/...`.
 
 Profile names must be alphanumeric with hyphens only. No leading or trailing hyphens.
 
@@ -229,7 +232,7 @@ Controls which environment variables are passed to the sandboxed process. When `
 |---------------|-----------------|---------|-------------|
 | `allow_vars`  | array of string | `[]`    | Allow-list of environment variable names. Supports exact names (`"PATH"`) and prefix patterns ending with `*` (`"AWS_*"` matches `AWS_REGION`, `AWS_SECRET_ACCESS_KEY`, etc.). The `*` wildcard is only valid as a trailing suffix. When the `environment` section is omitted entirely, all variables are allowed. When present with an empty array, no inherited variables are passed (only nono-injected credentials). Nono-injected credentials always bypass this list. |
 | `deny_vars`   | array of string | `[]`    | Deny-list of environment variable names stripped from the child. Same pattern syntax as `allow_vars` (exact names and trailing `*`). Denied vars are stripped even if they also match `allow_vars`. |
-| `set_vars`    | object (string→string) | `{}` | Static environment variables injected after allow/deny filtering and before credential injection (injected credentials win on conflict). Values support the same expansion as profile paths (`$HOME`, `~`, `$WORKDIR`, `$TMPDIR`, `$XDG_*`, `$NONO_PACKAGES`); keys are not expanded. `PATH` and any `NONO_*` key are reserved and rejected at load time. Unlike inherited host vars, keys here are NOT subject to the dangerous-variable blocklist (`LD_PRELOAD`, `NODE_OPTIONS`, …) — setting one is an explicit operator decision. |
+| `set_vars`    | object (string→string) | `{}` | Static environment variables injected after allow/deny filtering and before credential injection (injected credentials win on conflict). Values support the same expansion as profile paths (`$HOME`, `~`, `$WORKDIR`, `$TMPDIR`, `$XDG_*`, `$NONO_CONFIG`, `$NONO_PACKAGES`); keys are not expanded. `PATH` and any `NONO_*` key are reserved and rejected at load time. Unlike inherited host vars, keys here are NOT subject to the dangerous-variable blocklist (`LD_PRELOAD`, `NODE_OPTIONS`, …) — setting one is an explicit operator decision. |
 
 Inheritance: child `allow_vars` and `deny_vars` are appended to base values and deduplicated; `set_vars` merges as a map, with the child's value winning on key conflict.
 

--- a/crates/nono-cli/src/config/mod.rs
+++ b/crates/nono-cli/src/config/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module handles loading and merging configuration from multiple sources:
 //! - Embedded policy.json (composable security groups, single source of truth)
-//! - User-level config at ~/.config/nono/ (overrides with acknowledgment)
+//! - User-level config at `$XDG_CONFIG_HOME/nono/` (default `~/.config/nono/`)
 //! - CLI flags (highest precedence)
 
 pub mod embedded;
@@ -57,10 +57,14 @@ pub fn validated_tmpdir() -> Result<String> {
     }
 }
 
-/// Get the user config directory path
-#[allow(dead_code)]
+/// User-level nono config root (`$XDG_CONFIG_HOME/nono`, default `~/.config/nono`).
+///
+/// Uses the same XDG resolution as profiles and packages (`resolve_user_config_dir`),
+/// not platform-specific dirs such as macOS `~/Library/Application Support`.
 pub fn user_config_dir() -> Option<PathBuf> {
-    dirs::config_dir().map(|p| p.join("nono"))
+    crate::profile::resolve_user_config_dir()
+        .ok()
+        .map(|dir| dir.join("nono"))
 }
 
 /// Get the user state directory path (for version tracking and runtime state)
@@ -206,6 +210,11 @@ mod tests {
 
     #[test]
     fn test_check_sensitive_path() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+
         assert!(
             check_sensitive_path("~/.ssh")
                 .expect("should not fail")
@@ -236,7 +245,34 @@ mod tests {
     }
 
     #[test]
+    fn test_user_config_dir_uses_xdg_fallback() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().to_str().expect("temp path");
+        let _env = crate::test_env::EnvVarGuard::set_all(&[
+            ("HOME", home),
+            ("XDG_CONFIG_HOME", "__placeholder__"),
+        ]);
+        _env.remove("XDG_CONFIG_HOME");
+
+        let dir = user_config_dir().expect("user config dir");
+        let expected = tmp.path().join(".config").join("nono");
+        assert_eq!(
+            nono::try_canonicalize(&dir),
+            nono::try_canonicalize(&expected)
+        );
+    }
+
+    #[test]
     fn test_check_sensitive_path_component_wise() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+
         // ~/.sshevil must NOT match ~/.ssh (component-wise comparison)
         let home = validated_home().expect("HOME must be set");
         let evil_path = format!("{}/.sshevil", home);

--- a/crates/nono-cli/src/config/user.rs
+++ b/crates/nono-cli/src/config/user.rs
@@ -1,6 +1,7 @@
 //! User configuration loading
 //!
-//! Loads user-level configuration from ~/.config/nono/config.toml
+//! Loads user-level configuration from `$XDG_CONFIG_HOME/nono/config.toml`
+//! (default `~/.config/nono/config.toml`).
 
 #![allow(dead_code)]
 
@@ -308,7 +309,8 @@ impl Default for RollbackSettings {
     }
 }
 
-/// Load user configuration from ~/.config/nono/config.toml
+/// Load user configuration from `$XDG_CONFIG_HOME/nono/config.toml`
+/// (default `~/.config/nono/config.toml`).
 ///
 /// Returns None if the config file doesn't exist.
 /// Returns Err if the file exists but is malformed.

--- a/crates/nono-cli/src/pack_update_hint.rs
+++ b/crates/nono-cli/src/pack_update_hint.rs
@@ -8,7 +8,7 @@
 //!
 //! Respects `NONO_NO_PACK_UPDATE_HINTS=1`, plus the same opt-out as the CLI
 //! update check: `NONO_NO_UPDATE_CHECK=1` or `[updates] check = false` in
-//! `~/.config/nono/config.toml`.
+//! `$XDG_CONFIG_HOME/nono/config.toml` (default `~/.config/nono/config.toml`).
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Profiles provide named configurations for common applications like
 //! claude-code, openclaw, and opencode. They can be built-in (compiled
-//! into the binary) or user-defined (in ~/.config/nono/profiles/).
+//! into the binary) or user-defined (in `$XDG_CONFIG_HOME/nono/profiles/`).
 
 pub(crate) mod builtin;
 
@@ -1490,7 +1490,7 @@ pub struct EnvironmentConfig {
     /// Maps variable names to values, set after allow/deny filtering and before
     /// credential injection (so injected credentials win on conflict). Values
     /// support the same expansion as profile paths (`$HOME`, `~`, `$WORKDIR`,
-    /// `$TMPDIR`, `$XDG_*`, `$NONO_PACKAGES`).
+    /// `$TMPDIR`, `$XDG_*`, `$NONO_CONFIG`, `$NONO_PACKAGES`).
     ///
     /// `PATH` and any `NONO_*` key are reserved and rejected at parse time.
     /// Unlike inherited host variables, keys here are NOT subject to the
@@ -1771,7 +1771,7 @@ impl<'de> Deserialize<'de> for Profile {
 
 /// Check whether a profile name is loaded from a user file rather than the built-in set.
 ///
-/// Returns `true` when a user profile file exists at `~/.config/nono/profiles/<name>.json`,
+/// Returns `true` when a user profile file exists at `$XDG_CONFIG_HOME/nono/profiles/<name>.json`,
 /// which means the user has overridden or shadowed any built-in profile of the same name.
 pub fn is_user_override(name: &str) -> bool {
     if !is_valid_profile_name(name) {
@@ -1841,7 +1841,7 @@ pub fn load_profile_extends(name_or_path: &str) -> Option<Vec<String>> {
 /// treated as a direct file path. Otherwise it is resolved as a profile name.
 ///
 /// Name loading precedence:
-/// 1. User profiles from `~/.config/nono/profiles/<name>.json` — never written
+/// 1. User profiles from `$XDG_CONFIG_HOME/nono/profiles/<name>.json` — never written
 ///    by nono. Users (and Claude's "Option B" guidance) own this directory.
 /// 2. Pack-store scan — any installed pack with a profile artifact whose
 ///    `install_as` matches the requested name. Self-heals Claude Code plugin
@@ -2848,13 +2848,30 @@ pub(crate) fn resolve_user_profile_path(name: &str) -> Result<PathBuf> {
 }
 
 pub(crate) fn user_profile_dir() -> Result<PathBuf> {
-    Ok(resolve_user_config_dir()?.join("nono").join("profiles"))
+    Ok(crate::package::nono_config_dir()?.join("profiles"))
+}
+
+/// Display hint for `$XDG_CONFIG_HOME/nono` when runtime resolution fails.
+pub const NONO_CONFIG_DIR_HINT: &str = "$XDG_CONFIG_HOME/nono (default ~/.config/nono)";
+
+/// Resolved user profile directory for user-facing output.
+#[must_use]
+pub fn display_user_profiles_dir() -> String {
+    user_profile_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| format!("{NONO_CONFIG_DIR_HINT}/profiles"))
+}
+
+/// Resolved user trust-policy path for user-facing output.
+#[must_use]
+pub fn display_trust_policy_path() -> String {
+    crate::package::nono_config_dir()
+        .map(|p| p.join("trust-policy.json").display().to_string())
+        .unwrap_or_else(|_| format!("{NONO_CONFIG_DIR_HINT}/trust-policy.json"))
 }
 
 pub(crate) fn user_profile_draft_dir() -> Result<PathBuf> {
-    Ok(resolve_user_config_dir()?
-        .join("nono")
-        .join("profile-drafts"))
+    Ok(crate::package::nono_config_dir()?.join("profile-drafts"))
 }
 
 pub(crate) fn get_user_profile_draft_path(name: &str) -> Result<PathBuf> {
@@ -2929,6 +2946,7 @@ pub(crate) fn is_valid_profile_name(name: &str) -> bool {
 /// - $WORKDIR: Working directory (--workdir or cwd)
 /// - $HOME: User's home directory
 /// - $XDG_CONFIG_HOME: XDG config directory
+/// - $NONO_CONFIG: nono config root (`$XDG_CONFIG_HOME/nono`)
 /// - $XDG_DATA_HOME: XDG data directory
 /// - $XDG_STATE_HOME: XDG state directory
 /// - $XDG_CACHE_HOME: XDG cache directory
@@ -3013,7 +3031,11 @@ pub fn expand_vars(path: &str, workdir: &Path) -> Result<PathBuf> {
         expanded = expanded.replace("$XDG_RUNTIME_DIR", rt);
     }
 
-    // Expand $NONO_PACKAGES to the package store directory
+    // Expand $NONO_CONFIG / $NONO_PACKAGES to resolved nono config paths
+    if expanded.contains("$NONO_CONFIG") {
+        let config_dir = crate::package::nono_config_dir()?;
+        expanded = expanded.replace("$NONO_CONFIG", &config_dir.to_string_lossy());
+    }
     if expanded.contains("$NONO_PACKAGES") {
         let packages_dir = crate::package::package_store_dir()?;
         expanded = expanded.replace("$NONO_PACKAGES", &packages_dir.to_string_lossy());
@@ -3285,6 +3307,49 @@ mod tests {
         _env.remove("XDG_STATE_HOME");
         let expanded = expand_vars("$XDG_STATE_HOME/history", &workdir).expect("valid env");
         assert_eq!(expanded, PathBuf::from("/home/user/.local/state/history"));
+    }
+
+    #[test]
+    fn test_expand_vars_xdg_config_home() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let _env = crate::test_env::EnvVarGuard::set_all(&[
+            ("HOME", "/home/user"),
+            ("XDG_CONFIG_HOME", "/custom/config"),
+        ]);
+
+        let workdir = PathBuf::from("/projects/myapp");
+        let expanded = expand_vars("$XDG_CONFIG_HOME/nono/profiles", &workdir).expect("valid env");
+        assert_eq!(expanded, PathBuf::from("/custom/config/nono/profiles"));
+
+        _env.remove("XDG_CONFIG_HOME");
+        let expanded = expand_vars("$XDG_CONFIG_HOME/nono/profiles", &workdir).expect("valid env");
+        assert_eq!(expanded, PathBuf::from("/home/user/.config/nono/profiles"));
+    }
+
+    #[test]
+    fn test_expand_vars_nono_config() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config_home = tmp.path().join("config");
+        std::fs::create_dir_all(&config_home).expect("create config home");
+        let config_home_str = config_home.to_string_lossy().to_string();
+        let _env = crate::test_env::EnvVarGuard::set_all(&[
+            ("HOME", "/home/user"),
+            ("XDG_CONFIG_HOME", &config_home_str),
+        ]);
+
+        let workdir = PathBuf::from("/projects/myapp");
+        let expanded = expand_vars("$NONO_CONFIG/profiles", &workdir).expect("valid env");
+        assert_eq!(
+            nono::try_canonicalize(&expanded),
+            nono::try_canonicalize(&config_home.join("nono").join("profiles"))
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -787,7 +787,11 @@ pub(crate) fn cmd_list(args: ProfileListArgs) -> Result<()> {
         println!();
         println!(
             "  {}",
-            theme::fg("User (~/.config/nono/profiles/):", t.subtext).bold()
+            theme::fg(
+                &format!("User ({}):", profile::display_user_profiles_dir()),
+                t.subtext
+            )
+            .bold()
         );
         for (name, result) in &user_profiles {
             print_profile_line(name, result, t);

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -571,7 +571,7 @@ fn profile_name_from_command(cmd_name: &str) -> Option<String> {
     }
 }
 
-/// Return true when writing `~/.config/nono/profiles/<name>.json` would shadow
+/// Return true when writing `$XDG_CONFIG_HOME/nono/profiles/<name>.json` would shadow
 /// a built-in or installed pack profile of the same name. User files are loaded
 /// in preference to built-ins and pack-store profiles, so saving under an
 /// existing profile's name silently reroutes all future `--profile <name>`

--- a/crates/nono-cli/src/setup.rs
+++ b/crates/nono-cli/src/setup.rs
@@ -404,11 +404,10 @@ impl SetupRunner {
 
             if self.generate_profiles {
                 println!("Custom profiles:");
-                let profile_dir = crate::profile::resolve_user_config_dir()
-                    .map(|p| p.join("nono").join("profiles"))
-                    .map(|p| p.display().to_string())
-                    .unwrap_or_else(|_| "~/.config/nono/profiles".to_string());
-                println!("  Edit example profiles in: {}", profile_dir);
+                println!(
+                    "  Edit example profiles in: {}",
+                    crate::profile::display_user_profiles_dir()
+                );
                 println!();
             }
 

--- a/crates/nono-cli/src/trust_cmd.rs
+++ b/crates/nono-cli/src/trust_cmd.rs
@@ -704,7 +704,7 @@ fn run_sign_policy(args: TrustSignPolicyArgs) -> Result<()> {
         None if args.user => {
             let user_path =
                 user_trust_policy_path().ok_or_else(|| nono::NonoError::TrustSigning {
-                    path: "~/.config/nono/trust-policy.json".to_string(),
+                    path: crate::profile::display_trust_policy_path(),
                     reason: "could not resolve user config directory".to_string(),
                 })?;
             if !user_path.exists() {
@@ -1362,7 +1362,7 @@ fn load_trust_policy(explicit_path: Option<&Path>) -> Result<trust::TrustPolicy>
         }
         let user_path = user_trust_policy_path()
             .map(|p| p.display().to_string())
-            .unwrap_or_else(|| "~/.config/nono/trust-policy.json".to_string());
+            .unwrap_or_else(crate::profile::display_trust_policy_path);
         eprintln!(
             "  {}",
             "Warning: project-level trust-policy.json found but no user-level policy exists."
@@ -1436,9 +1436,9 @@ pub(crate) fn user_trust_policy_path() -> Option<PathBuf> {
         }
     }
 
-    crate::profile::resolve_user_config_dir()
+    crate::package::nono_config_dir()
         .ok()
-        .map(|d| d.join("nono").join("trust-policy.json"))
+        .map(|d| d.join("trust-policy.json"))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -69,7 +69,7 @@ pub fn load_scan_policy(
             let policy_path = user_path
                 .as_deref()
                 .map(|p| p.display().to_string())
-                .unwrap_or_else(|| "~/.config/nono/trust-policy.json".to_string());
+                .unwrap_or_else(crate::profile::display_trust_policy_path);
             eprintln!(
                 "  {}",
                 format!("Create a signed policy at {policy_path} to enforce verification.")

--- a/crates/nono-cli/src/update_check.rs
+++ b/crates/nono-cli/src/update_check.rs
@@ -10,7 +10,7 @@
 //! No IP addresses are logged by the update service.
 //!
 //! To disable the update check, set `NONO_NO_UPDATE_CHECK=1` or add
-//! `[updates] check = false` to `~/.config/nono/config.toml`.
+//! `[updates] check = false` to `$XDG_CONFIG_HOME/nono/config.toml` (default `~/.config/nono/config.toml`).
 
 use chrono::{DateTime, Utc};
 use nono::Result;

--- a/crates/nono-cli/src/wiring.rs
+++ b/crates/nono-cli/src/wiring.rs
@@ -1610,7 +1610,8 @@ mod tests {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
-        let _env = EnvVarGuard::set_all(&[("HOME", "/h")]);
+        let _env = EnvVarGuard::set_all(&[("HOME", "/h"), ("XDG_CONFIG_HOME", "__placeholder__")]);
+        _env.remove("XDG_CONFIG_HOME");
         assert_eq!(expand_vars("$PACK_DIR/x", &ctx).expect("expand"), "/p/x");
         assert_eq!(expand_vars("$NS/$PLUGIN", &ctx).expect("expand"), "ns/name");
         assert_eq!(

--- a/crates/nono-cli/src/wiring.rs
+++ b/crates/nono-cli/src/wiring.rs
@@ -15,8 +15,9 @@
 //!     reverse — the install plan never has to be re-derived.
 //!   - Variables expanded at execution time: `$PACK_DIR`, `$NS`
 //!     (pack namespace), `$PLUGIN` (pack name, the second segment
-//!     of `<ns>/<pack>`), `$HOME`, `$XDG_CONFIG_HOME`. No shell
-//!     evaluation, no user-controlled inputs flow in.
+//!     of `<ns>/<pack>`), `$HOME`, `$XDG_CONFIG_HOME`, `$NONO_CONFIG`,
+//!     `$NONO_PACKAGES`. No shell evaluation, no user-controlled inputs
+//!     flow in.
 //!   - Idempotent: re-running a directive with the same inputs is a
 //!     no-op and reports `wiring_changed = false`.
 
@@ -679,10 +680,16 @@ fn expand_vars(template: &str, ctx: &WiringContext) -> Result<String> {
         .filter(|v| !v.is_empty())
         .map(PathBuf::from)
         .unwrap_or_else(|| home.join(".config"));
+    let nono_config = crate::package::nono_config_dir()
+        .map_err(|e| NonoError::PackageInstall(format!("failed to resolve $NONO_CONFIG: {e}")))?;
+    let nono_packages = crate::package::package_store_dir()
+        .map_err(|e| NonoError::PackageInstall(format!("failed to resolve $NONO_PACKAGES: {e}")))?;
 
     let pack_dir = ctx.pack_dir.to_string_lossy().into_owned();
     let home_str = home.to_string_lossy().into_owned();
     let xdg_str = xdg_config_home.to_string_lossy().into_owned();
+    let nono_config_str = nono_config.to_string_lossy().into_owned();
+    let nono_packages_str = nono_packages.to_string_lossy().into_owned();
 
     // `$` is a variable sigil only when followed by an ASCII uppercase
     // letter or underscore — i.e. the start of an identifier from the
@@ -719,6 +726,8 @@ fn expand_vars(template: &str, ctx: &WiringContext) -> Result<String> {
             "PLUGIN" => ctx.pack_name.clone(),
             "HOME" => home_str.clone(),
             "XDG_CONFIG_HOME" => xdg_str.clone(),
+            "NONO_CONFIG" => nono_config_str.clone(),
+            "NONO_PACKAGES" => nono_packages_str.clone(),
             // Install-time UTC timestamp (RFC3339, milliseconds), for
             // agents that require a `lastUpdated`-style field on their
             // config entries (Claude Code's marketplace registry being
@@ -1607,6 +1616,46 @@ mod tests {
         assert_eq!(
             expand_vars("$HOME/.config", &ctx).expect("expand"),
             "/h/.config"
+        );
+        assert_eq!(
+            expand_vars("$NONO_CONFIG/profile-drafts", &ctx).expect("expand"),
+            "/h/.config/nono/profile-drafts"
+        );
+        assert_eq!(
+            expand_vars("$NONO_PACKAGES/always-further/claude", &ctx).expect("expand"),
+            "/h/.config/nono/packages/always-further/claude"
+        );
+    }
+
+    #[test]
+    fn expand_vars_nono_config_respects_xdg_config_home() {
+        let _g = match ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let home = TempDir::new().expect("home tempdir");
+        let config = TempDir::new().expect("config tempdir");
+        let home_str = home.path().to_str().expect("home path");
+        let config_str = config.path().to_str().expect("config path");
+        let ctx = WiringContext {
+            pack_dir: PathBuf::from("/p"),
+            namespace: "always-further".to_string(),
+            pack_name: "claude".to_string(),
+        };
+        let _env = EnvVarGuard::set_all(&[("HOME", home_str), ("XDG_CONFIG_HOME", config_str)]);
+        let expected_config = format!("{config_str}/nono/profile-drafts");
+        let expected_packages = format!("{config_str}/nono/packages/always-further/claude");
+        assert_eq!(
+            nono::try_canonicalize(Path::new(
+                &expand_vars("$NONO_CONFIG/profile-drafts", &ctx).expect("expand")
+            )),
+            nono::try_canonicalize(Path::new(&expected_config))
+        );
+        assert_eq!(
+            nono::try_canonicalize(Path::new(
+                &expand_vars("$NONO_PACKAGES/always-further/claude", &ctx).expect("expand")
+            )),
+            nono::try_canonicalize(Path::new(&expected_packages))
         );
     }
 

--- a/crates/nono-cli/tests/deprecated_schema.rs
+++ b/crates/nono-cli/tests/deprecated_schema.rs
@@ -727,7 +727,7 @@ fn legacy_keys_in_extends_parent_emit_warnings_once_via_child() {
     // WarningSuppressionGuard fixes).
     //
     // `extends` resolves by profile name through the user-profiles dir
-    // (`$HOME/.config/nono/profiles/`) or built-ins, so we override HOME
+    // (`$XDG_CONFIG_HOME/nono/profiles/`) or built-ins, so we override HOME
     // to a tempdir for the spawned `nono` invocation and write the
     // parent there. The child references the parent by name.
     let dir = tempfile::tempdir().expect("tempdir");

--- a/docs/cli/features/environment.mdx
+++ b/docs/cli/features/environment.mdx
@@ -144,7 +144,7 @@ Use `set_vars` to inject environment variables with specific values into the san
 
 **Ordering:** `set_vars` is applied **after** allow/deny filtering and **before** credential injection. If a key in `set_vars` collides with a variable injected via `env_credentials`, the injected credential wins. A `set_vars` value overrides any inherited value with the same name.
 
-**Variable expansion:** values support the same expansion as profile paths — `$HOME`, `~`, `$WORKDIR`, `$TMPDIR`, `$UID`, `$XDG_CONFIG_HOME`, `$XDG_DATA_HOME`, `$XDG_STATE_HOME`, `$XDG_CACHE_HOME`, `$XDG_RUNTIME_DIR`, and `$NONO_PACKAGES`. For example, `"$HOME/.config"` expands to the user's config directory. Keys are never expanded.
+**Variable expansion:** values support the same expansion as profile paths — `$HOME`, `~`, `$WORKDIR`, `$TMPDIR`, `$UID`, `$XDG_CONFIG_HOME`, `$XDG_DATA_HOME`, `$XDG_STATE_HOME`, `$XDG_CACHE_HOME`, `$XDG_RUNTIME_DIR`, `$NONO_CONFIG`, and `$NONO_PACKAGES`. When `XDG_CONFIG_HOME` is unset — typical on macOS — `$XDG_CONFIG_HOME` expands to `$HOME/.config`, so `"$XDG_CONFIG_HOME/nono"` is the same as `~/.config/nono`. Keys are never expanded.
 
 **Reserved keys:** `PATH` and any key starting with `NONO_` are reserved and rejected at profile load time (`PATH` is controlled via `allow_vars`/`deny_vars`; the `NONO_*` prefix is reserved for nono's own injected variables). Keys must be valid environment variable names (`[A-Za-z_][A-Za-z0-9_]*`).
 

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -39,6 +39,14 @@ Profiles can come from three sources, in order of precedence:
 
 CLI flags always override profile settings.
 
+<Note>
+  nono resolves config paths via `$XDG_CONFIG_HOME/nono/` on every platform. If
+  you have not set `XDG_CONFIG_HOME` — typical on macOS — that is the same as
+  **`~/.config/nono/`** shown above. Set `XDG_CONFIG_HOME` only when you want
+  config elsewhere; profile JSON path grants should use `$XDG_CONFIG_HOME`,
+  `$NONO_CONFIG`, or `$NONO_PACKAGES` rather than hardcoded `$HOME/.config/...`.
+</Note>
+
 ### Profile Format
 
 Profiles use JSON format:
@@ -479,7 +487,9 @@ Profiles support these environment variables in path values:
 |----------|------------|
 | `$WORKDIR` | Current working directory (from `--workdir` or cwd) |
 | `$HOME` | User's home directory |
-| `$XDG_CONFIG_HOME` | XDG config directory (default: `~/.config`) |
+| `$XDG_CONFIG_HOME` | XDG config directory (default: `~/.config`; used for `~/.config/nono/` when unset) |
+| `$NONO_CONFIG` | nono config root (`$XDG_CONFIG_HOME/nono`, default `~/.config/nono`) |
+| `$NONO_PACKAGES` | Installed pack store (`$NONO_CONFIG/packages`) |
 | `$XDG_DATA_HOME` | XDG data directory (default: `~/.local/share`) |
 | `$XDG_STATE_HOME` | XDG state directory (default: `~/.local/state`) |
 | `$XDG_CACHE_HOME` | XDG cache directory (default: `~/.cache`) |

--- a/docs/cli/features/trust.mdx
+++ b/docs/cli/features/trust.mdx
@@ -451,7 +451,7 @@ Trust policies compose across three levels:
 | Level | Location | Purpose |
 |-------|----------|---------|
 | Embedded | Built into nono binary | Baseline include patterns |
-| User | `$XDG_CONFIG_HOME/nono/trust-policy.json` | Personal trusted publishers |
+| User | `~/.config/nono/trust-policy.json` | Personal trusted publishers |
 | Project | `<project-root>/trust-policy.json` | Project-specific publishers |
 
 Merging rules:

--- a/docs/cli/internals/wsl2-feature-matrix.mdx
+++ b/docs/cli/internals/wsl2-feature-matrix.mdx
@@ -190,7 +190,7 @@ Legend: **Full** = identical to native Linux | **Blocked (default)** = fails sec
 |---------|--------|-------|
 | Environment sanitization | Full | |
 | `NONO_*` env var support | Full | |
-| User config (~/.config/nono/) | Full | |
+| User config (`~/.config/nono/`) | Full | |
 | Embedded policy (policy.json) | Full | |
 
 ## Summary

--- a/scripts/claude-clear-nono.sh
+++ b/scripts/claude-clear-nono.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # Clean up nono-managed Claude Code state for a fresh test of
 # `nono run --profile always-further/claude -- claude`. Removes:
-#   - the pulled pack at ~/.config/nono/packages/always-further/claude
-#   - any leftover legacy symlink at ~/.config/nono/profiles/claude-code.json
+#   - the pulled pack at $XDG_CONFIG_HOME/nono/packages/always-further/claude
+#   - any leftover legacy symlink at $XDG_CONFIG_HOME/nono/profiles/claude-code.json
 #   - the bare pre-marketplace symlink at ~/.claude/plugins/nono
 #   - the synthesised marketplace at ~/.claude/plugins/marketplaces/always-further
 #   - the cache dir at ~/.claude/plugins/cache/always-further
 #   - the `always-further/claude` entry from
-#     ~/.config/nono/packages/lockfile.json (so `nono pull` re-installs
+#     $XDG_CONFIG_HOME/nono/packages/lockfile.json (so `nono pull` re-installs
 #     instead of short-circuiting on "already up to date")
 #   - the `nono@always-further` and bare `nono` entries in
 #     ~/.claude/plugins/installed_plugins.json,
@@ -16,8 +16,10 @@
 
 set -euo pipefail
 
-rm -f  "$HOME/.config/nono/profiles/claude-code.json" 2>/dev/null || true
-rm -rf "$HOME/.config/nono/packages/always-further/claude" 2>/dev/null || true
+NONO_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/nono"
+
+rm -f  "$NONO_CONFIG/profiles/claude-code.json" 2>/dev/null || true
+rm -rf "$NONO_CONFIG/packages/always-further/claude" 2>/dev/null || true
 rm -rf "$HOME/.claude/plugins/nono" 2>/dev/null || true
 rm -rf "$HOME/.claude/plugins/marketplaces/always-further" 2>/dev/null || true
 rm -rf "$HOME/.claude/plugins/cache/always-further" 2>/dev/null || true
@@ -50,7 +52,7 @@ strip_with_jq "$HOME/.claude/plugins/installed_plugins.json" \
     'del(.plugins["nono@always-further"])'
 strip_with_jq "$HOME/.claude/plugins/known_marketplaces.json" \
     'del(."always-further")'
-strip_with_jq "$HOME/.config/nono/packages/lockfile.json" \
+strip_with_jq "$NONO_CONFIG/packages/lockfile.json" \
     'del(.packages["always-further/claude"])'
 
 echo "cleared nono-managed Claude Code state."

--- a/scripts/codex-clear-nono.sh
+++ b/scripts/codex-clear-nono.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Clean up nono-managed Codex state for a fresh test of
 # `nono run --profile always-further/codex -- codex`. Removes:
-#   - the pulled pack at ~/.config/nono/packages/always-further/codex
+#   - the pulled pack at $XDG_CONFIG_HOME/nono/packages/always-further/codex
 #   - the cache subtree at ~/.codex/plugins/cache/always-further
 #   - the nono-managed fenced block in ~/.codex/config.toml (between
 #     the `# >>> nono-managed (do not edit) >>>` markers — registers
@@ -9,7 +9,7 @@
 #   - hook entries in ~/.codex/hooks.json whose command path points
 #     into the nono pack store
 #   - the `always-further/codex` entry from
-#     ~/.config/nono/packages/lockfile.json (so `nono pull` re-installs
+#     $XDG_CONFIG_HOME/nono/packages/lockfile.json (so `nono pull` re-installs
 #     instead of short-circuiting on "already up to date")
 #
 # Does NOT touch:
@@ -17,14 +17,16 @@
 #     (so `[features] codex_hooks = true`, your model + project trust
 #     settings, etc. all stay)
 #   - ~/.codex/auth.json or ~/.codex/sessions/*
-#   - ~/.config/nono/profiles/ (your own profiles)
+#   - $XDG_CONFIG_HOME/nono/profiles/ (your own profiles)
 
 set -euo pipefail
 
-PACK_STORE="$HOME/.config/nono/packages/always-further/codex"
+NONO_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/nono"
+
+PACK_STORE="$NONO_CONFIG/packages/always-further/codex"
 CONFIG_TOML="$HOME/.codex/config.toml"
 HOOKS_JSON="$HOME/.codex/hooks.json"
-LOCKFILE="$HOME/.config/nono/packages/lockfile.json"
+LOCKFILE="$NONO_CONFIG/packages/lockfile.json"
 
 rm -rf "$PACK_STORE" 2>/dev/null || true
 rm -rf "$HOME/.codex/plugins/cache/always-further" 2>/dev/null || true

--- a/tests/integration/test_bypass_protection.sh
+++ b/tests/integration/test_bypass_protection.sh
@@ -162,8 +162,8 @@ echo "--- Profile Inheritance ---"
 
 if [[ -d "$DOCKER_DIR" ]]; then
     # Child profile inherits bypass_protection from parent via user profiles directory.
-    # The extends field resolves by name from ~/.config/nono/profiles/.
-    USER_PROFILES_DIR="$HOME/.config/nono/profiles"
+    # The extends field resolves by name from $XDG_CONFIG_HOME/nono/profiles/.
+    USER_PROFILES_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/nono/profiles"
     CREATED_USER_PROFILES=0
     if [[ ! -d "$USER_PROFILES_DIR" ]]; then
         mkdir -p "$USER_PROFILES_DIR"

--- a/tests/integration/test_pack_resolution.sh
+++ b/tests/integration/test_pack_resolution.sh
@@ -54,7 +54,7 @@ if [[ ! -f "$FIXTURE_DIR/package.json" ]]; then
 fi
 
 # Use a per-run XDG_CONFIG_HOME so the test pack-store install never
-# touches the user's real ~/.config/nono. The pack-store resolver
+# touches the user's real $XDG_CONFIG_HOME/nono. The pack-store resolver
 # walks $XDG_CONFIG_HOME/nono/packages/, so by isolating that root
 # we get clean install + cleanup for free.
 TMPDIR=$(setup_test_dir)


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1175

## Summary

Route user config (config.toml, trusted-keys cache) through resolve_user_config_dir() instead of dirs::config_dir(), so macOS matches ~/.config/nono like profiles and packages already did.

Add $NONO_CONFIG profile expansion, display path helpers for CLI output, and update schema/docs/scripts to prefer XDG variables in machine-readable paths while keeping ~/.config/nono in user-facing docs and --help.

tldr: user facing docs = use absolute path just so mac users aren't lost. For inside code files, use XDG since it is expanded/replaced by defaults internally anyway is set/unset on both platforms. With this, we will be fully unified on the XDG spec

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
