### PR TITLE
fix(tool-sandbox): ack frame before SCM_RIGHTS send to prevent EMSGSIZE on macOS

### DIFF
--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -20,8 +20,8 @@ use crate::tool_sandbox::protocol::{
     StdioStreamLimitSpec, TOOL_SANDBOX_LAUNCH_SPEC_ENV, TOOL_SANDBOX_SHIM_DIR_ENV,
     TOOL_SANDBOX_SOCKET_ENV, TOOL_SANDBOX_URL_IO_TIMEOUT, ToolSandboxChildLaunchSpec,
     ToolSandboxOpenUrlRequest, ToolSandboxOpenUrlResponse, ToolSandboxShimRequest,
-    ToolSandboxShimResponse, UnixSocketGrantSpec, read_frame, recv_stdio_fds, send_stdio_fds,
-    validate_ipc_request, write_frame, write_response,
+    ToolSandboxShimResponse, UnixSocketGrantSpec, read_frame, recv_frame_ack, recv_stdio_fds,
+    send_frame_ack, send_stdio_fds, validate_ipc_request, write_frame, write_response,
 };
 use landlock::{
     AccessFs, CompatLevel, Compatible, PathBeneath, PathFd, Ruleset, RulesetAttr,
@@ -777,6 +777,7 @@ fn run_shim() -> Result<()> {
     let start_send = std::time::Instant::now();
     send_shim_identity_fd(&stream, &shim_exe)?;
     write_frame(&mut stream, &request)?;
+    recv_frame_ack(&mut stream)?;
     send_stdio_fds(&stream)?;
     tool_sandbox_profile_log!(
         "shim:send_request: {:?} (entry-to-request: {:?})",
@@ -1211,6 +1212,7 @@ fn handle_shim_stream_inner(
     let peer_pid = peer_credentials(stream.as_raw_fd())?.pid;
     let shim_fd = recv_fd_via_socket(stream.as_raw_fd())?;
     let request: ToolSandboxShimRequest = read_frame(stream)?;
+    send_frame_ack(stream)?;
     validate_ipc_request(&request)?;
     let auth = authenticate_shim(peer_pid, shim_fd, &request.command, state)?;
     let stdio = recv_stdio_fds(stream)?;

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -19,8 +19,8 @@ use crate::tool_sandbox::protocol::{
     StdioStreamLimitSpec, TOOL_SANDBOX_LAUNCH_SPEC_ENV, TOOL_SANDBOX_SHIM_DIR_ENV,
     TOOL_SANDBOX_SOCKET_ENV, TOOL_SANDBOX_URL_IO_TIMEOUT, ToolSandboxChildLaunchSpec,
     ToolSandboxOpenUrlRequest, ToolSandboxOpenUrlResponse, ToolSandboxShimRequest,
-    ToolSandboxShimResponse, UnixSocketGrantSpec, read_frame, recv_stdio_fds, send_stdio_fds,
-    validate_ipc_request, write_frame, write_response,
+    ToolSandboxShimResponse, UnixSocketGrantSpec, read_frame, recv_frame_ack, recv_stdio_fds,
+    send_frame_ack, send_stdio_fds, validate_ipc_request, write_frame, write_response,
 };
 use nix::libc;
 use nono::supervisor::ApprovalRequest;
@@ -618,6 +618,7 @@ fn run_shim() -> Result<()> {
         ))
     })?;
     write_frame(&mut stream, &request)?;
+    recv_frame_ack(&mut stream)?;
     send_stdio_fds(&stream)?;
     let response: ToolSandboxShimResponse = read_frame(&mut stream)?;
 
@@ -881,6 +882,11 @@ fn handle_shim_stream_inner(
 ) -> Result<(i32, Vec<u8>)> {
     let auth = authenticate_shim(stream, state)?;
     let request: ToolSandboxShimRequest = read_frame(stream)?;
+    // Ack before receiving stdio FDs: on macOS, sendmsg with SCM_RIGHTS ancillary
+    // data returns EMSGSIZE if the peer's receive buffer still holds unread frame
+    // bytes. Sending the ack proves the buffer is drained so the shim's sendmsg
+    // can always queue its ancillary data atomically.
+    send_frame_ack(stream)?;
     validate_ipc_request(&request)?;
     if request.command != auth.command {
         return Err(NonoError::SandboxInit(format!(

--- a/crates/nono-cli/src/tool-sandbox/protocol.rs
+++ b/crates/nono-cli/src/tool-sandbox/protocol.rs
@@ -252,6 +252,28 @@ pub(crate) fn read_frame<T: for<'de> Deserialize<'de>>(stream: &mut UnixStream) 
     })
 }
 
+/// Send a 1-byte acknowledgement that the request frame has been fully read.
+///
+/// The runtime calls this after `read_frame` completes and before `recv_stdio_fds`.
+/// The shim waits for this ack before calling `send_stdio_fds`, ensuring the
+/// socket receive buffer is empty when `sendmsg` carries SCM_RIGHTS ancillary
+/// data. On macOS, `sendmsg` with ancillary data on a stream socket returns
+/// EMSGSIZE if the peer's receive buffer cannot accommodate the control message
+/// atomically — this ack eliminates that race.
+pub(crate) fn send_frame_ack(stream: &mut UnixStream) -> Result<()> {
+    stream
+        .write_all(&[0u8])
+        .map_err(|e| NonoError::SandboxInit(format!("tool-sandbox: failed to send frame ack: {e}")))
+}
+
+/// Receive the 1-byte acknowledgement sent by `send_frame_ack`.
+pub(crate) fn recv_frame_ack(stream: &mut UnixStream) -> Result<()> {
+    let mut buf = [0u8; 1];
+    stream.read_exact(&mut buf).map_err(|e| {
+        NonoError::SandboxInit(format!("tool-sandbox: failed to receive frame ack: {e}"))
+    })
+}
+
 pub(crate) fn send_stdio_fds(stream: &UnixStream) -> Result<()> {
     for fd in [libc::STDIN_FILENO, libc::STDOUT_FILENO, libc::STDERR_FILENO] {
         send_fd_via_socket(stream.as_raw_fd(), fd)?;


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #

## Summary

On macOS, sendmsg(2) with SCM_RIGHTS ancillary data on a SOCK_STREAM socket returns EMSGSIZE if the peers receive buffer cannot atomically accommodate the control message alongside the data byte. The shim IPC protocol sent the full request frame (which includes the process environment as JSON and can exceed the 8 KB default socket buffer) immediately before sending three stdio FDs via SCM_RIGHTS. If the runtime had not yet drained the frame from its receive buffer when the shim called sendmsg, the kernel rejected the message and the sandbox initialisation failed with exit 126.

Fix by inserting a single-byte acknowledgement between read_frame and recv_stdio_fds on the runtime side, and between write_frame and send_stdio_fds on the shim side. The ack proves the receive buffer is fully drained before any SCM_RIGHTS sendmsg is attempted, eliminating the race. The same change is applied to the Linux path for protocol consistency even though Linux stream sockets do not exhibit this behaviour.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
