### PR TITLE
fix(tool-sandbox): skip missing fs_read/fs_write dirs instead of erroring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - *(tool-sandbox)* Pass TLS trust bundle env vars (`SSL_CERT_FILE`, `CURL_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `GIT_SSL_CAINFO`) to tool-sandbox children so HTTPS certificate verification works when TLS interception is active (#1248)
 
+- *(tool-sandbox)* Skip missing `fs_read`/`fs_write` directories instead of erroring on startup; matches existing `fs_read_file` behaviour (#1252)
+
 ## [0.65.1] - 2026-06-23
 ## [0.65.0] - 2026-06-23
 

--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -3226,11 +3226,11 @@ fn add_policy_fs(
     use super::dynamic_providers::expand_dynamic_tokens;
     for entry in &expand_dynamic_tokens(&policy.fs_read)? {
         let path = resolve_policy_path(entry, policy_root)?;
-        caps.add_fs(FsCapability::new_dir(path, AccessMode::Read)?);
+        add_optional_dir(caps, path, AccessMode::Read)?;
     }
     for entry in &expand_dynamic_tokens(&policy.fs_write)? {
         let path = resolve_policy_path(entry, policy_root)?;
-        caps.add_fs(FsCapability::new_dir(path, AccessMode::ReadWrite)?);
+        add_optional_dir(caps, path, AccessMode::ReadWrite)?;
     }
     for entry in &expand_dynamic_tokens(&policy.fs_read_file)? {
         let path = resolve_policy_path(entry, policy_root)?;
@@ -3241,6 +3241,17 @@ fn add_policy_fs(
         caps.add_fs(FsCapability::new_file(path, AccessMode::ReadWrite)?);
     }
     Ok(())
+}
+
+fn add_optional_dir(caps: &mut CapabilitySet, path: PathBuf, access: AccessMode) -> Result<()> {
+    match FsCapability::new_dir(&path, access) {
+        Ok(capability) => {
+            caps.add_fs(capability);
+            Ok(())
+        }
+        Err(NonoError::PathNotFound(_)) => Ok(()),
+        Err(err) => Err(err),
+    }
 }
 
 fn add_optional_read_file(caps: &mut CapabilitySet, path: PathBuf) -> Result<()> {

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -2261,11 +2261,11 @@ fn add_policy_fs(
     use super::dynamic_providers::expand_dynamic_tokens;
     for entry in &expand_dynamic_tokens(&policy.fs_read)? {
         let path = resolve_policy_path(entry, policy_root)?;
-        caps.add_fs(FsCapability::new_dir(path, AccessMode::Read)?);
+        add_optional_dir(caps, path, AccessMode::Read)?;
     }
     for entry in &expand_dynamic_tokens(&policy.fs_write)? {
         let path = resolve_policy_path(entry, policy_root)?;
-        caps.add_fs(FsCapability::new_dir(path, AccessMode::ReadWrite)?);
+        add_optional_dir(caps, path, AccessMode::ReadWrite)?;
     }
     for entry in &expand_dynamic_tokens(&policy.fs_read_file)? {
         let path = resolve_policy_path(entry, policy_root)?;
@@ -2276,6 +2276,17 @@ fn add_policy_fs(
         caps.add_fs(FsCapability::new_file(path, AccessMode::ReadWrite)?);
     }
     Ok(())
+}
+
+fn add_optional_dir(caps: &mut CapabilitySet, path: PathBuf, access: AccessMode) -> Result<()> {
+    match FsCapability::new_dir(&path, access) {
+        Ok(capability) => {
+            caps.add_fs(capability);
+            Ok(())
+        }
+        Err(NonoError::PathNotFound(_)) => Ok(()),
+        Err(err) => Err(err),
+    }
 }
 
 fn add_optional_read_file(caps: &mut CapabilitySet, path: PathBuf) -> Result<()> {


### PR DESCRIPTION
## Linked Issue

  Closes #1252

  ## Summary

  `fs_read_file` entries in `add_policy_fs` already silently skip missing paths via `add_optional_read_file`. `fs_read` and `fs_write` directory entries used
  `FsCapability::new_dir(...)?` which propagated `PathNotFound` as a hard error, preventing the tool-sandbox from starting when a profile grants a directory that
  doesn't exist on that machine.

  Add `add_optional_dir` with the same warn-and-skip pattern and use it for both `fs_read` and `fs_write` in `add_policy_fs` on macOS and Linux.

  ## Test Plan

  Existing `nono-cli` test suite passes. Manual verification: profile with a non-existent `fs_read` directory no longer errors on tool-sandbox startup.

  ## Checklist

  - [x] An issue exists and is linked above
  - [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
  - [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
  - [ ] Public-facing changes are paired with documentation updates
  - [x] Release note has been added to `CHANGELOG.md` if needed