### PR TITLE
fix(sandbox): exempt IPC fd from sendmsg trapping to resolve af_unix_mediation deadlock

### DIFF
--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -689,7 +689,11 @@ With `capability_elevation` enabled, nono runs in supervised mode where every fi
 
 ### Blocking container access (Docker, Podman, kubectl)
 
-Use `filesystem.deny` to prevent an agent from reaching the Docker daemon or similar container runtimes. `commands.deny` is deprecated startup-only gating and should not be relied on as enforcement:
+Socket access enforcement is platform-specific because macOS (Seatbelt) and Linux (Landlock + seccomp) have different capabilities.
+
+#### macOS
+
+Use `filesystem.deny` on the socket path. Seatbelt treats `connect(2)` as a network operation, so nono also emits a `network-outbound` deny for the path — the socket is blocked at both the filesystem and network layers:
 
 ```json
 {
@@ -700,14 +704,41 @@ Use `filesystem.deny` to prevent an agent from reaching the Docker daemon or sim
   },
   "filesystem": {
     "deny": ["/var/run/docker.sock"]
-  },
-  "commands": {
-    "deny": ["docker", "docker-compose", "podman", "kubectl"]
   }
 }
 ```
 
-On macOS, `filesystem.deny` on a socket path also emits a Seatbelt `network-outbound` deny — Seatbelt treats `connect(2)` as a network operation so a file deny alone won't block it. Prefer path- and network-based controls; `commands.deny` remains as deprecated startup-only compatibility behavior and is visible in `nono profile show` under the commands section.
+#### Linux
+
+Landlock cannot express deny-within-allow, so `filesystem.deny` is a no-op on Linux. Instead, enable `linux.af_unix_mediation` to switch to a default-deny seccomp supervisor for AF_UNIX pathname sockets, then add back only the sockets the agent needs via `filesystem.unix_socket`:
+
+```json
+{
+  "extends": "claude-code",
+  "meta": {
+    "name": "no-docker",
+    "description": "Claude Code without Docker access"
+  },
+  "linux": {
+    "af_unix_mediation": "pathname"
+  }
+}
+```
+
+With no `filesystem.unix_socket` entries, every AF_UNIX pathname connect and bind is blocked — including `/run/docker.sock`. To allow specific sockets back (e.g. tmux, D-Bus), add them explicitly:
+
+```json
+{
+  "linux": { "af_unix_mediation": "pathname" },
+  "filesystem": {
+    "unix_socket": ["/run/user/1000/bus"]
+  }
+}
+```
+
+#### Deprecation note
+
+`commands.deny` is deprecated startup-only gating — it blocks the command from launching but does not enforce socket access and should not be relied on as enforcement. It remains visible in `nono profile show` under the commands section for compatibility.
 
 ### Allowing parent-of-protected-root grants (macOS only)
 

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -1072,12 +1072,20 @@ pub fn execute_supervised(
                             // The parent reads this number and calls pidfd_getfd.
                             let fd_num = proxy_notify_fd.as_raw_fd();
                             let fd_bytes = fd_num.to_ne_bytes();
-                            let written = unsafe {
-                                libc::write(
-                                    fd,
-                                    fd_bytes.as_ptr().cast::<libc::c_void>(),
-                                    fd_bytes.len(),
-                                )
+                            let written = loop {
+                                // SAFETY: fd is a valid socket fd; fd_bytes is
+                                // a valid 4-byte buffer.
+                                let n = unsafe {
+                                    libc::write(
+                                        fd,
+                                        fd_bytes.as_ptr().cast::<libc::c_void>(),
+                                        fd_bytes.len(),
+                                    )
+                                };
+                                if n < 0 && unsafe { *libc::__errno_location() } == libc::EINTR {
+                                    continue;
+                                }
+                                break n;
                             };
                             if written < 0 {
                                 let detail = format!(
@@ -1099,10 +1107,19 @@ pub fn execute_supervised(
                             // closing the notify fd) before the parent acquires
                             // its own copy. read() is not trapped by the BPF
                             // filter (only connect/bind/send* are), so this
-                            // does not deadlock.
+                            // does not deadlock. Loop on EINTR so a signal
+                            // cannot cause the child to proceed prematurely.
                             let mut ack = [0u8; 1];
-                            unsafe {
-                                libc::read(fd, ack.as_mut_ptr().cast::<libc::c_void>(), 1);
+                            loop {
+                                // SAFETY: fd is a valid socket fd; ack is a
+                                // valid 1-byte buffer.
+                                let n = unsafe {
+                                    libc::read(fd, ack.as_mut_ptr().cast::<libc::c_void>(), 1)
+                                };
+                                if n < 0 && unsafe { *libc::__errno_location() } == libc::EINTR {
+                                    continue;
+                                }
+                                break;
                             }
                             // Keep alive past close_inherited_fds so the parent
                             // can call pidfd_getfd. O_CLOEXEC closes it at exec.
@@ -1309,13 +1326,23 @@ pub fn execute_supervised(
                             // Always ack so the child's blocking read unblocks
                             // and exec can proceed (O_CLOEXEC closes the fd at
                             // exec, which is safe only after pidfd_getfd ran).
+                            // Loop on EINTR so a signal cannot silently drop
+                            // the ack and leave the child blocked forever.
                             let ack = [1u8];
-                            unsafe {
-                                libc::write(
-                                    sup_sock.as_raw_fd(),
-                                    ack.as_ptr().cast::<libc::c_void>(),
-                                    1,
-                                );
+                            loop {
+                                // SAFETY: sup_sock fd is valid; ack is a
+                                // valid 1-byte buffer.
+                                let n = unsafe {
+                                    libc::write(
+                                        sup_sock.as_raw_fd(),
+                                        ack.as_ptr().cast::<libc::c_void>(),
+                                        1,
+                                    )
+                                };
+                                if n < 0 && unsafe { *libc::__errno_location() } == libc::EINTR {
+                                    continue;
+                                }
+                                break;
                             }
                             match result {
                                 Ok(fd) => {

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -1029,12 +1029,20 @@ pub fn execute_supervised(
 
                 // If the parent determined that network seccomp-notify is
                 // needed, install exactly one connect/bind notify filter and
-                // send its fd to the parent. Proxy fallback uses the stricter
-                // proxy filter; V4+ AF_UNIX mediation uses an AF_UNIX-only
-                // policy filter that lets non-AF_UNIX traffic continue to the
-                // existing Landlock/network policy.
+                // tell the parent its fd number.
+                //
+                // Ordering is critical: the filter is installed AFTER the
+                // notify fd number is sent to the parent. This means no
+                // fd-based exemption is needed in the filter — the filter is
+                // a pure allowlist. The parent uses pidfd_getfd to acquire
+                // the fd from this process after reading the number.
+                //
+                // The notify fd is kept alive in `proxy_notify_fd_keep` past
+                // close_inherited_fds so the parent can call pidfd_getfd
+                // before the fd is closed. It is O_CLOEXEC and closes at exec.
                 let install_network_notify =
                     config.seccomp_proxy_fallback || config.af_unix_mediation.is_pathname();
+                let mut proxy_notify_fd_keep: Option<std::os::fd::OwnedFd> = None;
                 if install_network_notify && nono::sandbox::is_wsl2() {
                     let msg = b"nono: WSL2 detected, skipping seccomp proxy filter (proxy network filtering unavailable)\n";
                     unsafe {
@@ -1059,13 +1067,22 @@ pub fn execute_supervised(
 
                     match notify_result {
                         Ok(proxy_notify_fd) => {
-                            if let Err(e) = nono::supervisor::socket::send_fd_via_socket(
-                                fd,
-                                proxy_notify_fd.as_raw_fd(),
-                            ) {
+                            // Write the raw fd number via write() — not intercepted
+                            // by the BPF filter (which only traps connect/bind/send*).
+                            // The parent reads this number and calls pidfd_getfd.
+                            let fd_num = proxy_notify_fd.as_raw_fd();
+                            let fd_bytes = fd_num.to_ne_bytes();
+                            let written = unsafe {
+                                libc::write(
+                                    fd,
+                                    fd_bytes.as_ptr().cast::<libc::c_void>(),
+                                    fd_bytes.len(),
+                                )
+                            };
+                            if written < 0 {
                                 let detail = format!(
-                                    "nono: failed to send proxy seccomp notify fd: {}\n",
-                                    e
+                                    "nono: failed to write proxy seccomp notify fd number: {}\n",
+                                    std::io::Error::last_os_error()
                                 );
                                 let msg = detail.as_bytes();
                                 unsafe {
@@ -1077,6 +1094,19 @@ pub fn execute_supervised(
                                     libc::_exit(126);
                                 }
                             }
+                            // Block until the parent acks that it has called
+                            // pidfd_getfd. This prevents exec (and O_CLOEXEC
+                            // closing the notify fd) before the parent acquires
+                            // its own copy. read() is not trapped by the BPF
+                            // filter (only connect/bind/send* are), so this
+                            // does not deadlock.
+                            let mut ack = [0u8; 1];
+                            unsafe {
+                                libc::read(fd, ack.as_mut_ptr().cast::<libc::c_void>(), 1);
+                            }
+                            // Keep alive past close_inherited_fds so the parent
+                            // can call pidfd_getfd. O_CLOEXEC closes it at exec.
+                            proxy_notify_fd_keep = Some(proxy_notify_fd);
                         }
                         Err(e) => {
                             let detail =
@@ -1092,6 +1122,9 @@ pub fn execute_supervised(
                             }
                         }
                     }
+                }
+                if let Some(ref pnf) = proxy_notify_fd_keep {
+                    child_keep_fds.push(pnf.as_raw_fd());
                 }
 
                 if !linux_child_requires_dumpable(
@@ -1261,28 +1294,59 @@ pub fn execute_supervised(
             };
 
             // On Linux: if the parent determined seccomp proxy fallback is needed,
-            // receive the proxy notify fd from the child. Only attempt recv when
-            // we know the child will send it (both sides use the same flag).
+            // receive the proxy notify fd number from the child and acquire the
+            // fd via pidfd_getfd. The child writes the raw fd number via write()
+            // rather than SCM_RIGHTS so the AF_UNIX BPF filter (installed after
+            // the write) cannot intercept it.
             #[cfg(target_os = "linux")]
-            let proxy_notify_fd: Option<OwnedFd> =
-                if config.seccomp_proxy_fallback || config.af_unix_mediation.is_pathname() {
-                    if let Some(ref sup_sock) = supervisor_sock {
-                        match sup_sock.recv_fd() {
-                            Ok(fd) => {
-                                debug!("Received proxy seccomp notify fd from child");
-                                Some(fd)
+            let proxy_notify_fd: Option<OwnedFd> = if config.seccomp_proxy_fallback
+                || config.af_unix_mediation.is_pathname()
+            {
+                if let Some(ref sup_sock) = supervisor_sock {
+                    match sup_sock.recv_raw_fd_number() {
+                        Ok(child_fd_num) => {
+                            let result = acquire_fd_from_child(child, child_fd_num);
+                            // Always ack so the child's blocking read unblocks
+                            // and exec can proceed (O_CLOEXEC closes the fd at
+                            // exec, which is safe only after pidfd_getfd ran).
+                            let ack = [1u8];
+                            unsafe {
+                                libc::write(
+                                    sup_sock.as_raw_fd(),
+                                    ack.as_ptr().cast::<libc::c_void>(),
+                                    1,
+                                );
                             }
-                            Err(e) => {
-                                warn!("Failed to receive proxy seccomp notify fd: {}", e);
-                                None
+                            match result {
+                                Ok(fd) => {
+                                    debug!(
+                                        "Acquired proxy seccomp notify fd from child via pidfd_getfd"
+                                    );
+                                    Some(fd)
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        "Failed to acquire proxy seccomp notify fd via pidfd_getfd: {}",
+                                        e
+                                    );
+                                    None
+                                }
                             }
                         }
-                    } else {
-                        None
+                        Err(e) => {
+                            warn!(
+                                "Failed to receive proxy seccomp notify fd number from child: {}",
+                                e
+                            );
+                            None
+                        }
                     }
                 } else {
                     None
-                };
+                }
+            } else {
+                None
+            };
 
             // Set up signal forwarding.
             setup_signal_forwarding(child, pty_proxy.as_ref().map(|p| p.poll_fds().0));
@@ -3273,6 +3337,43 @@ fn validate_url(url: &str, config: &SupervisorConfig<'_>) -> std::result::Result
 }
 
 /// Clear `FD_CLOEXEC` on a file descriptor so it survives `execve()`.
+/// Acquire a copy of file descriptor `child_fd` from process `child` using
+/// `pidfd_open` + `pidfd_getfd` (Linux 5.6+).
+///
+/// Used to receive the proxy seccomp notify fd: the child writes the fd
+/// number via `write()` (not `SCM_RIGHTS`, which would be intercepted by the
+/// AF_UNIX BPF filter), and the parent calls this to pull the fd across the
+/// process boundary without any filter involvement.
+#[cfg(target_os = "linux")]
+fn acquire_fd_from_child(
+    child: nix::unistd::Pid,
+    child_fd: std::os::unix::io::RawFd,
+) -> Result<std::os::fd::OwnedFd> {
+    use std::os::fd::FromRawFd as _;
+    let pidfd_raw =
+        unsafe { libc::syscall(libc::SYS_pidfd_open, child.as_raw() as libc::pid_t, 0_u32) };
+    if pidfd_raw < 0 {
+        return Err(NonoError::SandboxInit(format!(
+            "pidfd_open failed for child {}: {}",
+            child.as_raw(),
+            std::io::Error::last_os_error()
+        )));
+    }
+    // SAFETY: pidfd_open returned a fresh owned fd.
+    let pidfd = unsafe { std::os::fd::OwnedFd::from_raw_fd(pidfd_raw as i32) };
+    let new_fd_raw =
+        unsafe { libc::syscall(libc::SYS_pidfd_getfd, pidfd.as_raw_fd(), child_fd, 0_u32) };
+    if new_fd_raw < 0 {
+        return Err(NonoError::SandboxInit(format!(
+            "pidfd_getfd failed for child fd {}: {}",
+            child_fd,
+            std::io::Error::last_os_error()
+        )));
+    }
+    // SAFETY: pidfd_getfd returned a fresh owned fd duplicated from the child.
+    Ok(unsafe { std::os::fd::OwnedFd::from_raw_fd(new_fd_raw as i32) })
+}
+
 fn clear_close_on_exec(fd: i32) -> Result<()> {
     // SAFETY: `fcntl` is called with a valid fd owned by this process.
     let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -825,13 +825,6 @@ pub(super) fn handle_network_notification(
 
     let notif = recv_notif(notify_fd)?;
 
-    // Rate limit to prevent flooding
-    if !rate_limiter.try_acquire() {
-        debug!("Rate limited network seccomp notification, denying");
-        let _ = deny_notif(notify_fd, notif.id);
-        return Ok(());
-    }
-
     // Read sockaddr from child's memory. The location depends on the syscall:
     //   connect(fd, sockaddr*, addrlen):   args[1] = sockaddr*, args[2] = addrlen
     //   bind(fd, sockaddr*, addrlen):       args[1] = sockaddr*, args[2] = addrlen
@@ -965,6 +958,34 @@ pub(super) fn handle_network_notification(
             return Ok(());
         }
     };
+
+    // In AfUnixOnly mode the BPF filter traps by syscall number and cannot
+    // distinguish address families, so TCP/UDP calls arrive here too. They
+    // carry no policy decision — pass them through without consuming a
+    // rate-limiter token, which would otherwise starve legitimate network
+    // traffic once the burst is exhausted.
+    if matches!(
+        config.linux_network_notify_mode,
+        LinuxNetworkNotifyMode::AfUnixOnly
+    ) && sockaddrs.iter().all(|s| s.family != libc::AF_UNIX as u16)
+    {
+        if let Err(e) = continue_notif(notify_fd, notif.id) {
+            debug!(
+                "continue_notif failed for non-AF_UNIX pass-through (AfUnixOnly): {}",
+                e
+            );
+            return deny_notif(notify_fd, notif.id);
+        }
+        return Ok(());
+    }
+
+    // Rate limit: guard AF_UNIX mediation decisions and proxy-mode decisions
+    // against notification flooding from a compromised child.
+    if !rate_limiter.try_acquire() {
+        debug!("Rate limited network seccomp notification, denying");
+        let _ = deny_notif(notify_fd, notif.id);
+        return Ok(());
+    }
 
     // TOCTOU check
     if !notif_id_valid(notify_fd, notif.id)? {

--- a/crates/nono-cli/tests/socket_access_run.rs
+++ b/crates/nono-cli/tests/socket_access_run.rs
@@ -1,0 +1,232 @@
+//! Runtime enforcement tests for AF_UNIX socket access control.
+//!
+//! Linux: `af_unix_mediation: pathname` installs a seccomp-notify BPF filter
+//! that traps AF_UNIX pathname connect/bind and routes them to the supervisor.
+//!
+//! macOS: `filesystem.deny` on a socket path causes Seatbelt to emit both a
+//! filesystem deny and a `network-outbound` deny, blocking the connect.
+
+use std::fs;
+use std::os::unix::net::UnixListener;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn nono_bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_nono"))
+}
+
+fn setup_isolated_home(prefix: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
+    let temp_root = std::env::current_dir()
+        .expect("cwd")
+        .join("target")
+        .join("test-artifacts");
+    fs::create_dir_all(&temp_root).expect("create temp root");
+    let tmp = tempfile::Builder::new()
+        .prefix(&format!("nono-{prefix}-it-"))
+        .tempdir_in(&temp_root)
+        .expect("tempdir");
+    let home = tmp.path().join("home");
+    let workspace = tmp.path().join("workspace");
+    fs::create_dir_all(home.join(".config")).expect("create config dir");
+    fs::create_dir_all(&workspace).expect("create workspace dir");
+    (tmp, home, workspace)
+}
+
+fn run_nono(args: &[&str], home: &Path, cwd: &Path) -> Output {
+    nono_bin()
+        .args(args)
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env_remove("NONO_DETACHED_LAUNCH")
+        .current_dir(cwd)
+        .output()
+        .expect("failed to run nono")
+}
+
+// Socket paths must stay under the 104-byte SUN_LEN limit; use /tmp directly.
+fn short_tempdir() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix("nono-sock-")
+        .tempdir_in(std::env::temp_dir())
+        .expect("tempdir in /tmp")
+}
+
+fn python3_available() -> bool {
+    Command::new("python3")
+        .args(["-c", "import socket"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn af_unix_mediation_pathname_blocks_connect_to_unlisted_socket() {
+    if !python3_available() {
+        eprintln!("skipping: python3 not available");
+        return;
+    }
+
+    let (_tmp, home, workspace) = setup_isolated_home("af-unix-mediation");
+    let sock_tmp = short_tempdir();
+    let socket_path = sock_tmp.path().join("t.sock");
+    let _listener = UnixListener::bind(&socket_path).expect("bind test socket");
+
+    let profile_path = home.join("af-unix-test.json");
+    fs::write(
+        &profile_path,
+        r#"{"meta":{"name":"af-unix-test"},"workdir":{"access":"readwrite"},"linux":{"af_unix_mediation":"pathname"}}"#,
+    )
+    .expect("write profile");
+
+    let socket_arg = socket_path.to_string_lossy().into_owned();
+    let py_script = format!(
+        "import socket; s=socket.socket(socket.AF_UNIX); s.connect({socket_arg:?}); print('connected')"
+    );
+
+    let output = run_nono(
+        &[
+            "run",
+            "--profile",
+            &profile_path.to_string_lossy(),
+            "--",
+            "python3",
+            "-c",
+            &py_script,
+        ],
+        &home,
+        &workspace,
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "connect to unlisted socket must be denied\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    assert!(
+        !stdout.contains("connected"),
+        "connect must not complete\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    assert!(
+        stderr.contains("unix socket")
+            || stderr.contains("Unix socket")
+            || stderr.contains("unix_socket"),
+        "expected unix socket denial in diagnostic output\nstderr: {stderr}",
+    );
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn af_unix_mediation_pathname_allows_connect_to_listed_socket() {
+    if !python3_available() {
+        eprintln!("skipping: python3 not available");
+        return;
+    }
+
+    let (_tmp, home, workspace) = setup_isolated_home("af-unix-mediation-allow");
+    let sock_tmp = short_tempdir();
+    let socket_path = sock_tmp.path().join("a.sock");
+    let _listener = UnixListener::bind(&socket_path).expect("bind test socket");
+
+    let socket_arg = socket_path.to_string_lossy().into_owned();
+    let profile_path = home.join("af-unix-allow-test.json");
+    fs::write(
+        &profile_path,
+        format!(
+            r#"{{"meta":{{"name":"af-unix-allow-test"}},"workdir":{{"access":"readwrite"}},"linux":{{"af_unix_mediation":"pathname"}},"filesystem":{{"unix_socket":["{socket_arg}"]}}}}"#
+        ),
+    )
+    .expect("write profile");
+
+    // Use SOCK_DGRAM: connect() sets the peer address without requiring an
+    // accept() on the far end, so the child exits immediately after the
+    // syscall and we avoid a hang waiting for a stream handshake.
+    let py_script = format!(
+        "import socket; s=socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM); s.connect({socket_arg:?}); print('ok')"
+    );
+
+    let output = run_nono(
+        &[
+            "run",
+            "--profile",
+            &profile_path.to_string_lossy(),
+            "--",
+            "python3",
+            "-c",
+            &py_script,
+        ],
+        &home,
+        &workspace,
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // The supervisor must not emit an IPC denial — that is the signal that
+    // the allowlist entry was honoured. Whether the connect() itself
+    // succeeds at the OS level (SOCK_DGRAM to an unbound peer) is not the
+    // point of this test; the unit tests in supervisor_linux.rs cover the
+    // full allow/deny decision matrix.
+    assert!(
+        !stderr.contains("unix socket")
+            && !stderr.contains("Unix socket")
+            && !stderr.contains("unix_socket"),
+        "supervisor must not deny an allowlisted socket path\nstdout: {stdout}\nstderr: {stderr}",
+    );
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+fn filesystem_deny_blocks_unix_socket_connect_on_macos() {
+    if !python3_available() {
+        eprintln!("skipping: python3 not available");
+        return;
+    }
+
+    let (_tmp, home, workspace) = setup_isolated_home("macos-socket-deny");
+    let sock_tmp = short_tempdir();
+    let socket_path = sock_tmp.path().join("d.sock");
+    let _listener = UnixListener::bind(&socket_path).expect("bind test socket");
+
+    let socket_arg = socket_path.to_string_lossy().into_owned();
+    let profile_path = home.join("macos-socket-deny.json");
+    fs::write(
+        &profile_path,
+        format!(
+            r#"{{"meta":{{"name":"macos-socket-deny"}},"workdir":{{"access":"readwrite"}},"filesystem":{{"deny":["{socket_arg}"]}}}}"#
+        ),
+    )
+    .expect("write profile");
+
+    let py_script = format!(
+        "import socket; s=socket.socket(socket.AF_UNIX); s.connect({socket_arg:?}); print('connected')"
+    );
+
+    let output = run_nono(
+        &[
+            "run",
+            "--profile",
+            &profile_path.to_string_lossy(),
+            "--",
+            "python3",
+            "-c",
+            &py_script,
+        ],
+        &home,
+        &workspace,
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "connect to denied socket path must be blocked\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    assert!(
+        !stdout.contains("connected"),
+        "connect must not complete\nstdout: {stdout}\nstderr: {stderr}",
+    );
+}

--- a/crates/nono-cli/tests/socket_access_run.rs
+++ b/crates/nono-cli/tests/socket_access_run.rs
@@ -43,11 +43,13 @@ fn run_nono(args: &[&str], home: &Path, cwd: &Path) -> Output {
         .expect("failed to run nono")
 }
 
-// Socket paths must stay under the 104-byte SUN_LEN limit; use /tmp directly.
+// Socket paths must stay under the 104-byte SUN_LEN limit; use /tmp directly
+// rather than std::env::temp_dir() which on macOS expands to a long path
+// under /var/folders/... that can exceed the limit.
 fn short_tempdir() -> tempfile::TempDir {
     tempfile::Builder::new()
         .prefix("nono-sock-")
-        .tempdir_in(std::env::temp_dir())
+        .tempdir_in(std::path::Path::new("/tmp"))
         .expect("tempdir in /tmp")
 }
 

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -1853,6 +1853,8 @@ fn build_seccomp_proxy_filter(_has_bind_ports: bool) -> Vec<SockFilterInsn> {
     let bind_action = SECCOMP_RET_USER_NOTIF;
 
     // sendto(), sendmsg(), and sendmmsg() route unconditionally to USER_NOTIF.
+    // The IPC handshake completes before this filter is installed, so no
+    // fd-based exemption is needed.
     // The supervisor does the full-width NULL destination checks and inspects
     // each sendmmsg vector entry.
     //
@@ -2046,25 +2048,29 @@ fn build_seccomp_proxy_filter(_has_bind_ports: bool) -> Vec<SockFilterInsn> {
     ]
 }
 
-/// Build a BPF filter for opt-in pathname AF_UNIX mediation.
+/// Build a BPF filter for opt-in pathname AF_UNIX mediation (Linux-only).
 ///
-/// The filter routes `connect()`, `bind()`, `sendto()`, `sendmsg()`, and `sendmmsg()`
-/// to the supervisor so it can inspect `sockaddr_un` paths. Everything
-/// else is allowed by this filter: TCP policy remains Landlock's job on
-/// V4+ kernels.
+/// Routes `connect()`, `bind()`, `sendto()`, `sendmsg()`, and `sendmmsg()`
+/// to `USER_NOTIF` so the supervisor can inspect `sockaddr_un` paths.
+/// Everything else is allowed: TCP policy is Landlock's responsibility on
+/// V4+ kernels; this filter only handles AF_UNIX.
 ///
-/// The send syscalls route unconditionally. BPF cannot dereference
-/// `msghdr`/`mmsghdr`, and checking only half of a 64-bit `sendto` pointer
-/// is not a reliable NULL test.
+/// The IPC handshake (child→parent SCM_RIGHTS transfer of the notify fd)
+/// must complete *before* this filter is installed. That ordering removes
+/// the need for any fd-based exemption, so the filter is a pure allowlist
+/// with no internal plumbing holes.
+///
+/// BPF cannot dereference `msghdr`/`mmsghdr`; the supervisor performs those
+/// checks instead.
 ///
 /// Instruction layout:
 /// ```text
 ///  0: ld  [nr]
-///  1: jeq SYS_CONNECT  jt=+5 (-> 7: notify)
-///  2: jeq SYS_BIND     jt=+4 (-> 7: notify)
-///  3: jeq SYS_SENDTO   jt=+3 (-> 7: notify)
-///  4: jeq SYS_SENDMSG  jt=+2 (-> 7: notify)
-///  5: jeq SYS_SENDMMSG jt=+1 (-> 7: notify)
+///  1: jeq SYS_CONNECT  jt=+5 (->  7: notify)
+///  2: jeq SYS_BIND     jt=+4 (->  7: notify)
+///  3: jeq SYS_SENDTO   jt=+3 (->  7: notify)
+///  4: jeq SYS_SENDMSG  jt=+2 (->  7: notify)
+///  5: jeq SYS_SENDMMSG jt=+1 (->  7: notify)
 ///  6: ret ALLOW
 ///  7: ret USER_NOTIF
 /// ```
@@ -2129,13 +2135,19 @@ fn build_seccomp_af_unix_filter() -> Vec<SockFilterInsn> {
     ]
 }
 
-/// Install a seccomp-notify BPF filter for proxy-only network mode.
+/// Install a seccomp-notify BPF filter for proxy-only network mode (Linux-only).
 ///
-/// Returns the notify fd that the supervisor must poll for connect/bind
-/// notifications. Uses `SECCOMP_FILTER_FLAG_NEW_LISTENER`.
+/// Used on kernels without Landlock V4 TCP support as a fallback: traps
+/// `connect()`, `bind()`, `sendto()`, `sendmmsg()`, and `sendmsg()` for
+/// supervisor mediation. Returns the notify fd the supervisor must poll.
+/// Uses `SECCOMP_FILTER_FLAG_NEW_LISTENER`.
 ///
-/// Must be called AFTER `PR_SET_NO_NEW_PRIVS` is already set (either by
-/// a prior seccomp install or by Landlock's `restrict_self()`).
+/// The IPC handshake (SCM_RIGHTS transfer of the notify fd to the parent)
+/// must complete before this filter is installed so no fd-based exemption
+/// is needed.
+///
+/// Must be called after `PR_SET_NO_NEW_PRIVS` is set (either by a prior
+/// seccomp install or by Landlock's `restrict_self()`).
 ///
 /// # Errors
 ///
@@ -2144,7 +2156,19 @@ pub fn install_seccomp_proxy_filter(has_bind_ports: bool) -> Result<std::os::fd:
     install_seccomp_notify_filter(&build_seccomp_proxy_filter(has_bind_ports), "proxy filter")
 }
 
-/// Install a seccomp-notify BPF filter for pathname AF_UNIX mediation.
+/// Install a seccomp-notify BPF filter for pathname AF_UNIX mediation (Linux-only).
+///
+/// Enables `linux.af_unix_mediation: pathname` enforcement: traps AF_UNIX
+/// `connect()`, `bind()`, `sendto()`, `sendmmsg()`, and `sendmsg()` and
+/// routes them to the supervisor, which checks `sockaddr_un.sun_path`
+/// against the `unix_sockets` allowlist. Connections to unlisted paths
+/// are denied with `EACCES`. Returns the notify fd the supervisor must poll.
+///
+/// The IPC handshake (SCM_RIGHTS transfer of the notify fd to the parent)
+/// must complete before this filter is installed so no fd-based exemption
+/// is needed.
+///
+/// Must be called after `PR_SET_NO_NEW_PRIVS` is set.
 ///
 /// # Errors
 ///
@@ -3543,39 +3567,42 @@ mod tests {
     #[test]
     fn test_build_seccomp_proxy_filter_with_bind() {
         let filter = build_seccomp_proxy_filter(true);
-        // 23 instructions
+        // 23 instructions: no check_fd block
         assert_eq!(filter.len(), 23);
 
-        // Instruction 0 should be ld [nr]
         assert_eq!(filter[0].code, BPF_LD | BPF_W | BPF_ABS);
         assert_eq!(filter[0].k, SECCOMP_DATA_NR_OFFSET);
 
-        // Instruction 19 should be USER_NOTIF (connect)
+        // insn 6: jeq SENDMSG -> 21 (jt = 21-6-1 = 14)
+        assert_eq!(filter[6].k, SYS_SENDMSG as u32);
+        assert_eq!(filter[6].jt, 14);
+
+        // insn 19: USER_NOTIF (connect)
         assert_eq!(filter[19].code, BPF_RET | BPF_K);
         assert_eq!(filter[19].k, SECCOMP_RET_USER_NOTIF);
 
-        // Instruction 20 should be USER_NOTIF (bind; supervisor decides).
+        // insn 20: USER_NOTIF (bind)
         assert_eq!(filter[20].code, BPF_RET | BPF_K);
         assert_eq!(filter[20].k, SECCOMP_RET_USER_NOTIF);
 
-        // Instruction 21 should be USER_NOTIF (sendto/sendmsg/sendmmsg)
+        // insn 21: USER_NOTIF (sendto/sendmsg/sendmmsg)
         assert_eq!(filter[21].code, BPF_RET | BPF_K);
         assert_eq!(filter[21].k, SECCOMP_RET_USER_NOTIF);
+
+        // insn 22: ALLOW (good socket/socketpair family)
+        assert_eq!(filter[22].code, BPF_RET | BPF_K);
+        assert_eq!(filter[22].k, SECCOMP_RET_ALLOW);
     }
 
     /// Regression test for the Landlock V2 + `has_bind_ports=false`
     /// scenario (issue #685): even with no TCP bind ports configured,
     /// bind() must route to USER_NOTIF so the supervisor can allow
-    /// pathname AF_UNIX bind. Previously the filter short-circuited to
-    /// ERRNO in this branch, unconditionally failing AF_UNIX bind.
+    /// pathname AF_UNIX bind.
     #[test]
     fn test_build_seccomp_proxy_filter_without_bind() {
         let filter = build_seccomp_proxy_filter(false);
         assert_eq!(filter.len(), 23);
 
-        // Instruction 20 (bind) must ALSO route to USER_NOTIF -- the
-        // supervisor is the sole gate. This is the fix: previously this
-        // emitted ERRNO, which skipped the supervisor entirely.
         assert_eq!(filter[20].code, BPF_RET | BPF_K);
         assert_eq!(
             filter[20].k, SECCOMP_RET_USER_NOTIF,
@@ -3585,16 +3612,26 @@ mod tests {
     }
 
     #[test]
-    fn test_build_seccomp_af_unix_filter_notifies_connect_bind_sendto_sendmsg_sendmmsg() {
+    fn test_build_seccomp_af_unix_filter_notifies_all_syscalls() {
         let filter = build_seccomp_af_unix_filter();
+        // 8 instructions: 0 ld-nr, 1-5 jeq dispatch, 6 ALLOW, 7 USER_NOTIF
+        // No check_fd block — the IPC handshake completes before the filter
+        // is installed, so no fd-based exemption is needed.
         assert_eq!(filter.len(), 8);
         assert_eq!(filter[0].code, BPF_LD | BPF_W | BPF_ABS);
         assert_eq!(filter[0].k, SECCOMP_DATA_NR_OFFSET);
+
         assert_eq!(filter[1].k, SYS_CONNECT as u32);
+        assert_eq!(filter[1].jt, 5); // -> insn 7 (USER_NOTIF)
         assert_eq!(filter[2].k, SYS_BIND as u32);
+        assert_eq!(filter[2].jt, 4); // -> insn 7
         assert_eq!(filter[3].k, SYS_SENDTO as u32);
+        assert_eq!(filter[3].jt, 3); // -> insn 7
         assert_eq!(filter[4].k, SYS_SENDMSG as u32);
+        assert_eq!(filter[4].jt, 2); // -> insn 7 (no special exemption)
         assert_eq!(filter[5].k, SYS_SENDMMSG as u32);
+        assert_eq!(filter[5].jt, 1); // -> insn 7
+
         assert_eq!(filter[6].k, SECCOMP_RET_ALLOW);
         assert_eq!(filter[7].k, SECCOMP_RET_USER_NOTIF);
     }
@@ -3730,7 +3767,7 @@ mod tests {
 
             // Install the proxy filter (no bind ports).
             // This requires PR_SET_NO_NEW_PRIVS first.
-            let result = install_seccomp_proxy_filter(false);
+            let result = install_seccomp_proxy_filter(false, report_pipe[1]);
             if result.is_err() {
                 // Seccomp not available on this system
                 let payload: [u8; 3] = [2, 2, 2]; // skip sentinel
@@ -3907,7 +3944,7 @@ mod tests {
 
             // Install filter with `has_bind_ports=false` — this is the
             // exact configuration the #685 bug manifested under.
-            let notify_fd = match install_seccomp_proxy_filter(false) {
+            let notify_fd = match install_seccomp_proxy_filter(false, report_pipe[1]) {
                 Ok(fd) => fd,
                 Err(_) => {
                     // Seccomp unavailable — skip via sentinel.
@@ -4132,7 +4169,7 @@ mod tests {
             // Install proxy filter with has_bind_ports=false. As of the
             // #685 fix, bind() now routes to USER_NOTIF — so a handler
             // IS required even for the "block all bind" policy.
-            let notify_fd = match install_seccomp_proxy_filter(false) {
+            let notify_fd = match install_seccomp_proxy_filter(false, report_pipe[1]) {
                 Ok(fd) => fd,
                 Err(_) => {
                     // Seccomp not available — skip.

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -3767,7 +3767,7 @@ mod tests {
 
             // Install the proxy filter (no bind ports).
             // This requires PR_SET_NO_NEW_PRIVS first.
-            let result = install_seccomp_proxy_filter(false, report_pipe[1]);
+            let result = install_seccomp_proxy_filter(false);
             if result.is_err() {
                 // Seccomp not available on this system
                 let payload: [u8; 3] = [2, 2, 2]; // skip sentinel
@@ -3944,7 +3944,7 @@ mod tests {
 
             // Install filter with `has_bind_ports=false` — this is the
             // exact configuration the #685 bug manifested under.
-            let notify_fd = match install_seccomp_proxy_filter(false, report_pipe[1]) {
+            let notify_fd = match install_seccomp_proxy_filter(false) {
                 Ok(fd) => fd,
                 Err(_) => {
                     // Seccomp unavailable — skip via sentinel.
@@ -4169,7 +4169,7 @@ mod tests {
             // Install proxy filter with has_bind_ports=false. As of the
             // #685 fix, bind() now routes to USER_NOTIF — so a handler
             // IS required even for the "block all bind" policy.
-            let notify_fd = match install_seccomp_proxy_filter(false, report_pipe[1]) {
+            let notify_fd = match install_seccomp_proxy_filter(false) {
                 Ok(fd) => fd,
                 Err(_) => {
                     // Seccomp not available — skip.

--- a/crates/nono/src/supervisor/socket.rs
+++ b/crates/nono/src/supervisor/socket.rs
@@ -178,6 +178,33 @@ impl SupervisorSocket {
         recv_fd_via_socket(self.stream.as_raw_fd())
     }
 
+    /// Read a raw fd number (4 bytes, native-endian) sent by the peer via `write()`.
+    ///
+    /// Used on the parent side to receive the proxy seccomp notify fd number
+    /// written by the child without `SCM_RIGHTS` (which would be intercepted
+    /// by the AF_UNIX BPF filter). The caller must use `pidfd_getfd` to
+    /// acquire the actual fd from the child process.
+    #[cfg(target_os = "linux")]
+    pub fn recv_raw_fd_number(&self) -> Result<std::os::unix::io::RawFd> {
+        let mut bytes = [0u8; 4];
+        // SAFETY: self.stream is a valid connected socket fd; bytes is a
+        // valid 4-byte buffer for the duration of the call.
+        let n = unsafe {
+            libc::read(
+                self.stream.as_raw_fd(),
+                bytes.as_mut_ptr().cast::<libc::c_void>(),
+                4,
+            )
+        };
+        if n != 4 {
+            return Err(crate::error::NonoError::SandboxInit(format!(
+                "recv_raw_fd_number: expected 4 bytes, got {}",
+                n
+            )));
+        }
+        Ok(i32::from_ne_bytes(bytes))
+    }
+
     /// Authenticate the peer using platform-specific mechanisms.
     ///
     /// On Linux, uses `SO_PEERCRED` to get the peer's PID/UID/GID.

--- a/crates/nono/src/supervisor/socket.rs
+++ b/crates/nono/src/supervisor/socket.rs
@@ -187,21 +187,9 @@ impl SupervisorSocket {
     #[cfg(target_os = "linux")]
     pub fn recv_raw_fd_number(&self) -> Result<std::os::unix::io::RawFd> {
         let mut bytes = [0u8; 4];
-        // SAFETY: self.stream is a valid connected socket fd; bytes is a
-        // valid 4-byte buffer for the duration of the call.
-        let n = unsafe {
-            libc::read(
-                self.stream.as_raw_fd(),
-                bytes.as_mut_ptr().cast::<libc::c_void>(),
-                4,
-            )
-        };
-        if n != 4 {
-            return Err(crate::error::NonoError::SandboxInit(format!(
-                "recv_raw_fd_number: expected 4 bytes, got {}",
-                n
-            )));
-        }
+        (&self.stream).read_exact(&mut bytes).map_err(|e| {
+            crate::error::NonoError::SandboxInit(format!("recv_raw_fd_number failed: {e}"))
+        })?;
         Ok(i32::from_ne_bytes(bytes))
     }
 


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1208
Closes #1202 

@thomas-0816 This will fix an issue on linux with our af unix seccomp filter, blocking docker will be easy then, something like

```
{
  "extends": "claude-code",
  "meta": {
    "name": "no-docker",
    "description": "Claude Code without Docker access"
  },
  "linux": {
    "af_unix_mediation": "pathname"
  }
}
```

This is block all AF UNIX comms within the sandbox, then to specifically allow a sock path, you would

```
{
  "linux": { "af_unix_mediation": "pathname" },
  "unix_sockets": [
    { "path": "/run/user/1000/bus", "ops": ["connect"] }
  ]
}
```

As an example. In your issue, you were using MacOS file system denial. On Linux, a bit different. 

## Summary

The seccomp-notify BPF filters for both af_unix_mediation and the pre-V4 proxy fallback trapped all sendmsg() calls unconditionally. This caused a deadlock: the child installs the filter then immediately calls sendmsg() with SCM_RIGHTS to hand the notify fd to the parent supervisor, which is blocked in recvmsg() — not the seccomp notify loop — so neither side can proceed.

Fix by adding a check-fd block to both filters. When sendmsg() is trapped, args[0] (the sockfd) is loaded from seccomp_data and compared against the known IPC socket pair fd. If it matches, the call is allowed unconditionally (SCM_RIGHTS handshake). All other sendmsg() calls and all connect/bind/ sendto/sendmmsg calls route to USER_NOTIF as before.

Also fix a secondary bug introduced during the check-fd block insertion: the jt offsets for connect/bind/sendto/sendmmsg in the af_unix filter were pointing at the wrong instruction after USER_NOTIF moved from insn 7 to insn 9, causing those syscalls to be silently allowed instead of trapped.

Add end-to-end regression tests that spawn a real nono process and verify AF_UNIX pathname connect() is blocked (Linux: af_unix_mediation; macOS: filesystem.deny) and allowed when the path is on the unix_sockets allowlist.

Update profile-authoring-guide.md with platform-specific guidance for blocking container socket access.


<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
