### PR TITLE
fix(docs): replace broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ From here **fork the config**, tweak it, theme it, make it your own, and share i
 brew install nono
 ```
 
-**Other platforms** — Debian/Ubuntu, Fedora, Arch, RHEL, openSUSE, WSL2, and Nix: [see install instructions](https://docs.nono.sh/docs/installation).
+**Other platforms** — Debian/Ubuntu, Fedora, Arch, RHEL, openSUSE, WSL2, and Nix: [see install instructions](https://nono.sh/docs/cli/getting_started/installation).
 
 ## Run it!
 


### PR DESCRIPTION
## Linked Issue

https://github.com/always-further/nono/issues/1220

## Summary

Replace the link in the Readme for non-Homebrew installs with the correct link.

## Agent Disclosure (if applicable)

N/A, all me

## Test Plan

Confirmed the link doesn't 404 and goes to a page with install instructions.

## Checklist

- [x] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [x] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
I didn't sign off with DOC as no code was modified, if this is unacceptable please close this PR. But hopefully someone can get this merged, as it's a trivial change and likely affects a lot of new users.

Thanks for your work on nono!