### PR TITLE
docs(credential-injection): document AWS SigV4 proxy signing

### DIFF
--- a/docs/cli/features/credential-injection.mdx
+++ b/docs/cli/features/credential-injection.mdx
@@ -388,7 +388,9 @@ For APIs not covered by the built-in services, you can define custom credentials
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `upstream` | Yes | - | Upstream URL to proxy requests to (must be HTTPS, or HTTP for localhost only) |
-| `credential_key` | Yes | - | Keystore account name (alphanumeric and underscores only), `op://` URI for [1Password](#1password-integration), `bw://` URI for [Bitwarden](#bitwarden-integration), `apple-password://` URI for [Apple Passwords](#apple-passwords-integration-macos), `keyring://` URI for a custom keyring service, `file://` URI for file-backed secrets, `env://` URI for host environment variables (e.g., `env://MY_TOKEN`), or `cmd://` URI for [CLI command capture](#cli-command-capture-cmd) |
+| `credential_key` | Conditional | - | Keystore account name (alphanumeric and underscores only), `op://` URI for [1Password](#1password-integration), `bw://` URI for [Bitwarden](#bitwarden-integration), `apple-password://` URI for [Apple Passwords](#apple-passwords-integration-macos), `keyring://` URI for a custom keyring service, `file://` URI for file-backed secrets, `env://` URI for host environment variables (e.g., `env://MY_TOKEN`), or `cmd://` URI for [CLI command capture](#cli-command-capture-cmd). Mutually exclusive with `auth` and `aws_auth` |
+| `auth` | Conditional | - | OAuth2 client-credentials configuration. The proxy exchanges the client secret for an access token and injects it upstream. Mutually exclusive with `credential_key` and `aws_auth` |
+| `aws_auth` | Conditional | - | AWS SigV4 signing configuration. The proxy signs outbound requests with resolved AWS credentials. Mutually exclusive with `credential_key` and `auth`. See [AWS SigV4 Signing](#aws-sigv4-signing) |
 | `inject_mode` | No | `header` | Credential injection mode: `header`, `url_path`, `query_param`, or `basic_auth` |
 | `inject_header` | No | `Authorization` | HTTP header to inject the credential into (used with `header` and `basic_auth` modes) |
 | `credential_format` | No | `Bearer {}` | Format string for the credential value (`{}` is replaced with the credential) |
@@ -707,6 +709,87 @@ Custom credentials are validated at startup:
 - **Credential key must be alphanumeric** (letters, numbers, and underscores only) unless it uses a supported URI scheme such as `op://`, `bw://`, `apple-password://`, `keyring://`, `file://`, or `env://`
 
 Invalid configurations will fail with a clear error message before the sandbox is applied.
+
+#### AWS SigV4 Signing
+
+Some upstreams authenticate with [AWS Signature Version 4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv4.html) rather than a static bearer token. Amazon Bedrock is the common case. Setting `aws_auth` on a custom credential turns the route into a signing route: the proxy resolves your AWS credentials on the host, strips whatever authentication the agent sent, and re-signs each outbound request with SigV4 before it reaches AWS. The agent never holds a usable AWS credential.
+
+Add an `aws_auth` block to the route and reference the route name in `credentials`:
+
+```json
+{
+  "meta": { "name": "bedrock-agent" },
+  "network": {
+    "credentials": ["bedrock"],
+    "custom_credentials": {
+      "bedrock": {
+        "upstream": "https://bedrock-runtime.us-east-1.amazonaws.com",
+        "aws_auth": {}
+      }
+    }
+  }
+}
+```
+
+An empty `aws_auth: {}` is the usual starting point. The proxy resolves credentials through the standard AWS credential chain and infers the signing region and service from the upstream host. All three fields are optional overrides:
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `profile` | No | default credential chain | Named profile from `~/.aws/config` / `~/.aws/credentials`. Case-sensitive, no whitespace. Omitting it uses the default chain (environment variables, the `default` profile, SSO, container and instance metadata) |
+| `region` | No | detected from `upstream` | Explicit signing region, e.g. `us-east-1`. Must be lowercase. Set this when the region cannot be read from the upstream host |
+| `service` | No | detected from `upstream` | Explicit service code, e.g. `bedrock`, `s3`, `execute-api`. Must be lowercase. Set this when the service cannot be read from the upstream host |
+
+`aws_auth` cannot be combined with `credential_key` or `auth` on the same route. A route signs with SigV4, injects a keystore secret, or runs the OAuth2 exchange, and only one of those applies at a time.
+
+##### Credential resolution
+
+Credentials resolve on the host, in the supervisor process, before the sandbox is applied. The same sources the AWS SDK and CLI already use keep working: `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in the launching environment, static or SSO profiles in `~/.aws`, and container or instance metadata. SSO profiles work without extra setup, so `aws sso login` followed by a `profile` reference is enough.
+
+Because signing happens host-side, you normally want to keep real AWS credentials out of the sandbox. Deny the AWS environment variables and hand the agent placeholders so an SDK inside the sandbox still initialises but cannot sign anything itself:
+
+```json
+{
+  "meta": { "name": "bedrock-agent" },
+  "network": {
+    "credentials": ["bedrock"],
+    "custom_credentials": {
+      "bedrock": {
+        "upstream": "https://bedrock-runtime.us-east-1.amazonaws.com",
+        "aws_auth": { "profile": "my-sso-profile" }
+      }
+    }
+  },
+  "environment": {
+    "deny_vars": ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_PROFILE"],
+    "set_vars": {
+      "AWS_ACCESS_KEY_ID": "dummy-access-key",
+      "AWS_SECRET_ACCESS_KEY": "dummy-secret-key"
+    }
+  }
+}
+```
+
+##### Region-pinned endpoints
+
+Bedrock and most AWS services expose region-specific hostnames, and the SigV4 signature is scoped to one region. The `upstream` host therefore pins the route to a single region. To reach a second region, define a second route with its own `upstream` (for example `bedrock-runtime.eu-west-1.amazonaws.com`). When the region cannot be read from the host, set `region` explicitly so the signature scope stays correct.
+
+##### Running it
+
+Signing routes run like any other custom credential. Reference the route through the profile's `credentials` list as shown above, or pass it on the command line:
+
+```bash
+nono run --profile bedrock-agent --credential bedrock -- opencode run "say hi"
+```
+
+To confirm signing end to end, watch the proxy log. Signed requests report the resolved service and region and the injected SigV4 headers:
+
+```
+DEBUG tls_intercept: signing AWS request: service='bedrock' region='us-east-1' ...
+DEBUG aws::sign: produced 4 signing headers: ["x-amz-date", "authorization", "x-amz-content-sha256", "x-amz-security-token"]
+INFO  l7 proxy response target="bedrock-runtime.us-east-1.amazonaws.com" method="POST" status=200
+```
+
+A `403` on the signed request usually means the resolved credentials lack permission for the target model or service, or the region scope does not match the endpoint.
 
 ## Session Token Authentication
 


### PR DESCRIPTION
Documents the feature delivered in #1189 and implemented by #1195, as requested during the #1195 review and discussed on Slack.

## Linked Issue

[#1189 ](https://github.com/nolabs-ai/nono/issues/1189). Is's already closed, however this PR adds the user-facing documentation that's part of the same work.

## Summary

Adds documentation for the `aws_auth` custom-credential option (AWS SigV4 request signing in the reverse proxy). This is a docs-only change; no code is modified.

The new material lives in `docs/cli/features/credential-injection.mdx`, since AWS SigV4 is a credential-injection mode alongside the existing keystore and OAuth2 routes:

- New "AWS SigV4 Signing" section: what the mode does, the `aws_auth` block, a `profile` / `region` / `service` field table, host-side credential resolution (default chain, SSO, env vars, instance metadata), the `deny_vars` / `set_vars` pattern for keeping real AWS credentials out of the sandbox, region-pinned endpoints, and how to run and verify a signing route.
- Updated the custom-credentials field table: `credential_key` moves from Required to Conditional, and `auth` and `aws_auth` are added as the two mutually exclusive alternatives.

## Agent Disclosure

This contribution was partly authored by an AI agent under my direction and review.

## Test Plan

N/A, docs-only change.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [N/A] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [N/A] Release note has been added to `CHANGELOG.md` if needed