### PR TITLE
feat(tool-sandbox): simplify self-invocation policy

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -1194,7 +1194,7 @@
         "can_use": {
           "type": "array",
           "items": { "$ref": "#/$defs/CommandPolicyIdentifier" },
-          "description": "Commands this command may invoke through tool-sandbox chaining."
+          "description": "Other commands this command may invoke through tool-sandbox chaining. If no explicit self-invocation entry is configured, self-invocation keeps the command's current effective policy and does not require listing the command here."
         },
         "sandbox": {
           "$ref": "#/$defs/CommandSandboxConfig",

--- a/crates/nono-cli/src/command_policy.rs
+++ b/crates/nono-cli/src/command_policy.rs
@@ -480,6 +480,16 @@ impl CommandPolicyConfig {
     }
 }
 
+pub(crate) fn has_explicit_self_invocation_entry(
+    config: &CommandPoliciesConfig,
+    command_name: &str,
+) -> bool {
+    config.commands.get(command_name).is_some_and(|command| {
+        command.can_use.iter().any(|name| name == command_name)
+            || command.from.contains_key(command_name)
+    })
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum CommandFromConfig {
@@ -2620,6 +2630,27 @@ mod tests {
                 .iter()
                 .any(|finding| finding.code == "contradictory_session_allow")
         );
+    }
+
+    #[test]
+    fn explicit_self_invocation_entry_detects_allow_and_deny_shapes() {
+        let mut config = active_git_config();
+
+        assert!(!has_explicit_self_invocation_entry(&config, "git"));
+
+        if let Some(git) = config.commands.get_mut("git") {
+            git.can_use = vec!["git".to_string()];
+        }
+        assert!(has_explicit_self_invocation_entry(&config, "git"));
+
+        if let Some(git) = config.commands.get_mut("git") {
+            git.can_use.clear();
+            git.from.insert(
+                "git".to_string(),
+                CommandFromConfig::Deny("deny".to_string()),
+            );
+        }
+        assert!(has_explicit_self_invocation_entry(&config, "git"));
     }
 
     #[test]

--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -4,7 +4,7 @@ use crate::audit_integrity::{
 };
 use crate::command_policy::{
     CommandFromConfig, CommandPoliciesConfig, CommandSandboxConfig, ResolvedCommandBinaries,
-    ResolvedCommandBinary, ResolvedExecutableKind,
+    ResolvedCommandBinary, ResolvedExecutableKind, has_explicit_self_invocation_entry,
 };
 use crate::profile;
 use crate::tool_sandbox::credentials::{ResolvedCredential, resolve_credentials};
@@ -1215,7 +1215,7 @@ fn handle_shim_stream_inner(
     let auth = authenticate_shim(peer_pid, shim_fd, &request.command, state)?;
     let stdio = recv_stdio_fds(stream)?;
 
-    let caller = match resolve_caller(auth.peer_pid, session_root_pid, state) {
+    let caller = match resolve_caller(auth.peer_pid, session_root_pid, state, &request.command) {
         Ok(caller) => caller,
         Err(err) => {
             record_command_policy_audit(
@@ -1892,16 +1892,22 @@ fn resolve_caller(
     peer_pid: u32,
     session_root_pid: u32,
     state: &ToolSandboxState,
+    command_name: &str,
 ) -> Result<Caller> {
     let mut pid = peer_pid;
     for _ in 0..ANCESTRY_DEPTH_LIMIT {
+        if let Some((command, launch_caller)) = live_active_child(pid, state)? {
+            if command == command_name
+                && !has_explicit_self_invocation_entry(&state.plan.config, command_name)
+            {
+                return Ok(launch_caller);
+            }
+            return Ok(Caller::Command { command, pid });
+        }
         if pid == session_root_pid {
             return Ok(Caller::Session {
                 pid: session_root_pid,
             });
-        }
-        if let Some(command) = live_active_child_command(pid, state)? {
-            return Ok(Caller::Command { command, pid });
         }
         if pid <= 1 {
             break;
@@ -1913,13 +1919,10 @@ fn resolve_caller(
     ))
 }
 
-fn live_active_child_command(pid: u32, state: &ToolSandboxState) -> Result<Option<String>> {
-    Ok(live_active_child(pid, state)?.map(|(command, _)| command))
-}
-
-/// Like [`live_active_child_command`] but also returns the caller the command
-/// was launched under. Used by the URL-open path to resolve the requesting
-/// command's own running policy.
+/// Returns the active command for `pid` and the caller it was launched under.
+/// Self-invocation with no explicit self-invocation entry uses the launch caller so
+/// recursive tool calls keep the current effective policy instead of requiring
+/// a `<cmd>.can_use[<cmd>]` edge.
 fn live_active_child(pid: u32, state: &ToolSandboxState) -> Result<Option<(String, Caller)>> {
     let map = state
         .active_children
@@ -5096,6 +5099,73 @@ mod tests {
         let result =
             ensure_outer_exec_gate_fully_enforced(landlock::RulesetStatus::PartiallyEnforced);
         assert!(matches!(result, Err(err) if err.to_string().contains("partially enforced")));
+    }
+
+    #[test]
+    fn resolve_caller_prefers_active_command_for_different_invocation() -> Result<()> {
+        let state = test_state_with_chaining_paths(
+            PathBuf::from("/tmp/nono-tool-sandbox-test"),
+            PathBuf::from("/tmp/nono-tool-sandbox-test/supervisor.sock"),
+            PathBuf::from("/tmp/nono-tool-sandbox-test/shims"),
+            ShimIdentity {
+                path: PathBuf::from("/tmp/nono-tool-sandbox-test/shims/git"),
+                id: FileId { dev: 1, ino: 1 },
+            },
+        );
+        let pid = std::process::id();
+        track_child(&state, pid, "git", &Caller::Session { pid })?;
+
+        let caller = resolve_caller(pid, pid, &state, "ssh")?;
+
+        assert!(matches!(caller, Caller::Command { command, .. } if command == "git"));
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_caller_uses_launch_caller_for_self_invocation() -> Result<()> {
+        let state = test_state_with_chaining_paths(
+            PathBuf::from("/tmp/nono-tool-sandbox-test"),
+            PathBuf::from("/tmp/nono-tool-sandbox-test/supervisor.sock"),
+            PathBuf::from("/tmp/nono-tool-sandbox-test/shims"),
+            ShimIdentity {
+                path: PathBuf::from("/tmp/nono-tool-sandbox-test/shims/git"),
+                id: FileId { dev: 1, ino: 1 },
+            },
+        );
+        let pid = std::process::id();
+        track_child(&state, pid, "git", &Caller::Session { pid })?;
+
+        let caller = resolve_caller(pid, pid, &state, "git")?;
+
+        assert!(matches!(caller, Caller::Session { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_caller_honors_explicit_self_edge() -> Result<()> {
+        let mut state = test_state_with_chaining_paths(
+            PathBuf::from("/tmp/nono-tool-sandbox-test"),
+            PathBuf::from("/tmp/nono-tool-sandbox-test/supervisor.sock"),
+            PathBuf::from("/tmp/nono-tool-sandbox-test/shims"),
+            ShimIdentity {
+                path: PathBuf::from("/tmp/nono-tool-sandbox-test/shims/git"),
+                id: FileId { dev: 1, ino: 1 },
+            },
+        );
+        state.plan.config.commands.insert(
+            "git".to_string(),
+            CommandPolicyConfig {
+                can_use: vec!["git".to_string()],
+                ..Default::default()
+            },
+        );
+        let pid = std::process::id();
+        track_child(&state, pid, "git", &Caller::Session { pid })?;
+
+        let caller = resolve_caller(pid, pid, &state, "git")?;
+
+        assert!(matches!(caller, Caller::Command { command, .. } if command == "git"));
+        Ok(())
     }
 
     #[test]

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -4,7 +4,7 @@ use crate::audit_integrity::{
 };
 use crate::command_policy::{
     CommandPoliciesConfig, CommandSandboxConfig, InterceptActionConfig, ResolvedCommandBinaries,
-    ResolvedCommandBinary,
+    ResolvedCommandBinary, has_explicit_self_invocation_entry,
 };
 use crate::tool_sandbox::credentials::{ResolvedCredential, resolve_credentials};
 use crate::tool_sandbox::env::{
@@ -909,7 +909,7 @@ fn handle_shim_stream_inner(
         });
     }
 
-    let caller = match resolve_caller(auth.peer_pid, session_root_pid, state) {
+    let caller = match resolve_caller(auth.peer_pid, session_root_pid, state, &request.command) {
         Ok(caller) => caller,
         Err(err) => {
             record_command_policy_audit(
@@ -1601,32 +1601,30 @@ fn resolve_caller(
     peer_pid: u32,
     session_root_pid: u32,
     state: &ToolSandboxState,
+    command_name: &str,
 ) -> Result<Caller> {
-    if let Some(cmd) = live_active_child_command(peer_pid, state)? {
-        return Ok(Caller::Command { name: cmd });
-    }
-
-    // Fast path: the shim IS the session root (simple exec, no intermediate shell).
-    if peer_pid == session_root_pid {
-        return Ok(Caller::Session);
-    }
     let mut pid = peer_pid;
     for _ in 0..ANCESTRY_DEPTH_LIMIT {
+        if let Some((cmd, launch_caller)) = live_active_child(pid, state)? {
+            if cmd == command_name
+                && !has_explicit_self_invocation_entry(&state.plan.config, command_name)
+            {
+                return Ok(launch_caller);
+            }
+            return Ok(Caller::Command { name: cmd });
+        }
+        if pid == session_root_pid {
+            return Ok(Caller::Session);
+        }
+        if pid == 0 || pid == 1 {
+            break;
+        }
         pid = match parent_pid(pid) {
             Ok(p) => p,
             // If proc_pidinfo fails partway up the chain the process likely
             // exited; stop walking rather than returning an opaque error.
             Err(_) => break,
         };
-        if pid == 0 || pid == 1 {
-            break;
-        }
-        if let Some(cmd) = live_active_child_command(pid, state)? {
-            return Ok(Caller::Command { name: cmd });
-        }
-        if pid == session_root_pid {
-            return Ok(Caller::Session);
-        }
     }
     Err(NonoError::BlockedCommand {
         command: "unknown".to_string(),
@@ -1657,13 +1655,10 @@ fn parent_pid(pid: u32) -> Result<u32> {
     }
 }
 
-fn live_active_child_command(pid: u32, state: &ToolSandboxState) -> Result<Option<String>> {
-    Ok(live_active_child(pid, state)?.map(|(command, _)| command))
-}
-
-/// Like [`live_active_child_command`] but also returns the caller the command
-/// was launched under. Used by the URL-open path to resolve the requesting
-/// command's own running policy.
+/// Returns the active command for `pid` and the caller it was launched under.
+/// Self-invocation with no explicit self-invocation entry uses the launch caller so
+/// recursive tool calls keep the current effective policy instead of requiring
+/// a `<cmd>.can_use[<cmd>]` edge.
 fn live_active_child(pid: u32, state: &ToolSandboxState) -> Result<Option<(String, Caller)>> {
     let map = state
         .active_children
@@ -4853,7 +4848,38 @@ mod tests {
         let pid = std::process::id();
         track_child(&state, pid, "git", &Caller::Session)?;
 
-        let caller = resolve_caller(pid, pid, &state)?;
+        let caller = resolve_caller(pid, pid, &state, "ssh")?;
+
+        assert!(matches!(caller, Caller::Command { name } if name == "git"));
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_caller_uses_launch_caller_for_self_invocation() -> Result<()> {
+        let state = test_state();
+        let pid = std::process::id();
+        track_child(&state, pid, "git", &Caller::Session)?;
+
+        let caller = resolve_caller(pid, pid, &state, "git")?;
+
+        assert!(matches!(caller, Caller::Session));
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_caller_honors_explicit_self_edge() -> Result<()> {
+        let mut state = test_state();
+        state.plan.config.commands.insert(
+            "git".to_string(),
+            CommandPolicyConfig {
+                can_use: vec!["git".to_string()],
+                ..Default::default()
+            },
+        );
+        let pid = std::process::id();
+        track_child(&state, pid, "git", &Caller::Session)?;
+
+        let caller = resolve_caller(pid, pid, &state, "git")?;
 
         assert!(matches!(caller, Caller::Command { name } if name == "git"));
         Ok(())

--- a/docs/cli/features/tool-sandbox.mdx
+++ b/docs/cli/features/tool-sandbox.mdx
@@ -16,7 +16,7 @@ A Tool Sandbox profile answers three questions:
 | Question | Field |
 |---|---|
 | What may the outer session run directly? | `command_policies.commands.<name>.sandbox` or `command_policies.commands.<name>.from.session` |
-| What may one Tool Sandbox command run next? | `command_policies.commands.<caller>.can_use` plus `command_policies.commands.<callee>.from.<caller>` |
+| What may one Tool Sandbox command run next? | `command_policies.commands.<caller>.can_use` plus `command_policies.commands.<callee>.from.<caller>` for other commands; self-invocation is implicit unless a self-invocation entry is configured |
 | What does the selected child command receive? | `sandbox` or caller-specific `from.<caller>` grants |
 
 `command_policies.entrypoint` is still parsed for older profiles, but current profiles should express direct session access with `commands.<name>.sandbox` or `commands.<name>.from.session`.
@@ -60,7 +60,7 @@ Each entry under `commands` uses the command name as the key:
 |---|---|---|
 | `sandbox` | object | Direct-session policy shorthand. This lets the outer session run the command. |
 | `from` | object | Caller-specific policies. Use `session` for direct session invocation or another command name for chaining. |
-| `can_use` | command-name array | Commands this command may invoke through Tool Sandbox. |
+| `can_use` | command-name array | Other commands this command may invoke through Tool Sandbox. If no self-invocation entry is configured, self-invocation keeps the current effective policy. |
 | `executable` | absolute path | Pin the command name to one executable file instead of the first `PATH` match. |
 | `allow_writable_executable` | boolean | Per-command trust downgrade for a pinned executable writable by the sandbox capability set. Requires absolute `executable`. |
 | `intercept` | array | Ordered argument-prefix mediation rules evaluated after invocation policy. |


### PR DESCRIPTION
The `resolve_caller` logic now treats self-invocation differently from invoking another command. When a command attempts to invoke itself, and there is no explicit `can_use` self-edge or `from` self-edge configured in its policy, the self-invoked command inherits the policy of its *launcher*. This means recursive calls effectively continue under the current effective policy without requiring explicit `can_use: ["<command>"]` configuration.

- Updated `nono-profile.schema.json` and documentation to clarify this implicit behavior for `can_use`.
- Modified `resolve_caller` on Linux and macOS to pass the requested command name and incorporate this new logic.
- Added `has_explicit_self_edge` helper to check for explicit self-policy.
- Introduced new tests to verify:
  - Different command invocation still resolves to the active parent command.
  - Self-invocation without explicit self-edge inherits the launcher's policy.
  - Self-invocation with an explicit self-edge honors that specific policy.

Resolves: #1266

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

