### PR TITLE
fix(trust): add predicate field to distinguish nono trust policies from foreign JSON

### DIFF
--- a/crates/nono-cli/src/trust_cmd.rs
+++ b/crates/nono-cli/src/trust_cmd.rs
@@ -728,8 +728,13 @@ fn run_sign_policy(args: TrustSignPolicyArgs) -> Result<()> {
         }
     };
 
-    // Validate the policy file is well-formed before signing.
-    trust::load_policy_from_file(&policy_path)?;
+    // Validate the policy file is a well-formed nono trust policy before signing.
+    crate::trust_scan::load_nono_policy(&policy_path)?.ok_or_else(|| {
+        nono::NonoError::TrustPolicy(format!(
+            "{} is not a nono trust policy (missing or unrecognised predicate)",
+            policy_path.display()
+        ))
+    })?;
 
     let bundle_json = trust::sign_policy_file(&policy_path, &key_pair, &key_id)?;
     trust::write_bundle(&policy_path, &bundle_json)?;
@@ -1343,7 +1348,12 @@ pub(crate) fn reconstruct_key_pair(pkcs8_bytes: &[u8]) -> Result<trust::KeyPair>
 fn load_trust_policy(explicit_path: Option<&Path>) -> Result<trust::TrustPolicy> {
     if let Some(path) = explicit_path {
         verify_policy_if_exists(path)?;
-        return trust::load_policy_from_file(path);
+        return crate::trust_scan::load_nono_policy(path)?.ok_or_else(|| {
+            nono::NonoError::TrustPolicy(format!(
+                "{} is not a nono trust policy (missing or unrecognised predicate)",
+                path.display()
+            ))
+        });
     }
 
     // Auto-discover: check CWD then user config dir
@@ -1351,14 +1361,19 @@ fn load_trust_policy(explicit_path: Option<&Path>) -> Result<trust::TrustPolicy>
     let cwd_policy = cwd.join("trust-policy.json");
     if cwd_policy.exists() {
         verify_policy_if_exists(&cwd_policy)?;
-        let project_policy = trust::load_policy_from_file(&cwd_policy)?;
+        let project_policy = crate::trust_scan::load_nono_policy(&cwd_policy)?;
+        let project_policy = match project_policy {
+            Some(p) => p,
+            None => return Ok(trust::TrustPolicy::default()),
+        };
         // Try to load user-level policy and merge
         if let Some(user_policy_path) = user_trust_policy_path()
             && user_policy_path.exists()
         {
             verify_policy_if_exists(&user_policy_path)?;
-            let user_policy = trust::load_policy_from_file(&user_policy_path)?;
-            return trust::merge_policies(&[user_policy, project_policy]);
+            if let Some(user_policy) = crate::trust_scan::load_nono_policy(&user_policy_path)? {
+                return trust::merge_policies(&[user_policy, project_policy]);
+            }
         }
         let user_path = user_trust_policy_path()
             .map(|p| p.display().to_string())
@@ -1388,7 +1403,9 @@ fn load_trust_policy(explicit_path: Option<&Path>) -> Result<trust::TrustPolicy>
         && user_path.exists()
     {
         verify_policy_if_exists(&user_path)?;
-        return trust::load_policy_from_file(&user_path);
+        if let Some(policy) = crate::trust_scan::load_nono_policy(&user_path)? {
+            return Ok(policy);
+        }
     }
 
     // No policy found — return a default empty policy

--- a/crates/nono-cli/src/trust_cmd.rs
+++ b/crates/nono-cli/src/trust_cmd.rs
@@ -123,7 +123,7 @@ fn run_init(args: TrustInitArgs) -> Result<()> {
     };
 
     let policy = serde_json::json!({
-        "version": 1,
+        "predicate": nono::trust::TRUST_POLICY_PREDICATE,
         "includes": patterns,
         "publishers": publishers,
         "blocklist": {

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -47,8 +47,12 @@ pub(crate) fn load_nono_policy(path: &Path) -> Result<Option<TrustPolicy>> {
             eprintln!(
                 "  {}",
                 format!(
-                    "Warning: {} has no predicate field — skipping. This is probably not a nono trust policy. If it is, recreate it with 'nono trust init --force'.",
-                    path.display()
+                    "Warning: {} has no predicate field — skipping. \
+                     This is probably not a nono trust policy. \
+                     If it is, add `\"predicate\": \"{}\"` as the first field \
+                     or recreate it with 'nono trust init --force'.",
+                    path.display(),
+                    nono::trust::TRUST_POLICY_PREDICATE,
                 )
                 .yellow()
             );

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -29,6 +29,51 @@ use std::path::{Path, PathBuf};
 ///
 /// Returns `NonoError::TrustPolicy` if a found policy file is malformed, or
 /// `NonoError::TrustVerification` if signature verification fails.
+/// Load a trust policy from `path`, returning `None` if the file exists but
+/// lacks the nono predicate field (i.e. is a foreign JSON file).
+fn load_nono_policy(path: &Path) -> Result<Option<TrustPolicy>> {
+    let content = std::fs::read_to_string(path).map_err(nono::NonoError::Io)?;
+
+    // Check for the predicate field before attempting full deserialization.
+    // Foreign JSON files (e.g. AWS IAM policies) share the filename but lack
+    // the predicate, and may also be missing required nono fields — attempting
+    // a full parse would produce a confusing error rather than a clean skip.
+    let raw: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
+        nono::NonoError::TrustPolicy(format!("failed to parse {}: {e}", path.display()))
+    })?;
+
+    match raw.get("predicate").and_then(|v| v.as_str()) {
+        None => {
+            eprintln!(
+                "  {}",
+                format!(
+                    "Warning: {} has no predicate field — skipping. This is probably not a nono trust policy. If it is, recreate it with 'nono trust init --force'.",
+                    path.display()
+                )
+                .yellow()
+            );
+            return Ok(None);
+        }
+        Some(p) if p != nono::trust::TRUST_POLICY_PREDICATE => {
+            eprintln!(
+                "  {}",
+                format!(
+                    "Warning: {} has an unrecognised predicate '{}' — skipping. Expected '{}'.",
+                    path.display(),
+                    p,
+                    nono::trust::TRUST_POLICY_PREDICATE
+                )
+                .yellow()
+            );
+            return Ok(None);
+        }
+        Some(_) => {}
+    }
+
+    let policy = trust::load_policy_from_str(&content)?;
+    Ok(Some(policy))
+}
+
 pub fn load_scan_policy(
     root: &Path,
     trust_override: bool,
@@ -37,20 +82,19 @@ pub fn load_scan_policy(
     let cwd_policy = root.join("trust-policy.json");
     let project_policy_path = cwd_policy.exists().then_some(cwd_policy);
 
-    let project = if let Some(ref policy_path) = project_policy_path {
-        Some(trust::load_policy_from_file(policy_path)?)
-    } else {
-        None
-    };
+    let project = project_policy_path
+        .as_deref()
+        .map(load_nono_policy)
+        .transpose()?
+        .flatten();
 
     let user_path = crate::trust_cmd::user_trust_policy_path();
     let user_policy_path = user_path.as_ref().filter(|path| path.exists());
 
-    let user = if let Some(path) = user_policy_path {
-        Some(trust::load_policy_from_file(path)?)
-    } else {
-        None
-    };
+    let user = user_policy_path
+        .map(|p| load_nono_policy(p.as_path()))
+        .transpose()?
+        .flatten();
 
     let effective = match (user, project) {
         (Some(u), Some(p)) => trust::merge_policies(&[u, p]),
@@ -1124,6 +1168,16 @@ fn format_identity(identity: &trust::SignerIdentity) -> String {
 mod tests {
     use super::*;
 
+    fn write_test_policy(path: &std::path::Path, includes: &[&str], enforcement: Enforcement) {
+        let policy = TrustPolicy {
+            includes: includes.iter().map(|s| s.to_string()).collect(),
+            enforcement,
+            ..TrustPolicy::default()
+        };
+        let json = serde_json::to_string(&policy).unwrap();
+        std::fs::write(path, json).unwrap();
+    }
+
     #[test]
     fn scan_empty_dir_returns_empty_result() {
         let dir = tempfile::tempdir().unwrap();
@@ -1349,11 +1403,11 @@ mod tests {
         )]);
 
         // Create a policy file with no .bundle — should still load with trust_override=true
-        std::fs::write(
-            dir.path().join("trust-policy.json"),
-            r#"{"version":1,"includes":["SKILLS*","CLAUDE*"],"publishers":[],"blocklist":{"digests":[],"publishers":[]},"enforcement":"warn"}"#,
-        )
-        .unwrap();
+        write_test_policy(
+            &dir.path().join("trust-policy.json"),
+            &["SKILLS*", "CLAUDE*"],
+            Enforcement::Warn,
+        );
 
         let policy = load_scan_policy(dir.path(), true, &[]).unwrap();
         assert_eq!(policy.enforcement, Enforcement::Warn);
@@ -1377,13 +1431,7 @@ mod tests {
         std::fs::write(scan_dir.path().join("notes.arbitrary"), "unsigned").unwrap();
 
         let project_policy_path = scan_dir.path().join("trust-policy.json");
-        std::fs::write(
-            &project_policy_path,
-            format!(
-                r#"{{"version":1,"includes":["{include_pattern}"],"publishers":[],"blocklist":{{"digests":[],"publishers":[]}},"enforcement":"warn"}}"#
-            ),
-        )
-        .unwrap();
+        write_test_policy(&project_policy_path, &[include_pattern], Enforcement::Warn);
 
         let policy = load_scan_policy(scan_dir.path(), false, &[]).unwrap();
         assert!(policy.includes.contains(&include_pattern.to_string()));

--- a/crates/nono-cli/src/trust_scan.rs
+++ b/crates/nono-cli/src/trust_scan.rs
@@ -31,7 +31,7 @@ use std::path::{Path, PathBuf};
 /// `NonoError::TrustVerification` if signature verification fails.
 /// Load a trust policy from `path`, returning `None` if the file exists but
 /// lacks the nono predicate field (i.e. is a foreign JSON file).
-fn load_nono_policy(path: &Path) -> Result<Option<TrustPolicy>> {
+pub(crate) fn load_nono_policy(path: &Path) -> Result<Option<TrustPolicy>> {
     let content = std::fs::read_to_string(path).map_err(nono::NonoError::Io)?;
 
     // Check for the predicate field before attempting full deserialization.
@@ -55,12 +55,15 @@ fn load_nono_policy(path: &Path) -> Result<Option<TrustPolicy>> {
             return Ok(None);
         }
         Some(p) if p != nono::trust::TRUST_POLICY_PREDICATE => {
+            // Strip control characters before printing — the predicate comes
+            // from an untrusted file and could contain terminal escape sequences.
+            let safe = p.chars().filter(|c| !c.is_control()).collect::<String>();
             eprintln!(
                 "  {}",
                 format!(
                     "Warning: {} has an unrecognised predicate '{}' — skipping. Expected '{}'.",
                     path.display(),
-                    p,
+                    safe,
                     nono::trust::TRUST_POLICY_PREDICATE
                 )
                 .yellow()

--- a/crates/nono/src/trust/mod.rs
+++ b/crates/nono/src/trust/mod.rs
@@ -62,5 +62,5 @@ pub use signing::{
 };
 pub use types::{
     BlockedPublisher, Blocklist, BlocklistEntry, Enforcement, IncludePatterns, Publisher,
-    SignerIdentity, TRUST_POLICY_VERSION, TrustPolicy, VerificationOutcome, VerificationResult,
+    SignerIdentity, TRUST_POLICY_PREDICATE, TrustPolicy, VerificationOutcome, VerificationResult,
 };

--- a/crates/nono/src/trust/policy.rs
+++ b/crates/nono/src/trust/policy.rs
@@ -19,7 +19,7 @@ use crate::error::{NonoError, Result};
 
 use super::types::{
     BlockedPublisher, Blocklist, BlocklistEntry, Enforcement, Publisher, SignerIdentity,
-    TrustPolicy, VerificationOutcome, VerificationResult,
+    TRUST_POLICY_PREDICATE, TrustPolicy, VerificationOutcome, VerificationResult,
 };
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -135,7 +135,8 @@ pub fn merge_policies(policies: &[TrustPolicy]) -> Result<TrustPolicy> {
     }
 
     Ok(TrustPolicy {
-        version: policies.iter().map(|p| p.version).max().unwrap_or(1),
+        predicate: Some(TRUST_POLICY_PREDICATE.to_string()),
+        version: None,
         includes: merged_patterns,
         files: merged_files,
         publishers: merged_publishers,
@@ -400,7 +401,8 @@ mod tests {
         blocklist_digests: Vec<BlocklistEntry>,
     ) -> TrustPolicy {
         TrustPolicy {
-            version: 1,
+            predicate: Some(TRUST_POLICY_PREDICATE.to_string()),
+            version: None,
             includes: vec!["SKILLS*".to_string(), "CLAUDE*".to_string()],
             files: vec![],
             publishers,
@@ -452,7 +454,7 @@ mod tests {
             "enforcement": "deny"
         }"#;
         let policy = load_policy_from_str(json).unwrap();
-        assert_eq!(policy.version, 1);
+        assert_eq!(policy.version, Some(1));
         assert_eq!(policy.enforcement, Enforcement::Deny);
         assert_eq!(policy.includes.len(), 1);
     }
@@ -657,14 +659,12 @@ mod tests {
     }
 
     #[test]
-    fn merge_rejects_unsupported_version() {
+    fn merge_ignores_legacy_version_field() {
+        // version is deprecated — merge succeeds regardless of its value.
         let p1 = make_policy(Enforcement::Audit, vec![], vec![]);
         let mut p2 = make_policy(Enforcement::Audit, vec![], vec![]);
-        p2.version = 99;
-        let result = merge_policies(&[p1, p2]);
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("unsupported trust policy version"));
+        p2.version = Some(99);
+        assert!(merge_policies(&[p1, p2]).is_ok());
     }
 
     // -----------------------------------------------------------------------

--- a/crates/nono/src/trust/types.rs
+++ b/crates/nono/src/trust/types.rs
@@ -99,12 +99,20 @@ impl TrustPolicy {
     /// Maximum number of publishers.
     const MAX_PUBLISHERS: usize = 1_000;
 
-    /// Validate structural bounds of the policy.
+    /// Validate the predicate and structural bounds of the policy.
     ///
     /// # Errors
     ///
-    /// Returns `NonoError::TrustPolicy` if collection sizes exceed safe bounds.
+    /// Returns `NonoError::TrustPolicy` if the predicate is present but
+    /// unrecognised, or if collection sizes exceed safe bounds.
     pub fn validate_version(&self) -> Result<()> {
+        if let Some(predicate) = &self.predicate
+            && predicate != TRUST_POLICY_PREDICATE
+        {
+            return Err(NonoError::TrustPolicy(format!(
+                "unrecognised trust policy predicate '{predicate}' (expected '{TRUST_POLICY_PREDICATE}')"
+            )));
+        }
         if self.blocklist.digests.len() > Self::MAX_BLOCKLIST_ENTRIES {
             return Err(NonoError::TrustPolicy(format!(
                 "blocklist has {} entries (max {})",

--- a/crates/nono/src/trust/types.rs
+++ b/crates/nono/src/trust/types.rs
@@ -9,7 +9,21 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 /// Current supported trust policy format version.
+/// Deprecated: versioning is now encoded in [`TRUST_POLICY_PREDICATE`].
+///
+/// Will be removed in v1.0.0.
+#[deprecated(
+    since = "0.66.0",
+    note = "versioning is encoded in TRUST_POLICY_PREDICATE; this constant and the version field will be removed in v1.0.0"
+)]
 pub const TRUST_POLICY_VERSION: u32 = 1;
+
+/// Predicate URI that identifies a JSON file as a nono trust policy.
+///
+/// Files lacking this field are not nono policies and should be skipped rather
+/// than rejected, to avoid false errors on identically-named foreign files
+/// (e.g. AWS IAM trust policies).
+pub const TRUST_POLICY_PREDICATE: &str = "https://nono.sh/attestation/trust-policy/v1";
 
 /// Trust policy for file verification.
 ///
@@ -18,8 +32,18 @@ pub const TRUST_POLICY_VERSION: u32 = 1;
 /// enforcement uses the strictest level.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TrustPolicy {
-    /// Policy format version
-    pub version: u32,
+    /// Predicate URI identifying this file as a nono trust policy.
+    ///
+    /// Must equal [`TRUST_POLICY_PREDICATE`] when present. Files without this
+    /// field are treated as non-nono JSON and skipped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub predicate: Option<String>,
+    /// Deprecated: versioning is encoded in the `predicate` URI.
+    ///
+    /// Parsed from existing policy files for backward compatibility but has no
+    /// runtime effect. Will be removed in v1.0.0.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<u32>,
     /// Glob patterns identifying files under attestation (relative to working directory)
     /// ALIAS(canonical="includes", introduced="v0.0.0", remove_by="indefinite", issue="#435")
     #[serde(alias = "instruction_patterns")]
@@ -43,7 +67,8 @@ pub struct TrustPolicy {
 impl Default for TrustPolicy {
     fn default() -> Self {
         Self {
-            version: 1,
+            predicate: Some(TRUST_POLICY_PREDICATE.to_string()),
+            version: None,
             includes: Vec::new(),
             files: Vec::new(),
             publishers: Vec::new(),
@@ -54,6 +79,17 @@ impl Default for TrustPolicy {
 }
 
 impl TrustPolicy {
+    /// Return `true` if this policy carries the correct nono predicate URI.
+    ///
+    /// Files without this field are foreign JSON (e.g. AWS IAM policies) and
+    /// should be skipped rather than rejected.
+    #[must_use]
+    pub fn has_nono_predicate(&self) -> bool {
+        self.predicate
+            .as_deref()
+            .is_some_and(|p| p == TRUST_POLICY_PREDICATE)
+    }
+
     /// Maximum number of blocklist entries to prevent resource exhaustion.
     const MAX_BLOCKLIST_ENTRIES: usize = 10_000;
     /// Maximum number of include patterns to prevent regex compilation exhaustion.
@@ -63,19 +99,12 @@ impl TrustPolicy {
     /// Maximum number of publishers.
     const MAX_PUBLISHERS: usize = 1_000;
 
-    /// Validate the policy version and structural bounds.
+    /// Validate structural bounds of the policy.
     ///
     /// # Errors
     ///
-    /// Returns `NonoError::TrustPolicy` if the version is unsupported or
-    /// collection sizes exceed safe bounds.
+    /// Returns `NonoError::TrustPolicy` if collection sizes exceed safe bounds.
     pub fn validate_version(&self) -> Result<()> {
-        if self.version != TRUST_POLICY_VERSION {
-            return Err(NonoError::TrustPolicy(format!(
-                "unsupported trust policy version {} (expected {})",
-                self.version, TRUST_POLICY_VERSION
-            )));
-        }
         if self.blocklist.digests.len() > Self::MAX_BLOCKLIST_ENTRIES {
             return Err(NonoError::TrustPolicy(format!(
                 "blocklist has {} entries (max {})",
@@ -504,7 +533,8 @@ mod tests {
 
     fn sample_policy() -> TrustPolicy {
         TrustPolicy {
-            version: 1,
+            predicate: Some(TRUST_POLICY_PREDICATE.to_string()),
+            version: None,
             includes: vec![
                 "SKILLS*.md".to_string(),
                 "CLAUDE*.md".to_string(),
@@ -1022,19 +1052,24 @@ mod tests {
     }
 
     #[test]
-    fn validate_version_rejects_unsupported() {
-        let mut policy = sample_policy();
-        policy.version = 99;
-        let result = policy.validate_version();
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("unsupported trust policy version 99"));
+    fn validate_version_accepts_policy() {
+        let policy = sample_policy();
+        assert!(policy.validate_version().is_ok());
     }
 
     #[test]
-    fn validate_version_accepts_current() {
-        let policy = sample_policy();
-        assert!(policy.validate_version().is_ok());
+    fn legacy_version_field_is_accepted_and_ignored() {
+        let json = r#"{
+            "predicate": "https://nono.sh/attestation/trust-policy/v1",
+            "version": 1,
+            "includes": [],
+            "publishers": [],
+            "blocklist": { "digests": [] },
+            "enforcement": "deny"
+        }"#;
+        let parsed: TrustPolicy = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.version, Some(1));
+        assert!(parsed.validate_version().is_ok());
     }
 
     #[test]
@@ -1042,7 +1077,7 @@ mod tests {
         let policy = sample_policy();
         let json = serde_json::to_string_pretty(&policy).unwrap();
         let parsed: TrustPolicy = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.version, 1);
+        assert_eq!(parsed.version, None);
         assert_eq!(parsed.publishers.len(), 2);
         assert_eq!(parsed.blocklist.digests.len(), 1);
         assert_eq!(parsed.enforcement, Enforcement::Deny);

--- a/docs/cli/features/trust.mdx
+++ b/docs/cli/features/trust.mdx
@@ -191,7 +191,7 @@ Trust policy is defined in `trust-policy.json`, separate from the sandbox policy
 
 ```json
 {
-  "version": 1,
+  "predicate": "https://nono.sh/attestation/trust-policy/v1",
   "includes": [
     "SKILLS*",
     "CLAUDE*",
@@ -349,7 +349,7 @@ jobs:
 
 ```json
 {
-  "version": 1,
+  "predicate": "https://nono.sh/attestation/trust-policy/v1",
   "includes": ["SKILLS*", "CLAUDE*", "AGENT*"],
   "publishers": [
     {
@@ -484,7 +484,7 @@ This creates `~/.config/nono/trust-policy.json` with empty `includes` and your s
 
 ```json
 {
-  "version": 1,
+  "predicate": "https://nono.sh/attestation/trust-policy/v1",
   "includes": [],
   "publishers": [
     {

--- a/tests/integration/test_trust_cli.sh
+++ b/tests/integration/test_trust_cli.sh
@@ -339,6 +339,7 @@ echo "--- Missing Literal Patterns ---"
 
 cat > "$MISSING_DIR/trust-policy.json" <<'EOF'
 {
+  "predicate": "https://nono.sh/attestation/trust-policy/v1",
   "version": 1,
   "includes": ["SKILLS.md"],
   "publishers": [],
@@ -373,6 +374,7 @@ echo "--- Startup Enforcement ---"
 
 cat > "$STARTUP_DIR/trust-policy.json" <<'EOF'
 {
+  "predicate": "https://nono.sh/attestation/trust-policy/v1",
   "version": 1,
   "includes": ["SKILLS.md"],
   "publishers": [],


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #772

## Summary

trust-policy.json is a common filename ; AWS IAM and other tools use it too. Without a discriminator, nono would attempt a full parse of any such file and crash with a confusing schema error.

Adds a `predicate` field ("https://nono.sh/attestation/trust-policy/v1") to TrustPolicy. load_nono_policy() now peeks at the raw JSON before attempting full deserialization: files with no predicate are skipped with a warning suggesting `nono trust init --force`, files with an unrecognised predicate report the unexpected value. The version field is deprecated in favour of versioning via the predicate URI and will be removed at `v1.0.0`; existing files carrying "version" still parse cleanly.

`nono trust init` no longer emits "version" in generated policy files.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
