### PR TITLE
fix(proxy): separate stdin and stderr inheritance for credential helpers

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -212,7 +212,7 @@
           "type": "string",
           "enum": ["null", "request_json"],
           "default": "null",
-          "description": "Controls stdin for the capture command. null closes stdin unless interaction.stdio is true. request_json writes request metadata JSON to stdin."
+          "description": "Controls stdin for the capture command. null closes stdin unless interaction.stdin is true. request_json writes request metadata JSON to stdin."
         },
         "output": {
           "oneOf": [
@@ -262,7 +262,12 @@
         "stdio": {
           "type": "boolean",
           "default": false,
-          "description": "Allow the capture command to use inherited stderr and, when stdin is null, inherited stdin."
+          "description": "Allow the capture command to write prompts to the terminal via inherited stderr."
+        },
+        "stdin": {
+          "type": "boolean",
+          "default": false,
+          "description": "Allow the capture command to read from the terminal via inherited stdin. Only set this when the helper genuinely needs to prompt the user for input. Requires stdio:true."
         },
         "open_urls": {
           "oneOf": [

--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -406,9 +406,9 @@ Defines supervisor-side commands that produce credentials for `cmd://` custom cr
 | `cache_ttl_secs`   | integer         | no       | `900`   | In-memory cache TTL, 0–3600 seconds. `0` disables caching. |
 | `ttl_secs`         | integer         | no       | `900`   | Older alias for `cache_ttl_secs`. Do not set both fields. |
 | `cache_path_regex` | string          | no       | host    | Regex evaluated against the request path. Capture group 1 becomes the cache scope; otherwise the full match is used. |
-| `stdin`            | string          | no       | `null`  | `null` closes stdin; `request_json` writes request metadata JSON to stdin. |
+| `stdin`            | string          | no       | `null`  | `null` closes stdin (unless `interaction.stdin` is `true`); `request_json` writes request metadata JSON to stdin. |
 | `output`           | string/object   | no       | `text`  | `text` captures stdout as one credential. `{"format":"json","allow_headers":[...]}` captures multiple headers. |
-| `interaction`      | object          | no       | none    | Explicit opt-in for capture commands that need inherited stdio or browser opening. |
+| `interaction`      | object          | no       | none    | Explicit opt-in for capture commands that need inherited stderr, inherited stdin, or browser opening. |
 
 Capture commands run with `NONO_SESSION_ID`, `NONO_REQUEST_HOST`, `NONO_REQUEST_PATH`, `NONO_REQUEST_METHOD`, `NONO_CACHE_SCOPE`, `NONO_CAPTURE_CREDENTIAL`, and `NONO_CAPTURE_ROUTE` set. Proxy environment variables are removed to avoid recursively using the same proxy route while capturing the credential.
 

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -429,8 +429,14 @@ pub struct CredentialCaptureOutputConfig {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CredentialCaptureInteraction {
+    /// Allow the capture command to write prompts to the terminal via inherited stderr.
     #[serde(default)]
     pub stdio: bool,
+    /// Allow the capture command to read from the terminal via inherited stdin.
+    /// Only set this when the helper genuinely needs to prompt the user for input.
+    /// Defaults to false; stdin is `/dev/null` unless explicitly enabled.
+    #[serde(default)]
+    pub stdin: bool,
     #[serde(default)]
     pub open_urls: Option<OpenUrlConfig>,
     #[serde(default)]

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -58,6 +58,7 @@ struct ResolvedCredentialCaptureEntry {
     allow_headers: HashSet<String>,
     interactive: bool,
     stdio: bool,
+    inherit_stdin: bool,
     open_urls: Option<CaptureOpenUrlPolicy>,
     allow_launch_services: bool,
 }
@@ -189,6 +190,7 @@ impl ProxyCredentialCaptureBackend {
                     })
             });
             let stdio = interaction.is_some_and(|interaction| interaction.stdio);
+            let inherit_stdin = interaction.is_some_and(|interaction| interaction.stdin);
             let allow_launch_services =
                 interaction.is_some_and(|interaction| interaction.allow_launch_services);
             resolved.insert(
@@ -215,6 +217,7 @@ impl ProxyCredentialCaptureBackend {
                     allow_headers: credential_capture_allow_headers(&entry.output),
                     interactive: stdio || open_urls.is_some() || allow_launch_services,
                     stdio,
+                    inherit_stdin,
                     open_urls,
                     allow_launch_services,
                 },
@@ -296,7 +299,9 @@ impl ProxyCredentialCaptureBackend {
         let start = Instant::now();
         let mut command = Command::new(&entry.command_path);
         let stdin = match entry.stdin_mode {
-            crate::profile::CredentialCaptureStdinMode::Null if entry.stdio => Stdio::inherit(),
+            crate::profile::CredentialCaptureStdinMode::Null if entry.inherit_stdin => {
+                Stdio::inherit()
+            }
             crate::profile::CredentialCaptureStdinMode::Null => Stdio::null(),
             crate::profile::CredentialCaptureStdinMode::RequestJson => Stdio::piped(),
         };
@@ -3289,6 +3294,7 @@ mod tests {
         ]);
         entry.interaction = Some(crate::profile::CredentialCaptureInteraction {
             stdio: false,
+            stdin: false,
             open_urls: Some(crate::profile::OpenUrlConfig {
                 allow_origins: vec!["https://github.com".to_string()],
                 allow_localhost: true,
@@ -3494,5 +3500,172 @@ mod tests {
             result.is_err(),
             "--allow-endpoint for a service without --credential must error"
         );
+    }
+
+    // Verify that a credential helper with `stdio: true` (interaction.stdio) does not
+    // inherit the terminal's stdin. The `stdio` flag is only meant to allow the helper
+    // to write prompts via stderr; stdin must always be /dev/null when stdin_mode is Null.
+    //
+    // The test replaces the process's stdin fd with a blocking pipe (write end kept open,
+    // so it never reaches EOF). If the fix is absent, the child inherits that blocking fd
+    // and `select` reports it as not ready; with the fix, the child gets /dev/null instead
+    // and `select` reports it as readable (EOF is a readable condition).
+    #[test]
+    #[cfg(unix)]
+    fn capture_helper_with_stdio_true_receives_null_not_terminal_stdin() -> Result<()> {
+        use nix::libc;
+
+        // Serialize stdin manipulation across concurrent test threads.
+        static STDIN_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = STDIN_LOCK
+            .lock()
+            .map_err(|e| NonoError::SandboxInit(format!("stdin lock poisoned: {e}")))?;
+
+        let mut pipe_fds = [-1i32; 2];
+        let saved_stdin;
+        unsafe {
+            assert_eq!(libc::pipe(pipe_fds.as_mut_ptr()), 0, "pipe() failed");
+            saved_stdin = libc::dup(libc::STDIN_FILENO);
+            assert!(saved_stdin >= 0, "dup(stdin) failed");
+            assert_eq!(
+                libc::dup2(pipe_fds[0], libc::STDIN_FILENO),
+                libc::STDIN_FILENO,
+                "dup2 failed"
+            );
+            libc::close(pipe_fds[0]);
+        }
+
+        let result = (|| -> Result<()> {
+            let mut entry = test_capture_entry_no_cache(vec![
+                "/usr/bin/python3".to_string(),
+                "-c".to_string(),
+                // select() with timeout=0: /dev/null stdin is immediately readable (EOF);
+                // a blocking pipe (write end open, no data) is not ready.
+                concat!(
+                    "import select, sys; ",
+                    "r, _, _ = select.select([sys.stdin], [], [], 0); ",
+                    "sys.stdout.write('null' if r else 'blocked'); ",
+                    "sys.stdout.flush()"
+                )
+                .to_string(),
+            ]);
+            entry.interaction = Some(crate::profile::CredentialCaptureInteraction {
+                stdio: true,
+                stdin: false,
+                open_urls: None,
+                allow_launch_services: false,
+            });
+            let mut entries = HashMap::new();
+            entries.insert("test-cred".to_string(), entry);
+            let backend =
+                ProxyCredentialCaptureBackend::new(&entries, "sess-stdio-stdin".to_string())?;
+            let response = nono_proxy::capture::CredentialCaptureBackend::capture(
+                &backend,
+                nono_proxy::capture::CredentialCaptureRequest {
+                    credential_name: "test-cred".to_string(),
+                    route_id: "test-cred".to_string(),
+                    request_host: "example.com".to_string(),
+                    request_path: "/".to_string(),
+                    request_method: "GET".to_string(),
+                    session_id: String::new(),
+                    cache_scope: String::new(),
+                },
+            )
+            .map_err(|err| NonoError::SandboxInit(err.to_string()))?;
+            assert_eq!(
+                capture_secret(&response),
+                "null",
+                "credential helper stdin must be /dev/null when stdio:true, not the inherited fd"
+            );
+            Ok(())
+        })();
+
+        // Restore stdin whether the test passed or failed.
+        unsafe {
+            libc::dup2(saved_stdin, libc::STDIN_FILENO);
+            libc::close(saved_stdin);
+            libc::close(pipe_fds[1]);
+        }
+
+        result
+    }
+
+    // Verify that setting interaction.stdin:true lets the credential helper inherit the
+    // terminal stdin. This is the explicit opt-in for helpers that genuinely need to
+    // prompt the user for input.
+    #[test]
+    #[cfg(unix)]
+    fn capture_helper_with_interaction_stdin_true_inherits_terminal_stdin() -> Result<()> {
+        use nix::libc;
+
+        static STDIN_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = STDIN_LOCK
+            .lock()
+            .map_err(|e| NonoError::SandboxInit(format!("stdin lock poisoned: {e}")))?;
+
+        let mut pipe_fds = [-1i32; 2];
+        let saved_stdin;
+        unsafe {
+            assert_eq!(libc::pipe(pipe_fds.as_mut_ptr()), 0, "pipe() failed");
+            saved_stdin = libc::dup(libc::STDIN_FILENO);
+            assert!(saved_stdin >= 0, "dup(stdin) failed");
+            assert_eq!(
+                libc::dup2(pipe_fds[0], libc::STDIN_FILENO),
+                libc::STDIN_FILENO,
+                "dup2 failed"
+            );
+            libc::close(pipe_fds[0]);
+        }
+
+        let result = (|| -> Result<()> {
+            let mut entry = test_capture_entry_no_cache(vec![
+                "/usr/bin/python3".to_string(),
+                "-c".to_string(),
+                concat!(
+                    "import select, sys; ",
+                    "r, _, _ = select.select([sys.stdin], [], [], 0); ",
+                    "sys.stdout.write('null' if r else 'blocked'); ",
+                    "sys.stdout.flush()"
+                )
+                .to_string(),
+            ]);
+            entry.interaction = Some(crate::profile::CredentialCaptureInteraction {
+                stdio: true,
+                stdin: true,
+                open_urls: None,
+                allow_launch_services: false,
+            });
+            let mut entries = HashMap::new();
+            entries.insert("test-cred".to_string(), entry);
+            let backend =
+                ProxyCredentialCaptureBackend::new(&entries, "sess-inherit-stdin".to_string())?;
+            let response = nono_proxy::capture::CredentialCaptureBackend::capture(
+                &backend,
+                nono_proxy::capture::CredentialCaptureRequest {
+                    credential_name: "test-cred".to_string(),
+                    route_id: "test-cred".to_string(),
+                    request_host: "example.com".to_string(),
+                    request_path: "/".to_string(),
+                    request_method: "GET".to_string(),
+                    session_id: String::new(),
+                    cache_scope: String::new(),
+                },
+            )
+            .map_err(|err| NonoError::SandboxInit(err.to_string()))?;
+            assert_eq!(
+                capture_secret(&response),
+                "blocked",
+                "credential helper stdin must be inherited when interaction.stdin:true"
+            );
+            Ok(())
+        })();
+
+        unsafe {
+            libc::dup2(saved_stdin, libc::STDIN_FILENO);
+            libc::close(saved_stdin);
+            libc::close(pipe_fds[1]);
+        }
+
+        result
     }
 }

--- a/docs/cli/features/credential-injection.mdx
+++ b/docs/cli/features/credential-injection.mdx
@@ -489,7 +489,7 @@ The helper prints:
 
 The proxy rejects unlisted headers, hop-by-hop headers, invalid header names, non-string values, and values containing CR or LF.
 
-Interactive capture is explicit. Set `interaction.stdio: true` when the command needs inherited stderr and, with `stdin: "null"`, inherited stdin.
+Interactive capture is explicit. Set `interaction.stdio: true` when the command needs to write prompts to the terminal via inherited stderr. To also read from the terminal (for helpers that genuinely need to prompt the user for input), additionally set `interaction.stdin: true`. Stdin defaults to `/dev/null` so that helpers which only need stderr do not accidentally inherit the terminal's stdin.
 
 Browser auth is also scoped to the individual capture command:
 


### PR DESCRIPTION
## Linked Issue

Closes #1299

## Summary

The `interaction.stdio` flag was documented to inherit both stderr and stdin
when set with `stdin_mode: null`. This caused credential helpers to steal
keypresses from the terminal when they blocked waiting for stdin input.

Add `interaction.stdin: bool` (default `false`) to `CredentialCaptureInteraction`
so stdin and stderr inheritance can be controlled independently. The `stdio` flag
now controls only stderr; stdin inheritance requires the explicit
`interaction.stdin: true` opt-in. Existing profiles that omit `stdin: true` will
no longer inherit terminal stdin.

## Agent Disclosure

This PR was prepared by an AI agent (Claude Code). Files consulted:
`crates/nono-cli/src/proxy_runtime.rs`, `crates/nono-cli/src/profile/mod.rs`,
`crates/nono-cli/data/nono-profile.schema.json`,
`crates/nono-cli/data/profile-authoring-guide.md`,
`docs/cli/features/credential-injection.mdx`, `AGENTS.md`, `CLAUDE.md`.
All repository coding and security rules for the affected area have been
reviewed and the contribution complies with them.

## Test Plan

Two regression tests added to `proxy_runtime.rs`:

- `capture_helper_with_stdio_true_receives_null_not_terminal_stdin` — sets process stdin
  to a blocking pipe, asserts subprocess receives `/dev/null` (immediate EOF) when
  `interaction.stdin` is absent (default false).
- `capture_helper_with_interaction_stdin_true_inherits_terminal_stdin` — same setup,
  asserts subprocess receives the inherited blocking pipe when `interaction.stdin: true`.

```
cargo test -p nono-cli -- capture_helper
```

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using DCO
- [x] All new code follows the project's coding standards (CLAUDE.md) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [x] Release note has been added to CHANGELOG.md if needed

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (N/A — wholly new code)
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths (N/A — no path handling in this change)
- [x] This PR matches the approved or disclosed issue scope