### PR TITLE
docs(allow-cwd): clarify access level is profile-driven

### DIFF
--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -174,7 +174,7 @@ The `workdir` section controls whether and how the current working directory is 
 | `"write"` | Write-only access to CWD |
 | `"readwrite"` | Full read+write access to CWD |
 
-When a profile specifies a workdir access level, nono will prompt the user to confirm CWD sharing (unless `--allow-cwd` is used to skip the prompt).
+When a profile specifies a workdir access level, nono will prompt the user to confirm CWD sharing (unless `--allow-cwd` is used to skip the prompt). `--allow-cwd` grants access to the directory at that profile's workdir level — so with `"none"` (the `default` profile) it grants nothing. Pair `--allow-cwd` with a profile that sets a workdir level, or grant the directory explicitly with `--allow`/`--read`.
 
 ### Filesystem Overrides and Group Composition
 

--- a/docs/cli/usage/developer-workflows.mdx
+++ b/docs/cli/usage/developer-workflows.mdx
@@ -222,9 +222,9 @@ Profiles make your workflow easier to repeat, share, and audit.
 
 ### Use `--allow-cwd` Deliberately
 
-`--allow-cwd` is convenient, but it means “grant the current repository read+write access”.
+`--allow-cwd` shares the current directory at the access level the active profile's [`workdir`](/cli/features/profiles-groups#working-directory) config declares: read+write for the coding profiles used here (`always-further/claude`, `always-further/codex`), read-only when no profile is specified, and nothing at all under the conservative `default` profile (`workdir: "none"`).
 
-That is often the right choice for coding agents, but treat it as an explicit workspace grant, not as boilerplate.
+That read+write grant is often the right choice for coding agents, but treat it as an explicit workspace grant, not as boilerplate.
 
 ### Keep Login/Bootstrap Permissions Temporary
 


### PR DESCRIPTION
Ran into this while reading the docs as a new user.

The workflows guide says `--allow-cwd` grants the repo read/write access, but that's only true for `readwrite` profiles. In practice, it grants access at the active profile's `workdir` level:

- `readwrite` for coding profiles (`claude`, `codex`)
- `readonly` with no profile
- `none` under `default`

`flags.mdx` already describes this correctly, so this updates the workflows guide to match and adds a short note to the Working Directory section. Without that context, `--allow-cwd --profile default` can look like it has no effect.

Docs only. 