### PR TITLE
feat(proxy): support plain HTTP forward-proxying via HTTP_PROXY

### DIFF
--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -15,6 +15,7 @@ use crate::credential::CredentialStore;
 use crate::error::{ProxyError, Result};
 use crate::external;
 use crate::filter::ProxyFilter;
+use crate::forward::{self, AuditCtx, UpstreamScheme, UpstreamSpec, UpstreamStrategy};
 use crate::oauth_capture::OAuthCaptureStore;
 use crate::pool::UpstreamPool;
 use crate::reverse;
@@ -54,6 +55,126 @@ fn parse_non_connect_target(line: &str) -> Result<(String, u16)> {
         .to_string();
     let port = parsed.port_or_known_default().unwrap_or(80);
     Ok((host, port))
+}
+
+/// Request-target form of a non-CONNECT proxy request line, used to
+/// discriminate forward-proxy (absolute-form) requests from reverse-proxy
+/// (origin-form) ones.
+///
+/// A forward-proxy client (one honoring `HTTP_PROXY`) sends the *absolute*
+/// URL in the request line: `GET http://example.com/path HTTP/1.1`. A
+/// reverse-proxy client sends *origin-form*: `GET /service/path HTTP/1.1`.
+/// Discriminating on the target's form (not the method) is what lets nono
+/// act as a drop-in `HTTP_PROXY` target without disturbing the existing
+/// origin-form reverse-proxy routing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RequestTargetForm {
+    /// Absolute-form `http://…` — plain HTTP forward proxy.
+    AbsoluteHttp,
+    /// Absolute-form `https://…` — must be tunneled via CONNECT, not forwarded.
+    AbsoluteHttps,
+    /// Origin-form (`/path`) or anything else — reverse-proxy / inline path.
+    Origin,
+}
+
+/// Classify the request-target of a non-CONNECT request line.
+///
+/// Only the scheme prefix of the request target is inspected. The check is
+/// ASCII-case-insensitive per RFC 3986 (schemes are case-insensitive) and
+/// deliberately conservative: anything that is not an `http://` or `https://`
+/// absolute URL is treated as origin-form so existing reverse-proxy and
+/// inline flows are completely unaffected.
+fn classify_request_target(line: &str) -> RequestTargetForm {
+    // Request line: METHOD SP request-target SP HTTP-version
+    let Some(target) = line.split_whitespace().nth(1) else {
+        return RequestTargetForm::Origin;
+    };
+    // Case-insensitive scheme match without allocating a lowercase copy of
+    // the whole (possibly long) URL.
+    let lower_starts_with = |s: &str, prefix: &str| {
+        s.len() >= prefix.len()
+            && s.as_bytes()[..prefix.len()].eq_ignore_ascii_case(prefix.as_bytes())
+    };
+    if lower_starts_with(target, "http://") {
+        RequestTargetForm::AbsoluteHttp
+    } else if lower_starts_with(target, "https://") {
+        RequestTargetForm::AbsoluteHttps
+    } else {
+        RequestTargetForm::Origin
+    }
+}
+
+/// Rewrite an absolute-form request line into origin-form for forwarding.
+///
+/// `GET http://host/p?q HTTP/1.1` -> `GET /p?q HTTP/1.1`
+/// `GET http://host HTTP/1.1`     -> `GET /`      (empty path becomes `/`)
+///
+/// The method and HTTP-version tokens are preserved verbatim. Returns the
+/// rewritten first line (with trailing CRLF) so it can be prepended to the
+/// forwarded header block.
+fn rewrite_absolute_to_origin_form(line: &str) -> Result<String> {
+    let mut parts = line.split_whitespace();
+    let method = parts
+        .next()
+        .ok_or_else(|| ProxyError::HttpParse(format!("malformed request line: {}", line)))?;
+    let target = parts
+        .next()
+        .ok_or_else(|| ProxyError::HttpParse(format!("malformed request line: {}", line)))?;
+    // Preserve the version if present; default to HTTP/1.1 otherwise.
+    let version = parts.next().unwrap_or("HTTP/1.1");
+
+    let parsed = Url::parse(target)
+        .map_err(|e| ProxyError::HttpParse(format!("invalid URL in request: {}: {}", target, e)))?;
+
+    let mut origin = parsed.path().to_string();
+    if origin.is_empty() {
+        origin.push('/');
+    }
+    if let Some(query) = parsed.query() {
+        origin.push('?');
+        origin.push_str(query);
+    }
+
+    // Defence in depth: the method/version tokens come from the client's
+    // request line and are echoed into the forwarded request line, which is
+    // itself a protocol-formatting boundary. `Url` already rejects control
+    // characters in the target, but strip CR/LF from the surrounding tokens
+    // so a crafted method/version can never split the forwarded request.
+    let sanitise = |s: &str| s.replace(['\r', '\n'], "");
+    Ok(format!(
+        "{} {} {}\r\n",
+        sanitise(method),
+        origin,
+        sanitise(version)
+    ))
+}
+
+/// Strip hop-by-hop proxy headers (`Proxy-Connection`, `Proxy-Authorization`)
+/// from a raw header block before forwarding upstream.
+///
+/// These headers are meaningful only on the client<->proxy hop and must never
+/// be forwarded: `Proxy-Authorization` carries the session token, and
+/// `Proxy-Connection` is a non-standard hop-by-hop hint. Other headers
+/// (including `Host`) are preserved verbatim so the forwarded request matches
+/// what the client sent.
+fn strip_proxy_headers(header_bytes: &[u8]) -> Vec<u8> {
+    let header_str = match std::str::from_utf8(header_bytes) {
+        Ok(s) => s,
+        // Non-UTF-8 headers: forward unchanged rather than corrupt the block.
+        // The upstream will reject malformed headers itself.
+        Err(_) => return header_bytes.to_vec(),
+    };
+    let mut out = Vec::with_capacity(header_bytes.len());
+    for line in header_str.split_inclusive("\r\n") {
+        let name = line.split(':').next().unwrap_or("").trim();
+        if name.eq_ignore_ascii_case("proxy-connection")
+            || name.eq_ignore_ascii_case("proxy-authorization")
+        {
+            continue;
+        }
+        out.extend_from_slice(line.as_bytes());
+    }
+    out
 }
 
 #[must_use]
@@ -1305,6 +1426,22 @@ async fn handle_connection(mut stream: tokio::net::TcpStream, state: &ProxyState
             )
             .await
         }
+    } else if classify_request_target(first_line) == RequestTargetForm::AbsoluteHttp {
+        // Absolute-form `http://…` request from an HTTP_PROXY-honoring client.
+        // Forward it as a plain-HTTP forward proxy (see handle_forward_http).
+        // This branch is checked BEFORE the origin-form reverse-proxy path so
+        // that absolute-form URLs never reach parse_service_prefix (which
+        // would misread the scheme as a service name — see issue #1334).
+        handle_forward_http(first_line, &mut stream, &header_bytes, &buffered, state).await
+    } else if classify_request_target(first_line) == RequestTargetForm::AbsoluteHttps {
+        // Absolute-form `https://…` cannot be forwarded as cleartext: the
+        // proxy would have to originate TLS to the upstream on the client's
+        // behalf, which no standard HTTP_PROXY client expects. Such clients
+        // use CONNECT for HTTPS. Reject with explicit guidance rather than a
+        // confusing 502.
+        let response = "HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\nContent-Length: 62\r\n\r\nhttps forward-proxying is not supported; use CONNECT for https";
+        stream.write_all(response.as_bytes()).await?;
+        Ok(())
     } else if !state.route_store.is_empty() {
         // Non-CONNECT request with routes configured -> reverse proxy
         let ctx = reverse::ReverseProxyCtx {
@@ -1347,6 +1484,211 @@ async fn handle_connection(mut stream: tokio::net::TcpStream, state: &ProxyState
                 .await?;
         }
         Ok(())
+    }
+}
+
+/// Handle an absolute-form `http://` forward-proxy request.
+///
+/// This is the plain-HTTP counterpart to the CONNECT tunnel: a client that
+/// honors `HTTP_PROXY` sends `GET http://host/path HTTP/1.1` for cleartext
+/// HTTP, and nono forwards it after applying the same trust boundary the
+/// tunnel path uses (session-token auth + host filter).
+///
+/// Steps:
+/// 1. Enforce `Proxy-Authorization` (same session-token gate as CONNECT /
+///    reverse). On failure: 407 + audit denial, matching the reverse path's
+///    no-credential branch.
+/// 2. Parse host+port from the absolute URL and run the host filter. On deny:
+///    403 + `HostDenied` audit event, mirroring the no-routes inline `else`.
+/// 3. Rewrite the request line to origin-form and strip hop-by-hop proxy
+///    headers, then forward via the shared L7 pipeline using the
+///    DNS-rebinding-safe resolved addresses (or the external proxy chain).
+///
+/// SAFETY / SECURITY: this path intentionally does NOT call
+/// `reverse::validate_http_upstream_target`. That check enforces
+/// loopback-only for `http` upstreams, which is correct for the *reverse*
+/// proxy (whose upstreams are operator-configured and where plain HTTP to a
+/// non-local host would be an accidental credential-leak footgun). A general
+/// forward proxy, by contrast, exists precisely to reach arbitrary allowed
+/// `http://` hosts on behalf of the agent. Here the host filter
+/// (`check_host`) is the sufficient and authoritative trust boundary: it
+/// applies the allowlist and the cloud-metadata / link-local SSRF guards, and
+/// returns the exact resolved addresses we then connect to. Do NOT assume
+/// "http upstream => loopback" holds on this path.
+async fn handle_forward_http(
+    first_line: &str,
+    stream: &mut tokio::net::TcpStream,
+    header_bytes: &[u8],
+    buffered: &[u8],
+    state: &ProxyState,
+) -> Result<()> {
+    // 1. Proxy-Authorization gate — identical to the reverse-proxy
+    //    no-credential branch: 407 on missing/invalid auth, with an audit
+    //    denial recording the authentication failure. No auth bypass.
+    if let Err(e) = token::validate_proxy_auth(header_bytes, &state.session_token) {
+        // Parse the target host for the audit record where possible; fall
+        // back to a placeholder so a malformed line still audits.
+        let (host, port) =
+            parse_non_connect_target(first_line).unwrap_or_else(|_| ("unknown".to_string(), 0));
+        audit::log_denied(
+            Some(&state.audit_log),
+            audit::ProxyMode::Reverse,
+            &audit::EventContext {
+                auth_mechanism: Some(nono::undo::NetworkAuditAuthMechanism::ProxyAuthorization),
+                auth_outcome: Some(nono::undo::NetworkAuditAuthOutcome::Failed),
+                denial_category: Some(nono::undo::NetworkAuditDenialCategory::AuthenticationFailed),
+                ..audit::EventContext::default()
+            },
+            &host,
+            port,
+            &e.to_string(),
+        );
+        let response = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm=\"nono\"\r\nContent-Length: 0\r\n\r\n";
+        stream.write_all(response.as_bytes()).await?;
+        return Ok(());
+    }
+
+    // 2. Parse host+port and run the host filter (DNS resolution + SSRF guard).
+    let (host, port) = parse_non_connect_target(first_line)?;
+    let check = state.filter.check_host(&host, port).await?;
+    if !check.result.is_allowed() {
+        let reason = check.result.reason();
+        audit::log_denied(
+            Some(&state.audit_log),
+            audit::ProxyMode::Reverse,
+            &audit::EventContext {
+                denial_category: Some(nono::undo::NetworkAuditDenialCategory::HostDenied),
+                ..audit::EventContext::default()
+            },
+            &host,
+            port,
+            &reason,
+        );
+        let sanitised = reason.replace(['\r', '\n'], " ");
+        let response = format!("HTTP/1.1 403 Forbidden: {}\r\n\r\n", sanitised);
+        stream.write_all(response.as_bytes()).await?;
+        return Ok(());
+    }
+
+    // 3. Build the origin-form request bytes: rewritten request line +
+    //    proxy-header-stripped header block + terminating CRLF.
+    let origin_line = rewrite_absolute_to_origin_form(first_line)?;
+    let inbound_path = origin_line
+        .split_whitespace()
+        .nth(1)
+        .unwrap_or("/")
+        .to_string();
+    let method = first_line
+        .split_whitespace()
+        .next()
+        .unwrap_or("GET")
+        .to_string();
+
+    let filtered_headers = strip_proxy_headers(header_bytes);
+    let mut request_bytes = Vec::with_capacity(origin_line.len() + filtered_headers.len() + 2);
+    request_bytes.extend_from_slice(origin_line.as_bytes());
+    request_bytes.extend_from_slice(&filtered_headers);
+    request_bytes.extend_from_slice(b"\r\n");
+
+    // Read the request body honoring Content-Length. `buffered` holds any
+    // bytes the BufReader already read past the header terminator.
+    let content_length = reverse::extract_content_length(header_bytes);
+    let body = match reverse::read_request_body(stream, content_length, buffered).await? {
+        Some(body) => body,
+        None => return Ok(()), // send_error already written (e.g. 413)
+    };
+
+    // 4. Choose the upstream strategy: chain through the external/enterprise
+    //    proxy when configured (unless the host is a bypass host), else
+    //    connect directly to the resolved addresses (DNS-rebinding-safe).
+    let ext_proxy_addr = match state.config.external_proxy.as_ref() {
+        Some(ext) if !(state.bypass_matcher.matches(&host)) => {
+            // Mirror the CONNECT/intercept paths: external proxy auth is
+            // configured-but-unimplemented, so fail loudly rather than
+            // silently connecting unauthenticated.
+            if ext.auth.is_some() {
+                let msg = "external proxy authentication is configured but not yet \
+                     implemented; remove the auth section from the external proxy \
+                     config or wait for a future release";
+                audit::log_denied(
+                    Some(&state.audit_log),
+                    audit::ProxyMode::Reverse,
+                    &audit::EventContext {
+                        denial_category: Some(
+                            nono::undo::NetworkAuditDenialCategory::UpstreamConnectFailed,
+                        ),
+                        ..audit::EventContext::default()
+                    },
+                    &host,
+                    port,
+                    msg,
+                );
+                let response = "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n";
+                stream.write_all(response.as_bytes()).await?;
+                return Err(ProxyError::ExternalProxy(msg.to_string()));
+            }
+            Some(ext.address.clone())
+        }
+        _ => None,
+    };
+
+    let strategy = match ext_proxy_addr.as_deref() {
+        Some(addr) => UpstreamStrategy::ExternalProxy {
+            proxy_addr: addr,
+            proxy_auth_header: None,
+        },
+        None => UpstreamStrategy::Direct {
+            resolved_addrs: &check.resolved_addrs,
+        },
+    };
+
+    let upstream = UpstreamSpec {
+        scheme: UpstreamScheme::Http,
+        host: &host,
+        port,
+        strategy,
+        // Unused for the Http scheme (no TLS to the upstream), but the shared
+        // pipeline requires a connector value. Reuse the shared default.
+        tls_connector: &state.tls_connector,
+    };
+
+    let audit_ctx = AuditCtx {
+        log: Some(&state.audit_log),
+        mode: audit::ProxyMode::Reverse,
+        event_ctx: audit::EventContext {
+            auth_mechanism: Some(nono::undo::NetworkAuditAuthMechanism::ProxyAuthorization),
+            auth_outcome: Some(nono::undo::NetworkAuditAuthOutcome::Succeeded),
+            managed_credential_active: Some(false),
+            ..audit::EventContext::default()
+        },
+        target: &host,
+        method: &method,
+        path: &inbound_path,
+    };
+
+    match forward::forward_request(stream, &request_bytes, &body, upstream, audit_ctx).await {
+        Ok(_status) => Ok(()),
+        Err(e) => {
+            warn!("forward-http upstream connection failed: {}", e);
+            audit::log_denied(
+                Some(&state.audit_log),
+                audit::ProxyMode::Reverse,
+                &audit::EventContext {
+                    denial_category: Some(
+                        nono::undo::NetworkAuditDenialCategory::UpstreamConnectFailed,
+                    ),
+                    ..audit::EventContext::default()
+                },
+                &host,
+                port,
+                &e.to_string(),
+            );
+            // The upstream connect failed before any response bytes were
+            // streamed, so it is safe to emit a 502 to the client here.
+            let response = "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n";
+            stream.write_all(response.as_bytes()).await?;
+            Ok(())
+        }
     }
 }
 
@@ -2885,8 +3227,13 @@ mod tests {
         assert!(err.to_string().contains("malformed request line"));
     }
 
-    /// Regression for #1062: a denied non-CONNECT request must return 403
-    /// (not 400) and produce a `http` audit deny event.
+    /// Regression for #1062: a denied absolute-form `http://` request must
+    /// return 403 (not 400) and produce a deny audit event.
+    ///
+    /// Since #1334, absolute-form `http://` requests are handled by the
+    /// forward-proxy path (`handle_forward_http`), which audits denials under
+    /// `Reverse` mode rather than the old inline `Connect` mode. The 403
+    /// status, target, and port are unchanged.
     #[tokio::test]
     async fn test_denied_non_connect_returns_403_and_audits() {
         use tokio::io::AsyncReadExt;
@@ -2899,10 +3246,20 @@ mod tests {
         };
         let handle = start(config).await.unwrap();
         let addr = format!("127.0.0.1:{}", handle.port);
+        let token = handle.token.to_string();
 
         let mut stream = TcpStream::connect(&addr).await.unwrap();
-        let request = b"GET http://google.com/ HTTP/1.1\r\nHost: google.com\r\n\r\n";
-        tokio::io::AsyncWriteExt::write_all(&mut stream, request)
+        // Include valid proxy auth so the request reaches the host filter
+        // (rather than being rejected at the auth gate).
+        let creds = {
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD.encode(format!("nono:{}", token))
+        };
+        let request = format!(
+            "GET http://google.com/ HTTP/1.1\r\nHost: google.com\r\nProxy-Authorization: Basic {}\r\n\r\n",
+            creds
+        );
+        tokio::io::AsyncWriteExt::write_all(&mut stream, request.as_bytes())
             .await
             .unwrap();
 
@@ -2918,10 +3275,463 @@ mod tests {
         let events = handle.drain_audit_events();
         assert_eq!(events.len(), 1, "expected one audit event");
         let event = &events[0];
-        assert_eq!(event.mode, nono::undo::NetworkAuditMode::Connect);
+        assert_eq!(event.mode, nono::undo::NetworkAuditMode::Reverse);
         assert_eq!(event.decision, nono::undo::NetworkAuditDecision::Deny);
         assert_eq!(event.target, "google.com");
         assert_eq!(event.port, Some(80));
+
+        handle.shutdown();
+    }
+
+    // ========================================================================
+    // Forward-proxy (absolute-form http://) tests — issue #1334
+    // ========================================================================
+
+    #[test]
+    fn classify_request_target_detects_absolute_and_origin_forms() {
+        assert_eq!(
+            classify_request_target("GET http://example.com/path HTTP/1.1"),
+            RequestTargetForm::AbsoluteHttp
+        );
+        // Scheme match is case-insensitive.
+        assert_eq!(
+            classify_request_target("GET HTTP://example.com/ HTTP/1.1"),
+            RequestTargetForm::AbsoluteHttp
+        );
+        assert_eq!(
+            classify_request_target("CONNECT https://example.com/ HTTP/1.1"),
+            RequestTargetForm::AbsoluteHttps
+        );
+        assert_eq!(
+            classify_request_target("GET /openai/v1/chat HTTP/1.1"),
+            RequestTargetForm::Origin
+        );
+        // Malformed / empty lines are treated as origin-form (unaffected).
+        assert_eq!(classify_request_target("GET"), RequestTargetForm::Origin);
+        assert_eq!(classify_request_target(""), RequestTargetForm::Origin);
+    }
+
+    #[test]
+    fn rewrite_absolute_to_origin_form_produces_origin_line() {
+        assert_eq!(
+            rewrite_absolute_to_origin_form("GET http://host.example/p/q?a=1 HTTP/1.1").unwrap(),
+            "GET /p/q?a=1 HTTP/1.1\r\n"
+        );
+        // Bare authority with no path becomes "/".
+        assert_eq!(
+            rewrite_absolute_to_origin_form("GET http://host.example HTTP/1.1").unwrap(),
+            "GET / HTTP/1.1\r\n"
+        );
+        // Method and version are preserved verbatim.
+        assert_eq!(
+            rewrite_absolute_to_origin_form("POST http://host.example:8080/x HTTP/1.0").unwrap(),
+            "POST /x HTTP/1.0\r\n"
+        );
+    }
+
+    #[test]
+    fn strip_proxy_headers_removes_proxy_hop_by_hop_only() {
+        let headers = b"Host: example.com\r\nProxy-Connection: keep-alive\r\nProxy-Authorization: Basic abc\r\nAccept: */*\r\n";
+        let stripped = strip_proxy_headers(headers);
+        let s = String::from_utf8(stripped).unwrap();
+        assert!(s.contains("Host: example.com"));
+        assert!(s.contains("Accept: */*"));
+        assert!(
+            !s.to_lowercase().contains("proxy-connection"),
+            "Proxy-Connection must be stripped, got: {s:?}"
+        );
+        assert!(
+            !s.to_lowercase().contains("proxy-authorization"),
+            "Proxy-Authorization must be stripped, got: {s:?}"
+        );
+    }
+
+    /// Spawn a one-shot local HTTP/1.1 origin server that echoes the received
+    /// request line back in the body and returns 200. Returns its address and
+    /// a receiver that yields the raw request bytes it saw.
+    async fn spawn_echo_origin() -> (std::net::SocketAddr, tokio::sync::oneshot::Receiver<String>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                let mut buf = [0u8; 4096];
+                let n = sock.read(&mut buf).await.unwrap_or(0);
+                let received = String::from_utf8_lossy(&buf[..n]).to_string();
+                let body = "ok";
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = sock.write_all(response.as_bytes()).await;
+                let _ = sock.flush().await;
+                let _ = tx.send(received);
+            }
+        });
+        (addr, rx)
+    }
+
+    /// Absolute-form http:// to an ALLOWED host is forwarded and returns the
+    /// upstream status. Also asserts the upstream saw an origin-form request
+    /// line with the proxy headers stripped.
+    #[tokio::test]
+    async fn forward_http_allowed_host_is_forwarded() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpStream;
+
+        let (origin_addr, origin_rx) = spawn_echo_origin().await;
+
+        let config = ProxyConfig {
+            allowed_hosts: vec!["127.0.0.1".to_string()],
+            ..ProxyConfig::default()
+        };
+        let handle = start(config).await.unwrap();
+        let token = handle.token.to_string();
+
+        let mut stream = TcpStream::connect(("127.0.0.1", handle.port))
+            .await
+            .unwrap();
+        let creds = {
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD.encode(format!("nono:{}", token))
+        };
+        let request = format!(
+            "GET http://127.0.0.1:{}/hello?x=1 HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nProxy-Connection: keep-alive\r\nProxy-Authorization: Basic {}\r\nAccept: */*\r\n\r\n",
+            origin_addr.port(),
+            origin_addr.port(),
+            creds
+        );
+        stream.write_all(request.as_bytes()).await.unwrap();
+
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.unwrap();
+        let response_str = String::from_utf8_lossy(&response);
+        assert!(
+            response_str.starts_with("HTTP/1.1 200"),
+            "expected upstream 200 status, got: {}",
+            response_str
+        );
+
+        // The upstream must have seen an origin-form request line with the
+        // proxy headers stripped.
+        let received = origin_rx.await.unwrap();
+        assert!(
+            received.starts_with("GET /hello?x=1 HTTP/1.1"),
+            "upstream should see origin-form request line, got: {received:?}"
+        );
+        assert!(
+            !received.to_lowercase().contains("proxy-connection"),
+            "Proxy-Connection must not reach upstream: {received:?}"
+        );
+        assert!(
+            !received.to_lowercase().contains("proxy-authorization"),
+            "Proxy-Authorization must not reach upstream: {received:?}"
+        );
+        assert!(
+            received.contains("Accept: */*"),
+            "non-proxy headers must be preserved: {received:?}"
+        );
+
+        // An L7 audit event should have been recorded for the allowed request.
+        let events = handle.drain_audit_events();
+        assert!(
+            events
+                .iter()
+                .any(|e| e.decision == nono::undo::NetworkAuditDecision::Allow
+                    && e.target == "127.0.0.1"
+                    && e.status == Some(200)),
+            "expected an allow L7 audit event, got: {events:?}"
+        );
+
+        handle.shutdown();
+    }
+
+    /// The forward path is a TRANSPARENT proxy: it must never inject a managed
+    /// credential, even when credential-injecting routes are configured.
+    /// Credential injection is reserved for the reverse path (HTTPS or
+    /// http-loopback upstreams).
+    ///
+    /// The configured route carries an UNRESOLVABLE credential key. If the
+    /// forward path ever attempted injection it would fail credential
+    /// resolution and return 503 (the reverse path's missing-credential
+    /// behavior) — so a 200 with the client's own Authorization header intact
+    /// proves the forward path bypasses routing/injection entirely. We also
+    /// assert the audit event reports `managed_credential_active = false`.
+    #[tokio::test]
+    async fn forward_http_does_not_inject_managed_credential() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpStream;
+
+        let (origin_addr, origin_rx) = spawn_echo_origin().await;
+
+        // A credential-injecting route whose key cannot resolve. The forward
+        // path must ignore it entirely rather than fail resolving it.
+        let config = ProxyConfig {
+            allowed_hosts: vec!["127.0.0.1".to_string()],
+            routes: vec![crate::config::RouteConfig {
+                prefix: "svc".to_string(),
+                upstream: "https://api.example.com".to_string(),
+                credential_key: Some("env://NONO_TEST_TOTALLY_MISSING".to_string()),
+                inject_mode: Default::default(),
+                inject_header: "Authorization".to_string(),
+                credential_format: Some("Bearer {}".to_string()),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                proxy: None,
+                env_var: None,
+                endpoint_rules: vec![],
+                endpoint_policy: None,
+                tls_ca: None,
+                tls_client_cert: None,
+                tls_client_key: None,
+                oauth2: None,
+                aws_auth: None,
+            }],
+            ..ProxyConfig::default()
+        };
+        let handle = start(config).await.unwrap();
+        let token = handle.token.to_string();
+
+        let mut stream = TcpStream::connect(("127.0.0.1", handle.port))
+            .await
+            .unwrap();
+        let creds = {
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD.encode(format!("nono:{}", token))
+        };
+        // The client sends its own Authorization header. A transparent proxy
+        // forwards it unchanged.
+        let request = format!(
+            "GET http://127.0.0.1:{}/data HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nProxy-Authorization: Basic {}\r\nAuthorization: Bearer client-token\r\n\r\n",
+            origin_addr.port(),
+            origin_addr.port(),
+            creds
+        );
+        stream.write_all(request.as_bytes()).await.unwrap();
+
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.unwrap();
+        let response_str = String::from_utf8_lossy(&response);
+        // 200 (not 503) proves no credential resolution/injection was attempted.
+        assert!(
+            response_str.starts_with("HTTP/1.1 200"),
+            "expected upstream 200 (no injection attempt), got: {}",
+            response_str
+        );
+
+        let received = origin_rx.await.unwrap();
+        // The client's own credential must survive verbatim, unmodified.
+        assert!(
+            received.contains("Authorization: Bearer client-token"),
+            "client Authorization must be forwarded verbatim: {received:?}"
+        );
+
+        // The audit event must record that no managed credential was active.
+        let events = handle.drain_audit_events();
+        let l7 = events
+            .iter()
+            .find(|e| e.status == Some(200))
+            .expect("expected an L7 audit event for the forwarded request");
+        assert_eq!(
+            l7.managed_credential_active,
+            Some(false),
+            "forward path must audit managed_credential_active=false: {l7:?}"
+        );
+
+        handle.shutdown();
+    }
+
+    /// Absolute-form http:// to a DENIED host returns 403 with an audit denial.
+    #[tokio::test]
+    async fn forward_http_denied_host_returns_403_and_audits() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpStream;
+
+        // Allowlist a different host so 127.0.0.1 is denied.
+        let config = ProxyConfig {
+            allowed_hosts: vec!["example.com".to_string()],
+            ..ProxyConfig::default()
+        };
+        let handle = start(config).await.unwrap();
+        let token = handle.token.to_string();
+
+        let mut stream = TcpStream::connect(("127.0.0.1", handle.port))
+            .await
+            .unwrap();
+        let creds = {
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD.encode(format!("nono:{}", token))
+        };
+        let request = format!(
+            "GET http://denied.example.org/secret HTTP/1.1\r\nHost: denied.example.org\r\nProxy-Authorization: Basic {}\r\n\r\n",
+            creds
+        );
+        stream.write_all(request.as_bytes()).await.unwrap();
+
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.unwrap();
+        let response_str = String::from_utf8_lossy(&response);
+        assert!(
+            response_str.starts_with("HTTP/1.1 403"),
+            "expected 403 for denied host, got: {}",
+            response_str
+        );
+
+        let events = handle.drain_audit_events();
+        assert!(
+            events
+                .iter()
+                .any(|e| e.decision == nono::undo::NetworkAuditDecision::Deny
+                    && e.target == "denied.example.org"
+                    && e.denial_category
+                        == Some(nono::undo::NetworkAuditDenialCategory::HostDenied)),
+            "expected a HostDenied audit event, got: {events:?}"
+        );
+
+        handle.shutdown();
+    }
+
+    /// Absolute-form https:// is rejected with guidance to use CONNECT.
+    #[tokio::test]
+    async fn forward_https_absolute_form_is_rejected_with_connect_guidance() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpStream;
+
+        let config = ProxyConfig {
+            allowed_hosts: vec!["example.com".to_string()],
+            ..ProxyConfig::default()
+        };
+        let handle = start(config).await.unwrap();
+
+        let mut stream = TcpStream::connect(("127.0.0.1", handle.port))
+            .await
+            .unwrap();
+        let request = b"GET https://example.com/ HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        stream.write_all(request).await.unwrap();
+
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.unwrap();
+        let response_str = String::from_utf8_lossy(&response);
+        assert!(
+            response_str.starts_with("HTTP/1.1 400"),
+            "expected 400 for absolute-form https, got: {}",
+            response_str
+        );
+        assert!(
+            response_str.to_lowercase().contains("connect"),
+            "response should direct the client to use CONNECT, got: {}",
+            response_str
+        );
+
+        handle.shutdown();
+    }
+
+    /// Missing/invalid Proxy-Authorization with the strict filter active is
+    /// rejected with 407 (matching the reverse-proxy no-credential branch).
+    #[tokio::test]
+    async fn forward_http_missing_proxy_auth_is_rejected_407() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpStream;
+
+        let config = ProxyConfig {
+            allowed_hosts: vec!["127.0.0.1".to_string()],
+            ..ProxyConfig::default()
+        };
+        let handle = start(config).await.unwrap();
+
+        let mut stream = TcpStream::connect(("127.0.0.1", handle.port))
+            .await
+            .unwrap();
+        // No Proxy-Authorization header at all.
+        let request = b"GET http://127.0.0.1:9/hello HTTP/1.1\r\nHost: 127.0.0.1:9\r\n\r\n";
+        stream.write_all(request).await.unwrap();
+
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.unwrap();
+        let response_str = String::from_utf8_lossy(&response);
+        assert!(
+            response_str.starts_with("HTTP/1.1 407"),
+            "expected 407 for missing proxy auth, got: {}",
+            response_str
+        );
+
+        let events = handle.drain_audit_events();
+        assert!(
+            events
+                .iter()
+                .any(|e| e.decision == nono::undo::NetworkAuditDecision::Deny
+                    && e.denial_category
+                        == Some(nono::undo::NetworkAuditDenialCategory::AuthenticationFailed)),
+            "expected an AuthenticationFailed audit event, got: {events:?}"
+        );
+
+        handle.shutdown();
+    }
+
+    /// Regression guard: origin-form requests with routes configured still
+    /// route to the reverse proxy (unaffected by the forward-proxy dispatch).
+    #[tokio::test]
+    async fn origin_form_request_still_routes_to_reverse_proxy() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpStream;
+
+        // A route whose credential is missing -> reverse proxy returns 503
+        // (managed credential unavailable). The point is that it reaches the
+        // reverse handler at all, not the forward path.
+        let config = ProxyConfig {
+            routes: vec![crate::config::RouteConfig {
+                prefix: "openai".to_string(),
+                upstream: "https://api.openai.com".to_string(),
+                credential_key: Some("env://NONO_TEST_TOTALLY_MISSING".to_string()),
+                inject_mode: Default::default(),
+                inject_header: "Authorization".to_string(),
+                credential_format: Some("Bearer {}".to_string()),
+                path_pattern: None,
+                path_replacement: None,
+                query_param_name: None,
+                proxy: None,
+                env_var: None,
+                endpoint_rules: vec![],
+                endpoint_policy: None,
+                tls_ca: None,
+                tls_client_cert: None,
+                tls_client_key: None,
+                oauth2: None,
+                aws_auth: None,
+            }],
+            ..Default::default()
+        };
+        let handle = start(config).await.unwrap();
+
+        let mut stream = TcpStream::connect(("127.0.0.1", handle.port))
+            .await
+            .unwrap();
+        let request = b"GET /openai/v1/models HTTP/1.1\r\nHost: 127.0.0.1\r\nAuthorization: Bearer whatever\r\n\r\n";
+        stream.write_all(request).await.unwrap();
+
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.unwrap();
+        let response_str = String::from_utf8_lossy(&response);
+        // The reverse handler answers 503 for a route with a missing managed
+        // credential. Any structured HTTP answer (not a dropped socket / 502
+        // forward failure) proves the reverse path handled it.
+        assert!(
+            response_str.starts_with("HTTP/1.1 503"),
+            "origin-form request must reach the reverse proxy (503 for missing \
+             credential), got: {}",
+            response_str
+        );
+
+        let events = handle.drain_audit_events();
+        assert!(
+            events
+                .iter()
+                .any(|e| e.mode == nono::undo::NetworkAuditMode::Reverse),
+            "expected a Reverse-mode audit event, got: {events:?}"
+        );
 
         handle.shutdown();
     }


### PR DESCRIPTION
## Linked Issue

Closes #1334

## Summary

Adds support for plain-HTTP forward-proxying so `nono-proxy` works as a drop-in
`HTTP_PROXY` target for cleartext HTTP traffic.

Clients that honor `HTTP_PROXY` send **absolute-form** request lines
(`GET http://example.com/path HTTP/1.1`). Previously these either hit the
reverse-proxy handler — which assumes **origin-form** and misread the URL scheme
as a service prefix (`Unknown service prefix: http:`) — or fell through to a
`502`. There was no way to use nono transparently for cleartext HTTP.

This PR makes the non-CONNECT dispatch discriminate on the request-target
**form** rather than the method:

```
if CONNECT                          -> tunnel                (unchanged)
else if absolute-form http://       -> NEW forward path
else if absolute-form https://      -> 400 + "use CONNECT"   (guidance)
else (origin-form, "/path")
    routes configured               -> reverse proxy         (unchanged)
    otherwise                       -> inline 403/502         (unchanged)
```

### Design notes

- **Transparent by design.** The new `http://` forward path does **not** inject
  managed credentials and does **not** consult the route/credential stores. It
  rewrites the request line to origin-form, strips only the two client↔proxy
  hop-by-hop headers (`Proxy-Connection`, `Proxy-Authorization`), and forwards
  everything else — including the client's own `Authorization` and `Host` —
  verbatim. Audit events are stamped `managed_credential_active = false`.
- **Credential injection stays confined to the reverse path** (HTTPS upstreams,
  or HTTP loopback upstreams), exactly as before. That path still enforces
  `validate_http_upstream_target` (loopback-only for `http`).
- **Same trust boundary as CONNECT.** The forward path enforces
  `Proxy-Authorization` (session-token) first (`407` on failure) and then runs
  the host filter (`check_host`) — the allowlist plus link-local/cloud-metadata
  SSRF guards — connecting only to the DNS-rebinding-safe resolved addresses.
- **Deliberate difference vs. the reverse path.** The forward path intentionally
  does **not** call `validate_http_upstream_target`: a general forward proxy
  exists to reach arbitrary *allowed* `http://` hosts, so the host filter is the
  sole authoritative boundary here. This is documented in a `SAFETY / SECURITY`
  comment on the handler so nobody assumes "http upstream ⇒ loopback" holds on
  this path.

### Existing flows are unchanged

The CONNECT branch and both origin-form branches (reverse proxy, inline
`403/502`) are byte-for-byte unchanged in the diff — the new arms are inserted
between them, and the classifier routes anything that isn't `http(s)://`
absolute-form to the pre-existing `Origin` path.

## Test Plan

New / updated tests:

- **Unit**
  - `classify_request_target_detects_absolute_and_origin_forms` — absolute vs.
    origin discrimination, case-insensitive scheme.
  - `rewrite_absolute_to_origin_form_produces_origin_line` — request-line rewrite
    (incl. empty-path ⇒ `/`).
  - `strip_proxy_headers_removes_proxy_hop_by_hop_only` — only proxy headers
    stripped; others (incl. `Host`) preserved.
- **Integration (real local TCP listeners)**
  - `forward_http_allowed_host_is_forwarded` — allowed host forwarded, upstream
    sees origin-form line, proxy headers stripped, non-proxy headers preserved,
    allow L7 audit emitted.
  - `forward_http_does_not_inject_managed_credential` — with a credential-
    injecting route configured, the forward path returns `200` (no `503` from
    credential resolution), the client's own `Authorization` is forwarded
    verbatim, and the audit event reports `managed_credential_active = false`.
  - `forward_http_denied_host_returns_403_and_audits` — denied host ⇒ `403` +
    `HostDenied` audit.
  - `forward_https_absolute_form_is_rejected_with_connect_guidance` — absolute
    `https://` ⇒ `400` with guidance to use CONNECT.
  - `forward_http_missing_proxy_auth_is_rejected_407` — missing/invalid
    `Proxy-Authorization` ⇒ `407` + auth-failure audit.
  - `origin_form_request_still_routes_to_reverse_proxy` — regression guard that
    origin-form requests still reach the reverse handler unchanged.
  - Updated `test_denied_non_connect_returns_403_and_audits` — now sends valid
    proxy auth and asserts the audit mode/target/port (absolute-form
    `http://` denials audit under the forward path).

## Agent Disclosure

- This PR was prepared by an AI agent (Claude Code).

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect (test module uses the existing `#[allow(clippy::unwrap_used)]`)
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope
