### PR TITLE
feat(policy): add bun runtime preset

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -761,6 +761,25 @@
       "workdir": { "access": "readwrite" },
       "interactive": false
     },
+    "bun-dev": {
+      "extends": "default",
+      "meta": {
+        "name": "bun-dev",
+        "version": "1.0.0",
+        "description": "Bun runtime development profile",
+        "author": "always-further"
+      },
+      "groups": {
+        "include": ["bun_runtime"]
+      },
+      "security": {
+        "signal_mode": "isolated"
+      },
+      "filesystem": {},
+      "network": { "block": false, "network_profile": "developer" },
+      "workdir": { "access": "readwrite" },
+      "interactive": false
+    },
     "go-dev": {
       "extends": "default",
       "meta": {

--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -20,6 +20,8 @@
           "~/.git-credentials",
           "~/.netrc",
           "~/.npmrc",
+          "~/.bunfig.toml",
+          "~/.config/bun/bunfig.toml",
           "~/.vault-token",
           "~/.credentials",
           "~/.secrets",

--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -375,6 +375,14 @@
         ]
       }
     },
+    "bun_runtime": {
+      "description": "Bun javascript runtime and package manager paths",
+      "allow": {
+        "read": [
+          "~/.bun"
+        ]
+      }
+    },
     "opencode_linux": {
       "description": "OpenCode binary directory (Landlock requires directory read to execute binaries)",
       "platform": "linux",

--- a/crates/nono-cli/tests/manifest_roundtrip.rs
+++ b/crates/nono-cli/tests/manifest_roundtrip.rs
@@ -614,7 +614,6 @@ const AVAILABLE_GROUPS: &[&str] = &[
     "deny_shell_history",
     "dangerous_commands",
     "git_config",
-    "bun_runtime"
     "node_runtime",
     "bun_runtime",
     "python_runtime",

--- a/crates/nono-cli/tests/manifest_roundtrip.rs
+++ b/crates/nono-cli/tests/manifest_roundtrip.rs
@@ -614,6 +614,7 @@ const AVAILABLE_GROUPS: &[&str] = &[
     "deny_shell_history",
     "dangerous_commands",
     "git_config",
+    "bun_runtime"
     "node_runtime",
     "python_runtime",
     "rust_runtime",

--- a/crates/nono-cli/tests/manifest_roundtrip.rs
+++ b/crates/nono-cli/tests/manifest_roundtrip.rs
@@ -616,6 +616,7 @@ const AVAILABLE_GROUPS: &[&str] = &[
     "git_config",
     "bun_runtime"
     "node_runtime",
+    "bun_runtime",
     "python_runtime",
     "rust_runtime",
     "user_tools",


### PR DESCRIPTION
## Linked Issue

Closes #1289

## Summary

Adds dedicated policy for bun runtime, allowing read-only access to ~/.bun

## Test Plan

Does it even need to be tested? I'm not sure about that part because there is no real bun and some node tests are skipped from what i've saw in fixtures, should i just do dry-run with "fake" ~/.bun folder? What will be correct approach?

## Checklist

- [x] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed
