### PR TITLE
feat(packs): migrate official pack namespace from always-further to nolabs-ai

### DIFF
--- a/.github/ISSUE_TEMPLATE/onboarding_issue.yml
+++ b/.github/ISSUE_TEMPLATE/onboarding_issue.yml
@@ -18,7 +18,7 @@ body:
         - Installation (Homebrew / cargo / binary download)
         - First run (`nono run` returned an error immediately)
         - Writing or loading a profile (JSON)
-        - Using a built-in profile (e.g. `--profile always-further/claude`)
+        - Using a built-in profile (e.g. `--profile nolabs-ai/claude`)
         - nono ran but didn't seem to enforce anything
         - Something else (describe below)
     validations:
@@ -29,7 +29,7 @@ body:
     attributes:
       label: What happened?
       description: What did you try, and what went wrong?
-      placeholder: "I followed the quickstart and ran `nono run --profile always-further/claude -- claude` but got..."
+      placeholder: "I followed the quickstart and ran `nono run --profile nolabs-ai/claude -- claude` but got..."
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ Search for an agent in the registry, then run it:
 
 ```bash
 $ nono search opencode
-always-further/opencode	-	Official Opencode Plugin
+nolabs-ai/opencode	-	Official Opencode Plugin
 
-$ nono run --profile always-further/opencode -- opencode
+$ nono run --profile nolabs-ai/opencode -- opencode
 ```
 
 That's it. `opencode` now runs with read/write access to the current directory and **nothing else** — your SSH keys, your cloud credentials, the rest of your disk are invisible to it.
@@ -77,7 +77,7 @@ Profiles for all the popular agents live at [registry.nono.sh](https://registry.
 Outgrow the defaults? Scaffold a profile and tweak it — same command you already know:
 
 ```bash
-nono profile init opencode --extends always-further/opencode
+nono profile init opencode --extends nolabs-ai/opencode
 nono run --profile opencode -- opencode
 ```
 

--- a/crates/nono-cli/README.md
+++ b/crates/nono-cli/README.md
@@ -39,14 +39,14 @@ nono run --allow ./project-a --allow ./project-b -- command
 # Block network access
 nono run --allow-cwd --block-net -- command
 
-# Use a pack profile (requires: nono pull always-further/claude)
-nono run --profile always-further/claude -- claude
+# Use a pack profile (requires: nono pull nolabs-ai/claude)
+nono run --profile nolabs-ai/claude -- claude
 
 # Use a built-in profile
-nono run --profile always-further/opencode -- opencode
+nono run --profile nolabs-ai/opencode -- opencode
 
 # Keep a profile but temporarily allow unrestricted network
-nono run --profile always-further/claude --allow-net -- claude
+nono run --profile nolabs-ai/claude --allow-net -- claude
 
 # Start an interactive shell inside the sandbox
 nono shell --allow .
@@ -85,14 +85,14 @@ Precedence is: CLI flag, then `NONO_THEME`, then config file, then the default `
 
 | Profile | Install | Command |
 |---------|---------|---------|
-| Claude Code | `nono pull always-further/claude` | `nono run --profile always-further/claude -- claude` |
-| Codex | `nono pull always-further/codex` | `nono run --profile always-further/codex -- codex` |
+| Claude Code | `nono pull nolabs-ai/claude` | `nono run --profile nolabs-ai/claude -- claude` |
+| Codex | `nono pull nolabs-ai/codex` | `nono run --profile nolabs-ai/codex -- codex` |
 
 ### Built-in profiles
 
 | Profile | Command |
 |---------|---------|
-| OpenCode | `nono run --profile always-further/opencode -- opencode` |
+| OpenCode | `nono run --profile nolabs-ai/opencode -- opencode` |
 | OpenClaw | `nono run --profile openclaw -- openclaw gateway` |
 | Swival | `nono run --profile swival -- swival` |
 

--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -631,7 +631,7 @@
         "name": "default",
         "version": "1.0.0",
         "description": "Default conservative base profile",
-        "author": "always-further"
+        "author": "nolabs-ai"
       },
       "groups": {
         "include": [
@@ -669,7 +669,7 @@
         "name": "linux-host-compat",
         "version": "1.0.0",
         "description": "Linux compatibility profile for host runtime, sysfs, and temp access",
-        "author": "always-further"
+        "author": "nolabs-ai"
       },
       "groups": {
         "include": [
@@ -692,7 +692,7 @@
         "name": "openclaw",
         "version": "1.0.0",
         "description": "OpenClaw messaging gateway",
-        "author": "always-further"
+        "author": "nolabs-ai"
       },
       "groups": {
         "include": ["node_runtime"]
@@ -720,7 +720,7 @@
         "name": "python-dev",
         "version": "1.0.0",
         "description": "Python SDK development profile with pyenv, conda, and pip support",
-        "author": "always-further"
+        "author": "nolabs-ai"
       },
       "groups": {
         "include": ["python_runtime"]
@@ -740,7 +740,7 @@
         "name": "node-dev",
         "version": "1.0.0",
         "description": "Node.js SDK development profile with nvm, fnm, pnpm, and npm support",
-        "author": "always-further"
+        "author": "nolabs-ai"
       },
       "groups": {
         "include": ["node_runtime"]
@@ -759,7 +759,7 @@
         "name": "go-dev",
         "version": "1.0.0",
         "description": "Go SDK development profile with GOPATH and module support",
-        "author": "always-further"
+        "author": "nolabs-ai"
       },
       "groups": {
         "include": ["go_runtime", "go_runtime_linux", "go_runtime_macos"]
@@ -778,7 +778,7 @@
         "name": "java-dev",
         "version": "1.0.0",
         "description": "Java SDK development profile with SDKMAN, Maven, and Gradle support",
-        "author": "always-further"
+        "author": "nolabs-ai"
       },
       "groups": {
         "include": ["java_runtime"]
@@ -800,7 +800,7 @@
         "name": "rust-dev",
         "version": "1.0.0",
         "description": "Rust SDK development profile with cargo and rustup support",
-        "author": "always-further"
+        "author": "nolabs-ai"
       },
       "groups": {
         "include": ["rust_runtime"]
@@ -819,7 +819,7 @@
         "name": "swival",
         "version": "1.0.0",
         "description": "Swival CLI coding agent",
-        "author": "always-further"
+        "author": "nolabs-ai"
       },
       "groups": {
         "include": [

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -133,8 +133,8 @@ pub enum Commands {
 {after-help}")]
     #[command(after_help = "\x1b[1mEXAMPLES\x1b[0m
   nono run --allow . claude                    # Read/write current dir, run claude
-  nono run --profile always-further/claude claude        # Use a profile
-  nono run --profile always-further/claude --allow-domain api.openai.com claude
+  nono run --profile nolabs-ai/claude claude        # Use a profile
+  nono run --profile nolabs-ai/claude --allow-domain api.openai.com claude
                                                # Restrict outbound access to listed domains
   nono run --read ./src --write ./output cargo build
                                                # Separate read/write permissions
@@ -155,7 +155,7 @@ pub enum Commands {
 {after-help}")]
     #[command(after_help = "\x1b[1mEXAMPLES\x1b[0m
   nono shell --allow .                         # Shell with read/write to current dir
-  nono shell --profile always-further/claude             # Use a named profile
+  nono shell --profile nolabs-ai/claude             # Use a named profile
   nono shell --allow . --shell /bin/zsh        # Override shell binary
 ")]
     Shell(Box<ShellArgs>),
@@ -539,9 +539,9 @@ IN-BAND DETACH:
 {all-args}
 {after-help}")]
     #[command(after_help = "\x1b[1mEXAMPLES\x1b[0m
-  nono pull always-further/claude
-  nono pull always-further/claude@1.2.0 --registry http://localhost:3000
-  nono pull always-further/claude --init
+  nono pull nolabs-ai/claude
+  nono pull nolabs-ai/claude@1.2.0 --registry http://localhost:3000
+  nono pull nolabs-ai/claude --init
 ")]
     Pull(PullArgs),
 
@@ -555,7 +555,7 @@ IN-BAND DETACH:
 {all-args}
 {after-help}")]
     #[command(after_help = "\x1b[1mEXAMPLES\x1b[0m
-  nono remove always-further/claude
+  nono remove nolabs-ai/claude
 ")]
     Remove(RemoveArgs),
 
@@ -570,7 +570,7 @@ IN-BAND DETACH:
 {after-help}")]
     #[command(after_help = "\x1b[1mEXAMPLES\x1b[0m
   nono update
-  nono update always-further/claude
+  nono update nolabs-ai/claude
   nono update --dry-run
   nono update --force                          # also update pinned packs
 ")]
@@ -616,7 +616,7 @@ IN-BAND DETACH:
 {all-args}
 {after-help}")]
     #[command(after_help = "\x1b[1mEXAMPLES\x1b[0m
-  nono pin always-further/claude
+  nono pin nolabs-ai/claude
 ")]
     Pin(PinArgs),
 
@@ -630,7 +630,7 @@ IN-BAND DETACH:
 {all-args}
 {after-help}")]
     #[command(after_help = "\x1b[1mEXAMPLES\x1b[0m
-  nono unpin always-further/claude
+  nono unpin nolabs-ai/claude
 ")]
     Unpin(UnpinArgs),
 

--- a/crates/nono-cli/src/legacy_cleanup.rs
+++ b/crates/nono-cli/src/legacy_cleanup.rs
@@ -3,7 +3,7 @@
 //! Pre-0.43 installs wrote `~/.claude/hooks/nono-hook.sh` and patched
 //! `~/.claude/settings.json::hooks` with one matching command entry.
 //! Post-0.43 the integration ships as a registry pack
-//! (`always-further/claude`) with its own marketplace-based plugin
+//! (`nolabs-ai/claude`) with its own marketplace-based plugin
 //! install. If the legacy state isn't removed, Claude Code runs both —
 //! duplicate hook execution at best, broken behaviour if the legacy
 //! `nono-hook.sh` references binaries the current nono no longer ships.
@@ -32,6 +32,7 @@ use std::path::{Path, PathBuf};
 const LEGACY_HOOK_SCRIPT_REL: &str = ".claude/hooks/nono-hook.sh";
 const LEGACY_HOOK_COMMAND_TEMPLATE: &str = "$HOME/.claude/hooks/nono-hook.sh";
 const LEGACY_BAK_SUFFIX: &str = ".legacy-bak";
+const LEGACY_PLUGIN_KEY: &str = "nono@always-further";
 
 /// What `scan` found on disk. Empty = nothing to do.
 #[derive(Debug, Default, Clone)]
@@ -41,6 +42,11 @@ pub struct LegacyArtifacts {
     /// Hook entries inside `~/.claude/settings.json` that reference the
     /// legacy script. Stored as `(event, command)` for display.
     pub settings_entries: Vec<(String, String)>,
+    /// Whether `enabledPlugins["nono@always-further"]` is present in
+    /// `~/.claude/settings.json`. The new pack writes `nono@nolabs-ai`;
+    /// leaving both in place causes Claude Code to see two `nono` plugins
+    /// from different marketplaces and silently fail one or both.
+    pub legacy_plugin_key: bool,
     /// Resolved path to `~/.claude/settings.json` (only set when at
     /// least one matching entry was found).
     settings_path: Option<PathBuf>,
@@ -48,7 +54,7 @@ pub struct LegacyArtifacts {
 
 impl LegacyArtifacts {
     pub fn is_empty(&self) -> bool {
-        self.files.is_empty() && self.settings_entries.is_empty()
+        self.files.is_empty() && self.settings_entries.is_empty() && !self.legacy_plugin_key
     }
 }
 
@@ -57,12 +63,15 @@ impl LegacyArtifacts {
 pub struct LegacyCleanupReport {
     pub renamed_files: Vec<(PathBuf, PathBuf)>,
     pub removed_settings_entries: Vec<(String, String)>,
+    pub removed_plugin_key: bool,
     pub settings_path: Option<PathBuf>,
 }
 
 impl LegacyCleanupReport {
     fn is_empty(&self) -> bool {
-        self.renamed_files.is_empty() && self.removed_settings_entries.is_empty()
+        self.renamed_files.is_empty()
+            && self.removed_settings_entries.is_empty()
+            && !self.removed_plugin_key
     }
 }
 
@@ -101,48 +110,59 @@ fn scan(home: &Path) -> LegacyArtifacts {
     }
 
     let settings_path = home.join(".claude").join("settings.json");
-    if let Some(entries) = scan_settings(&settings_path, home)
-        && !entries.is_empty()
-    {
-        artifacts.settings_entries = entries;
-        artifacts.settings_path = Some(settings_path);
+    if let Some((entries, has_plugin_key)) = scan_settings(&settings_path, home) {
+        if !entries.is_empty() {
+            artifacts.settings_entries = entries;
+        }
+        if has_plugin_key {
+            artifacts.legacy_plugin_key = true;
+        }
+        if !artifacts.settings_entries.is_empty() || artifacts.legacy_plugin_key {
+            artifacts.settings_path = Some(settings_path);
+        }
     }
 
     artifacts
 }
 
-/// Walk `settings.json::hooks` looking for entries whose `command` is
-/// the legacy `nono-hook.sh` reference (template or expanded form).
-/// Returns `None` if the file is missing or unparseable (treated as
-/// "nothing to clean", not an error). Pure inspection — no mutation.
-fn scan_settings(path: &Path, home: &Path) -> Option<Vec<(String, String)>> {
+/// Walk `settings.json` looking for legacy artifacts. Returns `None` if
+/// the file is missing or unparseable (treated as "nothing to clean").
+/// Returns `Some((hook_entries, has_legacy_plugin_key))`. Pure inspection
+/// — no mutation.
+fn scan_settings(path: &Path, home: &Path) -> Option<(Vec<(String, String)>, bool)> {
     if !path.exists() {
         return None;
     }
     let content = fs::read_to_string(path).ok()?;
     let settings: Value = serde_json::from_str(&content).ok()?;
-    let hooks = settings.get("hooks")?.as_object()?;
+
+    let has_plugin_key = settings
+        .get("enabledPlugins")
+        .and_then(Value::as_object)
+        .map_or(false, |p| p.contains_key(LEGACY_PLUGIN_KEY));
 
     let mut found = Vec::new();
-    for (event, matchers) in hooks {
-        let Some(matchers) = matchers.as_array() else {
-            continue;
-        };
-        for matcher in matchers {
-            let Some(inner) = matcher.get("hooks").and_then(Value::as_array) else {
+    if let Some(hooks) = settings.get("hooks").and_then(Value::as_object) {
+        for (event, matchers) in hooks {
+            let Some(matchers) = matchers.as_array() else {
                 continue;
             };
-            for entry in inner {
-                let Some(cmd) = entry.get("command").and_then(Value::as_str) else {
+            for matcher in matchers {
+                let Some(inner) = matcher.get("hooks").and_then(Value::as_array) else {
                     continue;
                 };
-                if matches_legacy_command(cmd, home) {
-                    found.push((event.clone(), cmd.to_string()));
+                for entry in inner {
+                    let Some(cmd) = entry.get("command").and_then(Value::as_str) else {
+                        continue;
+                    };
+                    if matches_legacy_command(cmd, home) {
+                        found.push((event.clone(), cmd.to_string()));
+                    }
                 }
             }
         }
     }
-    Some(found)
+    Some((found, has_plugin_key))
 }
 
 fn matches_legacy_command(cmd: &str, home: &Path) -> bool {
@@ -200,6 +220,18 @@ fn confirm(artifacts: &LegacyArtifacts) -> bool {
         }
         let _ = writeln!(err);
     }
+    if artifacts.legacy_plugin_key {
+        let _ = writeln!(
+            err,
+            "     {} (~/.claude/settings.json):",
+            "Plugin key to remove".dimmed()
+        );
+        let _ = writeln!(
+            err,
+            "       enabledPlugins[\"{LEGACY_PLUGIN_KEY}\"] — replaced by nono@nolabs-ai"
+        );
+        let _ = writeln!(err);
+    }
 
     let interactive = io::stdin().is_terminal() && io::stderr().is_terminal();
     if !interactive {
@@ -227,10 +259,15 @@ fn apply(artifacts: &LegacyArtifacts, home: &Path) -> Result<LegacyCleanupReport
     let mut report = LegacyCleanupReport::default();
 
     if let Some(path) = &artifacts.settings_path {
-        let removed = strip_settings_entries(path, home)?;
-        if !removed.is_empty() {
-            report.removed_settings_entries = removed;
+        let (removed_entries, removed_plugin_key) =
+            strip_settings_entries(path, home, artifacts.legacy_plugin_key)?;
+        if !removed_entries.is_empty() {
+            report.removed_settings_entries = removed_entries;
             report.settings_path = Some(path.clone());
+        }
+        if removed_plugin_key {
+            report.removed_plugin_key = true;
+            report.settings_path.get_or_insert_with(|| path.clone());
         }
     }
 
@@ -250,54 +287,65 @@ fn apply(artifacts: &LegacyArtifacts, home: &Path) -> Result<LegacyCleanupReport
     Ok(report)
 }
 
-/// Mutate the on-disk settings.json: drop hook entries whose `command`
-/// is a legacy reference, prune empty matchers and empty event arrays,
-/// preserve every other key. Atomic write (tempfile + rename). Returns
-/// the `(event, command)` list that was removed.
-fn strip_settings_entries(path: &Path, home: &Path) -> Result<Vec<(String, String)>> {
+/// Mutate the on-disk settings.json in one atomic write: drop hook
+/// entries whose `command` is a legacy reference (pruning empty matchers
+/// and event arrays), and optionally remove `enabledPlugins["nono@always-further"]`.
+/// All other keys are preserved. Returns `(removed_hook_entries, plugin_key_removed)`.
+fn strip_settings_entries(
+    path: &Path,
+    home: &Path,
+    remove_plugin_key: bool,
+) -> Result<(Vec<(String, String)>, bool)> {
     let content = fs::read_to_string(path).map_err(NonoError::Io)?;
     let mut settings: Value = serde_json::from_str(&content)
         .map_err(|e| NonoError::HookInstall(format!("parse {}: {e}", path.display())))?;
 
     let Some(obj) = settings.as_object_mut() else {
-        return Ok(Vec::new());
-    };
-    let Some(hooks) = obj.get_mut("hooks").and_then(Value::as_object_mut) else {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), false));
     };
 
     let mut removed: Vec<(String, String)> = Vec::new();
-    let event_keys: Vec<String> = hooks.keys().cloned().collect();
-    for event in event_keys {
-        let drop_event = {
-            let Some(matchers) = hooks.get_mut(&event).and_then(Value::as_array_mut) else {
-                continue;
-            };
-            matchers.retain_mut(|matcher| {
-                let Some(inner) = matcher.get_mut("hooks").and_then(Value::as_array_mut) else {
-                    return true;
+    if let Some(hooks) = obj.get_mut("hooks").and_then(Value::as_object_mut) {
+        let event_keys: Vec<String> = hooks.keys().cloned().collect();
+        for event in event_keys {
+            let drop_event = {
+                let Some(matchers) = hooks.get_mut(&event).and_then(Value::as_array_mut) else {
+                    continue;
                 };
-                inner.retain(|h| {
-                    let Some(cmd) = h.get("command").and_then(Value::as_str) else {
+                matchers.retain_mut(|matcher| {
+                    let Some(inner) = matcher.get_mut("hooks").and_then(Value::as_array_mut)
+                    else {
                         return true;
                     };
-                    if matches_legacy_command(cmd, home) {
-                        removed.push((event.clone(), cmd.to_string()));
-                        return false;
-                    }
-                    true
+                    inner.retain(|h| {
+                        let Some(cmd) = h.get("command").and_then(Value::as_str) else {
+                            return true;
+                        };
+                        if matches_legacy_command(cmd, home) {
+                            removed.push((event.clone(), cmd.to_string()));
+                            return false;
+                        }
+                        true
+                    });
+                    !inner.is_empty()
                 });
-                !inner.is_empty()
-            });
-            matchers.is_empty()
-        };
-        if drop_event {
-            hooks.remove(&event);
+                matchers.is_empty()
+            };
+            if drop_event {
+                hooks.remove(&event);
+            }
         }
     }
 
-    if removed.is_empty() {
-        return Ok(removed);
+    let mut plugin_key_removed = false;
+    if remove_plugin_key {
+        if let Some(plugins) = obj.get_mut("enabledPlugins").and_then(Value::as_object_mut) {
+            plugin_key_removed = plugins.remove(LEGACY_PLUGIN_KEY).is_some();
+        }
+    }
+
+    if removed.is_empty() && !plugin_key_removed {
+        return Ok((removed, false));
     }
 
     let serialized = serde_json::to_string_pretty(&settings)
@@ -306,7 +354,7 @@ fn strip_settings_entries(path: &Path, home: &Path) -> Result<Vec<(String, Strin
     fs::write(&tmp, format!("{serialized}\n")).map_err(NonoError::Io)?;
     fs::rename(&tmp, path).map_err(NonoError::Io)?;
 
-    Ok(removed)
+    Ok((removed, plugin_key_removed))
 }
 
 fn backup_path_for(path: &Path) -> PathBuf {
@@ -341,6 +389,10 @@ fn emit_summary(report: &LegacyCleanupReport) {
         for (event, cmd) in &report.removed_settings_entries {
             let _ = writeln!(err, "       [{event}]  {cmd}");
         }
+    }
+    if report.removed_plugin_key {
+        let _ = writeln!(err, "     {}:", "Removed plugin key".dimmed());
+        let _ = writeln!(err, "       enabledPlugins[\"{LEGACY_PLUGIN_KEY}\"]");
     }
     let _ = writeln!(err);
 }
@@ -450,7 +502,7 @@ mod tests {
         let expanded_cmd = format!("{}/.claude/hooks/nono-hook.sh", home.path().display());
         let settings = json!({
             "theme": "light",
-            "enabledPlugins": { "nono@always-further": true },
+            "enabledPlugins": { "nono@nolabs-ai": true },
             "hooks": {
                 "PreToolUse": [
                     { "matcher": "*", "hooks": [
@@ -481,7 +533,7 @@ mod tests {
 
         assert_eq!(after["theme"], "light", "unrelated keys preserved");
         assert_eq!(
-            after["enabledPlugins"]["nono@always-further"], true,
+            after["enabledPlugins"]["nono@nolabs-ai"], true,
             "plugin entries preserved"
         );
         assert!(
@@ -495,6 +547,70 @@ mod tests {
         let inner = post[0]["hooks"].as_array().expect("inner array");
         assert_eq!(inner.len(), 1, "user hook preserved");
         assert_eq!(inner[0]["command"], "/usr/local/bin/user-hook");
+    }
+
+    #[test]
+    fn scan_detects_legacy_plugin_key() {
+        let home = TempDir::new().expect("tempdir");
+        let claude = home.path().join(".claude");
+        fs::create_dir_all(&claude).expect("mkdir");
+        let settings = json!({
+            "enabledPlugins": { "nono@always-further": true, "other-plugin@somewhere": true }
+        });
+        fs::write(
+            claude.join("settings.json"),
+            serde_json::to_string_pretty(&settings).expect("ser"),
+        )
+        .expect("write");
+
+        let artifacts = scan(home.path());
+        assert!(artifacts.legacy_plugin_key, "should detect legacy plugin key");
+        assert!(artifacts.settings_entries.is_empty());
+        assert!(!artifacts.is_empty());
+    }
+
+    #[test]
+    fn apply_removes_legacy_plugin_key_preserving_other_plugins() {
+        let home = TempDir::new().expect("tempdir");
+        let claude = home.path().join(".claude");
+        fs::create_dir_all(&claude).expect("mkdir");
+        let settings = json!({
+            "theme": "dark",
+            "enabledPlugins": {
+                "nono@always-further": true,
+                "nono@nolabs-ai": true,
+                "other-plugin@somewhere": true
+            }
+        });
+        let settings_path = claude.join("settings.json");
+        fs::write(
+            &settings_path,
+            serde_json::to_string_pretty(&settings).expect("ser"),
+        )
+        .expect("write");
+
+        let artifacts = scan(home.path());
+        assert!(artifacts.legacy_plugin_key);
+        let report = apply(&artifacts, home.path()).expect("apply");
+        assert!(report.removed_plugin_key);
+
+        let after: Value =
+            serde_json::from_str(&fs::read_to_string(&settings_path).expect("read"))
+                .expect("parse");
+
+        assert_eq!(after["theme"], "dark", "unrelated keys preserved");
+        assert!(
+            after["enabledPlugins"].get("nono@always-further").is_none(),
+            "legacy plugin key removed"
+        );
+        assert_eq!(
+            after["enabledPlugins"]["nono@nolabs-ai"], true,
+            "new plugin key preserved"
+        );
+        assert_eq!(
+            after["enabledPlugins"]["other-plugin@somewhere"], true,
+            "unrelated plugin preserved"
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/legacy_cleanup.rs
+++ b/crates/nono-cli/src/legacy_cleanup.rs
@@ -139,7 +139,7 @@ fn scan_settings(path: &Path, home: &Path) -> Option<(Vec<(String, String)>, boo
     let has_plugin_key = settings
         .get("enabledPlugins")
         .and_then(Value::as_object)
-        .map_or(false, |p| p.contains_key(LEGACY_PLUGIN_KEY));
+        .is_some_and(|p| p.contains_key(LEGACY_PLUGIN_KEY));
 
     let mut found = Vec::new();
     if let Some(hooks) = settings.get("hooks").and_then(Value::as_object) {
@@ -313,8 +313,7 @@ fn strip_settings_entries(
                     continue;
                 };
                 matchers.retain_mut(|matcher| {
-                    let Some(inner) = matcher.get_mut("hooks").and_then(Value::as_array_mut)
-                    else {
+                    let Some(inner) = matcher.get_mut("hooks").and_then(Value::as_array_mut) else {
                         return true;
                     };
                     inner.retain(|h| {
@@ -338,10 +337,10 @@ fn strip_settings_entries(
     }
 
     let mut plugin_key_removed = false;
-    if remove_plugin_key {
-        if let Some(plugins) = obj.get_mut("enabledPlugins").and_then(Value::as_object_mut) {
-            plugin_key_removed = plugins.remove(LEGACY_PLUGIN_KEY).is_some();
-        }
+    if remove_plugin_key
+        && let Some(plugins) = obj.get_mut("enabledPlugins").and_then(Value::as_object_mut)
+    {
+        plugin_key_removed = plugins.remove(LEGACY_PLUGIN_KEY).is_some();
     }
 
     if removed.is_empty() && !plugin_key_removed {
@@ -564,7 +563,10 @@ mod tests {
         .expect("write");
 
         let artifacts = scan(home.path());
-        assert!(artifacts.legacy_plugin_key, "should detect legacy plugin key");
+        assert!(
+            artifacts.legacy_plugin_key,
+            "should detect legacy plugin key"
+        );
         assert!(artifacts.settings_entries.is_empty());
         assert!(!artifacts.is_empty());
     }
@@ -594,9 +596,8 @@ mod tests {
         let report = apply(&artifacts, home.path()).expect("apply");
         assert!(report.removed_plugin_key);
 
-        let after: Value =
-            serde_json::from_str(&fs::read_to_string(&settings_path).expect("read"))
-                .expect("parse");
+        let after: Value = serde_json::from_str(&fs::read_to_string(&settings_path).expect("read"))
+            .expect("parse");
 
         assert_eq!(after["theme"], "dark", "unrelated keys preserved");
         assert!(

--- a/crates/nono-cli/src/legacy_cleanup.rs
+++ b/crates/nono-cli/src/legacy_cleanup.rs
@@ -349,9 +349,13 @@ fn strip_settings_entries(
 
     let serialized = serde_json::to_string_pretty(&settings)
         .map_err(|e| NonoError::HookInstall(format!("serialize {}: {e}", path.display())))?;
-    let tmp = path.with_extension("json.nono-tmp");
+    // Canonicalize before writing so that if settings.json is a symlink
+    // (common in dotfile repos), we write through to the real file rather
+    // than replacing the symlink itself with a plain file.
+    let real_path = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let tmp = real_path.with_extension("json.nono-tmp");
     fs::write(&tmp, format!("{serialized}\n")).map_err(NonoError::Io)?;
-    fs::rename(&tmp, path).map_err(NonoError::Io)?;
+    fs::rename(&tmp, &real_path).map_err(NonoError::Io)?;
 
     Ok((removed, plugin_key_removed))
 }

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -490,7 +490,7 @@ mod tests {
         let helper = Cli::parse_from([
             "nono",
             "pack-update-hint-helper",
-            "always-further/claude",
+            "nolabs-ai/claude",
             "1.0.0",
         ]);
         assert!(!allows_pre_exec_update_check(&helper.command));

--- a/crates/nono-cli/src/migration.rs
+++ b/crates/nono-cli/src/migration.rs
@@ -43,7 +43,7 @@ const LEARN_MORE_URL: &str = "https://github.com/nolabs-ai/nono/discussions/780"
 const OFFICIAL_PACKS: &[OfficialPack] = &[
     OfficialPack {
         profile_name: "claude",
-        namespace: "always-further",
+        namespace: "nolabs-ai",
         pack_name: "claude",
         description: Some("Anthropic Claude Code sandbox profile + plugin"),
         installs_summary: Some("sandbox profile + Claude Code plugin (hooks, skill)"),
@@ -52,24 +52,24 @@ const OFFICIAL_PACKS: &[OfficialPack] = &[
     // renamed to `claude` so it matches the pack name. Once the pack
     // is installed, the resolver also accepts `claude-code` via the
     // artifact's `aliases` field. This entry only matters for users
-    // who type `--profile always-further/claude` *before* the pack is installed.
+    // who type `--profile nolabs-ai/claude` *before* the pack is installed.
     OfficialPack {
         profile_name: "claude-code",
-        namespace: "always-further",
+        namespace: "nolabs-ai",
         pack_name: "claude",
         description: Some("Anthropic Claude Code (legacy profile name; canonical is `claude`)"),
         installs_summary: Some("sandbox profile + Claude Code plugin (hooks, skill)"),
     },
     OfficialPack {
         profile_name: "codex",
-        namespace: "always-further",
+        namespace: "nolabs-ai",
         pack_name: "codex",
         description: Some("OpenAI Codex CLI sandbox profile + plugin"),
         installs_summary: Some("sandbox profile + Codex plugin (hooks, skill)"),
     },
     OfficialPack {
         profile_name: "opencode",
-        namespace: "always-further",
+        namespace: "nolabs-ai",
         pack_name: "opencode",
         description: Some("OpenCode AI coding assistant sandbox profile + plugin"),
         installs_summary: Some("sandbox profile + OpenCode plugin (hooks, skill)"),
@@ -166,7 +166,7 @@ pub fn check_and_run(profile_name: &str) -> Result<MigrationOutcome> {
 }
 
 fn is_claude_pack(provider: &ProfileProvider) -> bool {
-    provider.namespace == "always-further" && provider.name == "claude"
+    provider.namespace == "nolabs-ai" && provider.name == "claude"
 }
 
 fn official_pack_for(profile_name: &str) -> Option<&'static OfficialPack> {
@@ -312,7 +312,7 @@ mod tests {
 
     #[test]
     fn registry_ref_skips_migration() {
-        assert!(is_path_or_registry_ref("always-further/claude"));
+        assert!(is_path_or_registry_ref("nolabs-ai/claude"));
         assert!(is_path_or_registry_ref("./local.json"));
         assert!(is_path_or_registry_ref("path/to/profile.json"));
         assert!(!is_path_or_registry_ref("claude-code"));
@@ -345,7 +345,7 @@ mod tests {
             .expect("claude-code")
             .as_provider();
         assert_eq!(canonical.pack_ref(), legacy.pack_ref());
-        assert_eq!(canonical.pack_ref(), "always-further/claude");
+        assert_eq!(canonical.pack_ref(), "nolabs-ai/claude");
     }
 
     #[test]

--- a/crates/nono-cli/src/pack_update_hint.rs
+++ b/crates/nono-cli/src/pack_update_hint.rs
@@ -331,8 +331,8 @@ mod tests {
     #[test]
     fn refresh_helper_args_round_trip() {
         let stale = vec![
-            ("always-further/claude".to_string(), "1.0.0".to_string()),
-            ("always-further/codex".to_string(), "2.3.4".to_string()),
+            ("nolabs-ai/claude".to_string(), "1.0.0".to_string()),
+            ("nolabs-ai/codex".to_string(), "2.3.4".to_string()),
         ];
 
         let args = refresh_helper_args(&stale);
@@ -342,7 +342,7 @@ mod tests {
 
     #[test]
     fn refresh_helper_args_reject_odd_values() {
-        assert!(parse_refresh_helper_args(vec!["always-further/claude".to_string()]).is_none());
+        assert!(parse_refresh_helper_args(vec!["nolabs-ai/claude".to_string()]).is_none());
     }
 
     #[test]

--- a/crates/nono-cli/src/package_cmd.rs
+++ b/crates/nono-cli/src/package_cmd.rs
@@ -117,9 +117,9 @@ pub fn run_pull(args: PullArgs) -> Result<()> {
     // pack (here, not via `migration::check_and_run`), also offer to
     // strip pre-0.43 inbuilt-hook leftovers. Idempotent — silent no-op
     // on a clean install. Mirrors the cleanup hook in `check_and_run`
-    // so power users who skip `--profile always-further/claude` don't end up with
+    // so power users who skip `--profile nolabs-ai/claude` don't end up with
     // both legacy and pack hooks firing.
-    if package_ref.namespace == "always-further" && package_ref.name == "claude" {
+    if package_ref.namespace == "nolabs-ai" && package_ref.name == "claude" {
         crate::legacy_cleanup::check_and_offer_cleanup()?;
     }
 

--- a/crates/nono-cli/src/package_cmd.rs
+++ b/crates/nono-cli/src/package_cmd.rs
@@ -9,11 +9,13 @@ use crate::package::{
 };
 use crate::registry_client::{RegistryClient, resolve_registry_url};
 use chrono::{DateTime, Local, Utc};
+use colored::Colorize;
 use nono::{NonoError, Result, SignerIdentity};
 use semver::Version;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
+use std::io::{self, BufRead, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
@@ -122,6 +124,86 @@ pub fn run_pull(args: PullArgs) -> Result<()> {
     if package_ref.namespace == "nolabs-ai" && package_ref.name == "claude" {
         crate::legacy_cleanup::check_and_offer_cleanup()?;
     }
+
+    // After installing any nolabs-ai pack, check whether the same pack
+    // under the legacy always-further namespace is still in the lockfile.
+    // If so, its wiring (marketplace dirs, TOML blocks, hook entries, etc.)
+    // is still live and conflicts with the new install. Offer to remove it.
+    offer_remove_legacy_namespace_pack(&package_ref)?;
+
+    Ok(())
+}
+
+/// If `always-further/<name>` is present in the lockfile after a successful
+/// `nolabs-ai/<name>` pull, prompt to remove it so the old wiring is reversed
+/// cleanly. This covers all packs (codex, claude, opencode, …) without
+/// requiring pack-specific cleanup logic.
+fn offer_remove_legacy_namespace_pack(new_ref: &PackageRef) -> Result<()> {
+    if new_ref.namespace != "nolabs-ai" {
+        return Ok(());
+    }
+    let legacy_key = format!("always-further/{}", new_ref.name);
+    let lockfile = package::read_lockfile()?;
+    if !lockfile.packages.contains_key(&legacy_key) {
+        return Ok(());
+    }
+
+    let mut err = io::stderr().lock();
+    let _ = writeln!(err);
+    let _ = writeln!(
+        err,
+        "  {}  Legacy pack {} is still installed.",
+        "⚠".yellow(),
+        legacy_key.bold(),
+    );
+    let _ = writeln!(err);
+    let _ = writeln!(
+        err,
+        "     Its wiring (marketplace dirs, config entries, hook entries) conflicts"
+    );
+    let _ = writeln!(
+        err,
+        "     with the newly installed {}. Remove it now?",
+        new_ref.key().bold()
+    );
+    let _ = writeln!(err);
+
+    let interactive = io::stdin().is_terminal() && io::stderr().is_terminal();
+    if !interactive {
+        let _ = writeln!(
+            err,
+            "  no TTY — skipping. Remove manually with: {}",
+            format!("nono remove {legacy_key}").bold()
+        );
+        let _ = writeln!(err);
+        return Ok(());
+    }
+
+    let _ = write!(err, "  Remove {}? [Y/n] ", legacy_key.bold());
+    let _ = err.flush();
+    drop(err);
+
+    let mut line = String::new();
+    if io::stdin().lock().read_line(&mut line).is_err() {
+        return Ok(());
+    }
+    let answer = line.trim().to_ascii_lowercase();
+    if !(answer.is_empty() || answer == "y" || answer == "yes") {
+        let mut err = io::stderr().lock();
+        let _ = writeln!(
+            err,
+            "  skipped — remove later with: {}",
+            format!("nono remove {legacy_key}").bold()
+        );
+        let _ = writeln!(err);
+        return Ok(());
+    }
+
+    run_remove(RemoveArgs {
+        package_ref: legacy_key,
+        force: false,
+        help: None,
+    })?;
 
     Ok(())
 }

--- a/crates/nono-cli/src/package_status.rs
+++ b/crates/nono-cli/src/package_status.rs
@@ -202,10 +202,7 @@ mod tests {
             "nolabs-ai/claude@1.2.3"
         ));
         assert!(is_official_package_ref(CODEX_PACK, "nolabs-ai/codex"));
-        assert!(is_official_package_ref(
-            CODEX_PACK,
-            "nolabs-ai/codex@1.2.3"
-        ));
+        assert!(is_official_package_ref(CODEX_PACK, "nolabs-ai/codex@1.2.3"));
         assert!(!is_official_package_ref(CLAUDE_PACK, "someone/claude"));
         assert!(!is_official_package_ref(
             CODEX_PACK,

--- a/crates/nono-cli/src/package_status.rs
+++ b/crates/nono-cli/src/package_status.rs
@@ -13,13 +13,13 @@ struct OfficialPackStatusTarget {
 }
 
 const CLAUDE_PACK: OfficialPackStatusTarget = OfficialPackStatusTarget {
-    namespace: "always-further",
+    namespace: "nolabs-ai",
     name: "claude",
     profiles: &["claude", "claude-code"],
 };
 
 const CODEX_PACK: OfficialPackStatusTarget = OfficialPackStatusTarget {
-    namespace: "always-further",
+    namespace: "nolabs-ai",
     name: "codex",
     profiles: &["codex"],
 };
@@ -179,8 +179,8 @@ mod tests {
             }),
         };
 
-        let message = yanked_message("always-further/claude", "1.2.2", &status);
-        assert!(message.contains("nono pull always-further/claude@1.2.3 --force"));
+        let message = yanked_message("nolabs-ai/claude", "1.2.2", &status);
+        assert!(message.contains("nono pull nolabs-ai/claude@1.2.3 --force"));
         assert!(message.contains("security"));
         assert!(message.contains("high - profile policy fix"));
     }
@@ -196,23 +196,20 @@ mod tests {
 
     #[test]
     fn canonical_package_refs_target_official_packs() {
+        assert!(is_official_package_ref(CLAUDE_PACK, "nolabs-ai/claude"));
         assert!(is_official_package_ref(
             CLAUDE_PACK,
-            "always-further/claude"
+            "nolabs-ai/claude@1.2.3"
         ));
-        assert!(is_official_package_ref(
-            CLAUDE_PACK,
-            "always-further/claude@1.2.3"
-        ));
-        assert!(is_official_package_ref(CODEX_PACK, "always-further/codex"));
+        assert!(is_official_package_ref(CODEX_PACK, "nolabs-ai/codex"));
         assert!(is_official_package_ref(
             CODEX_PACK,
-            "always-further/codex@1.2.3"
+            "nolabs-ai/codex@1.2.3"
         ));
         assert!(!is_official_package_ref(CLAUDE_PACK, "someone/claude"));
         assert!(!is_official_package_ref(
             CODEX_PACK,
-            "always-further/codex-extra"
+            "nolabs-ai/codex-extra"
         ));
     }
 }

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -1610,7 +1610,7 @@ mod tests {
     #[test]
     fn test_embedded_claude_code_profile_was_removed() {
         // Removed in v0.43.0: claude-code now ships via the registry pack
-        // `always-further/claude`. The platform GROUPS it referenced
+        // `nolabs-ai/claude`. The platform GROUPS it referenced
         // (claude_code_macos / claude_code_linux) remain so the pack profile
         // can resolve them by name.
         let policy = load_embedded_policy().expect("embedded policy");

--- a/crates/nono-cli/src/profile/builtin.rs
+++ b/crates/nono-cli/src/profile/builtin.rs
@@ -23,7 +23,7 @@ mod tests {
     #[test]
     fn test_claude_code_no_longer_inbuilt() {
         // Removed in v0.43.0: claude-code is now shipped via the registry pack
-        // `always-further/claude` and resolved through the user-profile
+        // `nolabs-ai/claude` and resolved through the user-profile
         // symlink, not the embedded policy.json.
         assert!(get_builtin("claude-code").is_none());
         assert!(get_builtin("claude-no-kc").is_none());
@@ -32,7 +32,7 @@ mod tests {
     #[test]
     fn test_opencode_no_longer_inbuilt() {
         // Removed: opencode is now shipped via the registry pack
-        // `always-further/opencode`, not embedded in policy.json.
+        // `nolabs-ai/opencode`, not embedded in policy.json.
         assert!(get_builtin("opencode").is_none());
     }
 
@@ -115,9 +115,9 @@ mod tests {
         assert!(profiles.contains(&"openclaw".to_string()));
         assert!(profiles.contains(&"swival".to_string()));
         // Profiles that ship via registry packs instead of as built-ins:
-        //   claude-code → always-further/claude   (removed v0.43.0)
-        //   codex       → always-further/codex    (removed v0.43.0)
-        //   opencode    → always-further/opencode (removed)
+        //   claude-code → nolabs-ai/claude   (removed v0.43.0)
+        //   codex       → nolabs-ai/codex    (removed v0.43.0)
+        //   opencode    → nolabs-ai/opencode (removed)
         // Tool Sandbox examples should also live outside embedded built-ins.
         assert!(!profiles.contains(&"claude-code".to_string()));
         assert!(!profiles.contains(&"claude-no-kc".to_string()));

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -2323,7 +2323,7 @@ pub fn load_profile_extends(name_or_path: &str) -> Option<Vec<String>> {
 ///    `install_as` matches the requested name. Self-heals Claude Code plugin
 ///    wiring (symlink + `enabledPlugins`) on every successful resolution.
 /// 3. Built-in profiles (compiled into binary).
-/// 4. Auto-pull prompt for the registry pack `always-further/claude` when
+/// 4. Auto-pull prompt for the registry pack `nolabs-ai/claude` when
 ///    the requested profile is `claude-code` (or inherits from it).
 pub fn load_profile(name_or_path: &str) -> Result<Profile> {
     load_profile_impl(name_or_path, &[])
@@ -2466,9 +2466,9 @@ fn load_profile_inner(name_or_path: &str, cli_extends: &[String]) -> Result<Opti
         if !profile.packs.contains(&pack_key) {
             profile.packs.push(pack_key);
         }
-        // If we just resolved through `always-further/claude`, also offer
+        // If we just resolved through `nolabs-ai/claude`, also offer
         // to strip pre-0.43 inbuilt-hook leftovers. Catches the path
-        // where users `nono pull always-further/claude` directly,
+        // where users `nono pull nolabs-ai/claude` directly,
         // bypassing the post-pull cleanup hook in `migration::check_and_run`.
         // Idempotent: silent no-op when no legacy artifacts exist, so safe
         // to fire on every claude resolution.
@@ -2494,7 +2494,7 @@ fn load_profile_inner(name_or_path: &str, cli_extends: &[String]) -> Result<Opti
     Ok(None)
 }
 
-/// True when `profile_path` lives inside `<package_store>/always-further/claude/`.
+/// True when `profile_path` lives inside `<package_store>/nolabs-ai/claude/`.
 /// Used to gate legacy-cleanup invocation on the canonical claude pack
 /// rather than any pack that happens to publish a profile named `claude`
 /// or `claude-code`.
@@ -2502,7 +2502,7 @@ fn is_always_further_claude_pack(profile_path: &Path) -> bool {
     let Ok(store) = crate::package::package_store_dir() else {
         return false;
     };
-    profile_path_is_in_pack(profile_path, &store, "always-further", "claude")
+    profile_path_is_in_pack(profile_path, &store, "nolabs-ai", "claude")
 }
 
 /// Pure path-component matcher: does `profile_path` live under
@@ -3032,7 +3032,7 @@ enum ResolvedBase {
 /// This handles the v0.42 → v0.43 upgrade case where a user profile
 /// `extends: ["claude-code"]` and the inbuilt `claude-code` is gone:
 /// instead of an inscrutable "base profile not found" error, the user
-/// sees the same install prompt that `--profile always-further/claude` would
+/// sees the same install prompt that `--profile nolabs-ai/claude` would
 /// produce, with the chain still resolving cleanly on accept.
 fn load_base_profile_raw(
     name: &str,
@@ -3646,7 +3646,7 @@ pub fn list_profiles() -> Vec<String> {
     }
 
     // Add pack-store profiles — names exposed by installed packs via
-    // `install_as`. Without this, `--profile always-further/claude` works (the
+    // `install_as`. Without this, `--profile nolabs-ai/claude` works (the
     // resolver finds it) but `nono profile list` doesn't surface it,
     // confusing users who expect a one-stop catalogue.
     for (name, _pack_ref) in list_pack_store_profiles() {
@@ -3732,11 +3732,11 @@ mod tests {
     #[test]
     fn profile_path_is_in_pack_matches_canonical_layout() {
         let store = Path::new("/store");
-        let claude_profile = Path::new("/store/always-further/claude/profile/claude.json");
+        let claude_profile = Path::new("/store/nolabs-ai/claude/profile/claude.json");
         assert!(profile_path_is_in_pack(
             claude_profile,
             store,
-            "always-further",
+            "nolabs-ai",
             "claude"
         ));
 
@@ -3747,25 +3747,25 @@ mod tests {
         assert!(!profile_path_is_in_pack(
             third_party,
             store,
-            "always-further",
+            "nolabs-ai",
             "claude"
         ));
 
         // Different pack name in the same namespace must not match.
-        let codex = Path::new("/store/always-further/codex/profile/codex.json");
+        let codex = Path::new("/store/nolabs-ai/codex/profile/codex.json");
         assert!(!profile_path_is_in_pack(
             codex,
             store,
-            "always-further",
+            "nolabs-ai",
             "claude"
         ));
 
         // Path outside the store entirely must not match.
-        let outside = Path::new("/elsewhere/always-further/claude/profile.json");
+        let outside = Path::new("/elsewhere/nolabs-ai/claude/profile.json");
         assert!(!profile_path_is_in_pack(
             outside,
             store,
-            "always-further",
+            "nolabs-ai",
             "claude"
         ));
     }
@@ -4258,9 +4258,9 @@ mod tests {
         assert!(profiles.contains(&"openclaw".to_string()));
         assert!(profiles.contains(&"swival".to_string()));
         // These profiles were removed from built-ins; they ship via registry packs:
-        //   claude-code / claude → always-further/claude   (removed v0.43.0)
-        //   codex               → always-further/codex    (removed v0.43.0)
-        //   opencode            → always-further/opencode (removed)
+        //   claude-code / claude → nolabs-ai/claude   (removed v0.43.0)
+        //   codex               → nolabs-ai/codex    (removed v0.43.0)
+        //   opencode            → nolabs-ai/opencode (removed)
         assert!(!profiles.contains(&"claude-code".to_string()));
         assert!(!profiles.contains(&"codex".to_string()));
         assert!(!profiles.contains(&"opencode".to_string()));

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -2472,7 +2472,7 @@ fn load_profile_inner(name_or_path: &str, cli_extends: &[String]) -> Result<Opti
         // bypassing the post-pull cleanup hook in `migration::check_and_run`.
         // Idempotent: silent no-op when no legacy artifacts exist, so safe
         // to fire on every claude resolution.
-        if is_always_further_claude_pack(&profile_path) {
+        if is_nolabs_ai_claude_pack(&profile_path) {
             crate::legacy_cleanup::check_and_offer_cleanup()?;
         }
         return Ok(Some(profile));
@@ -2498,7 +2498,7 @@ fn load_profile_inner(name_or_path: &str, cli_extends: &[String]) -> Result<Opti
 /// Used to gate legacy-cleanup invocation on the canonical claude pack
 /// rather than any pack that happens to publish a profile named `claude`
 /// or `claude-code`.
-fn is_always_further_claude_pack(profile_path: &Path) -> bool {
+fn is_nolabs_ai_claude_pack(profile_path: &Path) -> bool {
     let Ok(store) = crate::package::package_store_dir() else {
         return false;
     };
@@ -2506,7 +2506,7 @@ fn is_always_further_claude_pack(profile_path: &Path) -> bool {
 }
 
 /// Pure path-component matcher: does `profile_path` live under
-/// `<store>/<ns>/<name>/...`? Split out of `is_always_further_claude_pack`
+/// `<store>/<ns>/<name>/...`? Split out of `is_nolabs_ai_claude_pack`
 /// so it can be tested without touching `XDG_CONFIG_HOME` / `HOME`.
 fn profile_path_is_in_pack(profile_path: &Path, store: &Path, ns: &str, name: &str) -> bool {
     let Ok(rel) = profile_path.strip_prefix(store) else {

--- a/crates/nono-cli/src/profile_cmd.rs
+++ b/crates/nono-cli/src/profile_cmd.rs
@@ -103,7 +103,7 @@ fn cmd_init(args: ProfileInitArgs) -> Result<()> {
     }
 
     // Block names that match an embedded built-in profile. Pack profiles use
-    // `org/name` keys (e.g. `always-further/hermes`), which are invalid as
+    // `org/name` keys (e.g. `nolabs-ai/hermes`), which are invalid as
     // profile names, so a short name like `hermes` cannot shadow a pack.
     {
         let pol = policy::load_embedded_policy()?;
@@ -802,7 +802,7 @@ pub(crate) fn cmd_list(args: ProfileListArgs) -> Result<()> {
 }
 
 /// Like `print_profile_line` but appends the providing pack ref so the
-/// user sees `claude-code  Anthropic Claude Code …  always-further/claude`.
+/// user sees `claude-code  Anthropic Claude Code …  nolabs-ai/claude`.
 fn print_pack_profile_line(name: &str, pack_ref: &str, result: &Result<Profile>, t: &theme::Theme) {
     match result {
         Ok(p) => {

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -537,7 +537,7 @@ fn prepare_profile_with_options(
             Some(profile_name),
             options.hook_output_silent,
         )?;
-        // If the profile was addressed by pack ref (e.g. --profile always-further/hermes),
+        // If the profile was addressed by pack ref (e.g. --profile nolabs-ai/hermes),
         // ensure that pack is verified even if the profile JSON doesn't list it in `packs`.
         // Pack refs are injected into profile.packs at load time for every
         // pack-store resolution — both direct registry refs and name/alias

--- a/crates/nono-cli/src/profile_save_runtime.rs
+++ b/crates/nono-cli/src/profile_save_runtime.rs
@@ -583,7 +583,7 @@ pub(crate) fn would_shadow_existing_profile(profile_name: &str) -> bool {
         return false;
     }
     // Only block names that match embedded built-ins. Pack profiles are
-    // referenced by their full `org/name` key (e.g. `always-further/hermes`),
+    // referenced by their full `org/name` key (e.g. `nolabs-ai/hermes`),
     // which is an invalid profile name, so a short user profile name like
     // `hermes` cannot shadow a pack profile.
     crate::policy::load_embedded_policy()
@@ -2177,14 +2177,14 @@ mod tests {
             &patch,
             "claude",
             "claude-test",
-            Some("always-further/claude"),
+            Some("nolabs-ai/claude"),
         )
         .expect("prepare");
 
         assert!(matches!(prepared.action, SaveAction::Created));
         assert_eq!(
             prepared.profile.extends,
-            Some(vec!["always-further/claude".to_string()])
+            Some(vec!["nolabs-ai/claude".to_string()])
         );
     }
 
@@ -2208,13 +2208,13 @@ mod tests {
             &patch,
             "claude",
             "claude-test",
-            Some("always-further/claude@1.2.0"),
+            Some("nolabs-ai/claude@1.2.0"),
         )
         .expect("prepare");
 
         assert_eq!(
             prepared.profile.extends,
-            Some(vec!["always-further/claude@1.2.0".to_string()])
+            Some(vec!["nolabs-ai/claude@1.2.0".to_string()])
         );
     }
 

--- a/crates/nono-cli/src/pull_ui.rs
+++ b/crates/nono-cli/src/pull_ui.rs
@@ -1,7 +1,7 @@
 //! Sleek TUI for `nono pull`. Streams per-file download progress as it
 //! happens, then renders the install summary. Same output for the
 //! explicit `nono pull <ref>` command and the auto-pull path triggered
-//! by `--profile always-further/claude`.
+//! by `--profile nolabs-ai/claude`.
 //!
 //! Design rules (do not relax without thinking):
 //!   - No spinners, no in-place line rewrites — output stays readable in

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -996,7 +996,7 @@ mod tests {
                 },
                 crate::sandbox_state::EndpointRuleState {
                     method: "*".to_string(),
-                    path: "/always-further/**".to_string(),
+                    path: "/nolabs-ai/**".to_string(),
                 },
             ],
         }];

--- a/crates/nono-cli/src/registry_client.rs
+++ b/crates/nono-cli/src/registry_client.rs
@@ -111,9 +111,14 @@ impl RegistryClient {
                     msg.push_str(&format!("\nadvisory severity: {severity}"));
                 }
             }
+            let suggest_ns = if package_ref.namespace == "always-further" {
+                "nolabs-ai"
+            } else {
+                package_ref.namespace.as_str()
+            };
             msg.push_str(&format!(
                 "\ninstall the latest safe release: nono pull {}/{}",
-                package_ref.namespace, package_ref.name
+                suggest_ns, package_ref.name
             ));
             return Err(NonoError::RegistryError(msg));
         }

--- a/crates/nono-cli/src/setup.rs
+++ b/crates/nono-cli/src/setup.rs
@@ -374,7 +374,7 @@ impl SetupRunner {
 
         println!("  You can add these aliases to {}:", shell_rc);
         println!();
-        println!("    alias nono-claude='nono run --profile always-further/claude -- claude'");
+        println!("    alias nono-claude='nono run --profile nolabs-ai/claude -- claude'");
         println!("    alias nono-safe='nono run --allow-cwd --block-net --'");
         println!();
     }
@@ -393,7 +393,7 @@ impl SetupRunner {
             println!("Quick start examples:");
             println!();
             println!("  # Run Claude Code with built-in profile (recommended)");
-            println!("  nono run --profile always-further/claude -- claude");
+            println!("  nono run --profile nolabs-ai/claude -- claude");
             println!();
             println!("  # Run any command with current directory access");
             println!("  nono run --allow-cwd -- <command>");

--- a/crates/nono-cli/src/wiring.rs
+++ b/crates/nono-cli/src/wiring.rs
@@ -250,7 +250,7 @@ pub enum WiringRecord {
 
 /// Per-leaf record for `JsonMerge`. `path` is the chain of object
 /// keys from the document root to the leaf (e.g.
-/// `["enabledPlugins", "nono@always-further"]`). `installed_value` is
+/// `["enabledPlugins", "nono@nolabs-ai"]`). `installed_value` is
 /// what we wrote at that leaf; `prior_value` is what was there before
 /// (None when the leaf didn't exist pre-merge).
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -1510,7 +1510,7 @@ mod tests {
         let _ = home; // signature parity with test setup
         WiringContext {
             pack_dir,
-            namespace: "always-further".to_string(),
+            namespace: "nolabs-ai".to_string(),
             pack_name: "claude".to_string(),
         }
     }
@@ -1567,8 +1567,8 @@ mod tests {
             "/h/.config/nono/profile-drafts"
         );
         assert_eq!(
-            expand_vars("$NONO_PACKAGES/always-further/claude", &ctx).expect("expand"),
-            "/h/.config/nono/packages/always-further/claude"
+            expand_vars("$NONO_PACKAGES/nolabs-ai/claude", &ctx).expect("expand"),
+            "/h/.config/nono/packages/nolabs-ai/claude"
         );
     }
 
@@ -1584,12 +1584,12 @@ mod tests {
         let config_str = config.path().to_str().expect("config path");
         let ctx = WiringContext {
             pack_dir: PathBuf::from("/p"),
-            namespace: "always-further".to_string(),
+            namespace: "nolabs-ai".to_string(),
             pack_name: "claude".to_string(),
         };
         let _env = EnvVarGuard::set_all(&[("HOME", home_str), ("XDG_CONFIG_HOME", config_str)]);
         let expected_config = format!("{config_str}/nono/profile-drafts");
-        let expected_packages = format!("{config_str}/nono/packages/always-further/claude");
+        let expected_packages = format!("{config_str}/nono/packages/nolabs-ai/claude");
         assert_eq!(
             nono::try_canonicalize(Path::new(
                 &expand_vars("$NONO_CONFIG/profile-drafts", &ctx).expect("expand")
@@ -1598,7 +1598,7 @@ mod tests {
         );
         assert_eq!(
             nono::try_canonicalize(Path::new(
-                &expand_vars("$NONO_PACKAGES/always-further/claude", &ctx).expect("expand")
+                &expand_vars("$NONO_PACKAGES/nolabs-ai/claude", &ctx).expect("expand")
             )),
             nono::try_canonicalize(Path::new(&expected_packages))
         );

--- a/crates/nono-cli/tests/deprecated_policy.rs
+++ b/crates/nono-cli/tests/deprecated_policy.rs
@@ -64,7 +64,7 @@ fn policy_show_alias() {
 fn policy_diff_alias() {
     // Both profiles must be embedded so the test doesn't depend on a
     // registry pack being installed. `claude-code` was used here
-    // before it was moved to the always-further/claude pack.
+    // before it was moved to the nolabs-ai/claude pack.
     let (ok_old, stdout_old, stderr_old) =
         run(&["policy", "diff", "default", "node-dev", "--json"]);
     let (ok_new, stdout_new, _) = run(&["profile", "diff", "default", "node-dev", "--json"]);

--- a/crates/nono-cli/tests/profile_cli.rs
+++ b/crates/nono-cli/tests/profile_cli.rs
@@ -226,7 +226,7 @@ fn test_show_format_manifest_default_profile() {
 fn test_show_format_manifest_node_dev_profile() {
     // node-dev is an embedded profile with non-empty filesystem grants,
     // standing in for the claude-code coverage that moved to the
-    // always-further/claude registry pack.
+    // nolabs-ai/claude registry pack.
     let output = nono_bin()
         .args(["profile", "show", "node-dev", "--format", "manifest"])
         .output()

--- a/docs/cli/clients/claude-code.mdx
+++ b/docs/cli/clients/claude-code.mdx
@@ -16,14 +16,14 @@ Claude Code includes its own sandboxing, but Anthropic documents an intentional 
 ## Quick Start
 
 ```bash
-nono run --profile always-further/claude -- claude
+nono run --profile nolabs-ai/claude -- claude
 ```
 
 <Warning>
 **macOS users:** Claude Code needs LaunchServices access when a session will need browser login. `nono` now auto-enables this for the `claude-code` profile when it does not detect refresh-capable local auth. You can also pass the flag explicitly for first use or `claude /login`:
 
 ```bash
-nono run --profile always-further/claude --allow-launch-services -- claude
+nono run --profile nolabs-ai/claude --allow-launch-services -- claude
 ```
 After login completes, rerun without `--allow-launch-services` if you no longer need browser-opening help for that session.
 See [OAuth2 Login](#oauth2-login) for details.
@@ -84,12 +84,12 @@ If you want to inherit the Claude Code profile but remove its network filtering,
 Then run:
 
 ```bash
-nono run --profile always-further/claude-netopen -- claude
+nono run --profile nolabs-ai/claude-netopen -- claude
 ```
 
 **Usage:**
 ```bash
-nono run --profile always-further/claude -- claude
+nono run --profile nolabs-ai/claude -- claude
 ```
 
 <Note>
@@ -103,7 +103,7 @@ If you use multiple Claude Code configurations via the `CLAUDE_CONFIG_DIR` envir
 ```bash
 export CLAUDE_CONFIG_DIR=~/.claude-work
 
-nono run --profile always-further/claude \
+nono run --profile nolabs-ai/claude \
   --allow ~/.claude-work \
   --allow ~/.claude-work.lock \
   -- claude
@@ -147,7 +147,7 @@ secret-tool store --label="nono: anthropic_api_key" service nono username anthro
 
 Then run with secrets:
 ```bash
-nono run --profile always-further/claude --env-credential anthropic_api_key -- claude
+nono run --profile nolabs-ai/claude --env-credential anthropic_api_key -- claude
 ```
 
 See [Credential Injection](/cli/features/credential-injection) for full documentation.
@@ -173,7 +173,7 @@ nono run --read . --read ~/.claude --allow-file ~/.claude.json -- claude
 If you want to prevent any outbound connections (e.g., for reviewing local code without API calls):
 
 ```bash
-nono run --profile always-further/claude --block-net -- claude
+nono run --profile nolabs-ai/claude --block-net -- claude
 ```
 
 ### Add Extra Domains
@@ -181,7 +181,7 @@ nono run --profile always-further/claude --block-net -- claude
 If Claude Code needs to reach a domain not in the built-in network profile:
 
 ```bash
-nono run --profile always-further/claude --allow-domain my-internal-api.example.com -- claude
+nono run --profile nolabs-ai/claude --allow-domain my-internal-api.example.com -- claude
 ```
 
 ## OAuth2 Login
@@ -196,13 +196,13 @@ The `claude-code` profile includes an origin allowlist that controls which URLs 
 On Linux, no additional flags are needed:
 
 ```bash
-nono run --profile always-further/claude -- claude
+nono run --profile nolabs-ai/claude -- claude
 ```
 
 On macOS, `nono` auto-enables LaunchServices for the `claude-code` profile when no refresh-capable local auth is detected. You can also enable it explicitly for the login session:
 
 ```bash
-nono run --profile always-further/claude --allow-launch-services -- claude
+nono run --profile nolabs-ai/claude --allow-launch-services -- claude
 ```
 
 After login completes, rerun without `--allow-launch-services` unless you still need browser-opening help for that session.
@@ -264,7 +264,7 @@ echo "$PATH" | tr ':' '\n'
 Grant read access to any `~/` entry that appears before the directory containing your LSP binary:
 
 ```bash
-nono run --profile always-further/claude \
+nono run --profile nolabs-ai/claude \
   --read ~/.cargo/bin \
   --read ~/.local/bin \
   -- claude
@@ -309,7 +309,7 @@ Save as `~/.config/nono/profiles/claude-code-secretive.json`:
 
 **Usage:**
 ```bash
-nono run --profile always-further/claude-secretive --allow-cwd -- claude
+nono run --profile nolabs-ai/claude-secretive --allow-cwd -- claude
 ```
 
 The profile extends the standard Claude Code profile with:
@@ -326,29 +326,29 @@ CLI flags always take precedence over profile settings:
 
 ```bash
 # Use profile but add extra directory access
-nono run --profile always-further/claude --allow ~/other-project -- claude
+nono run --profile nolabs-ai/claude --allow ~/other-project -- claude
 
 # Use profile but block network
-nono run --profile always-further/claude --block-net -- claude
+nono run --profile nolabs-ai/claude --block-net -- claude
 
 # Use profile but add a custom domain
-nono run --profile always-further/claude --allow-domain custom-api.example.com -- claude
+nono run --profile nolabs-ai/claude --allow-domain custom-api.example.com -- claude
 ```
 
 See [Security Profiles](/cli/features/profiles-groups) for details on profile format and precedence rules.
 
 ## Automatic Pack Install and Plugin Wiring
 
-As of v0.43, the `claude-code` profile is no longer compiled into the CLI. It's distributed as a signed registry pack at `always-further/claude` along with a Claude Code plugin that provides sandbox-aware diagnostics.
+As of v0.43, the `claude-code` profile is no longer compiled into the CLI. It's distributed as a signed registry pack at `nolabs-ai/claude` along with a Claude Code plugin that provides sandbox-aware diagnostics.
 
-The first time you run `nono run --profile always-further/claude -- claude`, nono prompts to install the pack:
+The first time you run `nono run --profile nolabs-ai/claude -- claude`, nono prompts to install the pack:
 
 ```
-  ⊕  Install always-further/claude?
+  ⊕  Install nolabs-ai/claude?
 
      The `claude-code` profile is provided by this registry pack.
 
-     Publisher    always-further GitHub organisation
+     Publisher    nolabs-ai GitHub organisation
      Provenance   Sigstore cryptographic supply chain (verified on pull)
      Installs     sandbox profile + Claude Code plugin
 
@@ -359,28 +359,28 @@ Press `Y` (or just Enter). nono pulls the pack, verifies its Sigstore provenance
 
 ### What "Pull" Actually Does
 
-After verification, nono installs the pack to `~/.config/nono/packages/always-further/claude/` and wires it into Claude Code as a single-plugin marketplace:
+After verification, nono installs the pack to `~/.config/nono/packages/nolabs-ai/claude/` and wires it into Claude Code as a single-plugin marketplace:
 
 | What | Where |
 |------|-------|
-| Pack files (profile, plugin manifest, hooks, skills) | `~/.config/nono/packages/always-further/claude/` |
-| Marketplace manifest (synthesised by nono) | `~/.claude/plugins/marketplaces/always-further/.claude-plugin/marketplace.json` |
-| Plugin source (symlink → pack dir) | `~/.claude/plugins/marketplaces/always-further/plugins/nono` |
-| Cache pointer (symlink → pack dir) | `~/.claude/plugins/cache/always-further/nono/<version>` |
+| Pack files (profile, plugin manifest, hooks, skills) | `~/.config/nono/packages/nolabs-ai/claude/` |
+| Marketplace manifest (synthesised by nono) | `~/.claude/plugins/marketplaces/nolabs-ai/.claude-plugin/marketplace.json` |
+| Plugin source (symlink → pack dir) | `~/.claude/plugins/marketplaces/nolabs-ai/plugins/nono` |
+| Cache pointer (symlink → pack dir) | `~/.claude/plugins/cache/nolabs-ai/nono/<version>` |
 | Marketplace registry entry | `~/.claude/plugins/known_marketplaces.json` |
 | Plugin install record | `~/.claude/plugins/installed_plugins.json` |
-| Enabled-plugins toggle | `~/.claude/settings.json::enabledPlugins["nono@always-further"]` |
+| Enabled-plugins toggle | `~/.claude/settings.json::enabledPlugins["nono@nolabs-ai"]` |
 
-The pack store is the single source of truth — every Claude-side path is a symlink or registry entry pointing at it. Re-pulling the pack updates the contents in place; deleting the pack via `nono remove always-further/claude` unwires every Claude-side entry too.
+The pack store is the single source of truth — every Claude-side path is a symlink or registry entry pointing at it. Re-pulling the pack updates the contents in place; deleting the pack via `nono remove nolabs-ai/claude` unwires every Claude-side entry too.
 
 ### Subsequent Runs
 
-Once installed, `nono run --profile always-further/claude -- claude` runs silently — no prompt. nono's profile resolver finds `claude-code` in the pack store and re-asserts the marketplace wiring on every run, so deleting any of the symlinks above is recovered transparently on the next `nono run`.
+Once installed, `nono run --profile nolabs-ai/claude -- claude` runs silently — no prompt. nono's profile resolver finds `claude-code` in the pack store and re-asserts the marketplace wiring on every run, so deleting any of the symlinks above is recovered transparently on the next `nono run`.
 
 If a newer version of the pack is available, nono prints a one-line hint after the capabilities block:
 
 ```
-  update available  always-further/claude  0.0.12 → 0.0.13   run: nono update
+  update available  nolabs-ai/claude  0.0.12 → 0.0.13   run: nono update
 ```
 
 Run `nono update` to apply it, or `nono outdated` to check all installed packs at once. See [Managing Packs](/cli/features/managing-packs) for pinning and other options.
@@ -391,7 +391,7 @@ Run `nono update` to apply it, or `nono outdated` to check all installed packs a
 |-------------|-----------|
 | Interactive TTY | Prompt fires; press Enter or `Y` to install. |
 | `NONO_AUTO_MIGRATE=1` | Prompt skipped; pull runs immediately. Useful for CI/scripted setup. |
-| `NONO_NO_MIGRATE=1` | Pull blocked; nono exits cleanly with a hint pointing at `nono pull always-further/claude`. |
+| `NONO_NO_MIGRATE=1` | Pull blocked; nono exits cleanly with a hint pointing at `nono pull nolabs-ai/claude`. |
 | Non-TTY (no env override) | Same as `NONO_NO_MIGRATE=1` — nono exits cleanly with a hint. |
 
 ### User Profiles That Extend `claude-code`
@@ -406,7 +406,7 @@ If you have a custom profile under `~/.config/nono/profiles/` that does `"extend
 }
 ```
 
-The first time you run `nono run --profile claude-with-docs`, the prompt fires for `always-further/claude`. After accept, the profile resolves cleanly via the pack-installed `claude-code` base.
+The first time you run `nono run --profile claude-with-docs`, the prompt fires for `nolabs-ai/claude`. After accept, the profile resolves cleanly via the pack-installed `claude-code` base.
 
 ## Hook-Driven Sandbox Diagnostics
 
@@ -465,7 +465,7 @@ These commands are read-only diagnostics — none of them modify state — so it
 ### Removing the Pack
 
 ```bash
-nono remove always-further/claude
+nono remove nolabs-ai/claude
 ```
 
-This removes the pack store directory, the marketplace dir, the cache subtree, the entries in `known_marketplaces.json` / `installed_plugins.json`, and the `enabledPlugins["nono@always-further"]` toggle. Claude Code's view of the world is restored to what it was before the install. Re-running `nono run --profile always-further/claude` will prompt to re-install.
+This removes the pack store directory, the marketplace dir, the cache subtree, the entries in `known_marketplaces.json` / `installed_plugins.json`, and the `enabledPlugins["nono@nolabs-ai"]` toggle. Claude Code's view of the world is restored to what it was before the install. Re-running `nono run --profile nolabs-ai/claude` will prompt to re-install.

--- a/docs/cli/clients/codex.mdx
+++ b/docs/cli/clients/codex.mdx
@@ -11,7 +11,7 @@ When you run Codex under `nono`, prefer a single sandbox layer: let `nono` enfor
 Recommended invocation:
 
 ```bash
-nono run --profile always-further/codex -- codex --sandbox danger-full-access --ask-for-approval on-request
+nono run --profile nolabs-ai/codex -- codex --sandbox danger-full-access --ask-for-approval on-request
 ```
 
 This keeps Codex's approval flow while avoiding nested sandboxes that can make denials harder to diagnose. See OpenAI's [agent approvals and security docs](https://developers.openai.com/codex/agent-approvals-security).
@@ -30,10 +30,10 @@ nono makes those boundaries kernel-enforced instead of advisory.
 ## Quick Start
 
 ```bash
-nono run --profile always-further/codex -- codex --sandbox danger-full-access --ask-for-approval on-request
+nono run --profile nolabs-ai/codex -- codex --sandbox danger-full-access --ask-for-approval on-request
 ```
 
-If the registry pack `always-further/codex` isn't installed yet, nono prompts to pull it (see [Automatic Pack Install and Plugin Wiring](#automatic-pack-install-and-plugin-wiring) below).
+If the registry pack `nolabs-ai/codex` isn't installed yet, nono prompts to pull it (see [Automatic Pack Install and Plugin Wiring](#automatic-pack-install-and-plugin-wiring) below).
 
 The pack profile provides:
 
@@ -46,16 +46,16 @@ The pack profile provides:
 
 ## Automatic Pack Install and Plugin Wiring
 
-The `codex` profile is distributed as a signed registry pack at `always-further/codex` along with a Codex plugin that provides sandbox-aware diagnostic hooks and a skill for guiding the user through denial-recovery.
+The `codex` profile is distributed as a signed registry pack at `nolabs-ai/codex` along with a Codex plugin that provides sandbox-aware diagnostic hooks and a skill for guiding the user through denial-recovery.
 
-The first time you run `nono run --profile always-further/codex -- codex`, nono prompts to install the pack:
+The first time you run `nono run --profile nolabs-ai/codex -- codex`, nono prompts to install the pack:
 
 ```
-  ⊕  Install always-further/codex?
+  ⊕  Install nolabs-ai/codex?
 
      The `codex` profile is provided by this registry pack.
 
-     Publisher    always-further GitHub organisation
+     Publisher    nolabs-ai GitHub organisation
      Provenance   Sigstore cryptographic supply chain (verified on pull)
      Installs     sandbox profile + Codex hooks + diagnostic skill
 
@@ -68,20 +68,20 @@ Press `Y`. nono pulls the pack, verifies its Sigstore provenance, and writes Cod
 
 | Path | What goes there |
 |------|-----------------|
-| `~/.config/nono/packages/always-further/codex/` | The unpacked pack: profile, plugin manifest, hooks, skill. Single source of truth — every Codex-side path below is a symlink or registry entry pointing at this dir. |
-| `~/.codex/plugins/cache/always-further/codex/local` | Symlink → pack store. Codex's `PluginStore` (`codex-rs/core-plugins/src/store.rs`) walks this dir to discover installed plugin versions. |
-| `~/.codex/config.toml` (fenced block) | `[marketplaces.always-further]` registers the marketplace; `[plugins."nono@always-further"] enabled = true` enables the plugin. |
+| `~/.config/nono/packages/nolabs-ai/codex/` | The unpacked pack: profile, plugin manifest, hooks, skill. Single source of truth — every Codex-side path below is a symlink or registry entry pointing at this dir. |
+| `~/.codex/plugins/cache/nolabs-ai/codex/local` | Symlink → pack store. Codex's `PluginStore` (`codex-rs/core-plugins/src/store.rs`) walks this dir to discover installed plugin versions. |
+| `~/.codex/config.toml` (fenced block) | `[marketplaces.nolabs-ai]` registers the marketplace; `[plugins."nono@nolabs-ai"] enabled = true` enables the plugin. |
 | `~/.codex/hooks.json` | Hook entries pointing at `<pack store>/bin/nono-hook*.sh` for `PostToolUse`, `PermissionRequest`, `SessionStart`. |
 
 The `config.toml` block is fenced with markers so re-pulls and removals never touch your other settings:
 
 ```toml
 # >>> nono-managed (do not edit) >>>
-[marketplaces.always-further]
+[marketplaces.nolabs-ai]
 source_type = "local"
-source = "/Users/<you>/.config/nono/packages/always-further/codex"
+source = "/Users/<you>/.config/nono/packages/nolabs-ai/codex"
 
-[plugins."nono@always-further"]
+[plugins."nono@nolabs-ai"]
 enabled = true
 # <<< nono-managed <<<
 ```
@@ -105,12 +105,12 @@ note: Codex hooks need this in ~/.codex/config.toml to fire — add it once and 
 
 ### Subsequent runs
 
-Once installed, `nono run --profile always-further/codex -- codex` runs silently — no prompt. nono's profile resolver finds `codex` in the pack store and re-asserts the marketplace + cache wiring on every run, so deleting any of the entries above is recovered transparently on the next `nono run`.
+Once installed, `nono run --profile nolabs-ai/codex -- codex` runs silently — no prompt. nono's profile resolver finds `codex` in the pack store and re-asserts the marketplace + cache wiring on every run, so deleting any of the entries above is recovered transparently on the next `nono run`.
 
 If a newer version of the pack is available, nono prints a one-line hint after the capabilities block:
 
 ```
-  update available  always-further/codex  0.0.11 → 0.0.12   run: nono update
+  update available  nolabs-ai/codex  0.0.11 → 0.0.12   run: nono update
 ```
 
 Run `nono update` to apply it, or `nono outdated` to check all installed packs at once. See [Managing Packs](/cli/features/managing-packs) for pinning and other options.
@@ -121,7 +121,7 @@ Run `nono update` to apply it, or `nono outdated` to check all installed packs a
 |-------------|-----------|
 | Interactive TTY | Prompt fires; press Enter or `Y` to install. |
 | `NONO_AUTO_MIGRATE=1` | Prompt skipped; pull runs immediately. Useful for CI/scripted setup. |
-| `NONO_NO_MIGRATE=1` | Pull blocked; nono exits cleanly with a hint pointing at `nono pull always-further/codex`. |
+| `NONO_NO_MIGRATE=1` | Pull blocked; nono exits cleanly with a hint pointing at `nono pull nolabs-ai/codex`. |
 | Non-TTY (no env override) | Same as `NONO_NO_MIGRATE=1`. |
 
 ### Hook-driven sandbox diagnostics
@@ -137,7 +137,7 @@ In `permission_mode = "bypassPermissions"` (Codex's yolo mode), all three hooks 
 ### Removing the pack
 
 ```bash
-nono remove always-further/codex
+nono remove nolabs-ai/codex
 ```
 
 Removes the pack store directory, the cache subtree, the fenced block from `config.toml`, the hook entries from `hooks.json`, and the lockfile entry. `[features] codex_hooks = true` is left alone — it's a user-set Codex preference, not something nono installed.
@@ -180,13 +180,13 @@ The profile includes the required browser-open allowlist:
 On Linux, no additional flags are needed:
 
 ```bash
-nono run --profile always-further/codex -- codex --sandbox danger-full-access --ask-for-approval on-request
+nono run --profile nolabs-ai/codex -- codex --sandbox danger-full-access --ask-for-approval on-request
 ```
 
 On macOS, enable LaunchServices temporarily for the login session:
 
 ```bash
-nono run --profile always-further/codex --allow-launch-services -- codex --sandbox danger-full-access --ask-for-approval on-request
+nono run --profile nolabs-ai/codex --allow-launch-services -- codex --sandbox danger-full-access --ask-for-approval on-request
 ```
 
 After login completes, exit and rerun without `--allow-launch-services`.
@@ -200,7 +200,7 @@ After login completes, exit and rerun without `--allow-launch-services`.
 The profile grants access to the directory you run Codex from. To pin access to a specific repository:
 
 ```bash
-nono run --profile always-further/codex --workdir ~/projects/my-app -- codex --sandbox danger-full-access --ask-for-approval on-request
+nono run --profile nolabs-ai/codex --workdir ~/projects/my-app -- codex --sandbox danger-full-access --ask-for-approval on-request
 ```
 
 ### Read-Only Workspace
@@ -216,7 +216,7 @@ nono run --read . --allow ~/.codex -- codex --sandbox danger-full-access --ask-f
 If you want to inspect local code without allowing outbound access:
 
 ```bash
-nono run --profile always-further/codex --block-net -- codex --sandbox danger-full-access --ask-for-approval on-request
+nono run --profile nolabs-ai/codex --block-net -- codex --sandbox danger-full-access --ask-for-approval on-request
 ```
 
 ### Use Network Filtering
@@ -224,7 +224,7 @@ nono run --profile always-further/codex --block-net -- codex --sandbox danger-fu
 If you want Codex limited to the built-in host allowlist for coding workflows:
 
 ```bash
-nono run --profile always-further/codex --network-profile codex -- codex --sandbox danger-full-access --ask-for-approval on-request
+nono run --profile nolabs-ai/codex --network-profile codex -- codex --sandbox danger-full-access --ask-for-approval on-request
 ```
 
 ### Additional Home-Directory Tools
@@ -234,7 +234,7 @@ The profile covers common Rust, Node.js, Python, and Nix runtime locations under
 If a tool exists on your `PATH` but Codex cannot launch it inside the sandbox, grant read access to the specific path entry:
 
 ```bash
-nono run --profile always-further/codex \
+nono run --profile nolabs-ai/codex \
   --read ~/.bun/bin \
   --read ~/go/bin \
   -- codex --sandbox danger-full-access --ask-for-approval on-request

--- a/docs/cli/clients/opencode.mdx
+++ b/docs/cli/clients/opencode.mdx
@@ -18,7 +18,7 @@ nono prevents all of this at the kernel level.
 ## Quick Start
 
 ```bash
-nono run --profile always-further/opencode -- opencode
+nono run --profile nolabs-ai/opencode -- opencode
 ```
 
 The profile provides:
@@ -67,7 +67,7 @@ Create `~/.config/nono/profiles/opencode.json` for different permissions:
 
 **Usage:**
 ```bash
-nono run --profile always-further/opencode -- opencode
+nono run --profile nolabs-ai/opencode -- opencode
 ```
 
 ## Security Tips
@@ -88,7 +88,7 @@ secret-tool store --label="nono: openai_api_key" service nono username openai_ap
 
 Then run:
 ```bash
-nono run --profile always-further/opencode --env-credential openai_api_key -- opencode
+nono run --profile nolabs-ai/opencode --env-credential openai_api_key -- opencode
 ```
 
 See [Credential Injection](/cli/features/credential-injection) for full documentation.
@@ -113,10 +113,10 @@ CLI flags always take precedence:
 
 ```bash
 # Add extra directory access
-nono run --profile always-further/opencode --allow ~/shared-libs -- opencode
+nono run --profile nolabs-ai/opencode --allow ~/shared-libs -- opencode
 
 # Block network
-nono run --profile always-further/opencode --block-net -- opencode
+nono run --profile nolabs-ai/opencode --block-net -- opencode
 ```
 
 See [Security Profiles](/cli/features/profiles-groups) for details on profile format and precedence rules.
@@ -130,5 +130,5 @@ OpenCode routes Google Gemini requests directly to the Google API rather than th
 Use `--env-credential` instead of proxy injection when working with Gemini:
 
 ```bash
-nono run --profile always-further/opencode --env-credential gemini_api_key -- opencode
+nono run --profile nolabs-ai/opencode --env-credential gemini_api_key -- opencode
 ```

--- a/docs/cli/clients/quickstart.mdx
+++ b/docs/cli/clients/quickstart.mdx
@@ -26,13 +26,13 @@ For example:
 
 ```bash
 # Claude Code
-nono run --profile always-further/claude -- claude
+nono run --profile nolabs-ai/claude -- claude
 
 # Codex
-nono run --profile always-further/codex -- codex
+nono run --profile nolabs-ai/codex -- codex
 
 # OpenCode
-nono run --profile always-further/opencode -- opencode
+nono run --profile nolabs-ai/opencode -- opencode
 
 # OpenClaw gateway
 nono run --profile openclaw -- openclaw gateway

--- a/docs/cli/development/index.mdx
+++ b/docs/cli/development/index.mdx
@@ -17,7 +17,7 @@ This section covers development topics for contributors and maintainers of nono.
 
 1. **Clone the repository**
    ```bash
-   git clone https://github.com/always-further/nono.git
+   git clone https://github.com/nolabs-ai/nono.git
    cd nono
    ```
 
@@ -66,4 +66,4 @@ RUST_LOG=debug cargo run -- run --allow-cwd -- echo "test"
 - **Unsafe Code**: Restricted to FFI; must include `// SAFETY:` documentation
 - **Path Security**: All paths must be validated and canonicalized
 
-See [CLAUDE.md](https://github.com/always-further/nono/blob/main/CLAUDE.md) for complete coding standards.
+See [CLAUDE.md](https://github.com/nolabs-ai/nono/blob/main/CLAUDE.md) for complete coding standards.

--- a/docs/cli/features/atomic-rollbacks.mdx
+++ b/docs/cli/features/atomic-rollbacks.mdx
@@ -18,7 +18,7 @@ When you run a command with `--rollback`, nono:
 
 ```bash
 # Enable rollback snapshots
-nono run --rollback --profile always-further/claude -- claude
+nono run --rollback --profile nolabs-ai/claude -- claude
 ```
 
 <Note>

--- a/docs/cli/features/audit.mdx
+++ b/docs/cli/features/audit.mdx
@@ -156,7 +156,7 @@ To have the supervisor sign the completed session audit record, use `--audit-sig
 nono run --audit-sign-key default --allow-cwd -- my-agent
 
 # Sign with an explicit secret backend reference
-nono run --audit-sign-key op://Development/Nono/audit-key --profile always-further/claude -- claude
+nono run --audit-sign-key op://Development/Nono/audit-key --profile nolabs-ai/claude -- claude
 ```
 
 The signing key is loaded by the trusted supervisor before sandbox activation. After the session ends, the resulting keyed DSSE bundle is written into the audit session directory as `audit-attestation.bundle`, and a summary is stored in `session.json`.

--- a/docs/cli/features/managing-packs.mdx
+++ b/docs/cli/features/managing-packs.mdx
@@ -12,7 +12,7 @@ For the producer side (creating and publishing packs), see [Publishing Packs](/c
 Use `nono pull` to install a pack from the registry:
 
 ```bash
-nono pull always-further/claude
+nono pull nolabs-ai/claude
 ```
 
 On install, the CLI:
@@ -29,7 +29,7 @@ On install, the CLI:
 By default `nono pull` installs the latest version. Pin to a specific version with `@`:
 
 ```bash
-nono pull always-further/claude@1.2.0
+nono pull nolabs-ai/claude@1.2.0
 ```
 
 ### Initializing Project Files
@@ -37,7 +37,7 @@ nono pull always-further/claude@1.2.0
 Some packs include project-level instructions (e.g. a `CLAUDE.md` context file). Use `--init` to copy them into the current directory:
 
 ```bash
-nono pull always-further/claude --init
+nono pull nolabs-ai/claude --init
 ```
 
 Without `--init`, project-level instructions are installed into the pack store but not copied into your working directory.
@@ -47,7 +47,7 @@ Without `--init`, project-level instructions are installed into the pack store b
 Use `--force` to overwrite conflicts and accept signer changes:
 
 ```bash
-nono pull always-further/claude --force
+nono pull nolabs-ai/claude --force
 ```
 
 <Warning>
@@ -59,7 +59,7 @@ nono pull always-further/claude --force
 When you run `nono run --profile <name>`, nono checks whether any pack in the active profile's extends chain has a newer version available and prints a one-line hint if so:
 
 ```
-  update available  always-further/claude  0.0.12 → 0.0.13   run: nono update
+  update available  nolabs-ai/claude  0.0.12 → 0.0.13   run: nono update
 ```
 
 Results are cached for 24 hours so the check never blocks startup. Stale entries refresh in a detached helper process for the next run. To suppress only pack update hints, set `NONO_NO_PACK_UPDATE_HINTS=1`. The hint also respects the global CLI update-check opt-out: set `NONO_NO_UPDATE_CHECK=1` or `[updates] check = false` in `~/.config/nono/config.toml`.
@@ -91,7 +91,7 @@ nono update
 Or update a specific pack:
 
 ```bash
-nono update always-further/claude
+nono update nolabs-ai/claude
 ```
 
 The update checks the registry for newer versions, verifies signatures, and replaces local artifacts. Signer identity changes trigger a confirmation prompt (use `--force` to skip).
@@ -113,13 +113,13 @@ nono update --force
 Pin a pack to prevent it from being updated by `nono update`:
 
 ```bash
-nono pin always-further/claude
+nono pin nolabs-ai/claude
 ```
 
 Unpin to allow updates again:
 
 ```bash
-nono unpin always-further/claude
+nono unpin nolabs-ai/claude
 ```
 
 Pinned packs are still shown by `nono outdated`. The pin state is local — it does not affect other users or the registry.
@@ -127,7 +127,7 @@ Pinned packs are still shown by `nono outdated`. The pin state is local — it d
 ## Removing a Pack
 
 ```bash
-nono remove always-further/claude
+nono remove nolabs-ai/claude
 ```
 
 This removes all artifacts installed by the pack (profiles, plugins, hooks, wiring) and cleans up the lockfile entry.
@@ -135,7 +135,7 @@ This removes all artifacts installed by the pack (profiles, plugins, hooks, wiri
 If the pack applied wiring directives (e.g. injected hook entries into `hooks.json`), removal reverses them. If reversal partially fails, the lockfile entry is kept so you can retry. Use `--force` to proceed anyway:
 
 ```bash
-nono remove always-further/claude --force
+nono remove nolabs-ai/claude --force
 ```
 
 ## Searching the Registry

--- a/docs/cli/features/package-publishing.mdx
+++ b/docs/cli/features/package-publishing.mdx
@@ -409,7 +409,7 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - uses: always-further/agent-sign@<pinned-sha>
+      - uses: nolabs-ai/agent-sign@<pinned-sha>
         with:
           publish: "true"
           package-name: claude
@@ -503,13 +503,13 @@ The table lives at `crates/nono-cli/src/migration.rs` as `PACK_PROVIDED_PROFILES
 pub const PACK_PROVIDED_PROFILES: &[PackProvidedProfile] = &[
     PackProvidedProfile {
         profile_name: "claude-code",
-        pack_ref: "always-further/claude",
+        pack_ref: "nolabs-ai/claude",
         installs_summary: "sandbox profile + Claude Code plugin",
     },
     // Future:
     // PackProvidedProfile {
     //     profile_name: "codex",
-    //     pack_ref: "always-further/codex",
+    //     pack_ref: "nolabs-ai/codex",
     //     installs_summary: "sandbox profile + Codex integration assets",
     // },
 ];

--- a/docs/cli/features/profiles-groups.mdx
+++ b/docs/cli/features/profiles-groups.mdx
@@ -24,7 +24,7 @@ Profiles simplify this:
 
 ```bash
 # With profiles - concise and auditable
-nono run --profile always-further/claude -- claude
+nono run --profile nolabs-ai/claude -- claude
 ```
 
 ### Predefined Profiles vs User Profiles
@@ -356,7 +356,7 @@ This allows access to `~/.docker` even though `deny_credentials` blocks it by de
 This is equivalent to the CLI flag `--bypass-protection`:
 
 ```bash
-nono run --profile always-further/opencode --allow ~/.docker --bypass-protection ~/.docker -- opencode
+nono run --profile nolabs-ai/opencode --allow ~/.docker --bypass-protection ~/.docker -- opencode
 ```
 
 #### Suppressing Save Suggestions Without Granting Access
@@ -567,13 +567,13 @@ CLI flags always take precedence over profile settings:
 
 ```bash
 # Use claude-code profile but block network
-nono run --profile always-further/claude --block-net -- claude
+nono run --profile nolabs-ai/claude --block-net -- claude
 
 # Use claude-code profile but add a custom domain
-nono run --profile always-further/claude --allow-domain custom-api.example.com -- claude
+nono run --profile nolabs-ai/claude --allow-domain custom-api.example.com -- claude
 
 # Add extra directory access
-nono run --profile always-further/claude --allow ~/other-project -- claude
+nono run --profile nolabs-ai/claude --allow ~/other-project -- claude
 ```
 
 To keep a base profile but clear an inherited network profile, set `network.network_profile` to `null` in the child:
@@ -745,7 +745,7 @@ The base profile that all other profiles extend. Provides system path access, de
 ### claude-code
 
 ```bash
-nono run --profile always-further/claude -- claude
+nono run --profile nolabs-ai/claude -- claude
 ```
 
 **Groups:** `claude_code_macos`, `claude_code_linux`, `user_caches_macos`, `claude_cache_linux`, `node_runtime`, `rust_runtime`, `python_runtime`, `vscode_macos`, `vscode_linux`, `nix_runtime`, `git_config`, `unlink_protection` (plus `default` groups)
@@ -761,7 +761,7 @@ nono run --profile always-further/claude -- claude
 ### codex
 
 ```bash
-nono run --profile always-further/codex -- codex
+nono run --profile nolabs-ai/codex -- codex
 ```
 
 **Groups:** `codex_macos`, `node_runtime`, `rust_runtime`, `python_runtime`, `nix_runtime`, `git_config`, `unlink_protection` (plus `default` groups)
@@ -777,7 +777,7 @@ nono run --profile always-further/codex -- codex
 ### opencode
 
 ```bash
-nono run --profile always-further/opencode -- opencode
+nono run --profile nolabs-ai/opencode -- opencode
 ```
 
 **Groups:** `user_caches_macos`, `user_caches_linux`, `node_runtime`, `opencode_linux`, `git_config`, `unlink_protection` (plus `default` groups)
@@ -875,7 +875,7 @@ nono run --profile java-dev -- mvn package
 
 If you'd like a profile for a tool not listed here:
 
-1. Open an issue on the [nono GitHub repository](https://github.com/always-further/nono/issues)
+1. Open an issue on the [nono GitHub repository](https://github.com/nolabs-ai/nono/issues)
 2. Include:
    - Tool name and repository URL
    - Required filesystem access patterns

--- a/docs/cli/features/session-lifecycle.mdx
+++ b/docs/cli/features/session-lifecycle.mdx
@@ -46,7 +46,7 @@ In normal day-to-day usage, the common states are:
 ### Attached Start
 
 ```bash
-nono run --profile always-further/claude --allow-cwd -- claude
+nono run --profile nolabs-ai/claude --allow-cwd -- claude
 ```
 
 This starts the session attached to your current terminal. You interact with the agent directly from the start.
@@ -54,7 +54,7 @@ This starts the session attached to your current terminal. You interact with the
 ### Detached Start
 
 ```bash
-nono run --detached --profile always-further/claude --allow-cwd -- claude
+nono run --detached --profile nolabs-ai/claude --allow-cwd -- claude
 ```
 
 This starts the session with no client attached, but the session keeps running under supervisor and PTY management.
@@ -210,7 +210,7 @@ nono prune --keep 20
 Use this when you want an agent to keep running while you do something else:
 
 ```bash
-nono run --detached --rollback --profile always-further/claude --allow-cwd -- claude
+nono run --detached --rollback --profile nolabs-ai/claude --allow-cwd -- claude
 nono ps
 nono attach <session-id>
 ```
@@ -222,7 +222,7 @@ This is the recommended workflow for long-running coding or migration sessions.
 Use this when you want to watch the first phase of the run, then leave it working:
 
 ```bash
-nono run --rollback --profile always-further/claude --allow-cwd -- claude
+nono run --rollback --profile nolabs-ai/claude --allow-cwd -- claude
 ```
 
 Then detach with:
@@ -267,7 +267,7 @@ Prefer `nono stop` over killing the child directly, because the supervisor is re
 Detached sessions are especially useful when combined with rollback:
 
 ```bash
-nono run --detached --rollback --profile always-further/claude --allow-cwd -- claude
+nono run --detached --rollback --profile nolabs-ai/claude --allow-cwd -- claude
 ```
 
 This gives you two safety properties at once:

--- a/docs/cli/features/supervisor.mdx
+++ b/docs/cli/features/supervisor.mdx
@@ -11,10 +11,10 @@ Supervised execution is the default for `nono run` and `nono shell`. No extra fl
 
 ```bash
 # Supervised by default
-nono run --profile always-further/claude -- claude
+nono run --profile nolabs-ai/claude -- claude
 
 # Enable rollback snapshots
-nono run --rollback --profile always-further/claude -- claude
+nono run --rollback --profile nolabs-ai/claude -- claude
 ```
 
 The execution model:

--- a/docs/cli/features/trust.mdx
+++ b/docs/cli/features/trust.mdx
@@ -178,7 +178,7 @@ nono trust sign-policy --keyref file:///path/to/key.pem  # file-backed key
 For development and testing, disable attestation enforcement:
 
 ```bash
-nono run --profile always-further/claude --trust-override -- claude
+nono run --profile nolabs-ai/claude --trust-override -- claude
 ```
 
 Verification still runs and results are logged, but failures produce warnings instead of hard denies. This flag is CLI-only — it cannot be set in a profile or trust policy.
@@ -515,7 +515,7 @@ When `nono run` launches a command, it scans the working directory for files mat
 To keep startup latency bounded in large repositories, the scan prunes a small built-in set of regenerable heavy directories such as `.git`, `node_modules`, `target`, `dist`, and common cache directories. Hidden directories are otherwise still scanned. You can extend the skip set for a session with `--skip-dir <name>` or persist it in a profile with `skipdirs`.
 
 ```
-nono run --profile always-further/claude -- claude
+nono run --profile nolabs-ai/claude -- claude
   -> Scan CWD for files matching includes patterns
   -> For each match:
      -> Compute SHA-256 digest

--- a/docs/cli/getting_started/installation.mdx
+++ b/docs/cli/getting_started/installation.mdx
@@ -14,23 +14,23 @@ nono --version
 
 ### Debian/Ubuntu
 
-Download the `.deb` package from [GitHub Releases](https://github.com/always-further/nono/releases):
+Download the `.deb` package from [GitHub Releases](https://github.com/nolabs-ai/nono/releases):
 
 ```bash
-VERSION=$(curl -sI https://github.com/always-further/nono/releases/latest | grep -i location | grep -oP 'v\K[0-9a-zA-Z.-]+')
+VERSION=$(curl -sI https://github.com/nolabs-ai/nono/releases/latest | grep -i location | grep -oP 'v\K[0-9a-zA-Z.-]+')
 ARCH=$(dpkg --print-architecture)
-wget https://github.com/always-further/nono/releases/download/v${VERSION}/nono-cli_${VERSION}_${ARCH}.deb
+wget https://github.com/nolabs-ai/nono/releases/download/v${VERSION}/nono-cli_${VERSION}_${ARCH}.deb
 sudo dpkg -i nono-cli_${VERSION}_${ARCH}.deb
 nono --version
 ```
 
 ### Fedora (COPR)
 
-nono is available from the official [COPR repository](https://copr.fedorainfracloud.org/coprs/always-further/nono/):
+nono is available from the official [COPR repository](https://copr.fedorainfracloud.org/coprs/nolabs-ai/nono/):
 
 ```bash
 sudo dnf install 'dnf-command(copr)'
-sudo dnf copr enable always-further/nono
+sudo dnf copr enable nolabs-ai/nono
 sudo dnf install nono-cli
 nono --version
 ```
@@ -41,12 +41,12 @@ nono --version
 
 ### Manual RPM (RHEL/openSUSE and fallback)
 
-Download the `.rpm` package from [GitHub Releases](https://github.com/always-further/nono/releases):
+Download the `.rpm` package from [GitHub Releases](https://github.com/nolabs-ai/nono/releases):
 
 ```bash
-VERSION=$(curl -sI https://github.com/always-further/nono/releases/latest | grep -i location | grep -oP 'v\K[0-9a-zA-Z.-]+')
+VERSION=$(curl -sI https://github.com/nolabs-ai/nono/releases/latest | grep -i location | grep -oP 'v\K[0-9a-zA-Z.-]+')
 ARCH=$(uname -m)
-wget https://github.com/always-further/nono/releases/download/v${VERSION}/nono-cli-${VERSION}-1.${ARCH}.rpm
+wget https://github.com/nolabs-ai/nono/releases/download/v${VERSION}/nono-cli-${VERSION}-1.${ARCH}.rpm
 sudo dnf install ./nono-cli-${VERSION}-1.${ARCH}.rpm
 nono --version
 ```

--- a/docs/cli/getting_started/quickstart.mdx
+++ b/docs/cli/getting_started/quickstart.mdx
@@ -25,15 +25,15 @@ Just search for your favorite coding agent from the registry
 
 ```bash
 nono search opencode
-always-further/opencode	-	Official Always Further Opencode Plugin
+nolabs-ai/opencode	-	Official Always Further Opencode Plugin
 ```
 
 And then run..
 
 ```bash
-nono run --profile always-further/claude -- claude
-nono run --profile always-further/codex -- codex
-nono run --profile always-further/pi -- pi
+nono run --profile nolabs-ai/claude -- claude
+nono run --profile nolabs-ai/codex -- codex
+nono run --profile nolabs-ai/pi -- pi
 ```
 
 ## Network Access
@@ -145,7 +145,7 @@ For setting up nono with a specific AI agent:
 - [OpenClaw](/cli/clients/openclaw)
 
 <Note>
-  If the agent you want to use cannot be found, create an [issue](https://github.com/always-further/nono/issues) to request consideration for adding it to the registry, or fork an existing profile and submit a PR with the new agent profile. See [Package Publishing](/cli/features/package-publishing) for details on publishing profiles.
+  If the agent you want to use cannot be found, create an [issue](https://github.com/nolabs-ai/nono/issues) to request consideration for adding it to the registry, or fork an existing profile and submit a PR with the new agent profile. See [Package Publishing](/cli/features/package-publishing) for details on publishing profiles.
 </Note>
 
 ### Build your own profile
@@ -153,7 +153,7 @@ For setting up nono with a specific AI agent:
 It's likely that you are going to want to customize the pre-built profiles or create your own for different tools and needs. You can do this easily with `nono profile init` which will create a new profile based on an existing one, with the option to customize it interactively.
 
 ```bash
-nono profile init claude --extends always-further/claude --full
+nono profile init claude --extends nolabs-ai/claude --full
 
 nono profile Created profile at /Users/jdoe/.config/nono/profiles/claude.json
 nono profile Validate with: nono profile validate claude

--- a/docs/cli/internals/capability-manifest.mdx
+++ b/docs/cli/internals/capability-manifest.mdx
@@ -28,7 +28,7 @@ nono run --config manifest.json -- my-agent
 
 ## Schema
 
-The manifest schema is at [`crates/nono/schema/capability-manifest.schema.json`](https://github.com/always-further/nono/blob/main/crates/nono/schema/capability-manifest.schema.json), using JSON Schema Draft 2020-12.
+The manifest schema is at [`crates/nono/schema/capability-manifest.schema.json`](https://github.com/nolabs-ai/nono/blob/main/crates/nono/schema/capability-manifest.schema.json), using JSON Schema Draft 2020-12.
 
 ### Capability Domains
 

--- a/docs/cli/internals/containers.mdx
+++ b/docs/cli/internals/containers.mdx
@@ -133,7 +133,7 @@ Because nono and containers operate at different layers, they combine naturally.
 ```dockerfile
 # Dockerfile
 FROM ubuntu:22.04
-COPY --from=ghcr.io/always-further/nono:latest /usr/bin/nono /usr/bin/nono
+COPY --from=ghcr.io/nolabs-ai/nono:latest /usr/bin/nono /usr/bin/nono
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \
     rm -rf /var/lib/apt/lists/*

--- a/docs/cli/internals/landlock.mdx
+++ b/docs/cli/internals/landlock.mdx
@@ -120,14 +120,14 @@ nono derives these scopes from the effective capability set:
 Use verbose dry-run output to see what would be requested and enforced:
 
 ```bash
-nono run --dry-run -v --profile always-further/claude -- claude
+nono run --dry-run -v --profile nolabs-ai/claude -- claude
 ```
 
 Use `nono why` for a focused scope query:
 
 ```bash
-nono why --scope signal --profile always-further/claude
-nono why --scope abstract-unix-socket --profile always-further/claude
+nono why --scope signal --profile nolabs-ai/claude
+nono why --scope abstract-unix-socket --profile nolabs-ai/claude
 ```
 
 ## Pathname Unix Socket Mediation

--- a/docs/cli/usage/developer-workflows.mdx
+++ b/docs/cli/usage/developer-workflows.mdx
@@ -28,7 +28,7 @@ This does not mean turning off the agent's own approval UX. It means avoiding a 
 Recommended pattern:
 
 ```bash
-nono run --profile always-further/claude --allow-cwd -- claude
+nono run --profile nolabs-ai/claude --allow-cwd -- claude
 ```
 
 When running Claude Code under `nono`, prefer using `nono` as the real sandbox boundary and keep Claude Code's native sandbox disabled, or at minimum configured not to fall back to unsandboxed execution.
@@ -45,7 +45,7 @@ See [Claude Code](/cli/clients/claude-code) for the agent-specific details.
 Recommended pattern:
 
 ```bash
-nono run --profile always-further/codex --allow-cwd -- codex --sandbox danger-full-access --ask-for-approval on-request
+nono run --profile nolabs-ai/codex --allow-cwd -- codex --sandbox danger-full-access --ask-for-approval on-request
 ```
 
 The important part is the same: let `nono` enforce the filesystem and network boundary, and avoid layering another independent sandbox on top unless you have a specific reason.
@@ -75,7 +75,7 @@ The difference is that the session is still running inside the `nono` runtime mo
 ### Start Detached
 
 ```bash
-nono run --detached --profile always-further/claude --allow-cwd -- claude "Do some long-running work"
+nono run --detached --profile nolabs-ai/claude --allow-cwd -- claude "Do some long-running work"
 ```
 
 Then later:
@@ -88,7 +88,7 @@ nono attach <session-id>
 ### Start Attached, Then Detach
 
 ```bash
-nono run --profile always-further/claude --allow-cwd -- claude
+nono run --profile nolabs-ai/claude --allow-cwd -- claude
 ```
 
 Then detach with:
@@ -139,7 +139,7 @@ See [Session Lifecycle](/cli/features/session-lifecycle) for the full command re
 Use this when you expect to stay attached the whole time:
 
 ```bash
-nono run --profile always-further/claude --allow-cwd -- claude
+nono run --profile nolabs-ai/claude --allow-cwd -- claude
 ```
 
 Good for:
@@ -153,7 +153,7 @@ Good for:
 Use this when the agent may run for a while and you do not want to babysit the terminal:
 
 ```bash
-nono run --detached --profile always-further/claude --allow-cwd -- claude
+nono run --detached --profile nolabs-ai/claude --allow-cwd -- claude
 nono ps
 nono attach <session-id>
 ```
@@ -170,7 +170,7 @@ Good for:
 This is the safest default for agents that may modify a lot of code:
 
 ```bash
-nono run --detached --rollback --profile always-further/claude --allow-cwd -- claude
+nono run --detached --rollback --profile nolabs-ai/claude --allow-cwd -- claude
 ```
 
 This combines:
@@ -214,15 +214,15 @@ See [Session Lifecycle](/cli/features/session-lifecycle) for the full runtime co
 Use preset, pack, or custom profiles for repeatable workflows:
 
 ```bash
-nono run --profile always-further/claude -- claude
-nono run --profile always-further/codex -- codex --sandbox danger-full-access --ask-for-approval on-request
+nono run --profile nolabs-ai/claude -- claude
+nono run --profile nolabs-ai/codex -- codex --sandbox danger-full-access --ask-for-approval on-request
 ```
 
 Profiles make your workflow easier to repeat, share, and audit.
 
 ### Use `--allow-cwd` Deliberately
 
-`--allow-cwd` shares the current directory at the access level the active profile's [`workdir`](/cli/features/profiles-groups#working-directory) config declares: read+write for the coding profiles used here (`always-further/claude`, `always-further/codex`), read-only when no profile is specified, and nothing at all under the conservative `default` profile (`workdir: "none"`).
+`--allow-cwd` shares the current directory at the access level the active profile's [`workdir`](/cli/features/profiles-groups#working-directory) config declares: read+write for the coding profiles used here (`nolabs-ai/claude`, `nolabs-ai/codex`), read-only when no profile is specified, and nothing at all under the conservative `default` profile (`workdir: "none"`).
 
 That read+write grant is often the right choice for coding agents, but treat it as an explicit workspace grant, not as boilerplate.
 
@@ -231,7 +231,7 @@ That read+write grant is often the right choice for coding agents, but treat it 
 Some flows, especially browser-based login on macOS, need temporary extra permissions:
 
 ```bash
-nono run --profile always-further/claude --allow-launch-services -- claude
+nono run --profile nolabs-ai/claude --allow-launch-services -- claude
 ```
 
 Use those only for setup, then exit and rerun without them.
@@ -251,7 +251,7 @@ That preserves runtime cleanup, terminal cleanup, and rollback finalization.
 If you are going to let an agent run while detached, `--rollback` is usually worth the extra bookkeeping:
 
 ```bash
-nono run --detached --rollback --profile always-further/codex --allow-cwd -- codex --sandbox danger-full-access --ask-for-approval on-request
+nono run --detached --rollback --profile nolabs-ai/codex --allow-cwd -- codex --sandbox danger-full-access --ask-for-approval on-request
 ```
 
 This is the safer operational default for:
@@ -266,7 +266,7 @@ This is the safer operational default for:
 If you want one strong default workflow for powerful coding agents, use this:
 
 ```bash
-nono run --detached --rollback --profile always-further/claude --allow-cwd -- claude
+nono run --detached --rollback --profile nolabs-ai/claude --allow-cwd -- claude
 ```
 
 That gives you:

--- a/docs/cli/usage/examples.mdx
+++ b/docs/cli/usage/examples.mdx
@@ -67,7 +67,7 @@ nono why --path ./src --op write --allow .
 # Output: ALLOWED - Granted by: --allow .
 
 # Check against a profile
-nono why --path ./src --op read --profile always-further/claude
+nono why --path ./src --op read --profile nolabs-ai/claude
 ```
 
 ### Query from inside a sandbox
@@ -237,7 +237,7 @@ nono run --allow . \
 
 ```bash
 # Claude Code profile
-nono run --profile always-further/claude -- claude
+nono run --profile nolabs-ai/claude -- claude
 
 # OpenClaw profile
 nono run --profile openclaw -- openclaw gateway
@@ -246,19 +246,19 @@ nono run --profile openclaw -- openclaw gateway
 ### Profile with Extra Permissions
 
 ```bash
-nono run --profile always-further/claude --read /tmp/extra -- claude
+nono run --profile nolabs-ai/claude --read /tmp/extra -- claude
 ```
 
 ### Profile with Custom Workdir
 
 ```bash
-nono run --profile always-further/claude --workdir ./my-project -- claude
+nono run --profile nolabs-ai/claude --workdir ./my-project -- claude
 ```
 
 ### Restrict Profile to Specific Domains
 
 ```bash
-nono run --profile always-further/claude --allow-domain api.openai.com -- claude
+nono run --profile nolabs-ai/claude --allow-domain api.openai.com -- claude
 ```
 
 ## Real-World Scenarios

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -176,7 +176,7 @@ Subcommands:
 Compare against an existing profile to show only missing paths.
 
 ```bash
-nono learn --profile always-further/opencode -- opencode
+nono learn --profile nolabs-ai/opencode -- opencode
 ```
 
 ### `--extends`
@@ -304,7 +304,7 @@ not grant access and does not remove the diagnostic footer; it only prevents
 the same denied path from being offered as a profile addition repeatedly.
 
 ```bash
-nono run --profile always-further/claude \
+nono run --profile nolabs-ai/claude \
   --suppress-save-prompt ~/.copilot/settings.json \
   -- claude
 ```
@@ -829,7 +829,7 @@ See [Credential Injection](/cli/features/credential-injection) for full document
 Use a named profile (from installed packs or `~/.config/nono/profiles/`).
 
 ```bash
-nono run --profile always-further/claude -- claude
+nono run --profile nolabs-ai/claude -- claude
 nono run -p openclaw -- openclaw gateway
 ```
 
@@ -851,7 +851,7 @@ This is equivalent to temporarily prepending those bases to the profile JSON's `
 Working directory for `$WORKDIR` expansion in profiles (defaults to current directory).
 
 ```bash
-nono run --profile always-further/claude --workdir ./my-project -- claude
+nono run --profile nolabs-ai/claude --workdir ./my-project -- claude
 ```
 
 #### `--allow-cwd`
@@ -860,10 +860,10 @@ Allow access to the current working directory without prompting. By default, non
 
 ```bash
 # Non-interactive mode (e.g., CI/CD)
-nono run --profile always-further/claude --allow-cwd -- claude
+nono run --profile nolabs-ai/claude --allow-cwd -- claude
 
 # Silent mode requires --allow-cwd (cannot prompt)
-nono -s run --profile always-further/claude --allow-cwd -- claude
+nono -s run --profile nolabs-ai/claude --allow-cwd -- claude
 ```
 
 #### `--allow-launch-services`
@@ -871,7 +871,7 @@ nono -s run --profile always-further/claude --allow-cwd -- claude
 Allow direct LaunchServices opens on macOS for this session. This is intended for temporary login or setup flows that need to open a browser from inside the sandbox.
 
 ```bash
-nono run --profile always-further/claude --allow-launch-services -- claude
+nono run --profile nolabs-ai/claude --allow-launch-services -- claude
 ```
 
 <Note>
@@ -913,7 +913,7 @@ Start the supervised session without attaching the current terminal. The command
 
 ```bash
 # Start in the background, then attach later
-nono run --detached --profile always-further/claude --allow-cwd -- claude
+nono run --detached --profile nolabs-ai/claude --allow-cwd -- claude
 
 # Detached launch with an explicit session name
 nono run --detached --name gold-core --allow-cwd -- my-agent
@@ -956,7 +956,7 @@ Session names must be unique among live sessions. If you omit `--name`, nono gen
 Enable [atomic rollback snapshots](/cli/features/atomic-rollbacks) for the session. Takes content-addressable snapshots of writable directories so you can restore to the pre-session state after the command exits. Automatically selects supervised execution.
 
 ```bash
-nono run --rollback --profile always-further/claude -- claude
+nono run --rollback --profile nolabs-ai/claude -- claude
 nono run --rollback --allow-cwd -- my-agent
 ```
 
@@ -1031,7 +1031,7 @@ nono run --no-audit-integrity --allow-cwd -- my-agent
 nono run --audit-integrity --allow-cwd -- my-agent
 
 # Strongest mode: audit + filesystem integrity + restoreable rollback snapshots
-nono run --audit-integrity --rollback --profile always-further/claude -- claude
+nono run --audit-integrity --rollback --profile nolabs-ai/claude -- claude
 ```
 
 <Note>
@@ -1070,7 +1070,7 @@ nono run --audit-sign-key default --allow-cwd -- my-agent
 nono run --audit-sign-key file:///tmp/nono-audit-key.pem --allow-cwd -- my-agent
 
 # Sign with a 1Password-backed key
-nono run --audit-sign-key op://Development/Nono/audit-key --profile always-further/claude -- claude
+nono run --audit-sign-key op://Development/Nono/audit-key --profile nolabs-ai/claude -- claude
 ```
 
 The corresponding attestation can be pinned during verification:
@@ -1242,7 +1242,7 @@ Would execute: my-agent
 On Linux, combine `--dry-run` with `-v` to include detected Landlock ABI details and requested/enforced scope state:
 
 ```bash
-nono run --dry-run -v --profile always-further/claude -- claude
+nono run --dry-run -v --profile nolabs-ai/claude -- claude
 ```
 
 #### `--verbose`, `-v`
@@ -1349,8 +1349,8 @@ nono why --host example.com --port 8080
 Landlock scope to check. Supported values are `signal` and `abstract-unix-socket`.
 
 ```bash
-nono why --scope signal --profile always-further/claude
-nono why --scope abstract-unix-socket --profile always-further/claude
+nono why --scope signal --profile nolabs-ai/claude
+nono why --scope abstract-unix-socket --profile nolabs-ai/claude
 ```
 
 On Linux, scope queries report whether the effective capability set requested the scope, whether the detected Landlock ABI can support it, and whether nono will enforce it. On non-Linux platforms, scope queries return `not_applicable`.
@@ -1382,7 +1382,7 @@ When checking paths outside a sandbox, you can simulate a capability context:
 nono why --path ./src --op write --allow .
 
 # Check against a profile
-nono why --path ~/.config --op read --profile always-further/claude
+nono why --path ~/.config --op read --profile nolabs-ai/claude
 ```
 
 Available context flags:

--- a/docs/cli/usage/troubleshooting.mdx
+++ b/docs/cli/usage/troubleshooting.mdx
@@ -342,7 +342,7 @@ nono run --profile my-profile -- my-app
 
 1. Run the command to discover paths:
    ```bash
-   nono run --profile always-further/opencode -- opencode
+   nono run --profile nolabs-ai/opencode -- opencode
    ```
 
 2. Review the output to see which paths are needed:
@@ -406,7 +406,7 @@ This reports the detected kernel version, Landlock ABI, WSL2 detection status, a
 
 If you're still stuck:
 
-1. **Search existing issues**: [GitHub Issues](https://github.com/always-further/nono/issues)
+1. **Search existing issues**: [GitHub Issues](https://github.com/nolabs-ai/nono/issues)
 2. **Open a new issue** with:
    - nono version (`nono --version`)
    - OS and kernel version

--- a/scripts/claude-clear-nono.sh
+++ b/scripts/claude-clear-nono.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 # Clean up nono-managed Claude Code state for a fresh test of
-# `nono run --profile always-further/claude -- claude`. Removes:
-#   - the pulled pack at $XDG_CONFIG_HOME/nono/packages/always-further/claude
+# `nono run --profile nolabs-ai/claude -- claude`. Removes:
+#   - the pulled pack at $XDG_CONFIG_HOME/nono/packages/nolabs-ai/claude
 #   - any leftover legacy symlink at $XDG_CONFIG_HOME/nono/profiles/claude-code.json
 #   - the bare pre-marketplace symlink at ~/.claude/plugins/nono
-#   - the synthesised marketplace at ~/.claude/plugins/marketplaces/always-further
-#   - the cache dir at ~/.claude/plugins/cache/always-further
-#   - the `always-further/claude` entry from
+#   - the synthesised marketplace at ~/.claude/plugins/marketplaces/nolabs-ai
+#   - the cache dir at ~/.claude/plugins/cache/nolabs-ai
+#   - the `nolabs-ai/claude` entry from
 #     $XDG_CONFIG_HOME/nono/packages/lockfile.json (so `nono pull` re-installs
 #     instead of short-circuiting on "already up to date")
-#   - the `nono@always-further` and bare `nono` entries in
+#   - the `nono@nolabs-ai` and bare `nono` entries in
 #     ~/.claude/plugins/installed_plugins.json,
 #     ~/.claude/plugins/known_marketplaces.json,
 #     ~/.claude/settings.json (enabledPlugins keys)
@@ -19,17 +19,17 @@ set -euo pipefail
 NONO_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/nono"
 
 rm -f  "$NONO_CONFIG/profiles/claude-code.json" 2>/dev/null || true
-rm -rf "$NONO_CONFIG/packages/always-further/claude" 2>/dev/null || true
+rm -rf "$NONO_CONFIG/packages/nolabs-ai/claude" 2>/dev/null || true
 rm -rf "$HOME/.claude/plugins/nono" 2>/dev/null || true
-rm -rf "$HOME/.claude/plugins/marketplaces/always-further" 2>/dev/null || true
-rm -rf "$HOME/.claude/plugins/cache/always-further" 2>/dev/null || true
+rm -rf "$HOME/.claude/plugins/marketplaces/nolabs-ai" 2>/dev/null || true
+rm -rf "$HOME/.claude/plugins/cache/nolabs-ai" 2>/dev/null || true
 
 if ! command -v jq >/dev/null 2>&1; then
     echo "warning: jq not installed; skipping JSON registry cleanup." >&2
     echo "         hand-edit if needed:" >&2
-    echo "         - ~/.claude/settings.json::enabledPlugins[\"nono@always-further\"]" >&2
-    echo "         - ~/.claude/plugins/installed_plugins.json::plugins[\"nono@always-further\"]" >&2
-    echo "         - ~/.claude/plugins/known_marketplaces.json[\"always-further\"]" >&2
+    echo "         - ~/.claude/settings.json::enabledPlugins[\"nono@nolabs-ai\"]" >&2
+    echo "         - ~/.claude/plugins/installed_plugins.json::plugins[\"nono@nolabs-ai\"]" >&2
+    echo "         - ~/.claude/plugins/known_marketplaces.json[\"nolabs-ai\"]" >&2
     exit 0
 fi
 
@@ -47,12 +47,12 @@ strip_with_jq() {
 }
 
 strip_with_jq "$HOME/.claude/settings.json" \
-    'del(.enabledPlugins["nono@always-further"]) | del(.enabledPlugins.nono)'
+    'del(.enabledPlugins["nono@nolabs-ai"]) | del(.enabledPlugins.nono)'
 strip_with_jq "$HOME/.claude/plugins/installed_plugins.json" \
-    'del(.plugins["nono@always-further"])'
+    'del(.plugins["nono@nolabs-ai"])'
 strip_with_jq "$HOME/.claude/plugins/known_marketplaces.json" \
-    'del(."always-further")'
+    'del(."nolabs-ai")'
 strip_with_jq "$NONO_CONFIG/packages/lockfile.json" \
-    'del(.packages["always-further/claude"])'
+    'del(.packages["nolabs-ai/claude"])'
 
 echo "cleared nono-managed Claude Code state."

--- a/scripts/codex-clear-nono.sh
+++ b/scripts/codex-clear-nono.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # Clean up nono-managed Codex state for a fresh test of
-# `nono run --profile always-further/codex -- codex`. Removes:
-#   - the pulled pack at $XDG_CONFIG_HOME/nono/packages/always-further/codex
-#   - the cache subtree at ~/.codex/plugins/cache/always-further
+# `nono run --profile nolabs-ai/codex -- codex`. Removes:
+#   - the pulled pack at $XDG_CONFIG_HOME/nono/packages/nolabs-ai/codex
+#   - the cache subtree at ~/.codex/plugins/cache/nolabs-ai
 #   - the nono-managed fenced block in ~/.codex/config.toml (between
 #     the `# >>> nono-managed (do not edit) >>>` markers — registers
 #     the marketplace and enables the plugin)
 #   - hook entries in ~/.codex/hooks.json whose command path points
 #     into the nono pack store
-#   - the `always-further/codex` entry from
+#   - the `nolabs-ai/codex` entry from
 #     $XDG_CONFIG_HOME/nono/packages/lockfile.json (so `nono pull` re-installs
 #     instead of short-circuiting on "already up to date")
 #
@@ -23,16 +23,16 @@ set -euo pipefail
 
 NONO_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/nono"
 
-PACK_STORE="$NONO_CONFIG/packages/always-further/codex"
+PACK_STORE="$NONO_CONFIG/packages/nolabs-ai/codex"
 CONFIG_TOML="$HOME/.codex/config.toml"
 HOOKS_JSON="$HOME/.codex/hooks.json"
 LOCKFILE="$NONO_CONFIG/packages/lockfile.json"
 
 rm -rf "$PACK_STORE" 2>/dev/null || true
-rm -rf "$HOME/.codex/plugins/cache/always-further" 2>/dev/null || true
+rm -rf "$HOME/.codex/plugins/cache/nolabs-ai" 2>/dev/null || true
 # Synthesised marketplace dir nono owns (contains the marketplace.json
 # Codex's loader requires + the symlink to the pack store).
-rm -rf "$HOME/.codex/plugins/marketplaces/always-further" 2>/dev/null || true
+rm -rf "$HOME/.codex/plugins/marketplaces/nolabs-ai" 2>/dev/null || true
 
 # Strip our fenced block from config.toml. Pure text edit — no TOML
 # parser needed because we own the markers exactly.
@@ -50,7 +50,7 @@ if ! command -v jq >/dev/null 2>&1; then
     echo "warning: jq not installed; skipping JSON registry cleanup." >&2
     echo "         hand-edit if needed:" >&2
     echo "         - $HOOKS_JSON (drop entries whose command starts with $PACK_STORE)" >&2
-    echo "         - $LOCKFILE (drop always-further/codex)" >&2
+    echo "         - $LOCKFILE (drop nolabs-ai/codex)" >&2
     exit 0
 fi
 
@@ -91,6 +91,6 @@ edit_with_jq "$HOOKS_JSON" \
     '
 
 edit_with_jq "$LOCKFILE" \
-    'del(.packages["always-further/codex"])'
+    'del(.packages["nolabs-ai/codex"])'
 
 echo "cleared nono-managed Codex state."

--- a/scripts/diagnose-macos-browser-open.sh
+++ b/scripts/diagnose-macos-browser-open.sh
@@ -91,20 +91,20 @@ run_step \
 
 run_step \
     "nono claude-profile absolute-open" \
-    "$NONO_BIN" run --profile always-further/claude --allow-cwd -- /usr/bin/open -g "$URL"
+    "$NONO_BIN" run --profile nolabs-ai/claude --allow-cwd -- /usr/bin/open -g "$URL"
 
 run_step \
     "nono claude-profile path-open" \
-    "$NONO_BIN" run --profile always-further/claude --allow-cwd -- open -g "$URL"
+    "$NONO_BIN" run --profile nolabs-ai/claude --allow-cwd -- open -g "$URL"
 
 run_step \
     "nono claude-profile absolute-open with lsopen" \
-    "$NONO_BIN" run --profile always-further/claude --allow-cwd --allow-launch-services -- \
+    "$NONO_BIN" run --profile nolabs-ai/claude --allow-cwd --allow-launch-services -- \
     /usr/bin/open -g "$URL"
 
 run_step \
     "nono claude-profile path-open with lsopen" \
-    "$NONO_BIN" run --profile always-further/claude --allow-cwd --allow-launch-services -- \
+    "$NONO_BIN" run --profile nolabs-ai/claude --allow-cwd --allow-launch-services -- \
     open -g "$URL"
 
 log "Completed diagnostics. Full log: $LOG_FILE"

--- a/scripts/probe-claude-open-path.sh
+++ b/scripts/probe-claude-open-path.sh
@@ -66,6 +66,6 @@ echo
 env \
     PATH="$PROBE_DIR:$PATH" \
     NONO_OPEN_WRAPPER_LOG="$WRAPPER_LOG" \
-    "$NONO_BIN" run --profile always-further/claude --allow-cwd --allow-launch-services \
+    "$NONO_BIN" run --profile nolabs-ai/claude --allow-cwd --allow-launch-services \
     --read-file "$CLAUDE_BIN" -- \
     "$CLAUDE_BIN"

--- a/scripts/test-linux-container.sh
+++ b/scripts/test-linux-container.sh
@@ -16,7 +16,7 @@ usage() {
 Usage:
   ./scripts/test-linux-container.sh
   ./scripts/test-linux-container.sh cargo test -p nono-cli
-  ./scripts/test-linux-container.sh bash -c 'cargo run -q -p nono-cli -- run --profile always-further/claude --dry-run -- echo ok'
+  ./scripts/test-linux-container.sh bash -c 'cargo run -q -p nono-cli -- run --profile nolabs-ai/claude --dry-run -- echo ok'
 
 Behavior:
   - Builds a reusable Linux dev image with required system packages

--- a/scripts/test-linux.sh
+++ b/scripts/test-linux.sh
@@ -301,7 +301,7 @@ fi
 print_header "Claude Code Profile"
 
 # Test: Profile should load (dry-run to avoid modifying system)
-PROFILE_OUTPUT=$(echo "n" | $NONO run --profile always-further/claude --allow-cwd --dry-run -- echo test 2>&1 || true)
+PROFILE_OUTPUT=$(echo "n" | $NONO run --profile nolabs-ai/claude --allow-cwd --dry-run -- echo test 2>&1 || true)
 if echo "$PROFILE_OUTPUT" | grep -qiE "claude|profile|hook"; then
     pass "Claude Code profile loads"
 else


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #

## Summary

Updates all hardcoded references to the always-further pack namespace across the CLI to nolabs-ai, and improves the yank UX for users still on old pack refs.

Functional changes:
- OFFICIAL_PACKS in migration.rs and status targets in package_status.rs now point to nolabs-ai/{claude,codex,opencode}
- Package install path check in package_cmd.rs and profile resolver in profile/mod.rs updated to match nolabs-ai/claude pack store layout
- registry_client.rs: 410 responses for always-further/* packs now suggest nono pull nolabs-ai/<name> rather than repeating the old namespace
- legacy_cleanup.rs: scan and apply now also detect and remove enabledPlugins["nono@always-further"] from ~/.claude/settings.json, preventing Claude Code from seeing two nono plugins from conflicting marketplaces after the migration; prompt and summary updated to surface the change; two new tests added
- policy.json: author field updated to nolabs-ai
- setup.rs: shell alias examples updated

Non-functional (docs, comments, test data):
- All always-further/… references in READMEs, help text, comments, and test fixtures updated to nolabs-ai/… for consistency

Ref https://github.com/always-further/nono-registry/pull/104


<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
