### PR TITLE
fix(network): error early on contradictory network flag combinations

### DIFF
--- a/crates/nono-cli/src/command_runtime.rs
+++ b/crates/nono-cli/src/command_runtime.rs
@@ -11,7 +11,8 @@ use crate::profile;
 use crate::proxy_runtime::prepare_proxy_launch_options;
 use crate::sandbox_prepare::{
     prepare_sandbox, print_allow_gpu_warning, print_allow_launch_services_warning,
-    should_auto_enable_claude_launch_services, validate_external_proxy_bypass,
+    should_auto_enable_claude_launch_services, validate_block_net_conflicts,
+    validate_external_proxy_bypass,
 };
 use crate::theme;
 use nono::{NonoError, Result};
@@ -128,6 +129,7 @@ pub(crate) fn run_sandbox(mut run_args: RunArgs, silent: bool) -> Result<()> {
 
     if args.dry_run {
         let prepared = prepare_sandbox(&args, silent)?;
+        validate_block_net_conflicts(&args, &prepared)?;
         validate_external_proxy_bypass(&args, &prepared)?;
         if !prepared.secrets.is_empty() && !silent {
             eprintln!(

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -3,6 +3,7 @@ use crate::config;
 use crate::proxy_runtime::prepare_proxy_launch_options;
 use crate::sandbox_prepare::{
     PreparedSandbox, prepare_sandbox, print_allow_gpu_warning, print_allow_launch_services_warning,
+    validate_block_net_conflicts,
 };
 use crate::{exec_strategy, instruction_deny, profile, trust_scan};
 use colored::Colorize;
@@ -307,6 +308,7 @@ pub(crate) fn prepare_run_launch_plan(
     }
 
     let mut prepared = prepare_sandbox(&args, silent)?;
+    validate_block_net_conflicts(&args, &prepared)?;
     validate_rollback_destination(run_args.rollback_dest.as_ref(), &prepared)?;
 
     if prepared.allow_launch_services_active {

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -700,14 +700,12 @@ pub(crate) fn validate_block_net_conflicts(
 
     // --proxy-port without any proxy-triggering flag is almost certainly a
     // mistake: the port would be set but the proxy would never start.
-    if args.proxy_port.is_some() {
-        if !has_proxy_intent(args, prepared) {
-            return Err(NonoError::ConfigParse(
-                "--proxy-port has no effect without a proxy-mode flag \
-                 (e.g. --credential, --network-profile, --allow-domain)"
-                    .to_string(),
-            ));
-        }
+    if args.proxy_port.is_some() && !has_proxy_intent(args, prepared) {
+        return Err(NonoError::ConfigParse(
+            "--proxy-port has no effect without a proxy-mode flag \
+             (e.g. --credential, --network-profile, --allow-domain)"
+                .to_string(),
+        ));
     }
 
     Ok(())
@@ -2006,11 +2004,14 @@ mod tests {
 
     #[test]
     fn block_net_with_credential_errors() {
-        let mut args = SandboxArgs::default();
-        args.block_net = true;
-        args.proxy_credential = vec!["openai".to_string()];
+        let args = SandboxArgs {
+            block_net: true,
+            proxy_credential: vec!["openai".to_string()],
+            ..Default::default()
+        };
         let prepared = empty_prepared();
-        let err = validate_block_net_conflicts(&args, &prepared).unwrap_err();
+        let err = validate_block_net_conflicts(&args, &prepared)
+            .expect_err("expected error for --block-net + --credential");
         assert!(
             err.to_string().contains("--block-net") && err.to_string().contains("--credential"),
             "unexpected error: {err}"
@@ -2019,11 +2020,14 @@ mod tests {
 
     #[test]
     fn block_net_with_network_profile_errors() {
-        let mut args = SandboxArgs::default();
-        args.block_net = true;
-        args.network_profile = Some("strict".to_string());
+        let args = SandboxArgs {
+            block_net: true,
+            network_profile: Some("strict".to_string()),
+            ..Default::default()
+        };
         let prepared = empty_prepared();
-        let err = validate_block_net_conflicts(&args, &prepared).unwrap_err();
+        let err = validate_block_net_conflicts(&args, &prepared)
+            .expect_err("expected error for --block-net + --network-profile");
         assert!(
             err.to_string().contains("--block-net")
                 && err.to_string().contains("--network-profile"),
@@ -2033,11 +2037,14 @@ mod tests {
 
     #[test]
     fn block_net_with_allow_domain_errors() {
-        let mut args = SandboxArgs::default();
-        args.block_net = true;
-        args.allow_proxy = vec!["example.com".to_string()];
+        let args = SandboxArgs {
+            block_net: true,
+            allow_proxy: vec!["example.com".to_string()],
+            ..Default::default()
+        };
         let prepared = empty_prepared();
-        let err = validate_block_net_conflicts(&args, &prepared).unwrap_err();
+        let err = validate_block_net_conflicts(&args, &prepared)
+            .expect_err("expected error for --block-net + --allow-domain");
         assert!(
             err.to_string().contains("--block-net") && err.to_string().contains("--allow-domain"),
             "unexpected error: {err}"
@@ -2046,8 +2053,10 @@ mod tests {
 
     #[test]
     fn block_net_alone_is_valid() {
-        let mut args = SandboxArgs::default();
-        args.block_net = true;
+        let args = SandboxArgs {
+            block_net: true,
+            ..Default::default()
+        };
         let prepared = empty_prepared();
         assert!(validate_block_net_conflicts(&args, &prepared).is_ok());
     }
@@ -2058,7 +2067,8 @@ mod tests {
         let mut prepared = empty_prepared();
         prepared.profile_network_block = true;
         prepared.credentials = vec!["github".to_string()];
-        let err = validate_block_net_conflicts(&args, &prepared).unwrap_err();
+        let err = validate_block_net_conflicts(&args, &prepared)
+            .expect_err("expected error for profile network block + profile credential");
         assert!(
             err.to_string().contains("--block-net") && err.to_string().contains("--credential"),
             "unexpected error: {err}"
@@ -2067,10 +2077,13 @@ mod tests {
 
     #[test]
     fn allow_endpoint_without_credential_errors() {
-        let mut args = SandboxArgs::default();
-        args.allow_endpoint = vec!["openai:GET:/v1/chat/completions".to_string()];
+        let args = SandboxArgs {
+            allow_endpoint: vec!["openai:GET:/v1/chat/completions".to_string()],
+            ..Default::default()
+        };
         let prepared = empty_prepared();
-        let err = validate_block_net_conflicts(&args, &prepared).unwrap_err();
+        let err = validate_block_net_conflicts(&args, &prepared)
+            .expect_err("expected error for --allow-endpoint without --credential");
         assert!(
             err.to_string().contains("--allow-endpoint")
                 && err.to_string().contains("--credential"),
@@ -2080,19 +2093,24 @@ mod tests {
 
     #[test]
     fn allow_endpoint_with_credential_is_valid() {
-        let mut args = SandboxArgs::default();
-        args.allow_endpoint = vec!["openai:GET:/v1/chat/completions".to_string()];
-        args.proxy_credential = vec!["openai".to_string()];
+        let args = SandboxArgs {
+            allow_endpoint: vec!["openai:GET:/v1/chat/completions".to_string()],
+            proxy_credential: vec!["openai".to_string()],
+            ..Default::default()
+        };
         let prepared = empty_prepared();
         assert!(validate_block_net_conflicts(&args, &prepared).is_ok());
     }
 
     #[test]
     fn proxy_port_without_proxy_intent_errors() {
-        let mut args = SandboxArgs::default();
-        args.proxy_port = Some(8080);
+        let args = SandboxArgs {
+            proxy_port: Some(8080),
+            ..Default::default()
+        };
         let prepared = empty_prepared();
-        let err = validate_block_net_conflicts(&args, &prepared).unwrap_err();
+        let err = validate_block_net_conflicts(&args, &prepared)
+            .expect_err("expected error for --proxy-port without proxy mode");
         assert!(
             err.to_string().contains("--proxy-port"),
             "unexpected error: {err}"
@@ -2101,9 +2119,11 @@ mod tests {
 
     #[test]
     fn proxy_port_with_credential_is_valid() {
-        let mut args = SandboxArgs::default();
-        args.proxy_port = Some(8080);
-        args.proxy_credential = vec!["openai".to_string()];
+        let args = SandboxArgs {
+            proxy_port: Some(8080),
+            proxy_credential: vec!["openai".to_string()],
+            ..Default::default()
+        };
         let prepared = empty_prepared();
         assert!(validate_block_net_conflicts(&args, &prepared).is_ok());
     }

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -583,13 +583,9 @@ fn finalize_prepared_sandbox(
     silent: bool,
 ) -> Result<PreparedSandbox> {
     output::print_skipped_requested_paths(&collect_missing_cli_requested_paths(args), silent);
-    let has_proxy_intent = args.has_proxy_flags()
-        || prepared.network_profile.is_some()
-        || !prepared.allow_domain.is_empty()
-        || !prepared.credentials.is_empty()
-        || prepared.upstream_proxy.is_some();
-    let block_wins = args.block_net || (prepared.profile_network_block && !has_proxy_intent);
-    let proxy_pending = !block_wins && !args.allow_net && has_proxy_intent;
+    let proxy_intent = has_proxy_intent(args, &prepared);
+    let block_wins = args.block_net || (prepared.profile_network_block && !proxy_intent);
+    let proxy_pending = !block_wins && !args.allow_net && proxy_intent;
     output::print_capabilities(
         &prepared.caps,
         blocked_grants,
@@ -616,6 +612,16 @@ fn finalize_prepared_sandbox(
     Ok(prepared)
 }
 
+/// Returns true if any CLI flag or profile field requires the proxy to run.
+fn has_proxy_intent(args: &SandboxArgs, prepared: &PreparedSandbox) -> bool {
+    args.has_proxy_flags()
+        || !prepared.credentials.is_empty()
+        || !prepared.custom_credentials.is_empty()
+        || prepared.network_profile.is_some()
+        || !prepared.allow_domain.is_empty()
+        || prepared.upstream_proxy.is_some()
+}
+
 pub(crate) fn validate_external_proxy_bypass(
     args: &SandboxArgs,
     prepared: &PreparedSandbox,
@@ -630,6 +636,80 @@ pub(crate) fn validate_external_proxy_bypass(
                 .to_string(),
         ));
     }
+    Ok(())
+}
+
+/// Validate that `--block-net` is not combined with flags that imply proxy
+/// mode, and that `--allow-endpoint` always has a matching credential.
+///
+/// These combinations are logically contradictory: `--block-net` prevents all
+/// outbound traffic, so proxy-mode flags would be silently ignored.
+pub(crate) fn validate_block_net_conflicts(
+    args: &SandboxArgs,
+    prepared: &PreparedSandbox,
+) -> Result<()> {
+    let block_net = args.block_net || prepared.profile_network_block;
+
+    if block_net {
+        // Credential injection requires the proxy to be reachable.
+        let has_credentials = !args.proxy_credential.is_empty() || !prepared.credentials.is_empty();
+        if has_credentials {
+            return Err(NonoError::ConfigParse(
+                "--block-net and --credential are contradictory: \
+                 credential injection requires the proxy to be reachable"
+                    .to_string(),
+            ));
+        }
+
+        // A network profile configures proxy-mode filtering.
+        let has_network_profile =
+            args.network_profile.is_some() || prepared.network_profile.is_some();
+        if has_network_profile {
+            return Err(NonoError::ConfigParse(
+                "--block-net and --network-profile are contradictory: \
+                 a network profile requires proxy mode"
+                    .to_string(),
+            ));
+        }
+
+        // --allow-domain implies proxy-filtered mode.
+        let has_allow_domain = !args.allow_proxy.is_empty() || !prepared.allow_domain.is_empty();
+        if has_allow_domain {
+            return Err(NonoError::ConfigParse(
+                "--block-net and --allow-domain are contradictory: \
+                 domain filtering requires proxy mode"
+                    .to_string(),
+            ));
+        }
+    }
+
+    // --allow-endpoint without any credential is a no-op (and almost certainly
+    // a user error: the service name doesn't match any loaded credential).
+    if !args.allow_endpoint.is_empty() {
+        let has_credentials = !args.proxy_credential.is_empty()
+            || !prepared.credentials.is_empty()
+            || !prepared.custom_credentials.is_empty();
+        if !has_credentials {
+            return Err(NonoError::ConfigParse(
+                "--allow-endpoint requires at least one --credential \
+                 (no credential loaded for the named service)"
+                    .to_string(),
+            ));
+        }
+    }
+
+    // --proxy-port without any proxy-triggering flag is almost certainly a
+    // mistake: the port would be set but the proxy would never start.
+    if args.proxy_port.is_some() {
+        if !has_proxy_intent(args, prepared) {
+            return Err(NonoError::ConfigParse(
+                "--proxy-port has no effect without a proxy-mode flag \
+                 (e.g. --credential, --network-profile, --allow-domain)"
+                    .to_string(),
+            ));
+        }
+    }
+
     Ok(())
 }
 
@@ -1884,5 +1964,147 @@ mod tests {
             ),
             Some(DetachedCwdPromptResponse::Deny)
         );
+    }
+
+    fn empty_prepared() -> PreparedSandbox {
+        PreparedSandbox {
+            caps: CapabilitySet::default(),
+            secrets: Vec::new(),
+            profile_display_name: None,
+            command_policies: None,
+            session_hooks: profile::SessionHooks::default(),
+            rollback_exclude_patterns: Vec::new(),
+            rollback_exclude_globs: Vec::new(),
+            network_profile: None,
+            allow_domain: Vec::new(),
+            credentials: Vec::new(),
+            custom_credentials: std::collections::HashMap::new(),
+            credential_capture: std::collections::HashMap::new(),
+            tls_intercept: None,
+            upstream_proxy: None,
+            upstream_bypass: Vec::new(),
+            listen_ports: Vec::new(),
+            capability_elevation: false,
+            #[cfg(target_os = "linux")]
+            wsl2_proxy_policy: profile::Wsl2ProxyPolicy::default(),
+            #[cfg(target_os = "linux")]
+            af_unix_mediation: profile::LinuxAfUnixMediation::default(),
+            allow_launch_services_active: false,
+            allow_gpu_active: false,
+            open_url_origins: Vec::new(),
+            open_url_allow_localhost: false,
+            bypass_protection_paths: Vec::new(),
+            ignored_denial_paths: Vec::new(),
+            suppressed_system_service_operations: Vec::new(),
+            allowed_env_vars: None,
+            denied_env_vars: None,
+            set_vars: None,
+            profile_network_block: false,
+            allow_http2_requested: false,
+        }
+    }
+
+    #[test]
+    fn block_net_with_credential_errors() {
+        let mut args = SandboxArgs::default();
+        args.block_net = true;
+        args.proxy_credential = vec!["openai".to_string()];
+        let prepared = empty_prepared();
+        let err = validate_block_net_conflicts(&args, &prepared).unwrap_err();
+        assert!(
+            err.to_string().contains("--block-net") && err.to_string().contains("--credential"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn block_net_with_network_profile_errors() {
+        let mut args = SandboxArgs::default();
+        args.block_net = true;
+        args.network_profile = Some("strict".to_string());
+        let prepared = empty_prepared();
+        let err = validate_block_net_conflicts(&args, &prepared).unwrap_err();
+        assert!(
+            err.to_string().contains("--block-net")
+                && err.to_string().contains("--network-profile"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn block_net_with_allow_domain_errors() {
+        let mut args = SandboxArgs::default();
+        args.block_net = true;
+        args.allow_proxy = vec!["example.com".to_string()];
+        let prepared = empty_prepared();
+        let err = validate_block_net_conflicts(&args, &prepared).unwrap_err();
+        assert!(
+            err.to_string().contains("--block-net") && err.to_string().contains("--allow-domain"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn block_net_alone_is_valid() {
+        let mut args = SandboxArgs::default();
+        args.block_net = true;
+        let prepared = empty_prepared();
+        assert!(validate_block_net_conflicts(&args, &prepared).is_ok());
+    }
+
+    #[test]
+    fn profile_network_block_with_credential_from_profile_errors() {
+        let args = SandboxArgs::default();
+        let mut prepared = empty_prepared();
+        prepared.profile_network_block = true;
+        prepared.credentials = vec!["github".to_string()];
+        let err = validate_block_net_conflicts(&args, &prepared).unwrap_err();
+        assert!(
+            err.to_string().contains("--block-net") && err.to_string().contains("--credential"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn allow_endpoint_without_credential_errors() {
+        let mut args = SandboxArgs::default();
+        args.allow_endpoint = vec!["openai:GET:/v1/chat/completions".to_string()];
+        let prepared = empty_prepared();
+        let err = validate_block_net_conflicts(&args, &prepared).unwrap_err();
+        assert!(
+            err.to_string().contains("--allow-endpoint")
+                && err.to_string().contains("--credential"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn allow_endpoint_with_credential_is_valid() {
+        let mut args = SandboxArgs::default();
+        args.allow_endpoint = vec!["openai:GET:/v1/chat/completions".to_string()];
+        args.proxy_credential = vec!["openai".to_string()];
+        let prepared = empty_prepared();
+        assert!(validate_block_net_conflicts(&args, &prepared).is_ok());
+    }
+
+    #[test]
+    fn proxy_port_without_proxy_intent_errors() {
+        let mut args = SandboxArgs::default();
+        args.proxy_port = Some(8080);
+        let prepared = empty_prepared();
+        let err = validate_block_net_conflicts(&args, &prepared).unwrap_err();
+        assert!(
+            err.to_string().contains("--proxy-port"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn proxy_port_with_credential_is_valid() {
+        let mut args = SandboxArgs::default();
+        args.proxy_port = Some(8080);
+        args.proxy_credential = vec!["openai".to_string()];
+        let prepared = empty_prepared();
+        assert!(validate_block_net_conflicts(&args, &prepared).is_ok());
     }
 }


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1100

## Summary

Passing --block-net alongside --credential, --network-profile, or
--allow-domain was silently ignored: block_wins discarded the proxy
intent with no diagnostic. --allow-endpoint without a matching
credential was a no-op. --proxy-port without any proxy-triggering
flag would set the port but never start the proxy.

Add validate_block_net_conflicts() in sandbox_prepare.rs, called
from both the dry-run path in command_runtime and the main launch
path in launch_runtime, before any sandbox or proxy setup begins.
Both CLI flags and profile-sourced values are checked so the
validation fires regardless of whether the contradiction comes from
flags or a loaded profile.

Also extract has_proxy_intent() to remove a duplicate inline
computation in finalize_prepared_sandbox, which additionally fixes a
gap where custom_credentials from a profile were not counted toward
proxy intent for the purposes of the display output.
<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
