### PR TITLE
refactor(proxy): separate proxy intent from activation

### DIFF
--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -188,7 +188,7 @@ pub(crate) fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
     let proxy = prepare_proxy_launch_options(&args.sandbox, &prepared, silent)?;
     let strategy = select_exec_strategy(
         false,
-        proxy.active,
+        proxy.is_active(),
         prepared.capability_elevation,
         false,
         false,

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -182,15 +182,27 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     if let Some(profile) = recommended_profile {
         output::print_profile_hint(recommended_program_name, profile, flags.silent);
     }
-    let allowed_domain_strs: Vec<String> = flags
+    let plain_domain_entries = flags
         .proxy
-        .allow_domain
+        .domain_filter
+        .as_ref()
+        .map(|d| d.allow_domain.as_slice())
+        .unwrap_or(&[]);
+    let endpoint_domain_entries = flags
+        .proxy
+        .endpoint_filter
+        .as_ref()
+        .map(|e| e.routes.as_slice())
+        .unwrap_or(&[]);
+    let all_domain_entries: Vec<_> = plain_domain_entries
+        .iter()
+        .chain(endpoint_domain_entries.iter())
+        .collect();
+    let allowed_domain_strs: Vec<String> = all_domain_entries
         .iter()
         .map(|e| e.domain().to_string())
         .collect();
-    let domain_endpoints: Vec<sandbox_state::DomainEndpointState> = flags
-        .proxy
-        .allow_domain
+    let domain_endpoints: Vec<sandbox_state::DomainEndpointState> = all_domain_entries
         .iter()
         .filter_map(|e| match e {
             crate::profile::AllowDomainEntry::WithEndpoints { domain, endpoints }
@@ -231,7 +243,7 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     let strategy = flags.strategy;
 
     if matches!(strategy, exec_strategy::ExecStrategy::Supervised) {
-        output::print_supervised_info(flags.silent, rollback.requested, proxy.active);
+        output::print_supervised_info(flags.silent, rollback.requested, proxy.is_active());
     }
 
     let active_proxy = start_proxy_runtime(proxy, &mut caps)?;
@@ -307,7 +319,7 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
 
     let threading = select_threading_context(
         !loaded_secrets.is_empty(),
-        proxy.active,
+        proxy.is_active(),
         trust.scan_performed,
         trust.interception_active,
     );

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -70,27 +70,76 @@ pub(crate) struct TrustLaunchOptions {
     pub(crate) protected_paths: Vec<PathBuf>,
 }
 
+/// Plain CONNECT-tunnel domain allowlist entries and an optional network profile.
 #[derive(Clone, Default)]
-pub(crate) struct ProxyLaunchOptions {
-    pub(crate) active: bool,
+pub(crate) struct DomainFilterIntent {
     pub(crate) network_profile: Option<String>,
+    /// Only `AllowDomainEntry::Plain` entries — endpoint-bearing entries live in
+    /// `EndpointFilterIntent`.
     pub(crate) allow_domain: Vec<profile::AllowDomainEntry>,
+}
+
+/// `WithEndpoints` allow-domain entries that require TLS interception so the
+/// proxy can inspect method and path before forwarding.
+/// All entries must be `AllowDomainEntry::WithEndpoints` (enforced by `debug_assert`
+/// at construction in `prepare_proxy_launch_options`).
+#[derive(Clone, Default)]
+pub(crate) struct EndpointFilterIntent {
+    pub(crate) routes: Vec<profile::AllowDomainEntry>,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct CredentialProxyIntent {
     pub(crate) credentials: Vec<String>,
     pub(crate) custom_credentials: HashMap<String, profile::CustomCredentialDef>,
-    pub(crate) upstream_proxy: Option<String>,
-    pub(crate) upstream_bypass: Vec<String>,
-    pub(crate) allow_bind_ports: Vec<u16>,
-    pub(crate) proxy_port: Option<u16>,
-    pub(crate) open_url_origins: Vec<String>,
-    pub(crate) open_url_allow_localhost: bool,
-    pub(crate) allow_launch_services_active: bool,
+}
+
+#[derive(Clone)]
+pub(crate) struct UpstreamProxyIntent {
+    pub(crate) address: String,
+    pub(crate) bypass: Vec<String>,
+}
+
+/// TLS interception configuration supplied by the user. Presence means the user
+/// configured TLS intercept settings; it does not by itself activate the proxy.
+#[derive(Clone, Default)]
+pub(crate) struct TlsInterceptIntent {
+    /// macOS only: reuse a persistent CA bundle across sessions.
     #[cfg(target_os = "macos")]
     pub(crate) trust_proxy_ca: bool,
-    pub(crate) proxy_ca_validity: Option<std::time::Duration>,
+    pub(crate) ca_validity: Option<std::time::Duration>,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct OpenUrlIntent {
+    pub(crate) origins: Vec<String>,
+    pub(crate) allow_localhost: bool,
+    pub(crate) allow_launch_services: bool,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct ProxyLaunchOptions {
+    pub(crate) domain_filter: Option<DomainFilterIntent>,
+    pub(crate) endpoint_filter: Option<EndpointFilterIntent>,
+    pub(crate) credentials: Option<CredentialProxyIntent>,
+    pub(crate) upstream_proxy: Option<UpstreamProxyIntent>,
+    pub(crate) tls_intercept: Option<TlsInterceptIntent>,
+    pub(crate) open_url: Option<OpenUrlIntent>,
+    pub(crate) allow_bind_ports: Vec<u16>,
+    pub(crate) proxy_port: Option<u16>,
     /// True when the user requested `network.block` or `--block-net`.
     /// Propagated to `ProxyConfig.strict_filter` so the filter denies
     /// unlisted hosts instead of falling back to allow-all.
     pub(crate) network_block: bool,
+}
+
+impl ProxyLaunchOptions {
+    pub(crate) fn is_active(&self) -> bool {
+        self.domain_filter.is_some()
+            || self.endpoint_filter.is_some()
+            || self.credentials.is_some()
+            || self.upstream_proxy.is_some()
+    }
 }
 
 #[derive(Clone)]
@@ -242,7 +291,7 @@ pub(crate) fn prepare_run_launch_plan(
 
     let strategy = select_exec_strategy(
         rollback,
-        proxy.active,
+        proxy.is_active(),
         prepared.capability_elevation,
         trust.interception_active,
         run_args.detached,

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -81,7 +81,7 @@ pub(crate) fn prepare_proxy_launch_options(
 
     let (plain_entries, endpoint_entries): (Vec<_>, Vec<_>) = allow_domain
         .into_iter()
-        .partition(|e| matches!(e, crate::profile::AllowDomainEntry::Plain(_)));
+        .partition(|e| !matches!(e, crate::profile::AllowDomainEntry::WithEndpoints { endpoints, .. } if !endpoints.is_empty()));
 
     let domain_filter = if network_profile.is_some() || !plain_entries.is_empty() {
         Some(DomainFilterIntent {
@@ -96,8 +96,8 @@ pub(crate) fn prepare_proxy_launch_options(
         debug_assert!(
             endpoint_entries
                 .iter()
-                .all(|e| matches!(e, crate::profile::AllowDomainEntry::WithEndpoints { .. })),
-            "EndpointFilterIntent invariant violated: all entries must be WithEndpoints"
+                .all(|e| matches!(e, crate::profile::AllowDomainEntry::WithEndpoints { endpoints, .. } if !endpoints.is_empty())),
+            "EndpointFilterIntent invariant violated: all entries must have non-empty endpoints"
         );
         Some(EndpointFilterIntent {
             routes: endpoint_entries,
@@ -674,6 +674,34 @@ mod tests {
             !config.strict_filter,
             "strict_filter must default off when network_block is false"
         );
+    }
+
+    /// `{ "domain": "cdn.example.com" }` (no `endpoints` key) deserializes via serde default
+    /// to `WithEndpoints { endpoints: [] }`, which is semantically identical to `Plain`.
+    /// The partition must route it to `plain_entries` — not `endpoint_entries` — or the
+    /// domain silently disappears from the allowlist.
+    #[test]
+    fn test_object_form_domain_with_no_endpoints_key_is_treated_as_plain() {
+        use crate::profile::AllowDomainEntry;
+
+        // Mirrors exactly: { "network": { "allow_domain": [ { "domain": "cdn.example.com" } ] } }
+        let entries: Vec<AllowDomainEntry> = serde_json::from_str(r#"[
+            "plain.example.com",
+            { "domain": "object.example.com" },
+            { "domain": "filtered.example.com", "endpoints": [{ "method": "GET", "path": "/v1/**" }] }
+        ]"#)
+        .expect("deserialize allow_domain entries");
+
+        let (plain, endpoint): (Vec<_>, Vec<_>) = entries
+            .into_iter()
+            .partition(|e| !matches!(e, AllowDomainEntry::WithEndpoints { endpoints, .. } if !endpoints.is_empty()));
+
+        assert_eq!(plain.len(), 2, "both Plain and no-endpoints-key object must land in plain bucket");
+        assert_eq!(endpoint.len(), 1, "only the entry with actual endpoint rules goes to endpoint bucket");
+
+        assert!(plain.iter().any(|e| matches!(e, AllowDomainEntry::Plain(d) if d == "plain.example.com")));
+        assert!(plain.iter().any(|e| matches!(e, AllowDomainEntry::WithEndpoints { domain, .. } if domain == "object.example.com")));
+        assert!(endpoint.iter().any(|e| matches!(e, AllowDomainEntry::WithEndpoints { domain, .. } if domain == "filtered.example.com")));
     }
 
     /// A profile with only `custom_credentials` set (no built-in `credentials`,

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -696,10 +696,22 @@ mod tests {
             .into_iter()
             .partition(|e| !matches!(e, AllowDomainEntry::WithEndpoints { endpoints, .. } if !endpoints.is_empty()));
 
-        assert_eq!(plain.len(), 2, "both Plain and no-endpoints-key object must land in plain bucket");
-        assert_eq!(endpoint.len(), 1, "only the entry with actual endpoint rules goes to endpoint bucket");
+        assert_eq!(
+            plain.len(),
+            2,
+            "both Plain and no-endpoints-key object must land in plain bucket"
+        );
+        assert_eq!(
+            endpoint.len(),
+            1,
+            "only the entry with actual endpoint rules goes to endpoint bucket"
+        );
 
-        assert!(plain.iter().any(|e| matches!(e, AllowDomainEntry::Plain(d) if d == "plain.example.com")));
+        assert!(
+            plain
+                .iter()
+                .any(|e| matches!(e, AllowDomainEntry::Plain(d) if d == "plain.example.com"))
+        );
         assert!(plain.iter().any(|e| matches!(e, AllowDomainEntry::WithEndpoints { domain, .. } if domain == "object.example.com")));
         assert!(endpoint.iter().any(|e| matches!(e, AllowDomainEntry::WithEndpoints { domain, .. } if domain == "filtered.example.com")));
     }

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -1,5 +1,8 @@
 use crate::cli::SandboxArgs;
-use crate::launch_runtime::ProxyLaunchOptions;
+use crate::launch_runtime::{
+    CredentialProxyIntent, DomainFilterIntent, EndpointFilterIntent, OpenUrlIntent,
+    ProxyLaunchOptions, TlsInterceptIntent, UpstreamProxyIntent,
+};
 use crate::network_policy;
 use crate::sandbox_prepare::{PreparedSandbox, validate_external_proxy_bypass};
 #[cfg(not(target_os = "macos"))]
@@ -33,7 +36,7 @@ pub(crate) fn prepare_proxy_launch_options(
     let credentials = effective_proxy.credentials;
     let allow_bind_ports = merge_dedup_ports(&prepared.listen_ports, &args.allow_bind);
 
-    let upstream_proxy = if args.allow_net {
+    let upstream_proxy_addr = if args.allow_net {
         None
     } else {
         args.external_proxy
@@ -52,14 +55,12 @@ pub(crate) fn prepare_proxy_launch_options(
     };
 
     let has_custom_credentials = !prepared.custom_credentials.is_empty();
+    let has_domain_filter = network_profile.is_some() || !allow_domain.is_empty();
+    let has_credentials = !credentials.is_empty() || has_custom_credentials;
+    let would_activate = has_domain_filter || has_credentials || upstream_proxy_addr.is_some();
 
-    let active = if matches!(prepared.caps.network_mode(), nono::NetworkMode::Blocked) {
-        if !credentials.is_empty()
-            || has_custom_credentials
-            || network_profile.is_some()
-            || !allow_domain.is_empty()
-            || upstream_proxy.is_some()
-        {
+    if matches!(prepared.caps.network_mode(), nono::NetworkMode::Blocked) {
+        if would_activate {
             warn!(
                 "--block-net is active; ignoring proxy configuration \
                  that would re-enable network access"
@@ -71,38 +72,120 @@ pub(crate) fn prepare_proxy_launch_options(
                 );
             }
         }
-        false
+        return Ok(ProxyLaunchOptions {
+            allow_bind_ports,
+            network_block: prepared.network_block_requested,
+            ..ProxyLaunchOptions::default()
+        });
+    }
+
+    let (plain_entries, endpoint_entries): (Vec<_>, Vec<_>) = allow_domain
+        .into_iter()
+        .partition(|e| matches!(e, crate::profile::AllowDomainEntry::Plain(_)));
+
+    let domain_filter = if network_profile.is_some() || !plain_entries.is_empty() {
+        Some(DomainFilterIntent {
+            network_profile,
+            allow_domain: plain_entries,
+        })
     } else {
-        matches!(
-            prepared.caps.network_mode(),
-            nono::NetworkMode::ProxyOnly { .. }
-        ) || !credentials.is_empty()
-            || has_custom_credentials
-            || network_profile.is_some()
-            || !allow_domain.is_empty()
-            || upstream_proxy.is_some()
+        None
     };
 
-    Ok(ProxyLaunchOptions {
-        active,
-        network_profile,
-        allow_domain,
-        credentials,
-        custom_credentials: prepared.custom_credentials.clone(),
+    let endpoint_filter = if !endpoint_entries.is_empty() {
+        debug_assert!(
+            endpoint_entries
+                .iter()
+                .all(|e| matches!(e, crate::profile::AllowDomainEntry::WithEndpoints { .. })),
+            "EndpointFilterIntent invariant violated: all entries must be WithEndpoints"
+        );
+        Some(EndpointFilterIntent {
+            routes: endpoint_entries,
+        })
+    } else {
+        None
+    };
+
+    let credentials_intent = if has_credentials {
+        Some(CredentialProxyIntent {
+            credentials,
+            custom_credentials: prepared.custom_credentials.clone(),
+        })
+    } else {
+        None
+    };
+
+    let upstream_proxy = upstream_proxy_addr.map(|address| UpstreamProxyIntent {
+        address,
+        bypass: upstream_bypass,
+    });
+
+    let proxy_ca_validity = args
+        .proxy_ca_validity
+        .map(|days| std::time::Duration::from_secs(u64::from(days) * 24 * 60 * 60));
+
+    #[cfg(target_os = "macos")]
+    let tls_intercept = if args.trust_proxy_ca || proxy_ca_validity.is_some() {
+        Some(TlsInterceptIntent {
+            trust_proxy_ca: args.trust_proxy_ca,
+            ca_validity: proxy_ca_validity,
+        })
+    } else {
+        None
+    };
+    #[cfg(not(target_os = "macos"))]
+    let tls_intercept = if proxy_ca_validity.is_some() {
+        Some(TlsInterceptIntent {
+            ca_validity: proxy_ca_validity,
+        })
+    } else {
+        None
+    };
+
+    let open_url = if !prepared.open_url_origins.is_empty()
+        || prepared.open_url_allow_localhost
+        || prepared.allow_launch_services_active
+    {
+        Some(OpenUrlIntent {
+            origins: prepared.open_url_origins.clone(),
+            allow_localhost: prepared.open_url_allow_localhost,
+            allow_launch_services: prepared.allow_launch_services_active,
+        })
+    } else {
+        None
+    };
+
+    let opts = ProxyLaunchOptions {
+        domain_filter,
+        endpoint_filter,
+        credentials: credentials_intent,
         upstream_proxy,
-        upstream_bypass,
+        tls_intercept,
+        open_url,
         allow_bind_ports,
         proxy_port: args.proxy_port,
-        open_url_origins: prepared.open_url_origins.clone(),
-        open_url_allow_localhost: prepared.open_url_allow_localhost,
-        allow_launch_services_active: prepared.allow_launch_services_active,
-        #[cfg(target_os = "macos")]
-        trust_proxy_ca: args.trust_proxy_ca,
-        proxy_ca_validity: args
-            .proxy_ca_validity
-            .map(|days| std::time::Duration::from_secs(u64::from(days) * 24 * 60 * 60)),
         network_block: prepared.network_block_requested,
-    })
+    };
+
+    // Infra-only flags make no sense without an activating proxy feature.
+    if !opts.is_active() {
+        if opts.tls_intercept.is_some() {
+            return Err(NonoError::ConfigParse(
+                "--trust-proxy-ca / --proxy-ca-validity require a proxy feature \
+                 (--allow-domain, --credential, or --upstream-proxy)"
+                    .to_string(),
+            ));
+        }
+        if args.proxy_port.is_some() {
+            return Err(NonoError::ConfigParse(
+                "--proxy-port requires a proxy feature (--allow-domain, --credential, \
+                 or --upstream-proxy)"
+                    .to_string(),
+            ));
+        }
+    }
+
+    Ok(opts)
 }
 
 pub(crate) fn resolve_effective_proxy_settings(
@@ -173,7 +256,11 @@ pub(crate) fn build_proxy_config_from_flags(
     let net_policy_json = crate::config::embedded::embedded_network_policy_json();
     let net_policy = network_policy::load_network_policy(net_policy_json)?;
 
-    let mut resolved = if let Some(ref profile_name) = proxy.network_profile {
+    let mut resolved = if let Some(profile_name) = proxy
+        .domain_filter
+        .as_ref()
+        .and_then(|d| d.network_profile.as_ref())
+    {
         network_policy::resolve_network_profile(&net_policy, profile_name)?
     } else {
         network_policy::ResolvedNetworkPolicy {
@@ -185,27 +272,46 @@ pub(crate) fn build_proxy_config_from_flags(
     };
 
     let mut all_credentials = resolved.profile_credentials.clone();
-    for cred in &proxy.credentials {
-        if !all_credentials.contains(cred) {
-            all_credentials.push(cred.clone());
+    if let Some(ref creds) = proxy.credentials {
+        for cred in &creds.credentials {
+            if !all_credentials.contains(cred) {
+                all_credentials.push(cred.clone());
+            }
         }
     }
 
-    let mut routes = network_policy::resolve_credentials(
-        &net_policy,
-        &all_credentials,
-        &proxy.custom_credentials,
-    )?;
+    let empty_custom_credentials = std::collections::HashMap::new();
+    let custom_credentials = proxy
+        .credentials
+        .as_ref()
+        .map(|c| &c.custom_credentials)
+        .unwrap_or(&empty_custom_credentials);
 
-    let (mut plain_hosts, endpoint_routes) =
-        network_policy::partition_allow_domain(&net_policy, &proxy.allow_domain)?;
+    let mut routes =
+        network_policy::resolve_credentials(&net_policy, &all_credentials, custom_credentials)?;
+
+    let plain_allow_domain = proxy
+        .domain_filter
+        .as_ref()
+        .map(|d| d.allow_domain.as_slice())
+        .unwrap_or(&[]);
+    let (mut plain_hosts, _) =
+        network_policy::partition_allow_domain(&net_policy, plain_allow_domain)?;
+
+    let endpoint_allow_domain = proxy
+        .endpoint_filter
+        .as_ref()
+        .map(|e| e.routes.as_slice())
+        .unwrap_or(&[]);
+    let (_, endpoint_routes) =
+        network_policy::partition_allow_domain(&net_policy, endpoint_allow_domain)?;
     // Endpoint-restricted domains need filter allowlist access so the proxy
     // can reach upstream after TLS interception (h2 checks the filter at
     // connection setup, before per-stream route matching).
     for route in &endpoint_routes {
-        if let Some(ref hp) = route.upstream.strip_prefix("https://") {
+        if let Some(hp) = route.upstream.strip_prefix("https://") {
             plain_hosts.push(hp.to_string());
-        } else if let Some(ref hp) = route.upstream.strip_prefix("http://") {
+        } else if let Some(hp) = route.upstream.strip_prefix("http://") {
             plain_hosts.push(hp.to_string());
         }
     }
@@ -215,11 +321,11 @@ pub(crate) fn build_proxy_config_from_flags(
     let mut proxy_config = network_policy::build_proxy_config(&resolved, &plain_hosts);
     proxy_config.strict_filter = proxy.network_block;
 
-    if let Some(ref addr) = proxy.upstream_proxy {
+    if let Some(ref upstream) = proxy.upstream_proxy {
         proxy_config.external_proxy = Some(nono_proxy::config::ExternalProxyConfig {
-            address: addr.clone(),
+            address: upstream.address.clone(),
             auth: None,
-            bypass_hosts: proxy.upstream_bypass.clone(),
+            bypass_hosts: upstream.bypass.clone(),
         });
     }
 
@@ -227,7 +333,7 @@ pub(crate) fn build_proxy_config_from_flags(
         proxy_config.bind_port = port;
     }
 
-    proxy_config.ca_validity = proxy.proxy_ca_validity;
+    proxy_config.ca_validity = proxy.tls_intercept.as_ref().and_then(|t| t.ca_validity);
 
     Ok(proxy_config)
 }
@@ -236,7 +342,7 @@ pub(crate) fn start_proxy_runtime(
     proxy: &ProxyLaunchOptions,
     caps: &mut CapabilitySet,
 ) -> Result<ActiveProxyRuntime> {
-    if !proxy.active {
+    if !proxy.is_active() {
         return Ok(ActiveProxyRuntime {
             env_vars: Vec::new(),
             handle: None,
@@ -255,10 +361,16 @@ pub(crate) fn start_proxy_runtime(
     }
 
     #[cfg(target_os = "macos")]
-    if proxy.trust_proxy_ca {
+    if proxy
+        .tls_intercept
+        .as_ref()
+        .is_some_and(|t| t.trust_proxy_ca)
+    {
         if proxy_config.intercept_ca_dir.is_some() {
             let validity = proxy
-                .proxy_ca_validity
+                .tls_intercept
+                .as_ref()
+                .and_then(|t| t.ca_validity)
                 .unwrap_or(nono_proxy::tls_intercept::ca::CA_VALIDITY_DEFAULT);
             proxy_config.preloaded_ca = crate::macos_trust::load_or_generate_proxy_ca(validity);
         } else {
@@ -541,7 +653,6 @@ mod tests {
     #[test]
     fn test_build_proxy_config_propagates_network_block_to_strict_filter() {
         let proxy = ProxyLaunchOptions {
-            active: true,
             network_block: true,
             ..ProxyLaunchOptions::default()
         };
@@ -555,7 +666,6 @@ mod tests {
     #[test]
     fn test_build_proxy_config_strict_filter_off_when_no_block() {
         let proxy = ProxyLaunchOptions {
-            active: true,
             network_block: false,
             ..ProxyLaunchOptions::default()
         };
@@ -636,7 +746,7 @@ mod tests {
             .expect("prepare_proxy_launch_options");
 
         assert!(
-            opts.active,
+            opts.is_active(),
             "proxy must be active when custom_credentials is non-empty"
         );
     }

--- a/crates/nono-cli/src/supervised_runtime.rs
+++ b/crates/nono-cli/src/supervised_runtime.rs
@@ -232,12 +232,24 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
         session_id: &supervisor_session_id,
         attach_initial_client: !session.detached_start,
         detach_sequence: session.detach_sequence.as_deref(),
-        open_url_origins: &proxy.open_url_origins,
-        open_url_allow_localhost: proxy.open_url_allow_localhost,
+        open_url_origins: proxy
+            .open_url
+            .as_ref()
+            .map(|o| o.origins.as_slice())
+            .unwrap_or(&[]),
+        open_url_allow_localhost: proxy
+            .open_url
+            .as_ref()
+            .map(|o| o.allow_localhost)
+            .unwrap_or(false),
         audit_recorder: audit_recorder.as_ref(),
         network_audit_events: supervisor_network_audit_events.as_ref(),
         redaction_policy,
-        allow_launch_services_active: proxy.allow_launch_services_active,
+        allow_launch_services_active: proxy
+            .open_url
+            .as_ref()
+            .map(|o| o.allow_launch_services)
+            .unwrap_or(false),
         #[cfg(target_os = "linux")]
         proxy_port: match caps.network_mode() {
             nono::NetworkMode::ProxyOnly { port, .. } => *port,


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1099

## Summary

Replace the flat `ProxyLaunchOptions` struct with focused intent structs: `DomainFilterIntent`, `EndpointFilterIntent`, `CredentialProxyIntent`, `UpstreamProxyIntent`, `TlsInterceptIntent`, and `OpenUrlIntent`.

Remove the stored `active: bool` field. Proxy activation is now derived via `is_active()`, which returns true when any activating intent struct is `Some`. `WithEndpoints` allow-domain entries are split from plain CONNECT-tunnel entries at prepare time, making the TLS-intercept requirement explicit in the type.

Infra-only flags (`--proxy-port`, `--proxy-ca-validity`, `--trust-proxy-ca`) now return an error if used without an activating proxy feature instead of silently doing nothing.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
