### PR TITLE
feat(registry-client): attach installation context headers to registry requests

### DIFF
--- a/crates/nono-cli/src/registry_client.rs
+++ b/crates/nono-cli/src/registry_client.rs
@@ -26,6 +26,38 @@ pub struct RegistryClient {
     http: ureq::Agent,
 }
 
+/// Build the installation-context headers to attach to every registry request.
+///
+/// Headers included:
+/// - `X-Nono-UUID`: installation UUID if a state file exists (omitted otherwise)
+/// - `X-Nono-Platform`: OS name (`std::env::consts::OS`)
+/// - `X-Nono-Arch`: CPU architecture (`std::env::consts::ARCH`)
+/// - `X-Nono-CI`: `"true"` when a recognised CI environment is detected
+/// - `X-Nono-CI-Provider`: CI provider name when detected
+/// - `X-Nono-Install-Source`: install method (`homebrew`, `cargo`, `github_release`, `manual`, `unknown`)
+///
+/// This function never creates or writes any files.
+pub(crate) fn build_context_headers() -> Vec<(&'static str, String)> {
+    let mut headers: Vec<(&'static str, String)> = Vec::new();
+    if let Some(uuid) = crate::update_check::read_installation_uuid() {
+        headers.push(("X-Nono-UUID", uuid));
+    }
+    headers.push(("X-Nono-Platform", std::env::consts::OS.to_string()));
+    headers.push(("X-Nono-Arch", std::env::consts::ARCH.to_string()));
+    let ci_provider = crate::update_check::detect_ci_provider();
+    if ci_provider.is_some() {
+        headers.push(("X-Nono-CI", "true".to_string()));
+    }
+    if let Some(provider) = ci_provider {
+        headers.push(("X-Nono-CI-Provider", provider.to_string()));
+    }
+    headers.push((
+        "X-Nono-Install-Source",
+        crate::update_check::detect_install_source(),
+    ));
+    headers
+}
+
 impl RegistryClient {
     /// Build a registry client whose TLS verifier delegates to the OS-native
     /// trust store at handshake time (SecTrust on macOS, system CA stores on
@@ -33,11 +65,28 @@ impl RegistryClient {
     /// the kind injected by VPN-based TLS-inspecting proxies — that the bundled
     /// webpki roots wouldn't recognize, without any startup-time enumeration of
     /// the keychain (which can spuriously fail in restricted environments).
+    ///
+    /// Installation-context headers (`X-Nono-UUID`, `X-Nono-Platform`,
+    /// `X-Nono-Arch`, `X-Nono-CI`, `X-Nono-CI-Provider`,
+    /// `X-Nono-Install-Source`) are attached via a middleware registered on the
+    /// agent at construction time. The middleware only injects these headers
+    /// when the request host matches the registry host — preventing them from
+    /// being forwarded to CDN or other third-party hosts that may appear in
+    /// bundle or artifact download URLs.
     #[must_use]
     pub fn new(base_url: String) -> Self {
+        let version = env!("CARGO_PKG_VERSION");
         let tls_config = ureq::tls::TlsConfig::builder()
             .root_certs(ureq::tls::RootCerts::PlatformVerifier)
             .build();
+        let ctx_headers = build_context_headers();
+        // Extract the registry host once at construction; the middleware uses
+        // it to guard header injection so context headers are never forwarded
+        // to CDN hosts in bundle/artifact download URLs.
+        let registry_host = url::Url::parse(&base_url)
+            .ok()
+            .and_then(|u| u.host_str().map(|h| h.to_ascii_lowercase()))
+            .unwrap_or_default();
         let http = ureq::Agent::config_builder()
             .timeout_global(Some(REGISTRY_CALL_TIMEOUT))
             .timeout_resolve(Some(REGISTRY_CONNECT_TIMEOUT))
@@ -45,6 +94,27 @@ impl RegistryClient {
             .timeout_recv_response(Some(REGISTRY_RESPONSE_TIMEOUT))
             .timeout_recv_body(Some(REGISTRY_BODY_TIMEOUT))
             .tls_config(tls_config)
+            .user_agent(format!("nono-cli/{version}"))
+            .middleware(
+                move |mut req: ureq::http::Request<ureq::SendBody>,
+                      next: ureq::middleware::MiddlewareNext<'_>| {
+                    let req_host = req
+                        .uri()
+                        .host()
+                        .map(|h| h.to_ascii_lowercase())
+                        .unwrap_or_default();
+                    if req_host == registry_host {
+                        for (name, value) in &ctx_headers {
+                            if let Ok(hv) =
+                                ureq::http::header::HeaderValue::try_from(value.as_str())
+                            {
+                                req.headers_mut().insert(*name, hv);
+                            }
+                        }
+                    }
+                    next.handle(req)
+                },
+            )
             .build()
             .new_agent();
         Self {
@@ -320,6 +390,7 @@ fn enforce_content_length(content_length: Option<u64>, limit: u64, url: &str) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env::{ENV_LOCK, EnvVarGuard};
 
     #[test]
     fn registry_client_normalizes_base_url() {
@@ -327,5 +398,84 @@ mod tests {
         // TLS verification is delegated to the OS verifier at handshake time.
         let client = RegistryClient::new("https://example.invalid/".to_string());
         assert_eq!(client.base_url, "https://example.invalid");
+    }
+
+    #[test]
+    fn context_headers_contain_platform_and_arch() {
+        let headers = build_context_headers();
+        let platform = headers.iter().find(|(k, _)| *k == "X-Nono-Platform");
+        let arch = headers.iter().find(|(k, _)| *k == "X-Nono-Arch");
+        assert_eq!(
+            platform.map(|(_, v)| v.as_str()),
+            Some(std::env::consts::OS)
+        );
+        assert_eq!(arch.map(|(_, v)| v.as_str()), Some(std::env::consts::ARCH));
+    }
+
+    #[test]
+    fn context_headers_omit_ci_fields_outside_ci() {
+        let _lock = match ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        // Unset all recognised CI env vars so detect_ci_provider returns None.
+        let ci_vars: &[(&'static str, &str)] = &[
+            ("GITHUB_ACTIONS", ""),
+            ("GITLAB_CI", ""),
+            ("CIRCLECI", ""),
+            ("BUILDKITE", ""),
+            ("TF_BUILD", ""),
+            ("TRAVIS", ""),
+            ("JENKINS_URL", ""),
+            ("JENKINS_HOME", ""),
+            ("BITBUCKET_BUILD_NUMBER", ""),
+            ("APPVEYOR", ""),
+            ("TEAMCITY_VERSION", ""),
+            ("DRONE", ""),
+            ("SEMAPHORE", ""),
+            ("CODESHIP", ""),
+            ("WOODPECKER", ""),
+            ("NETLIFY", ""),
+            ("VERCEL", ""),
+            ("RENDER", ""),
+            ("CI", ""),
+        ];
+        let guard = EnvVarGuard::set_all(ci_vars);
+        for (k, _) in ci_vars {
+            guard.remove(k);
+        }
+
+        let headers = build_context_headers();
+        assert!(
+            !headers.iter().any(|(k, _)| *k == "X-Nono-CI"),
+            "X-Nono-CI should be absent outside CI"
+        );
+        assert!(
+            !headers.iter().any(|(k, _)| *k == "X-Nono-CI-Provider"),
+            "X-Nono-CI-Provider should be absent outside CI"
+        );
+    }
+
+    #[test]
+    fn context_headers_include_ci_fields_in_ci() {
+        let _lock = match ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let _guard = EnvVarGuard::set_all(&[("GITHUB_ACTIONS", "true")]);
+
+        let headers = build_context_headers();
+        let ci = headers.iter().find(|(k, _)| *k == "X-Nono-CI");
+        let provider = headers.iter().find(|(k, _)| *k == "X-Nono-CI-Provider");
+        assert_eq!(
+            ci.map(|(_, v)| v.as_str()),
+            Some("true"),
+            "X-Nono-CI should be 'true' in CI"
+        );
+        assert_eq!(
+            provider.map(|(_, v)| v.as_str()),
+            Some("github_actions"),
+            "X-Nono-CI-Provider should be 'github_actions'"
+        );
     }
 }

--- a/crates/nono-cli/src/update_check.rs
+++ b/crates/nono-cli/src/update_check.rs
@@ -14,6 +14,12 @@
 //! identifiers or user accounts. No personally identifiable information is
 //! collected or transmitted. No IP addresses are logged by the update service.
 //!
+//! The same UUID, platform, arch, CI, and install-source fields are also
+//! attached as HTTP headers to every `RegistryClient` request (see
+//! `registry_client.rs`). Version is conveyed via the `User-Agent` header
+//! rather than a dedicated field. The privacy posture is otherwise identical:
+//! the same anonymous installation identity, no PII.
+//!
 //! To disable the update check, set `NONO_NO_UPDATE_CHECK=1` or add
 //! `[updates] check = false` to `$XDG_CONFIG_HOME/nono/config.toml` (default `~/.config/nono/config.toml`).
 
@@ -286,7 +292,24 @@ fn is_newer_version(current: &str, latest: &str) -> bool {
     }
 }
 
-fn detect_ci_provider() -> Option<&'static str> {
+/// Return the persisted installation UUID, or `None` if no state file exists yet. Never writes.
+///
+/// Intentionally does not delegate to `load_or_create_state()` — that function
+/// creates the state file when none exists, which would violate this function's
+/// no-write contract. The deserialization logic is therefore duplicated here.
+/// If `UpdateCheckState` changes (e.g. the `uuid` field is renamed), update
+/// both sites.
+pub(crate) fn read_installation_uuid() -> Option<String> {
+    let path = state_file_path()?;
+    if !path.exists() {
+        return None;
+    }
+    let content = std::fs::read_to_string(&path).ok()?;
+    let state: UpdateCheckState = serde_json::from_str(&content).ok()?;
+    Some(state.uuid)
+}
+
+pub(crate) fn detect_ci_provider() -> Option<&'static str> {
     for (env_var, provider) in CI_PROVIDER_ENV_VARS {
         if env_marker_present(env_var) {
             return Some(provider);
@@ -304,7 +327,7 @@ fn detect_ci_provider() -> Option<&'static str> {
 ///
 /// Returns a coarse label from a fixed allowlist. `unknown` is used when the
 /// executable path cannot be resolved.
-fn detect_install_source() -> String {
+pub(crate) fn detect_install_source() -> String {
     if let Some(source) = std::option_env!("NONO_INSTALL_SOURCE") {
         // Baked in at compile time by the release pipeline; not runtime-controllable.
         return source.to_string();


### PR DESCRIPTION
## Summary

- Adds six HTTP headers to every `RegistryClient` request via a ureq middleware registered once at construction time: `X-Nono-UUID`, `X-Nono-Platform`, `X-Nono-Arch`, `X-Nono-CI`, `X-Nono-CI-Provider`, `X-Nono-Install-Source`
- `User-Agent: nono-cli/<version>` is also set on the agent
- Middleware is registered at `RegistryClient::new()` so future call sites cannot forget the headers
- `build_context_headers()` is a standalone `pub(crate)` fn, independently testable without a live client or network

## Dependencies

Stacked on #1340 (`metric-install-source`) — this branch is rebased on top of it. The `X-Nono-Install-Source` header uses `detect_install_source()` introduced there. Once #1340 merges, this branch will be rebased onto `main` before merge.

## Changes

- `crates/nono-cli/src/registry_client.rs` — `build_context_headers()`, middleware registration in `new()`, 3 new tests
- `crates/nono-cli/src/update_check.rs` — `read_installation_uuid()` new `pub(crate)` (read-only, never writes); `detect_install_source()` promoted to `pub(crate)`; module doc updated to reflect registry header parity

## Agent compliance checklist

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists (#1275)
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope