### PR TITLE
fix(tool-sandbox): pass TLS trust bundle env vars to tool-sandbox children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+- *(tool-sandbox)* Pass TLS trust bundle env vars (`SSL_CERT_FILE`, `CURL_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `GIT_SSL_CAINFO`) to tool-sandbox children so HTTPS certificate verification works when TLS interception is active (#1248)
+
 ## [0.65.1] - 2026-06-23
 ## [0.65.0] - 2026-06-23
 

--- a/crates/nono-cli/src/tool-sandbox/env.rs
+++ b/crates/nono-cli/src/tool-sandbox/env.rs
@@ -24,6 +24,11 @@ const DEFAULT_ENV_ALLOW: &[&str] = &[
     "https_proxy",
     "http_proxy",
     "no_proxy",
+    "SSL_CERT_FILE",
+    "CURL_CA_BUNDLE",
+    "NODE_EXTRA_CA_CERTS",
+    "REQUESTS_CA_BUNDLE",
+    "GIT_SSL_CAINFO",
 ];
 
 pub(crate) fn default_env_allow_patterns() -> Vec<String> {
@@ -146,4 +151,27 @@ pub(crate) fn inject_url_open_env(
 pub(crate) fn split_env_entry(entry: &[u8]) -> Option<(&[u8], &[u8])> {
     let pos = entry.iter().position(|byte| *byte == b'=')?;
     Some((&entry[..pos], &entry[pos + 1..]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::exec_strategy::env_sanitization::is_env_var_allowed;
+
+    #[test]
+    fn tls_trust_bundle_vars_are_in_default_allow() {
+        let patterns = default_env_allow_patterns();
+        for var in &[
+            "SSL_CERT_FILE",
+            "CURL_CA_BUNDLE",
+            "NODE_EXTRA_CA_CERTS",
+            "REQUESTS_CA_BUNDLE",
+            "GIT_SSL_CAINFO",
+        ] {
+            assert!(
+                is_env_var_allowed(var, &patterns),
+                "{var} must be allowed so tool-sandbox children can verify TLS through the intercept proxy"
+            );
+        }
+    }
 }

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -4887,6 +4887,46 @@ mod tests {
     }
 
     #[test]
+    fn filter_child_env_passes_tls_ca_vars_by_default() -> Result<()> {
+        let bundle = "/tmp/intercept-ca.pem";
+        let state = test_state();
+        let request = request_with_env(vec![
+            format!("SSL_CERT_FILE={bundle}").into_bytes(),
+            format!("CURL_CA_BUNDLE={bundle}").into_bytes(),
+            format!("NODE_EXTRA_CA_CERTS={bundle}").into_bytes(),
+            format!("REQUESTS_CA_BUNDLE={bundle}").into_bytes(),
+            format!("GIT_SSL_CAINFO={bundle}").into_bytes(),
+            b"UNRELATED=should-be-stripped".to_vec(),
+        ]);
+
+        let env = filter_child_env(&state, &request, &CommandSandboxConfig::default())?;
+
+        assert!(contains_entry(
+            &env,
+            format!("SSL_CERT_FILE={bundle}").as_bytes()
+        ));
+        assert!(contains_entry(
+            &env,
+            format!("CURL_CA_BUNDLE={bundle}").as_bytes()
+        ));
+        assert!(contains_entry(
+            &env,
+            format!("NODE_EXTRA_CA_CERTS={bundle}").as_bytes()
+        ));
+        assert!(contains_entry(
+            &env,
+            format!("REQUESTS_CA_BUNDLE={bundle}").as_bytes()
+        ));
+        assert!(contains_entry(
+            &env,
+            format!("GIT_SSL_CAINFO={bundle}").as_bytes()
+        ));
+        assert!(!contains_prefix(&env, b"UNRELATED="));
+
+        Ok(())
+    }
+
+    #[test]
     fn filter_child_env_resolves_broker_nonces() -> Result<()> {
         let state = test_state();
         let nonce = {


### PR DESCRIPTION
 ## Linked Issue

  Closes #1248

  ## Summary

  `DEFAULT_ENV_ALLOW` in the tool-sandbox did not include the TLS trust bundle
  env vars (`SSL_CERT_FILE`, `CURL_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`,
  `REQUESTS_CA_BUNDLE`, `GIT_SSL_CAINFO`) that nono injects when TLS
  interception is active. They were stripped before reaching tool-sandbox child
  processes, causing HTTPS certificate verification failures inside the sandbox.

  ## Test Plan

  Existing tool-sandbox env tests in `crates/nono-cli/src/tool-sandbox/env.rs`.
  Manually verified by running an agent with a profile that enables both
  `network.tls_intercept` and `command_policies`, confirming HTTPS requests
  from tool-sandbox children no longer fail certificate verification.

  ## Checklist

  - [x] An issue exists and is linked above
  - [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
  - [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
  - [ ] Public-facing changes are paired with documentation updates
  - [x] Release note has been added to `CHANGELOG.md` if needed