### PR TITLE
feat(tool-sandbox): add @git:common-dir dynamic token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Features
+
+- *(tool-sandbox)* Add `@git:common-dir` dynamic token: expands to the git common directory (`.git` in a regular repo; the main repo's `.git` when running inside a worktree). Use in `fs_write` to cover the object store when the agent session starts from a worktree and `--workdir` points to the worktree itself ([#1270](https://github.com/nolabs-ai/nono/issues/1270))
+
 ### Bug Fixes
 
 - *(tool-sandbox)* Pass TLS trust bundle env vars (`SSL_CERT_FILE`, `CURL_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `GIT_SSL_CAINFO`) to tool-sandbox children so HTTPS certificate verification works when TLS interception is active (#1248)

--- a/crates/nono-cli/src/tool-sandbox/dynamic_providers.rs
+++ b/crates/nono-cli/src/tool-sandbox/dynamic_providers.rs
@@ -66,6 +66,46 @@ pub(super) mod git {
         Ok(run(None, None)?.dirs)
     }
 
+    /// Return the path to the git common directory (`.git` or the main repo's
+    /// `.git` when running inside a worktree).
+    ///
+    /// In a regular repo this is `.git` (relative). In a worktree it is an
+    /// absolute path pointing to the main repo's `.git`. Either form is
+    /// suitable for `fs_write`/`fs_read` path lists — relative paths are
+    /// resolved against `$WORKDIR` by `resolve_policy_path`.
+    ///
+    /// Returns an empty list when git is absent, the command fails, or the
+    /// process is not inside a git repository.
+    pub(crate) fn read_common_dir() -> Result<Vec<String>> {
+        run_common_dir(None)
+    }
+
+    fn run_common_dir(cwd: Option<&Path>) -> Result<Vec<String>> {
+        let mut cmd = Command::new("git");
+        cmd.args(["rev-parse", "--git-common-dir"]);
+        if let Some(d) = cwd {
+            cmd.current_dir(d);
+        }
+        let output = match cmd.output() {
+            Ok(o) if o.status.success() => o,
+            _ => return Ok(vec![]),
+        };
+        let path = std::str::from_utf8(&output.stdout)
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if path.is_empty() {
+            return Ok(vec![]);
+        }
+        Ok(vec![path])
+    }
+
+    /// Test seam: run the common-dir provider from a specific directory.
+    #[cfg(test)]
+    pub(super) fn read_common_dir_in(cwd: &Path) -> Result<Vec<String>> {
+        run_common_dir(Some(cwd))
+    }
+
     /// Test seam: parse a known-fixture global config and return the
     /// files+dirs split.
     #[cfg(test)]
@@ -171,6 +211,7 @@ fn dispatch_token(provider: &str, query: &str) -> Result<Vec<String>> {
         "git" => match query {
             "config-files" => git::read_files(),
             "hooks-path" => git::read_hooks_path(),
+            "common-dir" => git::read_common_dir(),
             other => Err(NonoError::ProfileParse(format!(
                 "unknown git provider query '{other}'"
             ))),
@@ -205,6 +246,7 @@ mod tests {
             Some(("git", "config-files"))
         );
         assert_eq!(parse_token("@git:hooks-path"), Some(("git", "hooks-path")));
+        assert_eq!(parse_token("@git:common-dir"), Some(("git", "common-dir")));
     }
 
     #[test]
@@ -444,5 +486,79 @@ global\tfile:/home/u/.gitconfig\tuser.name=Alice
         assert!(out.files.contains(&"~/.gitexcludes".to_string()));
         assert!(out.files.contains(&"~/.gitmessage".to_string()));
         assert_eq!(out.dirs, vec!["~/.githooks".to_string()]);
+    }
+
+    #[test]
+    fn git_read_common_dir_returns_dot_git_in_regular_repo() {
+        use std::process::Command;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).expect("mkdir repo");
+        Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&repo)
+            .status()
+            .expect("git init");
+
+        let result = git::read_common_dir_in(&repo).expect("read_common_dir");
+        assert_eq!(result, vec![".git".to_string()]);
+    }
+
+    #[test]
+    fn git_read_common_dir_returns_absolute_path_in_worktree() {
+        use std::process::Command;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).expect("mkdir repo");
+        Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&repo)
+            .status()
+            .expect("git init");
+        Command::new("git")
+            .args([
+                "-c",
+                "user.email=t@t.com",
+                "-c",
+                "user.name=T",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "init",
+            ])
+            .current_dir(&repo)
+            .status()
+            .expect("git commit");
+
+        let wt = tmp.path().join("worktree");
+        Command::new("git")
+            .args(["worktree", "add", wt.to_str().expect("utf8")])
+            .current_dir(&repo)
+            .status()
+            .expect("git worktree add");
+
+        let result = git::read_common_dir_in(&wt).expect("read_common_dir in worktree");
+        assert_eq!(result.len(), 1, "expected one entry, got {:?}", result);
+        let common = std::path::Path::new(&result[0]);
+        assert!(
+            common.is_absolute(),
+            "expected absolute path in worktree, got {:?}",
+            result
+        );
+        assert_eq!(
+            common,
+            repo.join(".git").canonicalize().expect("canonicalize"),
+        );
+    }
+
+    #[test]
+    fn git_read_common_dir_returns_empty_outside_git_repo() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let result = git::read_common_dir_in(tmp.path()).expect("read_common_dir");
+        assert!(
+            result.is_empty(),
+            "expected empty outside repo, got {:?}",
+            result
+        );
     }
 }

--- a/docs/cli/features/tool-sandbox.mdx
+++ b/docs/cli/features/tool-sandbox.mdx
@@ -102,6 +102,7 @@ Supported tokens:
 |---|---|---|
 | `@git:config-files` | `fs_read_file` | Trusted global/system Git config files and configured Git file paths, such as attributes, excludes, and commit template files. |
 | `@git:hooks-path` | `fs_read` | Trusted global/system `core.hooksPath` directories. |
+| `@git:common-dir` | `fs_write`, `fs_read` | The git common directory: `.git` in a regular repo, or the absolute path to the main repo's `.git` when running inside a git worktree. Useful in `fs_write` when the agent session starts from a worktree and `--workdir` points to the worktree itself — the token ensures the git object store (which lives in the main repo) is covered. |
 
 Example:
 
@@ -112,7 +113,8 @@ Example:
       "git": {
         "sandbox": {
           "fs_read_file": ["@git:config-files"],
-          "fs_read": ["@git:hooks-path"]
+          "fs_read": ["@git:hooks-path"],
+          "fs_write": ["$WORKDIR", "@git:common-dir"]
         }
       }
     }
@@ -121,6 +123,8 @@ Example:
 ```
 
 The Git provider reads `git config --list --show-origin --show-scope` and keeps only `global` and `system` scoped paths. It ignores `local` and `worktree` scopes so a repository cannot grant itself additional host filesystem access through `.git/config`. If `git` is unavailable or returns no matching paths, the token expands to no paths.
+
+The `@git:common-dir` token runs `git rev-parse --git-common-dir` from nono's working directory at sandbox-prepare time. In a regular repo it returns `.git` (relative, resolved against `$WORKDIR`). In a worktree it returns the absolute path to the main repo's `.git`. If git is unavailable or the process is not inside a repo, the token expands to no paths.
 
 `network` accepts these values:
 


### PR DESCRIPTION
## Linked Issue

Closes nolabs-ai/nono#1270

## Summary

Adds `@git:common-dir` to the `git` dynamic-token provider in the tool-sandbox.

When a nono session runs from a git worktree, the git object store lives in the
main repo's `.git/` — not the worktree. Profiles that rely solely on `$WORKDIR`
in `fs_write` leave the object store uncovered, causing `git commit` to fail with
EPERM. The new token lets profiles express this coverage without changing `--workdir`.

`read_common_dir()` runs `git rev-parse --git-common-dir` from nono's CWD. In a
regular repo it returns `.git` (relative; resolved against `$WORKDIR` by
`resolve_policy_path`). In a worktree it returns an absolute path to the main
repo's `.git`. Returns an empty list when git is absent or the process is not
inside a repo, so `add_optional_dir` silently skips it.

## Agent Disclosure

This PR was generated by an AI agent (Claude Code). Files consulted:
- `crates/nono-cli/src/tool-sandbox/dynamic_providers.rs` (implementation site)
- `crates/nono-cli/src/tool-sandbox/platform/macos.rs` (`add_policy_fs`, `add_optional_dir`)
- `docs/cli/features/tool-sandbox.mdx` (documentation)
- `AGENTS.md` (coding standards, DCO, error-handling rules)

The implementation uses no `unwrap`/`expect`, follows the existing `read_files`/`read_hooks_path` pattern, and uses `NonoError`-free early returns.

## Test Plan

cargo test -p nono-cli

Manual verification: profile with `@git:common-dir` in git `fs_write`, `--workdir` set to a worktree directory → `git commit` succeeds; without the token → EPERM.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards (CLAUDE.md) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [x] Release note has been added to `CHANGELOG.md` if needed

---
Agent Compliance Check (for the hidden checklist):
- [x] Not prohibited from contributing
- [x] Issue exists (nolabs-ai/nono#1270)
- [x] Agent disclosed in issue
- [x] Intent and approach described in issue
- [x] Reviewed coding/security rules (AGENTS.md)
- [x] No reused/adapted code requiring attribution
- [x] No unwrap/expect used
- [x] NonoError not directly needed (function returns Ok(vec![]) on failure)
- [x] No path canonicalization needed (returned as-is; resolve_policy_path handles it downstream)
- [x] PR matches approved issue scope