### PR TITLE
fix(tests): share stdin-manipulation lock between capture_helper stdin tests

### DIFF
--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -2481,6 +2481,11 @@ mod tests {
         CommandCredentialGrantPolicyConfig, CommandPolicyConfig, EndpointRuleConfig,
     };
 
+    // Shared across all tests that dup/dup2 the process's stdin fd, so two such tests
+    // never race on fd 0 when cargo runs them concurrently.
+    #[cfg(unix)]
+    static STDIN_MANIPULATION_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[cfg(unix)]
     #[test]
     fn set_intercept_ca_dir_permissions_fails_closed() -> Result<()> {
@@ -3526,9 +3531,7 @@ mod tests {
     fn capture_helper_with_stdio_true_receives_null_not_terminal_stdin() -> Result<()> {
         use nix::libc;
 
-        // Serialize stdin manipulation across concurrent test threads.
-        static STDIN_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _guard = STDIN_LOCK
+        let _guard = STDIN_MANIPULATION_LOCK
             .lock()
             .map_err(|e| NonoError::SandboxInit(format!("stdin lock poisoned: {e}")))?;
 
@@ -3609,8 +3612,7 @@ mod tests {
     fn capture_helper_with_interaction_stdin_true_inherits_terminal_stdin() -> Result<()> {
         use nix::libc;
 
-        static STDIN_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _guard = STDIN_LOCK
+        let _guard = STDIN_MANIPULATION_LOCK
             .lock()
             .map_err(|e| NonoError::SandboxInit(format!("stdin lock poisoned: {e}")))?;
 


### PR DESCRIPTION
Fixes #1326

## Summary

`capture_helper_with_stdio_true_receives_null_not_terminal_stdin` and
`capture_helper_with_interaction_stdin_true_inherits_terminal_stdin`
each dup/dup2 the process's global stdin fd (0) to simulate terminal
vs. non-terminal stdin, guarded by their own separate `static Mutex`.
Since `cargo test` runs tests in parallel by default, the two per-test
mutexes don't prevent the tests from racing against each other on
fd 0, producing an intermittent `dup(stdin) failed` panic.

This replaces the two independent mutexes with one shared
`STDIN_MANIPULATION_LOCK` so the two tests can't run concurrently.
Test-only change; no production code paths affected.

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists (#1326)
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (n/a — no reused/adapted third-party code)
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths (n/a — no path handling in this change)
- [x] This PR matches the approved or disclosed issue scope

This contribution was prepared with the assistance of an AI coding agent (Claude Code), under my direct supervision and review.