### PR TITLE
fix: proxy should activate with customCredentials set

### DIFF
--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -184,11 +184,22 @@ pub fn resolve_credentials(
     service_names: &[String],
     custom_credentials: &HashMap<String, CustomCredentialDef>,
 ) -> Result<Vec<RouteConfig>> {
-    if service_names.is_empty() {
+    // Build the full set of names to resolve: explicitly requested names
+    // (from `credentials`) plus all custom_credentials keys. custom_credentials
+    // entries are always activated — they don't need to be listed in `credentials`.
+    let mut all_names: Vec<String> = custom_credentials.keys().cloned().collect();
+    for name in service_names {
+        if !all_names.contains(name) {
+            all_names.push(name.clone());
+        }
+    }
+
+    if all_names.is_empty() {
         return Ok(Vec::new());
     }
 
-    // Validate all requested services exist in either custom or built-in
+    // Validate all explicitly requested services exist in either custom or built-in.
+    // custom_credentials keys are always valid by definition.
     for name in service_names {
         if !custom_credentials.contains_key(name) && !policy.credentials.contains_key(name) {
             let mut available: Vec<_> = policy.credentials.keys().cloned().collect();
@@ -204,7 +215,7 @@ pub fn resolve_credentials(
 
     let mut routes = Vec::new();
 
-    for name in service_names {
+    for name in &all_names {
         // Custom credentials take precedence over built-in.
         // Note: Custom credentials are already validated at profile load time
         // in profile/mod.rs::validate_profile_custom_credentials(), so we don't

--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -1285,4 +1285,128 @@ mod tests {
         let result = partition_allow_domain(&policy, &entries);
         assert!(result.is_err());
     }
+
+    /// A profile with `custom_credentials` but no `credentials` list passes an
+    /// empty `service_names` slice.  `resolve_credentials` should still return
+    /// a route for each entry in `custom_credentials`.
+    #[test]
+    fn test_resolve_credentials_custom_credentials_without_service_names() {
+        use crate::profile::CustomCredentialDef;
+
+        let json = embedded_network_policy_json();
+        let policy = load_network_policy(json).unwrap();
+
+        let mut custom = HashMap::new();
+        custom.insert(
+            "mockhttp".to_string(),
+            CustomCredentialDef {
+                upstream: "https://mockhttp.org".to_string(),
+                credential_key: Some("env://MOCK_API_KEY".to_string()),
+                auth: None,
+                inject_mode: InjectMode::Header,
+                inject_header: "Authorization".to_string(),
+                credential_format: Some("Bearer {}".to_string()),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                proxy: None,
+                env_var: Some("MOCK_API_KEY".to_string()),
+                endpoint_rules: vec![],
+                tls_ca: None,
+                tls_client_cert: None,
+                tls_client_key: None,
+                aws_auth: None,
+            },
+        );
+
+        let routes = resolve_credentials(&policy, &[], &custom).unwrap();
+        assert_eq!(
+            routes.len(),
+            1,
+            "expected one route for the custom credential, got {}",
+            routes.len()
+        );
+        assert_eq!(routes[0].prefix, "mockhttp");
+        assert_eq!(routes[0].upstream, "https://mockhttp.org");
+        assert_eq!(
+            routes[0].env_var,
+            Some("MOCK_API_KEY".to_string()),
+            "env_var must be propagated from CustomCredentialDef"
+        );
+    }
+
+    /// When `service_names` is empty but multiple `custom_credentials` are
+    /// defined, `resolve_credentials` should return a route for every entry.
+    #[test]
+    fn test_resolve_credentials_all_custom_credentials_without_service_names() {
+        use crate::profile::CustomCredentialDef;
+
+        let json = embedded_network_policy_json();
+        let policy = load_network_policy(json).unwrap();
+
+        let mut custom = HashMap::new();
+        custom.insert(
+            "svc_a".to_string(),
+            CustomCredentialDef {
+                upstream: "https://svc-a.example.com".to_string(),
+                credential_key: Some("env://SVC_A_KEY".to_string()),
+                auth: None,
+                inject_mode: InjectMode::Header,
+                inject_header: "Authorization".to_string(),
+                credential_format: Some("Bearer {}".to_string()),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                proxy: None,
+                env_var: Some("SVC_A_KEY".to_string()),
+                endpoint_rules: vec![],
+                tls_ca: None,
+                tls_client_cert: None,
+                tls_client_key: None,
+                aws_auth: None,
+            },
+        );
+        custom.insert(
+            "svc_b".to_string(),
+            CustomCredentialDef {
+                upstream: "https://svc-b.example.com".to_string(),
+                credential_key: Some("env://SVC_B_KEY".to_string()),
+                auth: None,
+                inject_mode: InjectMode::Header,
+                inject_header: "Authorization".to_string(),
+                credential_format: Some("Bearer {}".to_string()),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                proxy: None,
+                env_var: Some("SVC_B_KEY".to_string()),
+                endpoint_rules: vec![],
+                tls_ca: None,
+                tls_client_cert: None,
+                tls_client_key: None,
+                aws_auth: None,
+            },
+        );
+
+        let routes = resolve_credentials(&policy, &[], &custom).unwrap();
+
+        assert_eq!(
+            routes.len(),
+            2,
+            "expected one route per custom credential, got {}",
+            routes.len()
+        );
+
+        let prefixes: Vec<&str> = routes.iter().map(|r| r.prefix.as_str()).collect();
+        assert!(
+            prefixes.contains(&"svc_a"),
+            "route for svc_a must be present; got: {:?}",
+            prefixes
+        );
+        assert!(
+            prefixes.contains(&"svc_b"),
+            "route for svc_b must be present; got: {:?}",
+            prefixes
+        );
+    }
 }

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -556,4 +556,79 @@ mod tests {
             "strict_filter must default off when network_block is false"
         );
     }
+
+    /// A profile with only `custom_credentials` set (no built-in `credentials`,
+    /// no `network_profile`, no `allow_domain`, no upstream proxy) should still
+    /// activate the proxy so that credential injection works.
+    #[test]
+    fn test_proxy_is_active_when_only_custom_credentials_are_set() {
+        use crate::profile::CustomCredentialDef;
+        use crate::sandbox_prepare::PreparedSandbox;
+        use nono::CapabilitySet;
+        use nono_proxy::config::InjectMode;
+        use std::collections::HashMap;
+
+        let mut custom_credentials: HashMap<String, CustomCredentialDef> = HashMap::new();
+        custom_credentials.insert(
+            "mockhttp".to_string(),
+            CustomCredentialDef {
+                upstream: "https://mockhttp.org".to_string(),
+                credential_key: Some("env://MOCK_API_KEY".to_string()),
+                auth: None,
+                inject_mode: InjectMode::Header,
+                inject_header: "Authorization".to_string(),
+                credential_format: Some("Bearer {}".to_string()),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                proxy: None,
+                env_var: Some("MOCK_API_KEY".to_string()),
+                endpoint_rules: vec![],
+                tls_ca: None,
+                tls_client_cert: None,
+                tls_client_key: None,
+                aws_auth: None,
+            },
+        );
+
+        let prepared = PreparedSandbox {
+            caps: CapabilitySet::new(),
+            secrets: Vec::new(),
+            session_hooks: crate::profile::SessionHooks::default(),
+            rollback_exclude_patterns: Vec::new(),
+            rollback_exclude_globs: Vec::new(),
+            network_profile: None,
+            allow_domain: Vec::new(),
+            credentials: Vec::new(),
+            custom_credentials,
+            upstream_proxy: None,
+            upstream_bypass: Vec::new(),
+            listen_ports: Vec::new(),
+            capability_elevation: false,
+            #[cfg(target_os = "linux")]
+            wsl2_proxy_policy: crate::profile::Wsl2ProxyPolicy::Error,
+            #[cfg(target_os = "linux")]
+            af_unix_mediation: crate::profile::LinuxAfUnixMediation::Off,
+            allow_launch_services_active: false,
+            allow_gpu_active: false,
+            open_url_origins: Vec::new(),
+            open_url_allow_localhost: false,
+            bypass_protection_paths: Vec::new(),
+            ignored_denial_paths: Vec::new(),
+            suppressed_system_service_operations: Vec::new(),
+            allowed_env_vars: None,
+            denied_env_vars: None,
+            set_vars: None,
+            network_block_requested: false,
+        };
+
+        let args = crate::cli::SandboxArgs::default();
+        let opts = prepare_proxy_launch_options(&args, &prepared, true)
+            .expect("prepare_proxy_launch_options");
+
+        assert!(
+            opts.active,
+            "proxy must be active when custom_credentials is non-empty"
+        );
+    }
 }

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -51,8 +51,11 @@ pub(crate) fn prepare_proxy_launch_options(
         bypass
     };
 
+    let has_custom_credentials = !prepared.custom_credentials.is_empty();
+
     let active = if matches!(prepared.caps.network_mode(), nono::NetworkMode::Blocked) {
         if !credentials.is_empty()
+            || has_custom_credentials
             || network_profile.is_some()
             || !allow_domain.is_empty()
             || upstream_proxy.is_some()
@@ -74,6 +77,7 @@ pub(crate) fn prepare_proxy_launch_options(
             prepared.caps.network_mode(),
             nono::NetworkMode::ProxyOnly { .. }
         ) || !credentials.is_empty()
+            || has_custom_credentials
             || network_profile.is_some()
             || !allow_domain.is_empty()
             || upstream_proxy.is_some()


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1196

## Summary

Ensure that the proxy loads routes from customCredentials (and not just credentials) when determining if the proxy should start

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

Created unit tests, ensured they failed. Then made the fix and ensure the unit tests pass. Also ran the original code from the bug report to ensure it is fixed

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
