### PR TITLE
docs(proxy): fix stale X-Nono-Token authentication claim

### DIFF
--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1286,7 +1286,7 @@ pub struct SandboxArgs {
 
     // ── Credentials ──────────────────────────────────────────────────────
     /// Inject credentials via reverse proxy for a service (repeatable)
-    /// ALIAS(canonical="--credential", introduced="v0.0.0", remove_by="indefinite", issue="#143")
+    /// ALIAS(canonical="--credential", introduced="v0.0.0", remove_by="v1.0.0", issue="#143")
     #[arg(
         long = "credential",
         alias = "proxy-credential",

--- a/crates/nono-cli/src/cli_bootstrap.rs
+++ b/crates/nono-cli/src/cli_bootstrap.rs
@@ -21,44 +21,60 @@ pub(crate) fn collect_legacy_network_warnings() -> Vec<String> {
     let mut warnings = Vec::new();
     let args: Vec<String> = std::env::args().skip(1).collect();
 
-    for (legacy, replacement) in [
-        ("--allow-net", Some("network is unrestricted by default")),
-        ("--net-allow", Some("network is unrestricted by default")),
-        ("--allow-proxy", Some("--allow-domain")),
-        ("--proxy-allow", Some("--allow-domain")),
-        ("--proxy-credential", Some("--credential")),
-        ("--allow-bind", Some("--listen-port")),
-        ("--allow-port", Some("--open-port")),
-        ("--external-proxy", Some("--upstream-proxy")),
-        ("--external-proxy-bypass", Some("--upstream-bypass")),
-        ("--net-block", Some("--block-net")),
+    // (legacy, replacement, remove_by)
+    for (legacy, replacement, remove_by) in [
+        (
+            "--allow-net",
+            Some("network is unrestricted by default"),
+            None,
+        ),
+        (
+            "--net-allow",
+            Some("network is unrestricted by default"),
+            None,
+        ),
+        ("--allow-proxy", Some("--allow-domain"), None),
+        ("--proxy-allow", Some("--allow-domain"), None),
+        ("--proxy-credential", Some("--credential"), Some("v1.0.0")),
+        ("--allow-bind", Some("--listen-port"), None),
+        ("--allow-port", Some("--open-port"), None),
+        ("--external-proxy", Some("--upstream-proxy"), None),
+        ("--external-proxy-bypass", Some("--upstream-bypass"), None),
+        ("--net-block", Some("--block-net"), None),
     ] {
         if args
             .iter()
             .any(|arg| arg == legacy || arg.starts_with(&format!("{legacy}=")))
         {
-            let message = if let Some(replacement) = replacement {
+            let mut message = if let Some(replacement) = replacement {
                 format!("Warning: `{legacy}` is deprecated; use `{replacement}` instead.")
             } else {
                 format!("Warning: `{legacy}` is deprecated.")
             };
+            if let Some(v) = remove_by {
+                message.push_str(&format!(" Will be removed in {v}."));
+            }
             warnings.push(message);
         }
     }
 
-    for (legacy, replacement) in [
-        ("NONO_NET_BLOCK", "NONO_BLOCK_NET"),
-        ("NONO_NET_ALLOW", "NONO_ALLOW_NET"),
-        ("NONO_ALLOW_PROXY", "NONO_ALLOW_DOMAIN"),
-        ("NONO_PROXY_ALLOW", "NONO_ALLOW_DOMAIN"),
-        ("NONO_PROXY_CREDENTIAL", "NONO_CREDENTIAL"),
-        ("NONO_EXTERNAL_PROXY", "NONO_UPSTREAM_PROXY"),
-        ("NONO_EXTERNAL_PROXY_BYPASS", "NONO_UPSTREAM_BYPASS"),
+    // (legacy, replacement, remove_by)
+    for (legacy, replacement, remove_by) in [
+        ("NONO_NET_BLOCK", "NONO_BLOCK_NET", None),
+        ("NONO_NET_ALLOW", "NONO_ALLOW_NET", None),
+        ("NONO_ALLOW_PROXY", "NONO_ALLOW_DOMAIN", None),
+        ("NONO_PROXY_ALLOW", "NONO_ALLOW_DOMAIN", None),
+        ("NONO_PROXY_CREDENTIAL", "NONO_CREDENTIAL", Some("v1.0.0")),
+        ("NONO_EXTERNAL_PROXY", "NONO_UPSTREAM_PROXY", None),
+        ("NONO_EXTERNAL_PROXY_BYPASS", "NONO_UPSTREAM_BYPASS", None),
     ] {
         if std::env::var_os(legacy).is_some() {
-            warnings.push(format!(
-                "Warning: `{legacy}` is deprecated; use `{replacement}` instead."
-            ));
+            let mut message =
+                format!("Warning: `{legacy}` is deprecated; use `{replacement}` instead.");
+            if let Some(v) = remove_by {
+                message.push_str(&format!(" Will be removed in {v}."));
+            }
+            warnings.push(message);
         }
     }
 

--- a/crates/nono-proxy/README.md
+++ b/crates/nono-proxy/README.md
@@ -18,7 +18,7 @@ Network filtering proxy for the [nono](https://crates.io/crates/nono) sandbox.
 
 - **Cloud metadata deny list is hardcoded** -- Cloud metadata hostnames (169.254.169.254, metadata.google.internal, metadata.azure.internal) are always blocked regardless of allowlist configuration. Private network addresses (RFC1918) are allowed to support enterprise environments.
 - **DNS rebinding protection** -- The proxy resolves DNS, checks all resolved IPs against the link-local range (169.254.0.0/16, fe80::/10), and connects to resolved addresses (not re-resolved hostnames). This prevents DNS rebinding attacks targeting cloud metadata.
-- **Session token authentication** -- Each session generates a 256-bit random token. CONNECT requests use `Proxy-Authorization` (Basic or Bearer); reverse proxy requests use `X-Nono-Token`.
+- **Session token authentication** -- Each session generates a 256-bit random token. CONNECT requests use `Proxy-Authorization` (Basic or Bearer); reverse proxy requests are authenticated transparently — nono sets the credential env var (e.g. `GITHUB_TOKEN`) to a phantom token inside the sandbox, so standard API clients send it automatically in the service-specific auth header (e.g. `Authorization: Bearer`), which the proxy validates before injecting the real credential.
 - **Credential isolation** -- API keys are loaded from the OS keyring, stored in `Zeroizing<String>`, injected at the HTTP header level, and never exposed to the sandboxed process.
 - **Constant-time token comparison** -- Prevents timing side-channel attacks on session token validation.
 
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Set these in the child process environment
     let env_vars = handle.env_vars();
-    // HTTP_PROXY, HTTPS_PROXY, NONO_PROXY_TOKEN, etc.
+    // HTTP_PROXY, HTTPS_PROXY, and the phantom credential env vars (e.g. GITHUB_TOKEN).
 
     // Shutdown when done
     handle.shutdown();

--- a/crates/nono-proxy/src/token.rs
+++ b/crates/nono-proxy/src/token.rs
@@ -1,9 +1,12 @@
 //! Session token generation, validation, and nonce resolution.
 //!
-//! Each proxy session gets a unique cryptographic token. The child process
-//! receives it via `NONO_PROXY_TOKEN` env var and must include it in all
-//! requests to the proxy. This prevents other local processes from using
-//! the proxy.
+//! Each proxy session gets a unique cryptographic token used to authenticate
+//! requests to the proxy. For reverse proxy credential routes the token is
+//! delivered transparently — nono sets the credential env var (e.g.
+//! `GITHUB_TOKEN`) to the phantom token inside the sandbox, so standard API
+//! clients include it automatically in the service-specific auth header. For
+//! CONNECT tunnel requests the token is validated via `Proxy-Authorization`.
+//! This prevents other local processes from hijacking the proxy session.
 //!
 //! The `NonceResolver` trait allows the proxy to resolve tool-sandbox broker
 //! nonces (`nono_<64hex>`) found in request headers, substituting the real


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #361

## Summary

The README incorrectly stated that reverse proxy requests authenticate via an X-Nono-Token header and NONO_PROXY_TOKEN env var. Neither exists in the implementation. The actual mechanism is transparent: nono shadows the credential env var (e.g. GITHUB_TOKEN) with a phantom token inside the sandbox, so standard API clients send it in the service-specific auth header automatically.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
