### PR TITLE
refactor(network): introduce NetworkIntent and remove ProxyOnly placeholders

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -975,18 +975,10 @@ impl CapabilitySetExt for CapabilitySet {
             caps.add_blocked_command(cmd);
         }
 
-        // Network blocking or proxy mode from profile
+        // Only block is written here — proxy mode is set by start_proxy_runtime
+        // once the proxy has a real port.
         if profile.network.block {
             caps.set_network_blocked(true);
-        } else if profile.network.has_proxy_flags() {
-            let bind_ports =
-                crate::merge_dedup_ports(&profile.network.listen_port, &args.allow_bind);
-            // Profile requests proxy mode; port 0 is a placeholder.
-            // bind_ports come from profile listen_port plus CLI --listen-port.
-            caps = caps.set_network_mode(nono::NetworkMode::ProxyOnly {
-                port: 0,
-                bind_ports,
-            });
         }
 
         // Localhost IPC ports from profile
@@ -1136,13 +1128,6 @@ fn apply_cli_network_mode(caps: &mut CapabilitySet, args: &SandboxArgs) {
         caps.set_network_blocked(true);
     } else if args.allow_net {
         caps.set_network_mode_mut(nono::NetworkMode::AllowAll);
-    } else if args.has_proxy_flags() {
-        // Proxy mode: port 0 is a placeholder, updated when proxy starts.
-        // bind_ports are passed through allow_bind CLI flag.
-        caps.set_network_mode_mut(nono::NetworkMode::ProxyOnly {
-            port: 0,
-            bind_ports: args.allow_bind.clone(),
-        });
     }
 }
 

--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -189,10 +189,11 @@ pub(crate) fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
         .ok()
         .filter(|id| !id.is_empty())
         .unwrap_or_else(crate::session::generate_session_id);
-    let proxy = prepare_proxy_launch_options(&args.sandbox, &prepared, silent, session_id.clone())?;
+    let network =
+        prepare_proxy_launch_options(&args.sandbox, &prepared, silent, session_id.clone())?;
     let strategy = select_exec_strategy(
         false,
-        proxy.is_active(),
+        network.is_proxy_active(),
         prepared.capability_elevation,
         false,
         false,
@@ -221,7 +222,7 @@ pub(crate) fn run_shell(args: ShellArgs, silent: bool) -> Result<()> {
             startup_timeout_secs: args.startup_timeout_secs,
             command_policies: prepared.command_policies,
             session_hooks: prepared.session_hooks,
-            proxy,
+            network,
             redaction_policy: load_configured_redaction_policy()?,
             session: SessionLaunchOptions {
                 session_id: Some(session_id),

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -142,7 +142,8 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     } = plan;
     let rollback = &flags.rollback;
     let trust = &flags.trust;
-    let proxy = &flags.proxy;
+    let network = &flags.network;
+    let proxy = network.proxy_options();
     let session = &flags.session;
     let tool_sandbox_active = flags
         .command_policies
@@ -193,16 +194,12 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     if let Some(profile) = recommended_profile {
         output::print_profile_hint(recommended_program_name, profile, flags.silent);
     }
-    let plain_domain_entries = flags
-        .proxy
-        .domain_filter
-        .as_ref()
+    let plain_domain_entries = proxy
+        .and_then(|p| p.domain_filter.as_ref())
         .map(|d| d.allow_domain.as_slice())
         .unwrap_or(&[]);
-    let endpoint_domain_entries = flags
-        .proxy
-        .endpoint_filter
-        .as_ref()
+    let endpoint_domain_entries = proxy
+        .and_then(|p| p.endpoint_filter.as_ref())
         .map(|e| e.routes.as_slice())
         .unwrap_or(&[]);
     let all_domain_entries: Vec<_> = plain_domain_entries
@@ -259,13 +256,13 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     }
 
     if matches!(strategy, exec_strategy::ExecStrategy::Supervised) {
-        output::print_supervised_info(flags.silent, rollback.requested, proxy.is_active());
+        output::print_supervised_info(flags.silent, rollback.requested, network.is_proxy_active());
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     let shared_broker = crate::tool_sandbox::token_broker::new_shared_broker();
     let active_proxy = start_proxy_runtime(
-        proxy,
+        network,
         &mut caps,
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         Some(shared_broker.clone()),
@@ -475,7 +472,7 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
 
     let threading = select_threading_context(
         !loaded_secrets.is_empty(),
-        proxy.is_active(),
+        network.is_proxy_active(),
         trust.scan_performed,
         trust.interception_active,
     );

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -72,7 +72,7 @@ pub(crate) struct TrustLaunchOptions {
 }
 
 /// Plain CONNECT-tunnel domain allowlist entries and an optional network profile.
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct DomainFilterIntent {
     pub(crate) network_profile: Option<String>,
     /// Only `AllowDomainEntry::Plain` entries — endpoint-bearing entries live in
@@ -84,18 +84,18 @@ pub(crate) struct DomainFilterIntent {
 /// proxy can inspect method and path before forwarding.
 /// All entries must be `AllowDomainEntry::WithEndpoints` (enforced by `debug_assert`
 /// at construction in `prepare_proxy_launch_options`).
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct EndpointFilterIntent {
     pub(crate) routes: Vec<profile::AllowDomainEntry>,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct CredentialProxyIntent {
     pub(crate) credentials: Vec<String>,
     pub(crate) custom_credentials: HashMap<String, profile::CustomCredentialDef>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct UpstreamProxyIntent {
     pub(crate) address: String,
     pub(crate) bypass: Vec<String>,
@@ -103,7 +103,7 @@ pub(crate) struct UpstreamProxyIntent {
 
 /// TLS interception configuration supplied by the user. Presence means the user
 /// configured TLS intercept settings; it does not by itself activate the proxy.
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct TlsInterceptIntent {
     /// macOS only: reuse a persistent CA bundle across sessions.
     #[cfg(target_os = "macos")]
@@ -111,14 +111,14 @@ pub(crate) struct TlsInterceptIntent {
     pub(crate) ca_validity: Option<std::time::Duration>,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct OpenUrlIntent {
     pub(crate) origins: Vec<String>,
     pub(crate) allow_localhost: bool,
     pub(crate) allow_launch_services: bool,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct ProxyLaunchOptions {
     pub(crate) domain_filter: Option<DomainFilterIntent>,
     pub(crate) endpoint_filter: Option<EndpointFilterIntent>,
@@ -128,10 +128,10 @@ pub(crate) struct ProxyLaunchOptions {
     pub(crate) open_url: Option<OpenUrlIntent>,
     pub(crate) allow_bind_ports: Vec<u16>,
     pub(crate) proxy_port: Option<u16>,
-    /// True when the user requested `network.block` or `--block-net`.
-    /// Propagated to `ProxyConfig.strict_filter` so the filter denies
-    /// unlisted hosts instead of falling back to allow-all.
-    pub(crate) network_block: bool,
+    /// When `true`, the proxy denies any host not explicitly allowed rather
+    /// than falling back to allow-all. Set when the user combined proxy
+    /// features with `--block-net` or profile `network.block`.
+    pub(crate) strict_filter: bool,
     pub(crate) proxy_leaf_validity: Option<std::time::Duration>,
     pub(crate) command_policies: Option<crate::command_policy::CommandPoliciesConfig>,
     /// Environment variables the proxy must source (e.g. credential-bearing
@@ -160,6 +160,40 @@ impl ProxyLaunchOptions {
     }
 }
 
+/// Resolved network intent, derived from CLI flags and profile before any
+/// proxy is started. This is the single source of truth for which network
+/// mode the sandbox will run in.
+///
+/// Variants are ordered by decreasing restriction:
+/// - `BlockAll` — OS sandbox denies all outbound connections.
+/// - `ProxyFiltered` — outbound connections are gated through the nono proxy.
+/// - `Unrestricted` — no network restriction.
+#[derive(Clone, Debug, Default)]
+pub(crate) enum NetworkIntent {
+    /// `--allow-net` or default when no network flags are given: no restriction.
+    #[default]
+    Unrestricted,
+    /// `--block-net` or profile `network.block` with no active proxy override:
+    /// outbound connections are denied by the OS sandbox.
+    BlockAll,
+    /// Proxy-activating features are configured. Proxy starts only if
+    /// `ProxyLaunchOptions::is_active()` — custom credentials alone do not.
+    ProxyFiltered(Box<ProxyLaunchOptions>),
+}
+
+impl NetworkIntent {
+    pub(crate) fn is_proxy_active(&self) -> bool {
+        matches!(self, Self::ProxyFiltered(opts) if opts.is_active())
+    }
+
+    pub(crate) fn proxy_options(&self) -> Option<&ProxyLaunchOptions> {
+        match self {
+            Self::ProxyFiltered(opts) => Some(opts),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct ExecutionFlags {
     pub(crate) strategy: exec_strategy::ExecStrategy,
@@ -180,7 +214,7 @@ pub(crate) struct ExecutionFlags {
     pub(crate) session: SessionLaunchOptions,
     pub(crate) rollback: RollbackLaunchOptions,
     pub(crate) trust: TrustLaunchOptions,
-    pub(crate) proxy: ProxyLaunchOptions,
+    pub(crate) network: NetworkIntent,
     pub(crate) redaction_policy: nono::ScrubPolicy,
     pub(crate) session_hooks: profile::SessionHooks,
     pub(crate) allowed_env_vars: Option<Vec<String>>,
@@ -217,7 +251,7 @@ impl ExecutionFlags {
                     .map_err(|e| NonoError::SandboxInit(format!("Failed to get cwd: {e}")))?,
                 ..TrustLaunchOptions::default()
             },
-            proxy: ProxyLaunchOptions::default(),
+            network: NetworkIntent::default(),
             redaction_policy: nono::ScrubPolicy::secure_default(),
             session_hooks: profile::SessionHooks::default(),
             allowed_env_vars: None,
@@ -317,7 +351,7 @@ pub(crate) fn prepare_run_launch_plan(
         .ok()
         .filter(|id| !id.is_empty())
         .unwrap_or_else(crate::session::generate_session_id);
-    let proxy = prepare_proxy_launch_options(&args, &prepared, silent, session_id.clone())?;
+    let network = prepare_proxy_launch_options(&args, &prepared, silent, session_id.clone())?;
     let rollback_options = prepare_rollback_launch_options(
         &run_args.rollback_exclude,
         run_args.rollback_all,
@@ -328,7 +362,7 @@ pub(crate) fn prepare_run_launch_plan(
 
     let strategy = select_exec_strategy(
         rollback,
-        proxy.is_active(),
+        network.is_proxy_active(),
         prepared.capability_elevation,
         trust.interception_active,
         run_args.detached,
@@ -374,7 +408,7 @@ pub(crate) fn prepare_run_launch_plan(
                 ..rollback_options
             },
             trust,
-            proxy,
+            network,
             redaction_policy,
             session_hooks: prepared.session_hooks,
             allowed_env_vars: prepared.allowed_env_vars,

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -105,7 +105,6 @@ const DETACHED_CWD_PROMPT_RESPONSE_ENV: &str = "NONO_DETACHED_CWD_PROMPT_RESPONS
 const DETACHED_SESSION_ID_ENV: &str = "NONO_DETACHED_SESSION_ID";
 
 pub(crate) use launch_runtime::rollback_base_exclusions;
-pub(crate) use proxy_runtime::merge_dedup_ports;
 
 fn main() {
     if tool_sandbox::maybe_run_internal_tool_sandbox_entrypoint() {
@@ -307,7 +306,7 @@ mod tests {
             allowed_env_vars: None,
             denied_env_vars: None,
             set_vars: None,
-            network_block_requested: false,
+            profile_network_block: false,
         };
 
         let effective = resolve_effective_proxy_settings(&args, &prepared);
@@ -364,7 +363,7 @@ mod tests {
             allowed_env_vars: None,
             denied_env_vars: None,
             set_vars: None,
-            network_block_requested: false,
+            profile_network_block: false,
         };
 
         let effective = resolve_effective_proxy_settings(&args, &prepared);

--- a/crates/nono-cli/src/output.rs
+++ b/crates/nono-cli/src/output.rs
@@ -57,6 +57,7 @@ pub fn print_capabilities(
     blocked_grants: &[(std::path::PathBuf, Option<String>)],
     verbose: u8,
     silent: bool,
+    proxy_pending: bool,
 ) {
     if silent {
         return;
@@ -175,37 +176,58 @@ pub fn print_capabilities(
     // Network status
     match caps.network_mode() {
         NetworkMode::Blocked => {
-            eprintln!(
-                "  {} {}",
-                theme::badge(" net ", t.red, BADGE_FG_DARK),
-                theme::fg("outbound blocked", t.subtext),
-            );
+            if proxy_pending {
+                // Profile set network.block but CLI added proxy flags — proxy
+                // will start in strict_filter mode and owns the network mode.
+                eprintln!(
+                    "  {} {}",
+                    theme::badge(" net ", t.yellow, BADGE_FG_DARK),
+                    theme::fg("proxy (strict)", t.subtext),
+                );
+            } else {
+                eprintln!(
+                    "  {} {}",
+                    theme::badge(" net ", t.red, BADGE_FG_DARK),
+                    theme::fg("outbound blocked", t.subtext),
+                );
+            }
         }
         NetworkMode::ProxyOnly { port, bind_ports } => {
+            let port_str = if *port == 0 {
+                String::new()
+            } else {
+                format!(" localhost:{port}")
+            };
             if bind_ports.is_empty() {
                 eprintln!(
                     "  {} {}",
                     theme::badge(" net ", t.yellow, BADGE_FG_DARK),
-                    theme::fg(&format!("proxy localhost:{port}"), t.subtext),
+                    theme::fg(&format!("proxy{port_str}"), t.subtext),
                 );
             } else {
                 let ports_str: Vec<String> = bind_ports.iter().map(|p| p.to_string()).collect();
+                let bind_info = format!(", bind: {}", ports_str.join(", "));
                 eprintln!(
                     "  {} {}",
                     theme::badge(" net ", t.yellow, BADGE_FG_DARK),
-                    theme::fg(
-                        &format!("proxy localhost:{port}, bind: {}", ports_str.join(", ")),
-                        t.subtext,
-                    ),
+                    theme::fg(&format!("proxy{port_str}{bind_info}"), t.subtext,),
                 );
             }
         }
         NetworkMode::AllowAll => {
-            eprintln!(
-                "  {} {}",
-                theme::badge(" net ", t.green, BADGE_FG_DARK),
-                theme::fg("outbound allowed", t.subtext),
-            );
+            if proxy_pending {
+                eprintln!(
+                    "  {} {}",
+                    theme::badge(" net ", t.yellow, BADGE_FG_DARK),
+                    theme::fg("proxy", t.subtext),
+                );
+            } else {
+                eprintln!(
+                    "  {} {}",
+                    theme::badge(" net ", t.green, BADGE_FG_DARK),
+                    theme::fg("outbound allowed", t.subtext),
+                );
+            }
         }
     }
     if !caps.localhost_ports().is_empty() {
@@ -1141,8 +1163,8 @@ mod tests {
             .allow_unix_socket_dir(dir.path(), UnixSocketMode::ConnectBind)
             .expect("bind dir grant");
 
-        print_capabilities(&caps, &[], 0, true);
-        print_capabilities(&caps, &[], 1, true);
+        print_capabilities(&caps, &[], 0, true, false);
+        print_capabilities(&caps, &[], 1, true, false);
     }
 
     #[test]

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1503,14 +1503,6 @@ impl NetworkConfig {
     pub fn resolved_credentials(&self) -> &[String] {
         self.credentials.as_deref().unwrap_or(&[])
     }
-
-    /// Whether any profile setting requires proxy mode activation.
-    pub fn has_proxy_flags(&self) -> bool {
-        self.resolved_network_profile().is_some()
-            || !self.allow_domain.is_empty()
-            || !self.resolved_credentials().is_empty()
-            || self.upstream_proxy.is_some()
-    }
 }
 
 /// Secrets configuration in a profile
@@ -6413,16 +6405,6 @@ mod tests {
     }
 
     #[test]
-    fn test_credentials_none_does_not_activate_proxy() {
-        let mut config = NetworkConfig::default();
-        assert!(!config.has_proxy_flags()); // None = no proxy
-        config.credentials = Some(Vec::new());
-        assert!(!config.has_proxy_flags()); // Some([]) = no proxy
-        config.credentials = Some(vec!["openai".to_string()]);
-        assert!(config.has_proxy_flags()); // Some(["openai"]) = proxy
-    }
-
-    #[test]
     fn test_credentials_deserialization_absent_vs_empty() {
         // Absent field → None (inherit)
         let json = r#"{ "meta": { "name": "no-creds" }, "network": {} }"#;
@@ -7053,7 +7035,8 @@ mod tests {
 
         let profile = load_profile_from_path(&profile_path).expect("load profile");
         assert_eq!(profile.network.resolved_network_profile(), None);
-        assert!(!profile.network.has_proxy_flags());
+        assert!(profile.network.resolved_credentials().is_empty());
+        assert!(profile.network.allow_domain.is_empty());
         assert!(
             profile
                 .filesystem

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -1210,8 +1210,8 @@ pub(crate) fn prepare_proxy_launch_options(
     let has_credentials = !credentials.is_empty();
     let would_activate = has_domain_filter || has_credentials || upstream_proxy_addr.is_some();
 
-    // --block-net always wins; profile network.block yields to CLI proxy flags.
-    let block_wins = args.block_net || (prepared.profile_network_block && !args.has_proxy_flags());
+    // --block-net always wins; profile network.block yields to any proxy config.
+    let block_wins = args.block_net || (prepared.profile_network_block && !would_activate);
     if block_wins {
         if would_activate {
             warn!(

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -4,7 +4,7 @@ use crate::command_policy::{
     CommandSandboxConfig, EndpointPolicyConfig, PolicyDecision, PolicyDecisionConfig,
 };
 use crate::launch_runtime::{
-    CredentialProxyIntent, DomainFilterIntent, EndpointFilterIntent, OpenUrlIntent,
+    CredentialProxyIntent, DomainFilterIntent, EndpointFilterIntent, NetworkIntent, OpenUrlIntent,
     ProxyLaunchOptions, TlsInterceptIntent, UpstreamProxyIntent,
 };
 use crate::network_policy;
@@ -1166,7 +1166,7 @@ pub(crate) fn prepare_proxy_launch_options(
     prepared: &PreparedSandbox,
     silent: bool,
     session_id: String,
-) -> Result<ProxyLaunchOptions> {
+) -> Result<NetworkIntent> {
     validate_external_proxy_bypass(args, prepared)?;
 
     let effective_proxy = resolve_effective_proxy_settings(args, prepared);
@@ -1210,7 +1210,9 @@ pub(crate) fn prepare_proxy_launch_options(
     let has_credentials = !credentials.is_empty();
     let would_activate = has_domain_filter || has_credentials || upstream_proxy_addr.is_some();
 
-    if matches!(prepared.caps.network_mode(), nono::NetworkMode::Blocked) {
+    // --block-net always wins; profile network.block yields to CLI proxy flags.
+    let block_wins = args.block_net || (prepared.profile_network_block && !args.has_proxy_flags());
+    if block_wins {
         if would_activate {
             warn!(
                 "--block-net is active; ignoring proxy configuration \
@@ -1223,12 +1225,11 @@ pub(crate) fn prepare_proxy_launch_options(
                 );
             }
         }
-        return Ok(ProxyLaunchOptions {
-            allow_bind_ports,
-            network_block: prepared.network_block_requested,
-            ..ProxyLaunchOptions::default()
-        });
+        return Ok(NetworkIntent::BlockAll);
     }
+
+    // Profile network.block + proxy flags → strict mode: deny unlisted hosts.
+    let strict_filter = prepared.profile_network_block;
 
     let (plain_entries, endpoint_entries): (Vec<_>, Vec<_>) = allow_domain
         .into_iter()
@@ -1311,7 +1312,7 @@ pub(crate) fn prepare_proxy_launch_options(
         open_url,
         allow_bind_ports,
         proxy_port: args.proxy_port,
-        network_block: prepared.network_block_requested,
+        strict_filter,
         proxy_leaf_validity: tls_options.leaf_validity,
         command_policies: prepared.command_policies.clone(),
         proxy_source_env_vars,
@@ -1339,7 +1340,7 @@ pub(crate) fn prepare_proxy_launch_options(
         }
     }
 
-    Ok(opts)
+    Ok(NetworkIntent::ProxyFiltered(Box::new(opts)))
 }
 
 struct ResolvedTlsInterceptOptions {
@@ -1995,7 +1996,7 @@ pub(crate) fn build_proxy_config_from_flags(
     resolved.routes = routes;
 
     let mut proxy_config = network_policy::build_proxy_config(&resolved, &plain_hosts);
-    proxy_config.strict_filter = proxy.network_block;
+    proxy_config.strict_filter = proxy.strict_filter;
 
     if let Some(ref upstream) = proxy.upstream_proxy {
         proxy_config.external_proxy = Some(nono_proxy::config::ExternalProxyConfig {
@@ -2026,13 +2027,21 @@ impl nono_proxy::NonceResolver for TokenBrokerNonceResolver {
 }
 
 pub(crate) fn start_proxy_runtime(
-    proxy: &ProxyLaunchOptions,
+    intent: &NetworkIntent,
     caps: &mut CapabilitySet,
     #[cfg(any(target_os = "linux", target_os = "macos"))] shared_broker: Option<
         crate::tool_sandbox::token_broker::SharedBroker,
     >,
     #[cfg(not(any(target_os = "linux", target_os = "macos")))] _shared_broker: Option<()>,
 ) -> Result<ActiveProxyRuntime> {
+    let NetworkIntent::ProxyFiltered(proxy) = intent else {
+        return Ok(ActiveProxyRuntime {
+            env_vars: Vec::new(),
+            tool_sandbox_credential_env_vars: BTreeMap::new(),
+            tool_sandbox_trust_bundle_paths: Vec::new(),
+            handle: None,
+        });
+    };
     if !proxy.is_active() {
         return Ok(ActiveProxyRuntime {
             env_vars: Vec::new(),
@@ -2463,30 +2472,27 @@ mod tests {
         }
     }
 
-    /// `network_block: true` must set `strict_filter` on the generated `ProxyConfig`.
+    /// `strict_filter: true` must propagate to `ProxyConfig.strict_filter`.
     #[test]
-    fn test_build_proxy_config_propagates_network_block_to_strict_filter() {
+    fn test_build_proxy_config_propagates_strict_filter() {
         let proxy = ProxyLaunchOptions {
-            network_block: true,
+            strict_filter: true,
             ..ProxyLaunchOptions::default()
         };
         let config = build_proxy_config_from_flags(&proxy).expect("build_proxy_config_from_flags");
         assert!(
             config.strict_filter,
-            "network_block: true must set strict_filter on ProxyConfig"
+            "strict_filter: true must propagate to ProxyConfig"
         );
     }
 
     #[test]
-    fn test_build_proxy_config_strict_filter_off_when_no_block() {
-        let proxy = ProxyLaunchOptions {
-            network_block: false,
-            ..ProxyLaunchOptions::default()
-        };
+    fn test_build_proxy_config_strict_filter_off_by_default() {
+        let proxy = ProxyLaunchOptions::default();
         let config = build_proxy_config_from_flags(&proxy).expect("build_proxy_config_from_flags");
         assert!(
             !config.strict_filter,
-            "strict_filter must default off when network_block is false"
+            "strict_filter must default off when not set"
         );
     }
 
@@ -2598,19 +2604,22 @@ mod tests {
             allowed_env_vars: None,
             denied_env_vars: None,
             set_vars: None,
-            network_block_requested: false,
+            profile_network_block: false,
         };
 
         let args = crate::cli::SandboxArgs::default();
-        let opts = prepare_proxy_launch_options(&args, &prepared, true, String::new())
+        let intent = prepare_proxy_launch_options(&args, &prepared, true, String::new())
             .expect("prepare_proxy_launch_options");
 
         assert!(
-            !opts.is_active(),
+            !intent.is_proxy_active(),
             "proxy must stay inactive when only custom credential definitions are present"
         );
+        let proxy_opts = intent
+            .proxy_options()
+            .expect("NetworkIntent should be ProxyFiltered when custom credentials are present");
         assert!(
-            opts.credentials.is_some(),
+            proxy_opts.credentials.is_some(),
             "custom credential definitions should still be carried for network profile overrides"
         );
     }

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -580,14 +580,13 @@ fn finalize_prepared_sandbox(
     silent: bool,
 ) -> Result<PreparedSandbox> {
     output::print_skipped_requested_paths(&collect_missing_cli_requested_paths(args), silent);
-    let block_wins = args.block_net || (prepared.profile_network_block && !args.has_proxy_flags());
-    let proxy_pending = !block_wins
-        && !args.allow_net
-        && (args.has_proxy_flags()
-            || prepared.network_profile.is_some()
-            || !prepared.allow_domain.is_empty()
-            || !prepared.credentials.is_empty()
-            || prepared.upstream_proxy.is_some());
+    let has_proxy_intent = args.has_proxy_flags()
+        || prepared.network_profile.is_some()
+        || !prepared.allow_domain.is_empty()
+        || !prepared.credentials.is_empty()
+        || prepared.upstream_proxy.is_some();
+    let block_wins = args.block_net || (prepared.profile_network_block && !has_proxy_intent);
+    let proxy_pending = !block_wins && !args.allow_net && has_proxy_intent;
     output::print_capabilities(
         &prepared.caps,
         blocked_grants,

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -447,10 +447,10 @@ pub(crate) struct PreparedSandbox {
     pub(crate) denied_env_vars: Option<Vec<String>>,
     /// Expanded `environment.set_vars` (key, expanded-value), `None` if absent.
     pub(crate) set_vars: Option<Vec<(String, String)>>,
-    /// True when the profile or CLI requested `network.block`. Carried
-    /// through because a CLI proxy flag (e.g. `--credential`) may later
-    /// override `caps` to `ProxyOnly`, losing the original intent.
-    pub(crate) network_block_requested: bool,
+    /// True when the profile's `network.block` is set. The CLI `--block-net`
+    /// flag is read directly from `SandboxArgs` at proxy-launch time, so only
+    /// the profile's contribution needs to be carried through.
+    pub(crate) profile_network_block: bool,
 }
 
 fn resolved_workdir(args: &SandboxArgs) -> PathBuf {
@@ -580,7 +580,21 @@ fn finalize_prepared_sandbox(
     silent: bool,
 ) -> Result<PreparedSandbox> {
     output::print_skipped_requested_paths(&collect_missing_cli_requested_paths(args), silent);
-    output::print_capabilities(&prepared.caps, blocked_grants, args.verbose, silent);
+    let block_wins = args.block_net || (prepared.profile_network_block && !args.has_proxy_flags());
+    let proxy_pending = !block_wins
+        && !args.allow_net
+        && (args.has_proxy_flags()
+            || prepared.network_profile.is_some()
+            || !prepared.allow_domain.is_empty()
+            || !prepared.credentials.is_empty()
+            || prepared.upstream_proxy.is_some());
+    output::print_capabilities(
+        &prepared.caps,
+        blocked_grants,
+        args.verbose,
+        silent,
+        proxy_pending,
+    );
 
     if let Some(ref profile_name) = args.profile {
         crate::pack_update_hint::show_pack_update_hints(profile_name, silent);
@@ -1086,7 +1100,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
                 allowed_env_vars: None,
                 denied_env_vars: None,
                 set_vars: None,
-                network_block_requested: args.block_net,
+                profile_network_block: false,
             },
             &[],
             args,
@@ -1369,7 +1383,6 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         .as_ref()
         .map(|p| p.network.block)
         .unwrap_or(false);
-    let network_block_requested = args.block_net || profile_network_block;
 
     let profile_secrets = loaded_profile
         .as_ref()
@@ -1418,7 +1431,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
             allowed_env_vars: profile_allowed_env_vars,
             denied_env_vars: profile_denied_env_vars,
             set_vars: profile_set_vars,
-            network_block_requested,
+            profile_network_block,
         },
         &blocked_grants,
         args,

--- a/crates/nono-cli/src/supervised_runtime.rs
+++ b/crates/nono-cli/src/supervised_runtime.rs
@@ -31,7 +31,7 @@ pub(crate) struct SupervisedRuntimeContext<'a> {
     pub(crate) session: &'a SessionLaunchOptions,
     pub(crate) rollback: &'a RollbackLaunchOptions,
     pub(crate) trust: &'a TrustLaunchOptions,
-    pub(crate) proxy: &'a ProxyLaunchOptions,
+    pub(crate) proxy: Option<&'a ProxyLaunchOptions>,
     pub(crate) proxy_handle: Option<&'a nono_proxy::server::ProxyHandle>,
     pub(crate) executable_identity: Option<&'a ExecutableIdentity>,
     pub(crate) audit_signer: Option<&'a AuditSigner>,
@@ -254,21 +254,18 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
         attach_initial_client: !session.detached_start,
         detach_sequence: session.detach_sequence.as_deref(),
         open_url_origins: proxy
-            .open_url
-            .as_ref()
+            .and_then(|p| p.open_url.as_ref())
             .map(|o| o.origins.as_slice())
             .unwrap_or(&[]),
         open_url_allow_localhost: proxy
-            .open_url
-            .as_ref()
+            .and_then(|p| p.open_url.as_ref())
             .map(|o| o.allow_localhost)
             .unwrap_or(false),
         audit_recorder: audit_recorder.clone(),
         network_audit_events: supervisor_network_audit_events.as_ref(),
         redaction_policy,
         allow_launch_services_active: proxy
-            .open_url
-            .as_ref()
+            .and_then(|p| p.open_url.as_ref())
             .map(|o| o.allow_launch_services)
             .unwrap_or(false),
         #[cfg(target_os = "linux")]

--- a/crates/nono-cli/src/terminal_approval.rs
+++ b/crates/nono-cli/src/terminal_approval.rs
@@ -265,11 +265,14 @@ mod tests {
     //
     // When stderr is not a terminal (e.g. in CI or when redirected), the
     // backend must return Denied for every request type without attempting to
-    // read from /dev/tty. These tests run fully automated.
+    // read from /dev/tty. These tests are skipped when running interactively
+    // (stderr is a TTY) because the real backend would block waiting for input.
 
     #[test]
     fn non_tty_auto_denies_capability_request() {
-        // In a test runner stderr is never a terminal.
+        if std::io::stderr().is_terminal() {
+            return;
+        }
         let backend = TerminalApproval;
         let decision = backend
             .request_approval(&capability_request())
@@ -282,6 +285,9 @@ mod tests {
 
     #[test]
     fn non_tty_auto_denies_network_request() {
+        if std::io::stderr().is_terminal() {
+            return;
+        }
         let backend = TerminalApproval;
         let decision = backend
             .request_approval(&network_request())
@@ -291,6 +297,9 @@ mod tests {
 
     #[test]
     fn non_tty_auto_denies_command_request() {
+        if std::io::stderr().is_terminal() {
+            return;
+        }
         let backend = TerminalApproval;
         let decision = backend
             .request_approval(&command_request())
@@ -300,6 +309,9 @@ mod tests {
 
     #[test]
     fn non_tty_auto_denies_endpoint_request() {
+        if std::io::stderr().is_terminal() {
+            return;
+        }
         let backend = TerminalApproval;
         let decision = backend
             .request_approval(&endpoint_request())
@@ -311,6 +323,9 @@ mod tests {
 
     #[test]
     fn non_tty_denial_carries_reason() {
+        if std::io::stderr().is_terminal() {
+            return;
+        }
         let backend = TerminalApproval;
         let decision = backend
             .request_approval(&command_request())


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1098

## Summary

Replace the ProxyOnly { port: 0 } placeholder pattern and the profile_network_block side channel with a single CLI-owned NetworkIntent enum that represents resolved user intent before any proxy starts.

NetworkIntent has three variants: Unrestricted, BlockAll, and ProxyFiltered carrying BoxedProxyLaunchOptions. prepare_proxy_launch_options now returns NetworkIntent directly. start_proxy_runtime pattern-matches on it - ProxyFiltered is the signal to start the proxy, not the absence of a Blocked cap. CapabilitySet only receives ProxyOnly with a real port once the proxy is actually listening.

network_block_requested on PreparedSandbox is replaced by profile_network_block, which carries only the profiles contribution. args.block_net is read directly at proxy-launch time. The combined block_wins logic in prepare_proxy_launch_options correctly handles all cases including profile-blocks-but-CLI-overrides (strict_filter mode).

ProxyLaunchOptions.network_block renamed to strict_filter to match its actual meaning: deny unlisted hosts rather than fall back to allow-all. All proxy intent structs gain Debug derives.

print_capabilities gains a proxy_pending parameter. When caps is AllowAll but a proxy will start, the display shows yellow proxy rather than green outbound allowed. When caps is Blocked but proxy flags override it, display shows yellow proxy (strict).
<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
