### PR TITLE
feat(network): add open_port_range and fix Linux ProxyOnly semantics

### DIFF
--- a/crates/nono-cli/README.md
+++ b/crates/nono-cli/README.md
@@ -145,6 +145,101 @@ Profiles can form chains (up to 10 levels deep). Circular dependencies are detec
 my-dev.json → team-base.json → claude-code (pack)
 ```
 
+## Network Modes
+
+nono has three network modes. You pick one per run; they cannot be combined.
+
+| Mode | CLI flag | Profile field | What it does |
+|------|----------|---------------|--------------|
+| **Unrestricted** | *(default)* | — | Child has full network access |
+| **Blocked** | `--block-net` | `"network": { "block": true }` | All outbound connections denied |
+| **Proxy-only** | `--allow-domain <host>` | `"network": { "allow_domain": [...] }` | Child may only reach the nono proxy; proxy enforces an allowlist |
+
+### Localhost IPC ports
+
+`open_port` and `open_port_range` punch loopback exceptions into an otherwise restricted network. They have no effect in unrestricted (AllowAll) mode.
+
+**Single port — CLI or profile:**
+```bash
+nono run --allow-cwd --block-net --open-port 3000 -- my-agent
+```
+```json
+{ "network": { "block": true, "open_port": [3000, 3001] } }
+```
+
+**Port range — profile only:**
+```json
+{ "network": { "block": true, "open_port_range": [[3000, 3100]] } }
+```
+
+Multiple ranges are supported: `[[3000, 3100], [49152, 49200]]`.
+
+#### Platform behaviour
+
+|  | macOS | Linux |
+|--|-------|-------|
+| **`open_port`** | One `(remote tcp "localhost:N")` Seatbelt rule per port. Bind/inbound become a blanket allow (Seatbelt cannot filter by port). | Block-net: individual Landlock rules per port. Proxy mode: seccomp supervisor enforces loopback-only for connect. |
+| **`open_port = [0]`** (wildcard) | `(remote tcp "localhost:*")` — any loopback port. | Proxy mode only. Errors at startup in block-net mode. |
+| **`open_port_range`** | Ranges ≤ 256 ports expand to individual rules. Ranges > 256 ports collapse to `localhost:*` with a warning. Bind/inbound become a blanket allow. | Expanded to individual Landlock rules. Works in both block-net and proxy mode. In proxy mode, connect is additionally loopback-only; bind is per-port (no blanket allow). |
+
+### Proxy-only mode (`--allow-domain`)
+
+Proxy mode starts a local nono proxy and restricts the child to that proxy only. The proxy enforces domain allowlists, injects credentials, and optionally inspects endpoints.
+
+```bash
+# Allow one external domain
+nono run --allow-cwd --allow-domain api.openai.com -- my-agent
+```
+
+```json
+{
+  "network": {
+    "allow_domain": ["api.openai.com", "registry.npmjs.org"],
+    "open_port_range": [[3000, 3002]]
+  }
+}
+```
+
+When proxy mode is active, `open_port` and `open_port_range` add **localhost IPC exceptions** on top — the proxy itself is always reachable and the listed ports are additionally allowed for loopback communication.
+
+For tools that bind to an OS-assigned ephemeral port (Testcontainers, Maven Surefire, etc.), use the wildcard:
+
+```json
+{
+  "network": {
+    "allow_domain": ["api.example.com"],
+    "open_port": [0]
+  }
+}
+```
+
+`open_port: [0]` allows any loopback connect or bind without knowing the port in advance. External traffic is still restricted to the domain allowlist.
+
+On Linux, proxy-only mode always uses seccomp-notify to mediate `connect()` and `bind()` calls, even on kernels with Landlock V4+ network support. This is intentional: Landlock TCP rules match by destination port only and cannot enforce the loopback-only invariant that proxy mode requires.
+
+### Blocking external network while allowing localhost IPC
+
+```json
+{
+  "network": {
+    "block": true,
+    "open_port": [6379, 6380]
+  }
+}
+```
+
+Works on both macOS and Linux, including port ranges:
+
+```json
+{
+  "network": {
+    "block": true,
+    "open_port": [6379],
+    "open_port_range": [[49152, 49200]]
+  }
+}
+```
+
 ## Deprecated Command Blocking
 
 Command blocking is deprecated in `v0.33.0`. It is only checked against the

--- a/crates/nono-cli/README.md
+++ b/crates/nono-cli/README.md
@@ -157,9 +157,9 @@ nono has three network modes. You pick one per run; they cannot be combined.
 
 ### Localhost IPC ports
 
-`open_port` and `open_port_range` punch loopback exceptions into an otherwise restricted network. They have no effect in unrestricted (AllowAll) mode.
+Use `open_port` and `open_port_range` to let the sandboxed process talk to other processes running on the same machine — dev servers, databases, test containers, sidecar agents, etc. These only take effect in blocked or proxy mode; in unrestricted mode all ports are already open.
 
-**Single port — CLI or profile:**
+**Single port:**
 ```bash
 nono run --allow-cwd --block-net --open-port 3000 -- my-agent
 ```
@@ -167,27 +167,36 @@ nono run --allow-cwd --block-net --open-port 3000 -- my-agent
 { "network": { "block": true, "open_port": [3000, 3001] } }
 ```
 
-**Port range — profile only:**
+**Port range** (profile only, works on both platforms):
 ```json
 { "network": { "block": true, "open_port_range": [[3000, 3100]] } }
 ```
 
-Multiple ranges are supported: `[[3000, 3100], [49152, 49200]]`.
+**Wildcard — allow any localhost port** (proxy mode only):
+```json
+{
+  "network": {
+    "allow_domain": ["api.example.com"],
+    "open_port": [0]
+  }
+}
+```
 
-#### Platform behaviour
+Use `open_port: [0]` when the port isn't known ahead of time — for example, Testcontainers and Maven Surefire bind to a random ephemeral port assigned by the OS. The `allow_domain` list still restricts what external hosts the agent can reach; only localhost traffic is unrestricted.
 
-|  | macOS | Linux |
-|--|-------|-------|
-| **`open_port`** | One `(remote tcp "localhost:N")` Seatbelt rule per port. Bind/inbound become a blanket allow (Seatbelt cannot filter by port). | Block-net: individual Landlock rules per port. Proxy mode: seccomp supervisor enforces loopback-only for connect. |
-| **`open_port = [0]`** (wildcard) | `(remote tcp "localhost:*")` — any loopback port. | Proxy mode only. Errors at startup in block-net mode. |
-| **`open_port_range`** | Ranges ≤ 256 ports expand to individual rules. Ranges > 256 ports collapse to `localhost:*` with a warning. Bind/inbound become a blanket allow. | Expanded to individual Landlock rules. Works in both block-net and proxy mode. In proxy mode, connect is additionally loopback-only; bind is per-port (no blanket allow). |
+> **Note:** `open_port: [0]` (wildcard) requires proxy mode on Linux. It will error at startup if used with `--block-net` on Linux, because block-net has no mechanism to express "any port". Use proxy mode with `allow_domain` instead.
+
+#### Platform differences
+
+On macOS, when any port or range is set, inbound connections to those ports are also allowed (macOS cannot filter inbound by port). On Linux, inbound is not automatically allowed — only the ports you list are open.
+
+On macOS, ranges over 256 ports collapse to a full localhost wildcard with a warning in the logs. On Linux, all ports in the range are allowed individually regardless of range width.
 
 ### Proxy-only mode (`--allow-domain`)
 
-Proxy mode starts a local nono proxy and restricts the child to that proxy only. The proxy enforces domain allowlists, injects credentials, and optionally inspects endpoints.
+Proxy mode restricts the agent to only the domains you list. All other outbound traffic is blocked.
 
 ```bash
-# Allow one external domain
 nono run --allow-cwd --allow-domain api.openai.com -- my-agent
 ```
 
@@ -200,35 +209,9 @@ nono run --allow-cwd --allow-domain api.openai.com -- my-agent
 }
 ```
 
-When proxy mode is active, `open_port` and `open_port_range` add **localhost IPC exceptions** on top — the proxy itself is always reachable and the listed ports are additionally allowed for loopback communication.
-
-For tools that bind to an OS-assigned ephemeral port (Testcontainers, Maven Surefire, etc.), use the wildcard:
-
-```json
-{
-  "network": {
-    "allow_domain": ["api.example.com"],
-    "open_port": [0]
-  }
-}
-```
-
-`open_port: [0]` allows any loopback connect or bind without knowing the port in advance. External traffic is still restricted to the domain allowlist.
-
-On Linux, proxy-only mode always uses seccomp-notify to mediate `connect()` and `bind()` calls, even on kernels with Landlock V4+ network support. This is intentional: Landlock TCP rules match by destination port only and cannot enforce the loopback-only invariant that proxy mode requires.
+`open_port` and `open_port_range` work alongside `allow_domain` — the domain list controls external traffic, and the port exceptions control localhost IPC. They are independent.
 
 ### Blocking external network while allowing localhost IPC
-
-```json
-{
-  "network": {
-    "block": true,
-    "open_port": [6379, 6380]
-  }
-}
-```
-
-Works on both macOS and Linux, including port ranges:
 
 ```json
 {
@@ -239,6 +222,8 @@ Works on both macOS and Linux, including port ranges:
   }
 }
 ```
+
+Works on both macOS and Linux.
 
 ## Deprecated Command Blocking
 

--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -985,6 +985,9 @@ impl CapabilitySetExt for CapabilitySet {
         for port in &profile.network.open_port {
             caps.add_localhost_port(*port);
         }
+        for &[start, end] in &profile.network.open_port_range {
+            caps.add_localhost_port_range(start, end);
+        }
 
         // Outbound TCP connect port allowlist from profile (Linux Landlock V4+ only)
         #[cfg(target_os = "macos")]

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1216,7 +1216,9 @@ pub struct SandboxArgs {
     )]
     pub allow_bind: Vec<u16>,
 
-    /// Allow bidirectional localhost TCP on a port: connect + listen (repeatable)
+    /// Allow bidirectional localhost TCP on a port: connect + listen (repeatable).
+    /// Port 0 = localhost wildcard (any port); macOS and Linux proxy mode only.
+    /// For ranges use open_port_range in a profile (no CLI flag equivalent).
     /// ALIAS(canonical="--open-port", introduced="v0.0.0", remove_by="indefinite", issue="#415")
     #[arg(
         long = "open-port",
@@ -1530,7 +1532,9 @@ pub struct WrapSandboxArgs {
     )]
     pub allow_bind: Vec<u16>,
 
-    /// Allow bidirectional localhost TCP on a port: connect + listen (repeatable)
+    /// Allow bidirectional localhost TCP on a port: connect + listen (repeatable).
+    /// Port 0 = localhost wildcard (any port); macOS and Linux proxy mode only.
+    /// For ranges use open_port_range in a profile (no CLI flag equivalent).
     /// ALIAS(canonical="--open-port", introduced="v0.0.0", remove_by="indefinite", issue="#415")
     #[arg(
         long = "open-port",

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -312,6 +312,13 @@ pub struct SupervisorConfig<'a> {
     /// Bind ports allowed for seccomp proxy-only fallback.
     #[cfg(target_os = "linux")]
     pub proxy_bind_ports: Vec<u16>,
+    /// Localhost IPC ports for seccomp proxy-only fallback. Port 0 = wildcard
+    /// (any loopback port); otherwise exact ports for connect and bind.
+    #[cfg(target_os = "linux")]
+    pub localhost_ports: Vec<u16>,
+    /// Localhost IPC port ranges `[start, end]` (inclusive) for seccomp proxy-only.
+    #[cfg(target_os = "linux")]
+    pub localhost_port_ranges: Vec<(u16, u16)>,
     /// Pathname AF_UNIX socket grants allowed for seccomp proxy-only fallback.
     #[cfg(target_os = "linux")]
     pub unix_socket_allowlist: &'a [nono::UnixSocketCapability],
@@ -4585,6 +4592,10 @@ mod tests {
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
             #[cfg(target_os = "linux")]
+            localhost_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            localhost_port_ranges: Vec::new(),
+            #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
             #[cfg(target_os = "linux")]
             linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
@@ -4705,6 +4716,10 @@ mod tests {
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
             #[cfg(target_os = "linux")]
+            localhost_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            localhost_port_ranges: Vec::new(),
+            #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
             #[cfg(target_os = "linux")]
             linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
@@ -4791,6 +4806,10 @@ mod tests {
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
             #[cfg(target_os = "linux")]
+            localhost_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            localhost_port_ranges: Vec::new(),
+            #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
             #[cfg(target_os = "linux")]
             linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
@@ -4834,6 +4853,10 @@ mod tests {
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
             #[cfg(target_os = "linux")]
+            localhost_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            localhost_port_ranges: Vec::new(),
+            #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
             #[cfg(target_os = "linux")]
             linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
@@ -4875,6 +4898,10 @@ mod tests {
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
             #[cfg(target_os = "linux")]
+            localhost_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            localhost_port_ranges: Vec::new(),
+            #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
             #[cfg(target_os = "linux")]
             linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
@@ -4897,6 +4924,10 @@ mod tests {
             proxy_port: 0,
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            localhost_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            localhost_port_ranges: Vec::new(),
             #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
             #[cfg(target_os = "linux")]
@@ -4943,6 +4974,10 @@ mod tests {
             proxy_port: 0,
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            localhost_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            localhost_port_ranges: Vec::new(),
             #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
             #[cfg(target_os = "linux")]
@@ -5095,6 +5130,10 @@ mod tests {
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
             #[cfg(target_os = "linux")]
+            localhost_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            localhost_port_ranges: Vec::new(),
+            #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
             #[cfg(target_os = "linux")]
             linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
@@ -5146,6 +5185,10 @@ mod tests {
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
             #[cfg(target_os = "linux")]
+            localhost_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            localhost_port_ranges: Vec::new(),
+            #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
             #[cfg(target_os = "linux")]
             linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
@@ -5185,6 +5228,10 @@ mod tests {
             proxy_port: 0,
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            localhost_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            localhost_port_ranges: Vec::new(),
             #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
             #[cfg(target_os = "linux")]
@@ -5244,6 +5291,10 @@ mod tests {
             proxy_port: 0,
             #[cfg(target_os = "linux")]
             proxy_bind_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            localhost_ports: Vec::new(),
+            #[cfg(target_os = "linux")]
+            localhost_port_ranges: Vec::new(),
             #[cfg(target_os = "linux")]
             unix_socket_allowlist: &[],
             #[cfg(target_os = "linux")]

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -563,9 +563,13 @@ pub(super) enum NetworkDecision {
 ///    no path to check.
 ///
 /// 2. For `AF_INET`/`AF_INET6`:
-///    - `connect()` is allowed only to `127.0.0.1:proxy_port` (the nono proxy).
-///    - `bind()` is allowed only on ports in `proxy_bind_ports`.
+///    - `connect()` is allowed to `127.0.0.1:proxy_port` (the nono proxy),
+///      any port in `localhost_ports` (port `0` = wildcard), or any port
+///      that falls within a `localhost_port_ranges` range — **loopback only**.
+///    - `bind()` is allowed on `proxy_bind_ports`, `localhost_ports`, or
+///      `localhost_port_ranges`. No loopback check on bind (matches macOS).
 ///    - Everything else is denied.
+///
 pub(super) fn decide_network_notification(
     child_pid: u32,
     syscall: i32,
@@ -615,10 +619,17 @@ pub(super) fn decide_network_notification(
 
     match syscall {
         SYS_CONNECT | SYS_SENDTO | SYS_SENDMSG | SYS_SENDMMSG => {
-            // Allow connect/sendto/sendmsg/sendmmsg only to loopback + proxy port.
-            // sendto/sendmsg/sendmmsg with a destination address is semantically
-            // equivalent to connect for network reach-out (issue #1089).
-            if sockaddr.is_loopback && sockaddr.port == config.proxy_port {
+            // Allow proxy port, or any loopback port when localhost_ports
+            // contains 0 (wildcard), or an exact match in localhost_ports.
+            let allowed = sockaddr.is_loopback
+                && (sockaddr.port == config.proxy_port
+                    || config.localhost_ports.contains(&0)
+                    || config.localhost_ports.contains(&sockaddr.port)
+                    || config
+                        .localhost_port_ranges
+                        .iter()
+                        .any(|&(s, e)| sockaddr.port >= s && sockaddr.port <= e));
+            if allowed {
                 debug!(
                     "Proxy seccomp: allowing network syscall nr={} to loopback:{}",
                     syscall, sockaddr.port
@@ -633,8 +644,15 @@ pub(super) fn decide_network_notification(
             }
         }
         SYS_BIND => {
-            // Allow bind only on configured bind ports
-            if config.proxy_bind_ports.contains(&sockaddr.port) {
+            // Allow configured bind ports, localhost_ports wildcard (0), or exact match.
+            let allowed = config.proxy_bind_ports.contains(&sockaddr.port)
+                || config.localhost_ports.contains(&0)
+                || config.localhost_ports.contains(&sockaddr.port)
+                || config
+                    .localhost_port_ranges
+                    .iter()
+                    .any(|&(s, e)| sockaddr.port >= s && sockaddr.port <= e);
+            if allowed {
                 debug!("Proxy seccomp: allowing bind on port {}", sockaddr.port);
                 NetworkDecision::Allow
             } else {
@@ -1535,6 +1553,8 @@ mod tests {
                 allow_launch_services_active: false,
                 proxy_port,
                 proxy_bind_ports,
+                localhost_ports: Vec::new(),
+                localhost_port_ranges: Vec::new(),
                 unix_socket_allowlist,
                 linux_network_notify_mode: LinuxNetworkNotifyMode::ProxyOnly,
                 tool_sandbox_runtime: None,
@@ -2007,6 +2027,151 @@ mod tests {
                 ),
                 NetworkDecision::Deny,
                 "AF_INET sendmmsg to external host must be denied"
+            );
+        }
+
+        /// open_port=0 wildcard: connect to any loopback port is allowed.
+        #[test]
+        fn localhost_wildcard_allows_connect_any_loopback_port() {
+            let backend = DenyAllBackend;
+            let mut config = make_config(&backend, 8080, Vec::new(), &[]);
+            config.localhost_ports = vec![0];
+            assert_eq!(
+                decide_network_notification(
+                    test_pid(),
+                    SYS_CONNECT,
+                    &inet_loopback(32768),
+                    &config
+                ),
+                NetworkDecision::Allow,
+                "open_port=0 must allow connect to any loopback port"
+            );
+        }
+
+        /// open_port=0 wildcard: connect to external host is still denied.
+        #[test]
+        fn localhost_wildcard_denies_external_connect() {
+            let backend = DenyAllBackend;
+            let mut config = make_config(&backend, 8080, Vec::new(), &[]);
+            config.localhost_ports = vec![0];
+            assert_eq!(
+                decide_network_notification(test_pid(), SYS_CONNECT, &inet_external(443), &config),
+                NetworkDecision::Deny,
+                "open_port=0 must not allow connect to external hosts"
+            );
+        }
+
+        /// open_port=0 wildcard: bind on any port is allowed.
+        #[test]
+        fn localhost_wildcard_allows_bind_any_port() {
+            let backend = DenyAllBackend;
+            let mut config = make_config(&backend, 8080, Vec::new(), &[]);
+            config.localhost_ports = vec![0];
+            assert_eq!(
+                decide_network_notification(test_pid(), SYS_BIND, &inet_loopback(55123), &config),
+                NetworkDecision::Allow,
+                "open_port=0 must allow bind on any port"
+            );
+        }
+
+        /// Specific open_port: connect to that loopback port is allowed.
+        #[test]
+        fn specific_localhost_port_allows_connect() {
+            let backend = DenyAllBackend;
+            let mut config = make_config(&backend, 8080, Vec::new(), &[]);
+            config.localhost_ports = vec![3000];
+            assert_eq!(
+                decide_network_notification(test_pid(), SYS_CONNECT, &inet_loopback(3000), &config),
+                NetworkDecision::Allow,
+                "open_port=3000 must allow connect to loopback:3000"
+            );
+        }
+
+        /// Specific open_port: connect to a different port is denied.
+        #[test]
+        fn specific_localhost_port_denies_other_loopback_port() {
+            let backend = DenyAllBackend;
+            let mut config = make_config(&backend, 8080, Vec::new(), &[]);
+            config.localhost_ports = vec![3000];
+            assert_eq!(
+                decide_network_notification(test_pid(), SYS_CONNECT, &inet_loopback(4000), &config),
+                NetworkDecision::Deny,
+                "open_port=3000 must not allow connect to loopback:4000"
+            );
+        }
+
+        /// Port range: connect to a port within the range is allowed.
+        #[test]
+        fn port_range_allows_connect_within_range() {
+            let backend = DenyAllBackend;
+            let mut config = make_config(&backend, 8080, Vec::new(), &[]);
+            config.localhost_port_ranges = vec![(3000, 3100)];
+            assert_eq!(
+                decide_network_notification(test_pid(), SYS_CONNECT, &inet_loopback(3050), &config),
+                NetworkDecision::Allow,
+                "port range 3000-3100 must allow connect to loopback:3050"
+            );
+        }
+
+        /// Port range: connect to a port outside the range is denied.
+        #[test]
+        fn port_range_denies_connect_outside_range() {
+            let backend = DenyAllBackend;
+            let mut config = make_config(&backend, 8080, Vec::new(), &[]);
+            config.localhost_port_ranges = vec![(3000, 3100)];
+            assert_eq!(
+                decide_network_notification(test_pid(), SYS_CONNECT, &inet_loopback(3101), &config),
+                NetworkDecision::Deny,
+                "port range 3000-3100 must deny connect to loopback:3101"
+            );
+        }
+
+        /// Port range: range boundary ports (start and end) are inclusive.
+        #[test]
+        fn port_range_boundary_ports_are_inclusive() {
+            let backend = DenyAllBackend;
+            let mut config = make_config(&backend, 8080, Vec::new(), &[]);
+            config.localhost_port_ranges = vec![(5000, 5001)];
+            assert_eq!(
+                decide_network_notification(test_pid(), SYS_CONNECT, &inet_loopback(5000), &config),
+                NetworkDecision::Allow,
+                "range start port must be inclusive"
+            );
+            assert_eq!(
+                decide_network_notification(test_pid(), SYS_CONNECT, &inet_loopback(5001), &config),
+                NetworkDecision::Allow,
+                "range end port must be inclusive"
+            );
+            assert_eq!(
+                decide_network_notification(test_pid(), SYS_CONNECT, &inet_loopback(4999), &config),
+                NetworkDecision::Deny,
+                "port below range start must be denied"
+            );
+        }
+
+        /// Port range: external host is denied even if port is within range.
+        #[test]
+        fn port_range_denies_external_host_in_range() {
+            let backend = DenyAllBackend;
+            let mut config = make_config(&backend, 8080, Vec::new(), &[]);
+            config.localhost_port_ranges = vec![(3000, 3100)];
+            assert_eq!(
+                decide_network_notification(test_pid(), SYS_CONNECT, &inet_external(3050), &config),
+                NetworkDecision::Deny,
+                "port range must not allow connect to external host even if port matches"
+            );
+        }
+
+        /// Port range: bind within range is allowed.
+        #[test]
+        fn port_range_allows_bind_within_range() {
+            let backend = DenyAllBackend;
+            let mut config = make_config(&backend, 8080, Vec::new(), &[]);
+            config.localhost_port_ranges = vec![(3000, 3100)];
+            assert_eq!(
+                decide_network_notification(test_pid(), SYS_BIND, &inet_loopback(3000), &config),
+                NetworkDecision::Allow,
+                "port range 3000-3100 must allow bind on port 3000"
             );
         }
 

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -515,9 +515,9 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
             }
             false
         } else if needs_proxy {
-            !Sandbox::detect_abi()
-                .ok()
-                .is_some_and(|abi| abi.has_network())
+            // Always use seccomp-notify for ProxyOnly: Landlock TCP rules
+            // have no IP component and cannot enforce loopback-only.
+            true
         } else {
             false
         }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1450,6 +1450,13 @@ pub struct NetworkConfig {
         alias = "allow_port"
     )]
     pub open_port: Vec<u16>,
+    /// Inclusive localhost port ranges, e.g. `[[3000, 3100], [49152, 49200]]`.
+    ///
+    /// macOS: ranges ≤ 256 ports expand to individual Seatbelt rules; wider ranges
+    /// collapse to `localhost:*` with a warning. Bind/inbound are blanket-allowed.
+    /// Linux: expanded to individual Landlock rules. Works in both block-net and proxy mode.
+    #[serde(default)]
+    pub open_port_range: Vec<[u16; 2]>,
     /// TCP ports the sandboxed child may listen on.
     /// Equivalent to `--listen-port` CLI flag.
     #[serde(default)]
@@ -3135,6 +3142,10 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
                 &child.network.allow_domain,
             ),
             open_port: dedup_append(&base.network.open_port, &child.network.open_port),
+            open_port_range: dedup_append(
+                &base.network.open_port_range,
+                &child.network.open_port_range,
+            ),
             listen_port: dedup_append(&base.network.listen_port, &child.network.listen_port),
             connect_port: dedup_append(&base.network.connect_port, &child.network.connect_port),
             // Child `Some([])` overrides parent credentials to empty (disables proxy).
@@ -5323,6 +5334,7 @@ mod tests {
                 network_profile: InheritableValue::Set("base-net".to_string()),
                 allow_domain: vec![AllowDomainEntry::Plain("base.example.com".to_string())],
                 open_port: vec![3000],
+                open_port_range: vec![],
                 listen_port: vec![4000],
                 connect_port: vec![],
                 credentials: Some(vec!["base_cred".to_string()]),
@@ -5408,6 +5420,7 @@ mod tests {
                 network_profile: InheritableValue::Inherit,
                 allow_domain: vec![AllowDomainEntry::Plain("child.example.com".to_string())],
                 open_port: vec![3000, 5000],
+                open_port_range: vec![],
                 listen_port: vec![4000, 6000],
                 connect_port: vec![],
                 credentials: None,

--- a/crates/nono-cli/src/supervised_runtime.rs
+++ b/crates/nono-cli/src/supervised_runtime.rs
@@ -279,6 +279,10 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
             _ => Vec::new(),
         },
         #[cfg(target_os = "linux")]
+        localhost_ports: caps.localhost_ports().to_vec(),
+        #[cfg(target_os = "linux")]
+        localhost_port_ranges: caps.localhost_port_ranges().to_vec(),
+        #[cfg(target_os = "linux")]
         unix_socket_allowlist: caps.unix_socket_capabilities(),
         #[cfg(target_os = "linux")]
         linux_network_notify_mode: if config.seccomp_proxy_fallback {

--- a/crates/nono/src/capability.rs
+++ b/crates/nono/src/capability.rs
@@ -892,6 +892,9 @@ pub struct CapabilitySet {
     /// by destination IP. Use with `--block-net` or proxy mode to ensure
     /// only localhost is reachable.
     localhost_ports: Vec<u16>,
+    /// Inclusive port ranges `[start, end]` for localhost IPC.
+    /// See [`CapabilitySet::allow_localhost_port_range`] for platform behaviour.
+    localhost_port_ranges: Vec<(u16, u16)>,
     /// Commands explicitly allowed (overrides blocklists - for CLI use)
     allowed_commands: Vec<String>,
     /// Additional commands to block (extends blocklists - for CLI use)
@@ -1083,6 +1086,23 @@ impl CapabilitySet {
         self
     }
 
+    /// Allow localhost TCP connect and bind on ports `start..=end`.
+    ///
+    /// **macOS**: ranges ≤ 256 ports expand to individual Seatbelt
+    /// `(remote tcp "localhost:N")` rules. Wider ranges collapse to
+    /// `localhost:*` (logged as a warning — Seatbelt has no range syntax).
+    /// Bind/inbound are blanket-allowed when any port or range is set;
+    /// Seatbelt cannot filter bind by port.
+    ///
+    /// **Linux**: expanded to individual Landlock `ConnectTcp`/`BindTcp` rules.
+    /// Works in both block-net and proxy mode. In proxy mode the seccomp supervisor
+    /// also enforces loopback-only for connect.
+    #[must_use]
+    pub fn allow_localhost_port_range(mut self, start: u16, end: u16) -> Self {
+        self.localhost_port_ranges.push((start, end));
+        self
+    }
+
     /// Allow TCP connect to standard HTTPS ports (443, 8443)
     ///
     /// Convenience method. Linux Landlock V4+ only.
@@ -1238,6 +1258,11 @@ impl CapabilitySet {
     /// Localhost IPC port; `0` is macOS-only (`localhost:*` TCP outbound).
     pub fn add_localhost_port(&mut self, port: u16) {
         self.localhost_ports.push(port);
+    }
+
+    /// Add a localhost IPC port range `[start, end]` (inclusive).
+    pub fn add_localhost_port_range(&mut self, start: u16, end: u16) {
+        self.localhost_port_ranges.push((start, end));
     }
 
     /// Set sandbox extensions state
@@ -1414,6 +1439,12 @@ impl CapabilitySet {
     #[must_use]
     pub fn localhost_ports(&self) -> &[u16] {
         &self.localhost_ports
+    }
+
+    /// Localhost IPC port ranges (inclusive `[start, end]`).
+    #[must_use]
+    pub fn localhost_port_ranges(&self) -> &[(u16, u16)] {
+        &self.localhost_port_ranges
     }
 
     /// Check if sandbox extensions are enabled for runtime capability expansion

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -538,12 +538,14 @@ pub fn apply_with_abi(caps: &CapabilitySet, abi: &DetectedAbi) -> Result<Seccomp
     info!("Using Landlock ABI {:?}", target_abi);
     let scopes = requested_scopes(caps, abi)?;
 
-    if !matches!(caps.network_mode(), NetworkMode::AllowAll) && caps.localhost_ports().contains(&0)
-    {
-        return Err(NonoError::SandboxInit(
-            "open_port 0 (localhost TCP wildcard) is macOS-only; on Linux use explicit ports or a network profile."
-                .to_string(),
-        ));
+    if matches!(caps.network_mode(), NetworkMode::Blocked) {
+        if caps.localhost_ports().contains(&0) {
+            return Err(NonoError::SandboxInit(
+                "open_port 0 (localhost wildcard) is not supported in --block-net mode on Linux; \
+                 use proxy mode (--allow-domain) with open_port 0, or list explicit ports."
+                    .to_string(),
+            ));
+        }
     }
 
     // Determine which access rights to handle based on ABI
@@ -566,9 +568,23 @@ pub fn apply_with_abi(caps: &CapabilitySet, abi: &DetectedAbi) -> Result<Seccomp
         || !caps.tcp_connect_ports().is_empty()
         || !caps.tcp_bind_ports().is_empty();
 
-    let mut seccomp_net_fallback = SeccompNetFallback::None;
+    // ProxyOnly always uses seccomp-notify regardless of Landlock ABI: Landlock
+    // TCP rules match by destination port only, with no IP component, so they
+    // cannot enforce the loopback-only invariant that ProxyOnly requires.
+    let mut seccomp_net_fallback =
+        if let NetworkMode::ProxyOnly { port, bind_ports } = caps.network_mode() {
+            SeccompNetFallback::ProxyOnly {
+                proxy_port: *port,
+                bind_ports: bind_ports.clone(),
+            }
+        } else {
+            SeccompNetFallback::None
+        };
 
-    let ruleset_builder = if needs_network_handling {
+    let needs_landlock_network =
+        matches!(seccomp_net_fallback, SeccompNetFallback::None) && needs_network_handling;
+
+    let ruleset_builder = if needs_landlock_network {
         let handled_net = AccessNet::from_all(target_abi);
         if !handled_net.is_empty() {
             debug!("Handling network access: {:?}", handled_net);
@@ -595,16 +611,9 @@ pub fn apply_with_abi(caps: &CapabilitySet, abi: &DetectedAbi) -> Result<Seccomp
                     seccomp_net_fallback = fallback;
                     ruleset_builder
                 }
-                SeccompNetFallback::ProxyOnly {
-                    proxy_port,
-                    bind_ports,
-                } => {
-                    warn!(
-                        "Landlock ABI {:?} lacks TCP network filtering; \
-                         using seccomp proxy-only fallback (port={}, bind_ports={:?})",
-                        target_abi, proxy_port, bind_ports
-                    );
-                    seccomp_net_fallback = fallback;
+                SeccompNetFallback::ProxyOnly { .. } => {
+                    // Unreachable: ProxyOnly is set unconditionally above and
+                    // excluded from needs_landlock_network.
                     ruleset_builder
                 }
                 SeccompNetFallback::None => {
@@ -707,6 +716,7 @@ pub fn apply_with_abi(caps: &CapabilitySet, abi: &DetectedAbi) -> Result<Seccomp
         // Add localhost IPC port rules (connect + bind per port).
         // Only meaningful in Blocked/ProxyOnly modes. In AllowAll mode, all ports are
         // already reachable and adding Landlock network handling would restrict them.
+        // Ranges are expanded to individual rules — Landlock has no range syntax.
         if !matches!(caps.network_mode(), NetworkMode::AllowAll) {
             for port in caps.localhost_ports() {
                 debug!("Adding localhost TCP connect rule for port {}", port);
@@ -727,6 +737,26 @@ pub fn apply_with_abi(caps: &CapabilitySet, abi: &DetectedAbi) -> Result<Seccomp
                             port, e
                         ))
                     })?;
+            }
+            for &(start, end) in caps.localhost_port_ranges() {
+                for port in start..=end {
+                    ruleset = ruleset
+                        .add_rule(NetPort::new(port, AccessNet::ConnectTcp))
+                        .map_err(|e| {
+                            NonoError::SandboxInit(format!(
+                                "Cannot add TCP connect rule for port {}: {}",
+                                port, e
+                            ))
+                        })?;
+                    ruleset = ruleset
+                        .add_rule(NetPort::new(port, AccessNet::BindTcp))
+                        .map_err(|e| {
+                            NonoError::SandboxInit(format!(
+                                "Cannot add TCP bind rule for port {}: {}",
+                                port, e
+                            ))
+                        })?;
+                }
             }
         }
     }
@@ -4121,38 +4151,30 @@ mod tests {
         );
     }
 
-    /// Integration test: ProxyOnly + Landlock V4+ does NOT install seccomp
-    /// proxy filter (Landlock handles networking natively).
-    ///
-    /// Verifies that apply_with_abi() returns SeccompNetFallback::None when
-    /// the kernel supports AccessNet, even with ProxyOnly mode.
+    /// ProxyOnly always returns `SeccompNetFallback::ProxyOnly`, even on V4+
+    /// kernels — Landlock TCP rules have no IP component and cannot enforce
+    /// the loopback-only invariant.
     #[cfg(target_os = "linux")]
     #[test]
-    fn test_proxy_only_with_landlock_v4_returns_no_fallback() {
+    fn test_proxy_only_always_returns_seccomp_fallback() {
         let detected = match detect_abi() {
             Ok(d) => d,
             Err(_) => return,
         };
 
-        if !detected.has_network() {
-            // Pre-V4 kernel: the fallback SHOULD be ProxyOnly, not None.
-            // Test that separately.
-            return;
-        }
-
-        // On V4+, Landlock handles ProxyOnly natively. apply_with_abi should
-        // return None (no seccomp fallback needed). We can't actually call
-        // apply_with_abi in the parent (irreversible), so fork a child.
         let pid = unsafe { libc::fork() };
         assert!(pid >= 0, "fork() failed");
 
         if pid == 0 {
             let caps = CapabilitySet::new().proxy_only(8080);
             let exit_code = match apply_with_abi(&caps, &detected) {
-                Ok(SeccompNetFallback::None) => 0,
-                Ok(SeccompNetFallback::BlockAll) => 1,
-                Ok(SeccompNetFallback::ProxyOnly { .. }) => 2,
-                Err(_) => 3,
+                Ok(SeccompNetFallback::ProxyOnly {
+                    proxy_port: 8080, ..
+                }) => 0,
+                Ok(SeccompNetFallback::ProxyOnly { .. }) => 1, // wrong port
+                Ok(SeccompNetFallback::None) => 2,
+                Ok(SeccompNetFallback::BlockAll) => 3,
+                Err(_) => 4,
             };
             unsafe { libc::_exit(exit_code) };
         }
@@ -4163,15 +4185,14 @@ mod tests {
         assert_eq!(
             libc::WEXITSTATUS(status),
             0,
-            "Expected SeccompNetFallback::None on V4+ kernel, got exit code {}",
+            "Expected SeccompNetFallback::ProxyOnly on any kernel, got exit code {}",
             libc::WEXITSTATUS(status)
         );
     }
 
-    /// Integration test: ProxyOnly on pre-V4 kernel returns ProxyOnly fallback.
-    ///
-    /// Verifies that apply_with_abi() returns SeccompNetFallback::ProxyOnly
-    /// when the kernel's Landlock ABI lacks AccessNet.
+    /// ProxyOnly on a pre-V4 kernel (no AccessNet) also returns ProxyOnly fallback.
+    /// Redundant with `test_proxy_only_always_returns_seccomp_fallback` but kept
+    /// to pin the pre-V4 path explicitly.
     #[cfg(target_os = "linux")]
     #[test]
     fn test_proxy_only_without_landlock_net_returns_proxy_fallback() {
@@ -4179,12 +4200,6 @@ mod tests {
             Ok(d) => d,
             Err(_) => return,
         };
-
-        if detected.has_network() {
-            // V4+ kernel: Landlock handles it, fallback not used.
-            // This test only runs on pre-V4 kernels.
-            return;
-        }
 
         let pid = unsafe { libc::fork() };
         assert!(pid >= 0, "fork() failed");

--- a/crates/nono/src/sandbox/linux.rs
+++ b/crates/nono/src/sandbox/linux.rs
@@ -538,14 +538,12 @@ pub fn apply_with_abi(caps: &CapabilitySet, abi: &DetectedAbi) -> Result<Seccomp
     info!("Using Landlock ABI {:?}", target_abi);
     let scopes = requested_scopes(caps, abi)?;
 
-    if matches!(caps.network_mode(), NetworkMode::Blocked) {
-        if caps.localhost_ports().contains(&0) {
-            return Err(NonoError::SandboxInit(
-                "open_port 0 (localhost wildcard) is not supported in --block-net mode on Linux; \
-                 use proxy mode (--allow-domain) with open_port 0, or list explicit ports."
-                    .to_string(),
-            ));
-        }
+    if matches!(caps.network_mode(), NetworkMode::Blocked) && caps.localhost_ports().contains(&0) {
+        return Err(NonoError::SandboxInit(
+            "open_port 0 (localhost wildcard) is not supported in --block-net mode on Linux; \
+             use proxy mode (--allow-domain) with open_port 0, or list explicit ports."
+                .to_string(),
+        ));
     }
 
     // Determine which access rights to handle based on ABI
@@ -3600,7 +3598,8 @@ mod tests {
         );
     }
 
-    /// Rejects `open_port: [0]` on Linux for any restricted network mode (not Landlock-only).
+    /// `open_port: [0]` (wildcard) is rejected in block-net mode on Linux —
+    /// Landlock has no wildcard port concept. Use proxy mode instead.
     #[test]
     fn test_reject_localhost_port_wildcard_zero_on_linux() {
         let Ok(detected) = detect_abi() else {
@@ -3610,7 +3609,8 @@ mod tests {
         caps.add_localhost_port(0);
         let err = apply_with_abi(&caps, &detected).expect_err("port 0 wildcard must be rejected");
         let msg = format!("{err}");
-        assert!(msg.contains("macOS-only"), "unexpected error: {msg}");
+        assert!(msg.contains("open_port 0"), "unexpected error: {msg}");
+        assert!(msg.contains("block-net"), "unexpected error: {msg}");
     }
 
     #[test]
@@ -4186,45 +4186,6 @@ mod tests {
             libc::WEXITSTATUS(status),
             0,
             "Expected SeccompNetFallback::ProxyOnly on any kernel, got exit code {}",
-            libc::WEXITSTATUS(status)
-        );
-    }
-
-    /// ProxyOnly on a pre-V4 kernel (no AccessNet) also returns ProxyOnly fallback.
-    /// Redundant with `test_proxy_only_always_returns_seccomp_fallback` but kept
-    /// to pin the pre-V4 path explicitly.
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn test_proxy_only_without_landlock_net_returns_proxy_fallback() {
-        let detected = match detect_abi() {
-            Ok(d) => d,
-            Err(_) => return,
-        };
-
-        let pid = unsafe { libc::fork() };
-        assert!(pid >= 0, "fork() failed");
-
-        if pid == 0 {
-            let caps = CapabilitySet::new().proxy_only(8080);
-            let exit_code = match apply_with_abi(&caps, &detected) {
-                Ok(SeccompNetFallback::ProxyOnly {
-                    proxy_port: 8080, ..
-                }) => 0,
-                Ok(SeccompNetFallback::ProxyOnly { .. }) => 1, // wrong port
-                Ok(SeccompNetFallback::None) => 2,
-                Ok(SeccompNetFallback::BlockAll) => 3,
-                Err(_) => 4,
-            };
-            unsafe { libc::_exit(exit_code) };
-        }
-
-        let mut status = 0;
-        unsafe { libc::waitpid(pid, &mut status, 0) };
-        assert!(libc::WIFEXITED(status));
-        assert_eq!(
-            libc::WEXITSTATUS(status),
-            0,
-            "Expected SeccompNetFallback::ProxyOnly on pre-V4 kernel, got exit code {}",
             libc::WEXITSTATUS(status)
         );
     }

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -12,6 +12,7 @@ use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::path::Path;
 use std::ptr;
+use tracing::warn;
 use tracing::{debug, info};
 
 // FFI bindings to macOS sandbox API
@@ -476,6 +477,33 @@ fn push_localhost_tcp_outbound_seatbelt_rules(profile: &mut String, localhost_po
     }
 }
 
+/// Max ports expanded as individual Seatbelt rules. Wider ranges collapse to
+/// `localhost:*` — Seatbelt has no range syntax.
+const MACOS_PORT_RANGE_EXPAND_LIMIT: u32 = 256;
+
+/// Emit Seatbelt outbound rules for `ranges`. Ranges within the limit expand
+/// to one rule per port; wider ranges collapse to `localhost:*` with a warning.
+fn push_localhost_port_range_seatbelt_rules(profile: &mut String, ranges: &[(u16, u16)]) {
+    for &(start, end) in ranges {
+        let width = (end as u32).saturating_sub(start as u32).saturating_add(1);
+        if width > MACOS_PORT_RANGE_EXPAND_LIMIT {
+            warn!(
+                "open_port_range [{}-{}] spans {} ports, exceeding the {}-port expansion \
+                 limit; collapsing to localhost:* wildcard (Seatbelt has no range syntax)",
+                start, end, width, MACOS_PORT_RANGE_EXPAND_LIMIT
+            );
+            profile.push_str("(allow network-outbound (remote tcp \"localhost:*\"))\n");
+        } else {
+            for port in start..=end {
+                profile.push_str(&format!(
+                    "(allow network-outbound (remote tcp \"localhost:{}\"))\n",
+                    port
+                ));
+            }
+        }
+    }
+}
+
 /// Generate a Seatbelt profile from capabilities
 ///
 /// This is a pure primitive - it generates rules ONLY for paths in the CapabilitySet.
@@ -699,6 +727,7 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
 (allow network-outbound (path \"/var/run/mDNSResponder\"))\n";
 
     let localhost_ports = caps.localhost_ports();
+    let localhost_port_ranges = caps.localhost_port_ranges();
     match caps.network_mode() {
         NetworkMode::Blocked => {
             profile.push_str("(deny network*)\n");
@@ -709,7 +738,7 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
             // `connect()`/`bind()` to sockets inside them. Directory
             // grants use a non-recursive regex.
             emit_unix_socket_rules(&mut profile, caps)?;
-            if !localhost_ports.is_empty() {
+            if !localhost_ports.is_empty() || !localhost_port_ranges.is_empty() {
                 // Allow system-socket for TCP (required for connect/bind)
                 profile.push_str(
                     "(allow system-socket (socket-domain AF_INET) (socket-type SOCK_STREAM))\n",
@@ -718,6 +747,7 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
                     "(allow system-socket (socket-domain AF_INET6) (socket-type SOCK_STREAM))\n",
                 );
                 push_localhost_tcp_outbound_seatbelt_rules(&mut profile, localhost_ports);
+                push_localhost_port_range_seatbelt_rules(&mut profile, localhost_port_ranges);
                 // Seatbelt cannot filter bind/inbound by port
                 profile.push_str("(allow network-bind)\n");
                 profile.push_str("(allow network-inbound)\n");
@@ -734,6 +764,7 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
                 port
             ));
             push_localhost_tcp_outbound_seatbelt_rules(&mut profile, localhost_ports);
+            push_localhost_port_range_seatbelt_rules(&mut profile, localhost_port_ranges);
             // Scope system-socket for TCP (required for connect/bind to proxy).
             profile.push_str(
                 "(allow system-socket (socket-domain AF_INET) (socket-type SOCK_STREAM))\n",
@@ -744,7 +775,10 @@ fn generate_profile(caps: &CapabilitySet) -> Result<String> {
             // If bind ports or localhost IPC ports are specified, allow network-bind
             // and network-inbound. Seatbelt cannot filter bind/inbound by port,
             // so this is a blanket allow.
-            if !bind_ports.is_empty() || !localhost_ports.is_empty() {
+            if !bind_ports.is_empty()
+                || !localhost_ports.is_empty()
+                || !localhost_port_ranges.is_empty()
+            {
                 profile.push_str("(allow network-bind)\n");
                 profile.push_str("(allow network-inbound)\n");
             }
@@ -1841,6 +1875,59 @@ mod tests {
         assert!(profile.contains("(allow network-inbound)"));
         assert!(profile.contains("(allow network-bind)"));
         assert!(!profile.contains("(deny network*)"));
+    }
+
+    #[test]
+    fn test_port_range_small_expands_to_individual_rules_in_proxy_mode() {
+        let caps = CapabilitySet::new()
+            .proxy_only(8080)
+            .allow_localhost_port_range(3000, 3002);
+        let profile = generate_profile(&caps).unwrap();
+        assert!(profile.contains("(allow network-outbound (remote tcp \"localhost:3000\"))"));
+        assert!(profile.contains("(allow network-outbound (remote tcp \"localhost:3001\"))"));
+        assert!(profile.contains("(allow network-outbound (remote tcp \"localhost:3002\"))"));
+        assert!(!profile.contains("localhost:*"));
+    }
+
+    #[test]
+    fn test_port_range_small_expands_in_blocked_mode() {
+        let caps = CapabilitySet::new()
+            .block_network()
+            .allow_localhost_port_range(5000, 5001);
+        let profile = generate_profile(&caps).unwrap();
+        assert!(profile.contains("(allow network-outbound (remote tcp \"localhost:5000\"))"));
+        assert!(profile.contains("(allow network-outbound (remote tcp \"localhost:5001\"))"));
+        assert!(profile.contains("(allow network-bind)"));
+        assert!(profile.contains("(allow network-inbound)"));
+    }
+
+    #[test]
+    fn test_port_range_wide_collapses_to_wildcard() {
+        // Range of 257 ports (> MACOS_PORT_RANGE_EXPAND_LIMIT) must collapse to localhost:*
+        let caps = CapabilitySet::new()
+            .proxy_only(8080)
+            .allow_localhost_port_range(3000, 3256);
+        let profile = generate_profile(&caps).unwrap();
+        assert!(
+            profile.contains("(allow network-outbound (remote tcp \"localhost:*\"))"),
+            "wide range must collapse to wildcard"
+        );
+        assert!(
+            !profile.contains("(allow network-outbound (remote tcp \"localhost:3000\"))"),
+            "must not expand individual rules for wide range"
+        );
+    }
+
+    #[test]
+    fn test_port_range_exactly_at_limit_expands() {
+        // Range of exactly MACOS_PORT_RANGE_EXPAND_LIMIT (256) ports must expand
+        let caps = CapabilitySet::new()
+            .proxy_only(8080)
+            .allow_localhost_port_range(3000, 3255); // 256 ports
+        let profile = generate_profile(&caps).unwrap();
+        assert!(profile.contains("(allow network-outbound (remote tcp \"localhost:3000\"))"));
+        assert!(profile.contains("(allow network-outbound (remote tcp \"localhost:3255\"))"));
+        assert!(!profile.contains("localhost:*"));
     }
 
     #[test]


### PR DESCRIPTION

## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1101 
Closes #611 

## Summary

- ProxyOnly on Linux now always uses seccomp-notify regardless of Landlock ABI; Landlock TCP rules have no IP component and cannot enforce loopback-only
- Add open_port_range to profiles and CapabilitySet for localhost IPC port ranges; macOS expands ≤256 ports to individual Seatbelt rules, wider ranges collapse to localhost:* with a warning; Linux expands to individual Landlock rules in both block-net and proxy mode
- Add open_port=0 wildcard in proxy mode: allows any loopback connect/bind without knowing the port at profile-write time (fixes ephemeral port use cases like Testcontainers and Maven Surefire)
- open_port=0 in block-net mode on Linux errors at startup (no supervisor)
- Document all network mode and port behaviour including platform differences

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
