### PR TITLE
feat(tool-sandbox): add exec intercept action

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -1181,6 +1181,20 @@
             "type": { "type": "string", "const": "approve" },
             "timeout_secs": { "type": "integer", "minimum": 1 }
           }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "command"],
+          "properties": {
+            "type": { "type": "string", "const": "exec" },
+            "command": {
+              "type": "array",
+              "items": { "type": "string" },
+              "minItems": 1,
+              "description": "Run a helper in place of the matched subcommand, inside the command's sandbox. command[0] is the helper path (after $VAR expansion, must be absolute); command[1..] are fixed leading args inserted before the forwarded original arguments. The helper's stdout/stderr are streamed and its exit code propagated. The helper is resolved with identity expectations and is subject to the same non-writable-executable trust gate as a pinned executable."
+            }
+          }
         }
       ]
     },

--- a/crates/nono-cli/src/command_policy.rs
+++ b/crates/nono-cli/src/command_policy.rs
@@ -1163,6 +1163,11 @@ pub(crate) fn resolve_policy_exec_helpers(
             };
             let expanded = crate::policy::expand_env_vars_strict(helper_raw)?;
             let helper_path = PathBuf::from(&expanded);
+            if !helper_path.is_absolute() {
+                return Err(nono::NonoError::ProfileParse(format!(
+                    "command '{command_name}' intercept rule {rule_index} exec helper must be an absolute path; got '{expanded}'"
+                )));
+            }
             if helpers.contains_key(&helper_path) {
                 continue;
             }
@@ -4088,6 +4093,16 @@ mod tests {
         let resolved = helpers.get(&helper).expect("helper resolved");
         assert!(!resolved.sha256.is_empty());
         assert!(resolved.canonical_path.is_absolute());
+    }
+
+    #[test]
+    fn resolve_policy_exec_helpers_rejects_relative_helper() {
+        let config = git_config_with_exec(vec!["relative/helper".to_string()]);
+        let err = resolve_policy_exec_helpers(&config).expect_err("must reject relative helper");
+        assert!(
+            err.to_string().contains("absolute path"),
+            "expected absolute-path rejection, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/command_policy.rs
+++ b/crates/nono-cli/src/command_policy.rs
@@ -400,6 +400,23 @@ pub enum InterceptActionConfig {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         timeout_secs: Option<u64>,
     },
+    /// Run a helper binary instead of the command's real binary, inside the
+    /// matched command's existing sandbox (same capabilities, env including
+    /// injected credentials/proxy routing, and cwd). The helper at `command[0]`
+    /// runs with `command[1..]` as fixed leading args, followed by the original
+    /// invocation's user args (`argv[1..]`). The helper's stdout/stderr are
+    /// streamed to the caller and its exit code is propagated.
+    ///
+    /// `command[0]` is `$VAR`-expanded then required to be an absolute path; it
+    /// is resolved exactly like a command binary (canonicalize/stat/sha256 with
+    /// identity expectations for TOCTOU protection) and is subject to the same
+    /// non-writable-executable trust gate as the `executable` field.
+    Exec {
+        /// Helper invocation: `command[0]` is the absolute helper path (after
+        /// `$VAR` expansion); `command[1..]` are fixed leading args prepended
+        /// before the forwarded original args.
+        command: Vec<String>,
+    },
 }
 
 /// A sub-command mediation rule on a [`CommandPolicyConfig`].
@@ -1114,6 +1131,65 @@ pub(crate) fn resolve_policy_command_binaries(
     Ok(ResolvedCommandBinaries { commands, warnings })
 }
 
+/// Pre-resolve every `exec` intercept helper referenced by any command policy.
+///
+/// We resolve helpers at plan-build time (rather than lazily at dispatch) so
+/// their identity expectations (dev/ino/size/mtime/sha256) are captured up
+/// front for TOCTOU protection, exactly like command binaries. Helpers are
+/// resolved the SAME way as command binaries — env-expand `command[0]`, then
+/// `candidate_command_match` (canonicalize, stat, sha256, classify shape).
+///
+/// The returned map is keyed by the env-expanded helper path as written in the
+/// profile, so dispatch can re-expand `command[0]` and look the helper up. A
+/// helper that fails to resolve (missing/non-executable) is surfaced as an
+/// error rather than skipped: unlike an absent command binary (which simply
+/// disables that command's policy), an exec helper that cannot run would leave
+/// the matched subcommand with no viable handler.
+#[cfg(any(test, target_os = "linux", target_os = "macos"))]
+pub(crate) fn resolve_policy_exec_helpers(
+    config: &CommandPoliciesConfig,
+) -> nono::Result<BTreeMap<PathBuf, ResolvedCommandBinary>> {
+    let mut helpers = BTreeMap::new();
+    for (command_name, command) in &config.commands {
+        for (rule_index, rule) in command.intercept.iter().enumerate() {
+            let InterceptActionConfig::Exec {
+                command: exec_command,
+            } = &rule.action
+            else {
+                continue;
+            };
+            let Some(helper_raw) = exec_command.first() else {
+                continue;
+            };
+            let expanded = crate::policy::expand_env_vars_strict(helper_raw)?;
+            let helper_path = PathBuf::from(&expanded);
+            if helpers.contains_key(&helper_path) {
+                continue;
+            }
+            let resolved = candidate_command_match(&helper_path)?.ok_or_else(|| {
+                nono::NonoError::ProfileParse(format!(
+                    "command '{command_name}' intercept rule {rule_index} exec helper '{expanded}' not found or not executable"
+                ))
+            })?;
+            helpers.insert(
+                helper_path,
+                ResolvedCommandBinary {
+                    name: format!("{command_name}.intercept[{rule_index}].exec"),
+                    canonical_path: resolved.canonical_path,
+                    dev: resolved.dev,
+                    ino: resolved.ino,
+                    size: resolved.size,
+                    mtime_nanos: resolved.mtime_nanos,
+                    sha256: resolved.sha256,
+                    duplicate_paths: Vec::new(),
+                    shape: resolved.shape,
+                },
+            );
+        }
+    }
+    Ok(helpers)
+}
+
 fn validate_command(
     command_name: &str,
     command: &CommandPolicyConfig,
@@ -1319,6 +1395,65 @@ fn validate_intercept_rules(
             // caller, so label it by rule index for error context.
             let caller = format!("intercept[{i}].sandbox");
             validate_sandbox(command_name, &caller, sandbox, config, scope, report);
+        }
+        if let InterceptActionConfig::Exec { command } = &rule.action {
+            validate_exec_action(command_name, i, command, report);
+        }
+    }
+}
+
+/// Validate an `exec` intercept action's `command`.
+///
+/// Config-level checks only: non-empty, NUL-free, `command[0]` is
+/// `$VAR`-expandable and resolves to an ABSOLUTE path. The non-writable
+/// executable security gate runs at plan-build time against the outer
+/// capability set (see `validate_controlled_binary_immutability` in the
+/// platform runtimes), exactly as for command binaries — it cannot be enforced
+/// here because the outer caps are not in scope.
+fn validate_exec_action(
+    command_name: &str,
+    rule_index: usize,
+    command: &[String],
+    report: &mut CommandPolicyValidationReport,
+) {
+    let Some(helper) = command.first() else {
+        report.error(
+            "intercept_exec_empty_command",
+            format!(
+                "command '{command_name}' intercept rule {rule_index} exec action has an empty command"
+            ),
+        );
+        return;
+    };
+    for element in command {
+        if element.as_bytes().contains(&0) {
+            report.error(
+                "intercept_exec_nul_byte",
+                format!(
+                    "command '{command_name}' intercept rule {rule_index} exec command contains a NUL byte"
+                ),
+            );
+            return;
+        }
+    }
+    match crate::policy::expand_env_vars_strict(helper) {
+        Ok(expanded) => {
+            if !Path::new(&expanded).is_absolute() {
+                report.error(
+                    "intercept_exec_requires_absolute_helper",
+                    format!(
+                        "command '{command_name}' intercept rule {rule_index} exec helper must expand to an absolute path; got '{expanded}'"
+                    ),
+                );
+            }
+        }
+        Err(err) => {
+            report.error(
+                "intercept_exec_unexpandable_helper",
+                format!(
+                    "command '{command_name}' intercept rule {rule_index} exec helper '{helper}' could not be expanded: {err}"
+                ),
+            );
         }
     }
 }
@@ -3846,6 +3981,113 @@ mod tests {
         assert!(json.contains("capture_credential"));
         let back: InterceptActionConfig = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(action, back);
+    }
+
+    #[test]
+    fn exec_action_serde_roundtrip() {
+        let action = InterceptActionConfig::Exec {
+            command: vec!["/abs/helper".to_string(), "x".to_string()],
+        };
+        let json = serde_json::to_string(&action).expect("serialize");
+        assert!(json.contains("\"type\":\"exec\""), "{json}");
+        assert!(json.contains("/abs/helper"), "{json}");
+        let back: InterceptActionConfig = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(action, back);
+
+        // Verify the documented wire shape deserializes.
+        let from_wire: InterceptActionConfig =
+            serde_json::from_str(r#"{"type":"exec","command":["/abs/helper","x"]}"#)
+                .expect("deserialize wire form");
+        assert_eq!(action, from_wire);
+    }
+
+    fn git_config_with_exec(command: Vec<String>) -> CommandPoliciesConfig {
+        let mut config = active_git_config();
+        let git = config.commands.get_mut("git").expect("git command");
+        git.intercept.push(InterceptRuleConfig {
+            args: vec!["auth".to_string(), "switch".to_string()],
+            action: InterceptActionConfig::Exec { command },
+        });
+        config
+    }
+
+    #[test]
+    fn exec_action_accepts_absolute_helper() {
+        let config = git_config_with_exec(vec!["/usr/bin/true".to_string(), "auth".to_string()]);
+        let report =
+            validate_command_policies(Some(&config), CommandPolicyValidationScope::Resolved);
+        assert!(
+            !report
+                .errors
+                .iter()
+                .any(|finding| finding.code.starts_with("intercept_exec")),
+            "{:?}",
+            report.errors
+        );
+    }
+
+    #[test]
+    fn exec_action_rejects_empty_command() {
+        let config = git_config_with_exec(vec![]);
+        let report =
+            validate_command_policies(Some(&config), CommandPolicyValidationScope::Resolved);
+        assert!(
+            report
+                .errors
+                .iter()
+                .any(|finding| finding.code == "intercept_exec_empty_command"),
+            "{:?}",
+            report.errors
+        );
+    }
+
+    #[test]
+    fn exec_action_rejects_relative_helper() {
+        let config = git_config_with_exec(vec!["relative/helper".to_string()]);
+        let report =
+            validate_command_policies(Some(&config), CommandPolicyValidationScope::Resolved);
+        assert!(
+            report
+                .errors
+                .iter()
+                .any(|finding| finding.code == "intercept_exec_requires_absolute_helper"),
+            "{:?}",
+            report.errors
+        );
+    }
+
+    #[test]
+    fn exec_action_rejects_nul_byte() {
+        let config = git_config_with_exec(vec!["/abs/helper".to_string(), "a\0b".to_string()]);
+        let report =
+            validate_command_policies(Some(&config), CommandPolicyValidationScope::Resolved);
+        assert!(
+            report
+                .errors
+                .iter()
+                .any(|finding| finding.code == "intercept_exec_nul_byte"),
+            "{:?}",
+            report.errors
+        );
+    }
+
+    #[test]
+    fn exec_helper_resolution_captures_identity() {
+        // /usr/bin/true (or /bin/true) is a stable absolute executable on both
+        // macOS and Linux.
+        let helper = ["/usr/bin/true", "/bin/true"]
+            .into_iter()
+            .map(PathBuf::from)
+            .find(|p| p.exists());
+        let Some(helper) = helper else {
+            // No stable helper available; skip rather than fail spuriously.
+            return;
+        };
+        let config = git_config_with_exec(vec![helper.display().to_string()]);
+        let helpers = resolve_policy_exec_helpers(&config).expect("resolve helpers");
+        let resolved = helpers.get(&helper).expect("helper resolved");
+        assert!(!resolved.sha256.is_empty());
+        assert!(resolved.canonical_path.is_absolute());
     }
 
     #[test]

--- a/crates/nono-cli/src/command_policy.rs
+++ b/crates/nono-cli/src/command_policy.rs
@@ -4012,6 +4012,7 @@ mod tests {
         git.intercept.push(InterceptRuleConfig {
             args: vec!["auth".to_string(), "switch".to_string()],
             action: InterceptActionConfig::Exec { command },
+            sandbox: None,
         });
         config
     }

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -325,6 +325,25 @@ pub(crate) fn expand_path(path_str: &str) -> Result<PathBuf> {
     Ok(PathBuf::from(expanded))
 }
 
+/// Expand `$VAR` references in a string against the process environment,
+/// erroring on an unset variable rather than leaving it literal like
+/// [`expand_env_vars`] — collapsing `$X/helper` to `/helper` on a typo'd var
+/// name would be a silent path-widening bug.
+pub(crate) fn expand_env_vars_strict(input: &str) -> Result<String> {
+    substitute_vars(
+        input,
+        |c| c.is_ascii_alphanumeric() || c == '_',
+        |name| {
+            std::env::var(name)
+                .map(Some)
+                .map_err(|_| NonoError::EnvVarValidation {
+                    var: name.to_string(),
+                    reason: format!("referenced in '{input}' but not set in the environment"),
+                })
+        },
+    )
+}
+
 /// Check whether a path resides inside the Nix store (`/nix/store`).
 ///
 /// The Nix store is immutable by design — its contents are content-addressed
@@ -1868,10 +1887,9 @@ mod tests {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
-        let _env =
-            crate::test_env::EnvVarGuard::set_all(&[("_TEST_SFROOT_POLICY", "/opt/shadowfax")]);
+        let _env = crate::test_env::EnvVarGuard::set_all(&[("_TEST_SFROOT_POLICY", "/opt/vendor")]);
         let path = expand_path("$_TEST_SFROOT_POLICY/profiles").expect("should expand");
-        assert_eq!(path, PathBuf::from("/opt/shadowfax/profiles"));
+        assert_eq!(path, PathBuf::from("/opt/vendor/profiles"));
     }
 
     #[test]
@@ -1898,6 +1916,41 @@ mod tests {
             expand_env_vars("$_TEST_POLICY_ROOT/bin/$_UNSET_VAR"),
             "/opt/tool/bin/$_UNSET_VAR"
         );
+    }
+
+    #[test]
+    fn expand_env_vars_strict_no_substitution() {
+        assert_eq!(
+            expand_env_vars_strict("/usr/bin/true").expect("literal"),
+            "/usr/bin/true"
+        );
+    }
+
+    #[test]
+    fn expand_env_vars_strict_substitutes_named_var() {
+        let _lock = match crate::test_env::ENV_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let var = "NONO_TEST_EXPAND_ENV_VARS_HELPER_DIR";
+        let _env = crate::test_env::EnvVarGuard::set_all(&[(var, "/opt/libexec")]);
+        let plain = expand_env_vars_strict(&format!("${var}/helper")).expect("plain expand");
+        assert_eq!(plain, "/opt/libexec/helper");
+    }
+
+    #[test]
+    fn expand_env_vars_strict_errors_on_unset() {
+        let _lock = match crate::test_env::ENV_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let var = "NONO_TEST_EXPAND_ENV_VARS_DEFINITELY_UNSET";
+        // Manage the key through the guard (so drop restores the original), then
+        // remove it to exercise the unset path.
+        let env = crate::test_env::EnvVarGuard::set_all(&[(var, "placeholder")]);
+        env.remove(var);
+        let err = expand_env_vars_strict(&format!("${var}/x")).expect_err("unset var must error");
+        assert!(matches!(err, NonoError::EnvVarValidation { .. }));
     }
 
     #[test]

--- a/crates/nono-cli/src/tool-sandbox/env.rs
+++ b/crates/nono-cli/src/tool-sandbox/env.rs
@@ -38,18 +38,32 @@ pub(crate) fn default_env_allow_patterns() -> Vec<String> {
         .collect()
 }
 
-pub(crate) fn effective_argv(
+/// Build the child argv: argv[0] is the binary's canonical path, then
+/// `extra_args` (the `exec` helper's fixed leading args, empty for normal
+/// commands), then the policy's `argv_prepend`, then the forwarded user args
+/// (`request.argv[1..]`). NUL bytes in `extra_args`/`argv_prepend` are rejected.
+pub(crate) fn effective_argv_for_binary(
     binary: &ResolvedCommandBinary,
     request: &ToolSandboxShimRequest,
     policy: &CommandSandboxConfig,
+    extra_args: &[Vec<u8>],
 ) -> Result<Vec<Vec<u8>>> {
     if request.argv.is_empty() {
         return Err(NonoError::SandboxInit(
             "tool-sandbox request had empty argv".to_string(),
         ));
     }
-    let mut argv = Vec::with_capacity(request.argv.len() + policy.argv_prepend.len());
+    let mut argv =
+        Vec::with_capacity(request.argv.len() + policy.argv_prepend.len() + extra_args.len());
     argv.push(binary.canonical_path.as_os_str().as_bytes().to_vec());
+    for arg in extra_args {
+        if arg.contains(&0) {
+            return Err(NonoError::ConfigParse(
+                "tool-sandbox exec helper arg contains NUL".to_string(),
+            ));
+        }
+        argv.push(arg.clone());
+    }
     for arg in &policy.argv_prepend {
         if arg.as_bytes().contains(&0) {
             return Err(NonoError::ConfigParse(
@@ -156,7 +170,90 @@ pub(crate) fn split_env_entry(entry: &[u8]) -> Option<(&[u8], &[u8])> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::command_policy::{ResolvedExecutableKind, ResolvedExecutableShape};
     use crate::exec_strategy::env_sanitization::is_env_var_allowed;
+
+    fn test_binary(path: &str) -> ResolvedCommandBinary {
+        ResolvedCommandBinary {
+            name: "cmd".to_string(),
+            canonical_path: std::path::PathBuf::from(path),
+            dev: 0,
+            ino: 0,
+            size: 0,
+            mtime_nanos: 0,
+            sha256: String::new(),
+            duplicate_paths: vec![],
+            shape: ResolvedExecutableShape {
+                kind: ResolvedExecutableKind::Other,
+                interpreter: None,
+                interpreter_args: vec![],
+            },
+        }
+    }
+
+    fn test_request(argv: &[&str]) -> ToolSandboxShimRequest {
+        ToolSandboxShimRequest {
+            command: "gh".to_string(),
+            argv: argv.iter().map(|a| a.as_bytes().to_vec()).collect(),
+            env: vec![],
+            cwd: b"/".to_vec(),
+            stdio_tty: [false; 3],
+        }
+    }
+
+    #[test]
+    fn effective_argv_forwards_helper_then_prepend_then_user_args() {
+        // argv layout for an `exec` helper:
+        // [helper, extra_args.., argv_prepend.., user_args (request.argv[1..])].
+        let helper = test_binary("/opt/vendor/gh-wrapper");
+        let request = test_request(&["gh", "auth", "switch", "--user", "someuser"]);
+        let policy = CommandSandboxConfig {
+            argv_prepend: vec!["--prepended".to_string()],
+            ..Default::default()
+        };
+        let extra = vec![b"helperarg".to_vec()];
+
+        let argv = effective_argv_for_binary(&helper, &request, &policy, &extra).expect("argv");
+        let rendered: Vec<String> = argv
+            .iter()
+            .map(|a| String::from_utf8_lossy(a).into_owned())
+            .collect();
+        assert_eq!(
+            rendered,
+            vec![
+                "/opt/vendor/gh-wrapper",
+                "helperarg",
+                "--prepended",
+                "auth",
+                "switch",
+                "--user",
+                "someuser",
+            ]
+        );
+    }
+
+    #[test]
+    fn effective_argv_normal_command_has_no_extra_args() {
+        // The non-exec path passes `&[]`, so argv is [binary, argv_prepend.., user_args].
+        let binary = test_binary("/usr/bin/gh");
+        let request = test_request(&["gh", "pr", "list"]);
+        let policy = CommandSandboxConfig::default();
+        let argv = effective_argv_for_binary(&binary, &request, &policy, &[]).expect("argv");
+        let rendered: Vec<String> = argv
+            .iter()
+            .map(|a| String::from_utf8_lossy(a).into_owned())
+            .collect();
+        assert_eq!(rendered, vec!["/usr/bin/gh", "pr", "list"]);
+    }
+
+    #[test]
+    fn effective_argv_rejects_nul_in_extra_args() {
+        let helper = test_binary("/opt/vendor/helper");
+        let request = test_request(&["gh", "auth", "switch"]);
+        let policy = CommandSandboxConfig::default();
+        let extra = vec![b"a\0b".to_vec()];
+        assert!(effective_argv_for_binary(&helper, &request, &policy, &extra).is_err());
+    }
 
     #[test]
     fn tls_trust_bundle_vars_are_in_default_allow() {

--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -9,7 +9,7 @@ use crate::command_policy::{
 use crate::profile;
 use crate::tool_sandbox::credentials::{ResolvedCredential, resolve_credentials};
 use crate::tool_sandbox::env::{
-    apply_environment_set_vars, default_env_allow_patterns, effective_argv,
+    apply_environment_set_vars, default_env_allow_patterns, effective_argv_for_binary,
     inject_chaining_control_env, inject_url_open_env, split_env_entry,
 };
 use crate::tool_sandbox::launch::{
@@ -137,6 +137,10 @@ struct BaselineCache {
 struct ResolvedToolSandboxPlan {
     config: CommandPoliciesConfig,
     resolved: ResolvedCommandBinaries,
+    /// Pre-resolved `exec` intercept helpers, keyed by their env-expanded path
+    /// as written in the profile. Identity expectations are captured here so
+    /// the helper launch is TOCTOU-protected like a command binary.
+    exec_helpers: BTreeMap<PathBuf, ResolvedCommandBinary>,
     executable_dirs: Vec<PathBuf>,
     deny_only: BTreeMap<String, ResolvedDenyOnlyCommand>,
     allowed_direct_bypasses: Vec<PathBuf>,
@@ -210,6 +214,8 @@ impl ResolvedToolSandboxPlan {
         // entries part of the child sandbox trust boundary.
         let deny_only = resolve_deny_only_commands(config, &[], &[], &search_dirs)?;
         validate_controlled_binary_immutability(config, &resolved, &deny_only, outer_caps)?;
+        let exec_helpers = crate::command_policy::resolve_policy_exec_helpers(config)?;
+        validate_controlled_exec_helper_immutability(config, &exec_helpers, outer_caps)?;
         let governance_denies = resolve_governance_denies(config)?;
         let allowed_direct_bypasses =
             resolve_allowed_direct_bypasses(config, &resolved, &deny_only, &governance_denies)?;
@@ -217,6 +223,7 @@ impl ResolvedToolSandboxPlan {
         Ok(Self {
             config: config.clone(),
             resolved,
+            exec_helpers,
             executable_dirs: search_dirs,
             deny_only,
             allowed_direct_bypasses,
@@ -1773,6 +1780,88 @@ fn handle_shim_stream_inner(
         return result.map(|(c, _)| (c, Vec::new()));
     }
 
+    if let crate::command_policy::InterceptActionConfig::Exec { command } = intercept_action {
+        let active = state.active_count.fetch_add(1, Ordering::SeqCst);
+        if active >= MAX_ACTIVE_TOOL_SANDBOX_CHILDREN {
+            state.active_count.fetch_sub(1, Ordering::SeqCst);
+            record_command_policy_audit(
+                audit_recorder.as_ref(),
+                &request,
+                &state.redaction_policy,
+                session_id,
+                auth.peer_pid,
+                session_root_pid,
+                Some(&caller),
+                "denied",
+                Some("resource_limit".to_string()),
+                None,
+            )?;
+            return Err(NonoError::SandboxInit(
+                "tool-sandbox active child limit exceeded".to_string(),
+            ));
+        }
+        let result = (|| {
+            let (helper, extra_args) =
+                super::policy::resolve_exec_helper(&state.plan.exec_helpers, command)?;
+            let launch =
+                build_child_launch_spec_for_binary(state, &request, policy, helper, &extra_args)?;
+            launch_child(state, &request.command, &caller, launch, stdio)
+        })();
+        state.active_count.fetch_sub(1, Ordering::SeqCst);
+        return match result {
+            Ok(launch_result) => {
+                if let Some(reason) = launch_result.blocked_reason.clone() {
+                    record_command_policy_audit_with_stdio(
+                        audit_recorder.as_ref(),
+                        &request,
+                        &state.redaction_policy,
+                        session_id,
+                        auth.peer_pid,
+                        session_root_pid,
+                        Some(&caller),
+                        "denied",
+                        Some(reason.clone()),
+                        None,
+                        launch_result.stdio,
+                    )?;
+                    return Err(NonoError::BlockedCommand {
+                        command: request.command,
+                        reason,
+                    });
+                }
+                record_command_policy_audit_with_stdio(
+                    audit_recorder.as_ref(),
+                    &request,
+                    &state.redaction_policy,
+                    session_id,
+                    auth.peer_pid,
+                    session_root_pid,
+                    Some(&caller),
+                    "exec",
+                    None,
+                    Some(launch_result.exit_code),
+                    launch_result.stdio,
+                )?;
+                Ok((launch_result.exit_code, Vec::new()))
+            }
+            Err(err) => {
+                record_command_policy_audit(
+                    audit_recorder.as_ref(),
+                    &request,
+                    &state.redaction_policy,
+                    session_id,
+                    auth.peer_pid,
+                    session_root_pid,
+                    Some(&caller),
+                    "denied",
+                    Some(err.to_string()),
+                    None,
+                )?;
+                Err(err)
+            }
+        };
+    }
+
     let active = state.active_count.fetch_add(1, Ordering::SeqCst);
     if active >= MAX_ACTIVE_TOOL_SANDBOX_CHILDREN {
         state.active_count.fetch_sub(1, Ordering::SeqCst);
@@ -2453,6 +2542,29 @@ fn validate_controlled_binary_immutability(
     Ok(())
 }
 
+/// Apply the same non-writable-executable trust gate to resolved `exec`
+/// intercept helpers as to command binaries (see the macOS twin for rationale).
+fn validate_controlled_exec_helper_immutability(
+    config: &CommandPoliciesConfig,
+    exec_helpers: &BTreeMap<PathBuf, ResolvedCommandBinary>,
+    outer_caps: &CapabilitySet,
+) -> Result<()> {
+    for binary in exec_helpers.values() {
+        let allow_writable_path = config.allow_writable_executables
+            || super::policy::command_referencing_exec_helper_allows_writable(
+                config,
+                &binary.canonical_path,
+            );
+        validate_controlled_file(
+            &binary.canonical_path,
+            outer_caps,
+            "exec intercept helper",
+            allow_writable_path,
+        )?;
+    }
+    Ok(())
+}
+
 fn command_allows_writable_executable(
     command: &crate::command_policy::CommandPolicyConfig,
 ) -> bool {
@@ -3023,6 +3135,23 @@ fn build_child_launch_spec(
         .ok_or_else(|| {
             NonoError::SandboxInit(format!("missing resolved binary for {}", request.command))
         })?;
+    build_child_launch_spec_for_binary(state, request, policy, binary, &[])
+}
+
+/// Build a child launch spec that runs `binary` (the command's real binary OR
+/// an `exec` intercept helper) inside the matched command's sandbox (`policy`).
+/// `extra_args` are inserted between argv[0] and the forwarded original args —
+/// used by the `exec` action for the helper's fixed leading args. The fs-read
+/// cap, Landlock execute allowlist (binary + its ELF/interpreter closure),
+/// runtime baseline, and identity expectations are all bound to `binary`, while
+/// network/credentials/proxy/fs/env come from `policy`.
+fn build_child_launch_spec_for_binary(
+    state: &ToolSandboxState,
+    request: &ToolSandboxShimRequest,
+    policy: &CommandSandboxConfig,
+    binary: &ResolvedCommandBinary,
+    extra_args: &[Vec<u8>],
+) -> Result<ToolSandboxChildLaunchSpec> {
     let start_vbi = std::time::Instant::now();
     verify_binary_identity(binary)?;
     tool_sandbox_profile_log!(
@@ -3105,7 +3234,7 @@ fn build_child_launch_spec(
             .as_ref()
             .map(|path| path.as_os_str().as_bytes().to_vec()),
         interpreter_args: binary.shape.interpreter_args.clone(),
-        argv: effective_argv(binary, request, policy)?,
+        argv: effective_argv_for_binary(binary, request, policy, extra_args)?,
         env,
         cwd: cwd.as_os_str().as_bytes().to_vec(),
         stdio_mode: selected_stdio_mode(request).to_string(),
@@ -3441,7 +3570,14 @@ fn build_baseline_cache<'a>(
     let system_files = compute_system_baseline_files()?;
     let mut closures: BTreeMap<PathBuf, Vec<PathBuf>> = BTreeMap::new();
 
-    for binary in plan.resolved.commands.values() {
+    // Command binaries and exec intercept helpers are launched the same way, so
+    // cache the ELF dependency closure for both (plus their script interpreters).
+    let cacheable = plan
+        .resolved
+        .commands
+        .values()
+        .chain(plan.exec_helpers.values());
+    for binary in cacheable {
         if !closures.contains_key(&binary.canonical_path) {
             closures.insert(
                 binary.canonical_path.clone(),
@@ -5084,6 +5220,7 @@ mod tests {
                     commands: BTreeMap::new(),
                     warnings: Vec::new(),
                 },
+                exec_helpers: BTreeMap::new(),
                 executable_dirs: Vec::new(),
                 deny_only: BTreeMap::new(),
                 allowed_direct_bypasses: Vec::new(),

--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -5103,9 +5103,9 @@ fn le_u64(data: &[u8], offset: usize) -> Result<u64> {
 mod tests {
     use super::*;
     use crate::command_policy::{
-        CommandEnvironmentConfig, CommandPolicyConfig, CommandSandboxConfig,
-        ResolvedCommandBinaries, ResolvedCommandBinary, ResolvedExecutableKind,
-        ResolvedExecutableShape,
+        CommandEnvironmentConfig, CommandPolicyConfig, CommandSandboxConfig, InterceptActionConfig,
+        InterceptRuleConfig, ResolvedCommandBinaries, ResolvedCommandBinary,
+        ResolvedExecutableKind, ResolvedExecutableShape,
     };
     use std::collections::BTreeMap;
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
@@ -5402,6 +5402,78 @@ mod tests {
             &BTreeMap::new(),
             &file_write_caps,
         )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn writable_exec_helper_override_is_explicit_for_sandbox_writable_paths() -> Result<()> {
+        let temp = test_tempdir()?;
+        let bin_dir = temp.path().join("bin");
+        create_dir(&bin_dir)?;
+        let helper = bin_dir.join("helper");
+        create_executable(&helper)?;
+
+        let mut config = CommandPoliciesConfig::default();
+        config.commands.insert(
+            "tool".to_string(),
+            CommandPolicyConfig {
+                intercept: vec![InterceptRuleConfig {
+                    args: vec![],
+                    action: InterceptActionConfig::Exec {
+                        command: vec![helper.to_string_lossy().into_owned()],
+                    },
+                }],
+                ..Default::default()
+            },
+        );
+
+        let mut exec_helpers = BTreeMap::new();
+        exec_helpers.insert(helper.clone(), test_binary("helper", &helper)?);
+
+        let caps = CapabilitySet::new();
+        validate_controlled_exec_helper_immutability(&config, &exec_helpers, &caps)?;
+
+        let mut file_write_caps = CapabilitySet::new();
+        file_write_caps.add_fs(FsCapability::new_file(&helper, AccessMode::ReadWrite)?);
+        let err =
+            validate_controlled_exec_helper_immutability(&config, &exec_helpers, &file_write_caps)
+                .err()
+                .ok_or_else(|| {
+                    NonoError::SandboxInit("expected sandbox-writable helper rejection".to_string())
+                })?;
+        assert!(
+            err.to_string()
+                .contains("writable by the outer session capability set")
+        );
+
+        let mut parent_write_caps = CapabilitySet::new();
+        parent_write_caps.add_fs(FsCapability::new_dir(&bin_dir, AccessMode::ReadWrite)?);
+        let err = validate_controlled_exec_helper_immutability(
+            &config,
+            &exec_helpers,
+            &parent_write_caps,
+        )
+        .err()
+        .ok_or_else(|| {
+            NonoError::SandboxInit("expected sandbox-writable parent rejection".to_string())
+        })?;
+        assert!(
+            err.to_string()
+                .contains("replaceable through writable parent directory")
+        );
+
+        config.allow_writable_executables = true;
+        validate_controlled_exec_helper_immutability(&config, &exec_helpers, &parent_write_caps)?;
+        config.allow_writable_executables = false;
+
+        let command = config
+            .commands
+            .get_mut("tool")
+            .ok_or_else(|| NonoError::SandboxInit("missing test command policy".to_string()))?;
+        command.allow_writable_executable = true;
+
+        validate_controlled_exec_helper_immutability(&config, &exec_helpers, &file_write_caps)?;
 
         Ok(())
     }

--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -5423,6 +5423,7 @@ mod tests {
                     action: InterceptActionConfig::Exec {
                         command: vec![helper.to_string_lossy().into_owned()],
                     },
+                    sandbox: None,
                 }],
                 ..Default::default()
             },

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -4811,6 +4811,7 @@ mod tests {
                     action: InterceptActionConfig::Exec {
                         command: vec![helper.to_string_lossy().into_owned()],
                     },
+                    sandbox: None,
                 }],
                 ..Default::default()
             },

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -4158,8 +4158,8 @@ fn is_tty(fd: i32) -> bool {
 mod tests {
     use super::*;
     use crate::command_policy::{
-        CommandEnvironmentConfig, CommandFromConfig, CommandPolicyConfig, ResolvedExecutableKind,
-        ResolvedExecutableShape,
+        CommandEnvironmentConfig, CommandFromConfig, CommandPolicyConfig, InterceptActionConfig,
+        InterceptRuleConfig, ResolvedExecutableKind, ResolvedExecutableShape,
     };
 
     fn test_binary(name: &str, path: &Path) -> Result<ResolvedCommandBinary> {
@@ -4790,6 +4790,78 @@ mod tests {
             &BTreeMap::new(),
             &file_write_caps,
         )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn writable_exec_helper_override_is_explicit_for_sandbox_writable_paths() -> Result<()> {
+        let temp = test_tempdir()?;
+        let bin_dir = temp.path().join("bin");
+        create_dir(&bin_dir)?;
+        let helper = bin_dir.join("helper");
+        create_executable(&helper)?;
+
+        let mut config = CommandPoliciesConfig::default();
+        config.commands.insert(
+            "tool".to_string(),
+            CommandPolicyConfig {
+                intercept: vec![InterceptRuleConfig {
+                    args: vec![],
+                    action: InterceptActionConfig::Exec {
+                        command: vec![helper.to_string_lossy().into_owned()],
+                    },
+                }],
+                ..Default::default()
+            },
+        );
+
+        let mut exec_helpers = BTreeMap::new();
+        exec_helpers.insert(helper.clone(), test_binary("helper", &helper)?);
+
+        let caps = CapabilitySet::new();
+        validate_controlled_exec_helper_immutability(&config, &exec_helpers, &caps)?;
+
+        let mut file_write_caps = CapabilitySet::new();
+        file_write_caps.add_fs(FsCapability::new_file(&helper, AccessMode::ReadWrite)?);
+        let err =
+            validate_controlled_exec_helper_immutability(&config, &exec_helpers, &file_write_caps)
+                .err()
+                .ok_or_else(|| {
+                    NonoError::SandboxInit("expected sandbox-writable helper rejection".to_string())
+                })?;
+        assert!(
+            err.to_string()
+                .contains("writable by the outer session capability set")
+        );
+
+        let mut parent_write_caps = CapabilitySet::new();
+        parent_write_caps.add_fs(FsCapability::new_dir(&bin_dir, AccessMode::ReadWrite)?);
+        let err = validate_controlled_exec_helper_immutability(
+            &config,
+            &exec_helpers,
+            &parent_write_caps,
+        )
+        .err()
+        .ok_or_else(|| {
+            NonoError::SandboxInit("expected sandbox-writable parent rejection".to_string())
+        })?;
+        assert!(
+            err.to_string()
+                .contains("replaceable through writable parent directory")
+        );
+
+        config.allow_writable_executables = true;
+        validate_controlled_exec_helper_immutability(&config, &exec_helpers, &parent_write_caps)?;
+        config.allow_writable_executables = false;
+
+        let command = config
+            .commands
+            .get_mut("tool")
+            .ok_or_else(|| NonoError::SandboxInit("missing test command policy".to_string()))?;
+        command.allow_writable_executable = true;
+
+        validate_controlled_exec_helper_immutability(&config, &exec_helpers, &file_write_caps)?;
 
         Ok(())
     }

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -8,7 +8,7 @@ use crate::command_policy::{
 };
 use crate::tool_sandbox::credentials::{ResolvedCredential, resolve_credentials};
 use crate::tool_sandbox::env::{
-    apply_environment_set_vars, default_env_allow_patterns, effective_argv,
+    apply_environment_set_vars, default_env_allow_patterns, effective_argv_for_binary,
     inject_chaining_control_env, inject_url_open_env, split_env_entry,
 };
 use crate::tool_sandbox::launch::{
@@ -157,6 +157,10 @@ struct ToolSandboxState {
 struct ResolvedToolSandboxPlan {
     config: CommandPoliciesConfig,
     resolved: ResolvedCommandBinaries,
+    /// Pre-resolved `exec` intercept helpers, keyed by their env-expanded path
+    /// as written in the profile. Identity expectations are captured here so
+    /// the helper launch is TOCTOU-protected like a command binary.
+    exec_helpers: BTreeMap<PathBuf, ResolvedCommandBinary>,
     deny_only: BTreeMap<String, ResolvedDenyOnlyCommand>,
     allowed_direct_bypass_ids: HashSet<FileId>,
 }
@@ -191,6 +195,8 @@ impl ResolvedToolSandboxPlan {
                 eprintln!("  [nono] Warning: {}", w.message);
             }
         }
+        let exec_helpers = crate::command_policy::resolve_policy_exec_helpers(config)?;
+        validate_controlled_exec_helper_immutability(config, &exec_helpers, outer_caps)?;
         let search_dirs = command_search_dirs(config, path_env, outer_caps)?;
         validate_trusted_executable_dirs(&search_dirs, outer_caps)?;
         // BMETE command policies are scoped to command_policies.commands.
@@ -206,6 +212,7 @@ impl ResolvedToolSandboxPlan {
         Ok(Self {
             config: config.clone(),
             resolved,
+            exec_helpers,
             deny_only,
             allowed_direct_bypass_ids,
         })
@@ -1445,6 +1452,89 @@ fn handle_shim_stream_inner(
         };
     }
 
+    // ── Exec ─────────────────────────────────────────────────────────────
+    if let InterceptActionConfig::Exec { command } = intercept_action {
+        let active = state.active_count.fetch_add(1, Ordering::SeqCst);
+        if active >= MAX_ACTIVE_TOOL_SANDBOX_CHILDREN {
+            state.active_count.fetch_sub(1, Ordering::SeqCst);
+            record_command_policy_audit(
+                audit_recorder.as_ref(),
+                &request,
+                &state.redaction_policy,
+                session_id,
+                auth.peer_pid,
+                session_root_pid,
+                Some(&caller),
+                "denied",
+                Some("resource_limit".to_string()),
+                None,
+            )?;
+            return Err(NonoError::SandboxInit(
+                "tool-sandbox active child limit exceeded".to_string(),
+            ));
+        }
+        let result = (|| {
+            let (helper, extra_args) =
+                super::policy::resolve_exec_helper(&state.plan.exec_helpers, command)?;
+            let launch =
+                build_child_launch_spec_for_binary(state, &request, policy, helper, &extra_args)?;
+            launch_child(state, &request.command, &caller, launch, stdio)
+        })();
+        state.active_count.fetch_sub(1, Ordering::SeqCst);
+        return match result {
+            Ok(launch_result) => {
+                if let Some(reason) = launch_result.blocked_reason.clone() {
+                    record_command_policy_audit_with_stdio(
+                        audit_recorder.as_ref(),
+                        &request,
+                        &state.redaction_policy,
+                        session_id,
+                        auth.peer_pid,
+                        session_root_pid,
+                        Some(&caller),
+                        "denied",
+                        Some(reason.clone()),
+                        None,
+                        launch_result.stdio,
+                    )?;
+                    return Err(NonoError::BlockedCommand {
+                        command: request.command,
+                        reason,
+                    });
+                }
+                record_command_policy_audit_with_stdio(
+                    audit_recorder.as_ref(),
+                    &request,
+                    &state.redaction_policy,
+                    session_id,
+                    auth.peer_pid,
+                    session_root_pid,
+                    Some(&caller),
+                    "exec",
+                    None,
+                    Some(launch_result.exit_code),
+                    launch_result.stdio,
+                )?;
+                Ok((launch_result.exit_code, Vec::new()))
+            }
+            Err(err) => {
+                record_command_policy_audit(
+                    audit_recorder.as_ref(),
+                    &request,
+                    &state.redaction_policy,
+                    session_id,
+                    auth.peer_pid,
+                    session_root_pid,
+                    Some(&caller),
+                    "denied",
+                    Some(err.to_string()),
+                    None,
+                )?;
+                Err(err)
+            }
+        };
+    }
+
     // ── Passthrough (and Approve→granted) ────────────────────────────────
     let active = state.active_count.fetch_add(1, Ordering::SeqCst);
     if active >= MAX_ACTIVE_TOOL_SANDBOX_CHILDREN {
@@ -1802,6 +1892,23 @@ fn build_child_launch_spec(
         .ok_or_else(|| {
             NonoError::SandboxInit(format!("missing resolved binary for {}", request.command))
         })?;
+    build_child_launch_spec_for_binary(state, request, policy, binary, &[])
+}
+
+/// Build a child launch spec that runs `binary` (which may be the command's
+/// real binary OR an `exec` intercept helper) inside the matched command's
+/// sandbox (`policy`). `extra_args` are inserted between argv[0] and the
+/// forwarded original args (`request.argv[1..]`) — used by the `exec` action to
+/// pass the helper's fixed leading args. The fs-read cap, exec-gate, executable
+/// shape baseline, and identity expectations are all bound to `binary`, while
+/// network/credentials/proxy/fs/env come from `policy`.
+fn build_child_launch_spec_for_binary(
+    state: &ToolSandboxState,
+    request: &ToolSandboxShimRequest,
+    policy: &CommandSandboxConfig,
+    binary: &ResolvedCommandBinary,
+    extra_args: &[Vec<u8>],
+) -> Result<ToolSandboxChildLaunchSpec> {
     verify_binary_identity(binary)?;
     let cwd = PathBuf::from(OsString::from_vec(request.cwd.clone()));
     let cwd = cwd
@@ -1822,7 +1929,7 @@ fn build_child_launch_spec(
             .as_ref()
             .map(|path| path.as_os_str().as_bytes().to_vec()),
         interpreter_args: binary.shape.interpreter_args.clone(),
-        argv: effective_argv(binary, request, policy)?,
+        argv: effective_argv_for_binary(binary, request, policy, extra_args)?,
         env: filter_child_env(state, request, policy)?,
         cwd: cwd.as_os_str().as_bytes().to_vec(),
         stdio_mode: selected_stdio_mode(request).to_string(),
@@ -3592,6 +3699,33 @@ fn validate_controlled_binary_immutability(
     Ok(())
 }
 
+/// Apply the same non-writable-executable trust gate to resolved `exec`
+/// intercept helpers as to command binaries: a helper must not be writable (nor
+/// replaceable via a writable parent) through the outer session capability set
+/// unless the referencing command opted into `allow_writable_executable` (or
+/// the global `allow_writable_executables`). This prevents writable-executable
+/// substitution of the helper.
+fn validate_controlled_exec_helper_immutability(
+    config: &CommandPoliciesConfig,
+    exec_helpers: &BTreeMap<PathBuf, ResolvedCommandBinary>,
+    outer_caps: &CapabilitySet,
+) -> Result<()> {
+    for binary in exec_helpers.values() {
+        let allow_writable_path = config.allow_writable_executables
+            || super::policy::command_referencing_exec_helper_allows_writable(
+                config,
+                &binary.canonical_path,
+            );
+        validate_controlled_file(
+            &binary.canonical_path,
+            outer_caps,
+            "exec intercept helper",
+            allow_writable_path,
+        )?;
+    }
+    Ok(())
+}
+
 fn command_allows_writable_executable(
     command: &crate::command_policy::CommandPolicyConfig,
 ) -> bool {
@@ -4075,6 +4209,7 @@ mod tests {
                     commands: BTreeMap::new(),
                     warnings: Vec::new(),
                 },
+                exec_helpers: BTreeMap::new(),
                 deny_only: BTreeMap::new(),
                 allowed_direct_bypass_ids: HashSet::new(),
             },

--- a/crates/nono-cli/src/tool-sandbox/policy.rs
+++ b/crates/nono-cli/src/tool-sandbox/policy.rs
@@ -63,6 +63,85 @@ pub(super) fn resolve_intercept_action<'a>(
     ResolvedInterceptAction::passthrough()
 }
 
+/// Resolve the env-expanded helper path and forwarded extra args for an `exec`
+/// intercept action's `command`.
+///
+/// Returns `(helper_path, extra_args)` where `helper_path` is `command[0]`
+/// after `$VAR` expansion (used as the lookup key into the plan's pre-resolved
+/// `exec_helpers` map) and `extra_args` are `command[1..]` after `$VAR`
+/// expansion, to be inserted ahead of the forwarded original args. Platform
+/// dispatch resolves the actual `ResolvedCommandBinary` from its own state map
+/// using `helper_path`, so this stays platform-agnostic.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(super) fn resolve_exec_command(
+    command: &[String],
+) -> nono::Result<(std::path::PathBuf, Vec<Vec<u8>>)> {
+    let helper_raw = command.first().ok_or_else(|| {
+        nono::NonoError::SandboxInit("tool-sandbox exec action has empty command".to_string())
+    })?;
+    let helper_path = std::path::PathBuf::from(crate::policy::expand_env_vars_strict(helper_raw)?);
+    let mut extra_args = Vec::with_capacity(command.len().saturating_sub(1));
+    for arg in command.iter().skip(1) {
+        extra_args.push(crate::policy::expand_env_vars_strict(arg)?.into_bytes());
+    }
+    Ok((helper_path, extra_args))
+}
+
+/// Looks up the pre-resolved binary rather than re-resolving it, to reuse the
+/// TOCTOU-protected identity captured at plan-build time.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(super) fn resolve_exec_helper<'a>(
+    exec_helpers: &'a std::collections::BTreeMap<
+        std::path::PathBuf,
+        crate::command_policy::ResolvedCommandBinary,
+    >,
+    command: &[String],
+) -> nono::Result<(
+    &'a crate::command_policy::ResolvedCommandBinary,
+    Vec<Vec<u8>>,
+)> {
+    let (helper_path, extra_args) = resolve_exec_command(command)?;
+    let helper = exec_helpers.get(&helper_path).ok_or_else(|| {
+        nono::NonoError::SandboxInit(format!(
+            "tool-sandbox exec helper not pre-resolved: {}",
+            helper_path.display()
+        ))
+    })?;
+    Ok((helper, extra_args))
+}
+
+/// True if any command whose `exec` intercept resolves to `canonical_helper`
+/// opts into `allow_writable_executable`.
+///
+/// Expansion/canonicalize failures resolve to "not exempted" rather than
+/// erroring, so an unrelated command's bad env var can't abort plan build.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(super) fn command_referencing_exec_helper_allows_writable(
+    config: &crate::command_policy::CommandPoliciesConfig,
+    canonical_helper: &std::path::Path,
+) -> bool {
+    config.commands.values().any(|command| {
+        if !command.allow_writable_executable {
+            return false;
+        }
+        command.intercept.iter().any(|rule| {
+            let crate::command_policy::InterceptActionConfig::Exec {
+                command: exec_command,
+            } = &rule.action
+            else {
+                return false;
+            };
+            let Some(helper_raw) = exec_command.first() else {
+                return false;
+            };
+            crate::policy::expand_env_vars_strict(helper_raw)
+                .ok()
+                .and_then(|expanded| std::path::PathBuf::from(expanded).canonicalize().ok())
+                .is_some_and(|canonical| canonical == canonical_helper)
+        })
+    })
+}
+
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum InvocationPolicyOutcome {
@@ -680,5 +759,35 @@ mod intercept_tests {
             Some(message)
                 if message.contains("sandbox.resources is parsed by tool-sandbox Schema 2 but not yet enforced")
         ));
+    }
+
+    #[test]
+    fn resolve_exec_command_expands_helper_and_extra_args() {
+        let _lock = match crate::test_env::ENV_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let var = "NONO_TEST_EXEC_LIBEXEC";
+        let _env = crate::test_env::EnvVarGuard::set_all(&[(var, "/opt/vendor/libexec")]);
+        let command = vec![
+            format!("${var}/gh-wrapper"),
+            format!("${var}/data"),
+            "literal".to_string(),
+        ];
+        let (helper, extra) = resolve_exec_command(&command).expect("resolve");
+        assert_eq!(
+            helper,
+            std::path::PathBuf::from("/opt/vendor/libexec/gh-wrapper")
+        );
+        let rendered: Vec<String> = extra
+            .iter()
+            .map(|a| String::from_utf8_lossy(a).into_owned())
+            .collect();
+        assert_eq!(rendered, vec!["/opt/vendor/libexec/data", "literal"]);
+    }
+
+    #[test]
+    fn resolve_exec_command_rejects_empty_command() {
+        assert!(resolve_exec_command(&[]).is_err());
     }
 }

--- a/crates/nono-cli/src/tool-sandbox/policy.rs
+++ b/crates/nono-cli/src/tool-sandbox/policy.rs
@@ -80,6 +80,12 @@ pub(super) fn resolve_exec_command(
         nono::NonoError::SandboxInit("tool-sandbox exec action has empty command".to_string())
     })?;
     let helper_path = std::path::PathBuf::from(crate::policy::expand_env_vars_strict(helper_raw)?);
+    if !helper_path.is_absolute() {
+        return Err(nono::NonoError::SandboxInit(format!(
+            "tool-sandbox exec helper must be an absolute path; got '{}'",
+            helper_path.display()
+        )));
+    }
     let mut extra_args = Vec::with_capacity(command.len().saturating_sub(1));
     for arg in command.iter().skip(1) {
         extra_args.push(crate::policy::expand_env_vars_strict(arg)?.into_bytes());
@@ -789,5 +795,10 @@ mod intercept_tests {
     #[test]
     fn resolve_exec_command_rejects_empty_command() {
         assert!(resolve_exec_command(&[]).is_err());
+    }
+
+    #[test]
+    fn resolve_exec_command_rejects_relative_helper() {
+        assert!(resolve_exec_command(&["relative/helper".to_string()]).is_err());
     }
 }

--- a/docs/cli/features/tool-sandbox.mdx
+++ b/docs/cli/features/tool-sandbox.mdx
@@ -109,6 +109,21 @@ An `intercept` rule may carry an optional `sandbox` (the same object described a
 }
 ```
 
+### Intercept Actions
+
+Each `intercept` entry is `{ "args": [...], "action": { "type": ... } }`. Rules are evaluated in order; the first whose `args` are a prefix of the invocation's arguments wins (an empty `args` is a catch-all). The `action.type` selects how the matched subcommand is handled:
+
+| `action.type` | Behavior |
+|---|---|
+| `passthrough` | Run the real binary in its sandbox. This is the default when no rule matches. |
+| `respond` | Return a static `stdout` string to the caller without forking the binary. |
+| `capture` | Run the real binary, buffering its stdout for broker inspection before returning it. |
+| `capture_credential` | Run the real binary, store its stdout as a named ambient `credential`, and return a broker nonce. |
+| `approve` | Route the invocation through an approval backend before forking (optional `timeout_secs`). |
+| `exec` | Run the helper at `command[0]` — with `command[1..]` then the original arguments — in place of the real binary, inside the matched command's sandbox; stream its stdout/stderr and propagate its exit code. `command[0]` is `$VAR`-expanded, must be absolute, is resolved with identity expectations, and is subject to the same non-writable-executable trust gate as a pinned `executable`. |
+
+`exec` is for handling one subcommand with a custom helper while the command's other subcommands run normally — for example, intercepting an `auth switch` subcommand with a helper that rewrites a config file, while `api` calls pass through with their brokered credentials.
+
 ### Dynamic Filesystem Grants
 
 `fs_read`, `fs_write`, `fs_read_file`, and `fs_write_file` can contain dynamic provider tokens as well as literal paths. Tokens are expanded at launch before the child sandbox is built. They are opt-in: no dynamic paths are added unless a selected command policy includes one of these tokens.

--- a/docs/cli/features/tool-sandbox.mdx
+++ b/docs/cli/features/tool-sandbox.mdx
@@ -124,6 +124,8 @@ Each `intercept` entry is `{ "args": [...], "action": { "type": ... } }`. Rules 
 
 `exec` is for handling one subcommand with a custom helper while the command's other subcommands run normally — for example, intercepting an `auth switch` subcommand with a helper that rewrites a config file, while `api` calls pass through with their brokered credentials.
 
+The helper runs with the matched command's real credentials, capabilities, and sandbox — it is not itself sandboxed further. Do not point `exec` at a general-purpose shell (`/bin/sh`, `/bin/bash`, etc.): it would let the caller run arbitrary commands with those credentials, defeating the sandbox. Use a purpose-specific helper that only does what the intercepted subcommand needs.
+
 ### Dynamic Filesystem Grants
 
 `fs_read`, `fs_write`, `fs_read_file`, and `fs_write_file` can contain dynamic provider tokens as well as literal paths. Tokens are expanded at launch before the child sandbox is built. They are opt-in: no dynamic paths are added unless a selected command policy includes one of these tokens.


### PR DESCRIPTION
## Linked Issue

Closes #1318

## Summary

Add an `exec` intercept action: `{ "type": "exec", "command": [...] }`. On a matching subcommand, nono runs the helper (with the original argv forwarded) in place of the real binary, inside the command's existing sandbox, and returns its stdout/stderr/exit — dynamic where `respond` is static. Helpers are pre-resolved with identity expectations and gated by the same non-writable-executable check as command binaries.

NB: this follows the existing pattern at the command level

## Test Plan

`make ci` clean (clippy -D warnings + fmt-check + tests). New tests cover serde, validation (empty/relative/NUL/absolute helper), helper identity capture, argv-forwarding order, and `$VAR` expansion.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using DCO
- [x] All new code follows the project's coding standards (CLAUDE.md) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to CHANGELOG.md if needed

## Agent Disclosure

Prepared by an AI coding agent. Added the `Exec` variant to `InterceptActionConfig`, TOCTOU-safe helper pre-resolution, a non-writable-executable trust gate, dispatch in `tool-sandbox/platform/{macos,linux}.rs` reusing the existing child-launch path so the helper runs in the matched command's sandbox, plus schema and `tool-sandbox.mdx` docs. Files consulted: `command_policy.rs`, `tool-sandbox/platform/{macos,linux}.rs`, `tool-sandbox/{env,policy}.rs`, `policy.rs`, `data/nono-profile.schema.json`, `docs/cli/features/tool-sandbox.mdx`, `AGENTS.md`.

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists (#1318)
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (no third-party code adapted)
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope
