### PR TITLE
docs(readme): add tool sandboxing for agents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,72 @@ nono profile init opencode --extends always-further/opencode
 nono run --profile opencode -- opencode
 ```
 
+`nono profile init` exports an extended and editable profile file for your agent, that inherits from the specified base profile. That profile is composable JSON, so you can review the exact filesystem, network, credentials, and tool rules before sharing it with a team or publishing it for the community.
+
 Are you an agent developer and want to publish your own agent package? We would love to have you and promote your work! [See the docs](https://nono.sh/docs/cli/features/package-publishing).
+
+## Sandbox the tools agents call
+
+nono does not stop at "put the agent in a sandbox". Agents delegate real work to tools: `git`, `gh`, `curl`, `kubectl`, package managers, build scripts, MCP clients / servers, and whatever else is on `PATH`. Those tools are often where secrets, network access, and side effects show up. Most sandboxes just give the agent a blanket policy where a secret is universally available to the entire agent and every tool, but nono is different:
+
+nono can put delegated tools in their own isolated child sandboxes, outside the agent's control. The agent gets its session sandbox; when it calls a controlled tool, nono's broker launches that tool with a separate policy, separate filesystem grants, separate network rules, and separate credentials. The tool does not inherit the agent's broad `--allow` grants, CWD access, raw credential paths, or network access unless its own policy says so.
+
+That means a profile can express rules like:
+
+- the agent may call `git`, but `git` only gets the repo, trusted Git config files, and the Git object store
+- the agent may call `gh`, but `gh` only receives a GitHub token through nono's credential proxy
+- that token may only be used against selected GitHub API methods and paths through L7 filtering
+- `git` may call `ssh` under a chained policy, while direct `ssh` from the agent stays denied
+
+The policy lives in the profile, not in the prompt. The agent can ask for a tool, but it cannot widen that tool's sandbox, mint new keys, or bypass endpoint policy from inside the session.
+
+```json
+{
+  "command_policies": {
+    "credentials": {
+      "github-api": {
+        "type": "proxy",
+        "upstream": "https://api.github.com",
+        "credential_key": "keyring://gh:github.com/example?decode=go-keyring",
+        "env_var": "GH_TOKEN",
+        "inject_header": "Authorization",
+        "credential_format": "Bearer {}"
+      }
+    },
+    "commands": {
+      "gh": {
+        "from": {
+          "session": {
+            "sandbox": {
+              "fs_read": ["."],
+              "credentials": [
+                {
+                  "name": "github-api",
+                  "endpoint_policy": {
+                    "default": "deny",
+                    "allow": [
+                      { "method": "GET", "path": "/repos/nolabs-ai/nono/issues/**" }
+                    ]
+                  }
+                }
+              ]
+            },
+            "invocation_policy": {
+              "default": "deny",
+              "allow": [
+                { "argv": { "prefix": ["issue", "list"] } },
+                { "argv": { "prefix": ["issue", "view"] } }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Read more in [Sandboxed Tool Execution](https://nono.sh/docs/cli/features/tool-sandbox).
 
 ## Ready to go deep?
 


### PR DESCRIPTION
Its a substantial feature, so merits having its own mention

This PR add a new section to the README detailing nono's ability to sandbox tools called by agents.

- Clarify how delegated tools like `git` or `gh` can operate in their own isolated child sandboxes, distinct from the agent's session.
- Emphasize that tools receive separate policies, filesystem grants, network rules, and credentials, preventing an agent from widening a tool's access.
- Include a JSON example illustrating a `command_policies` configuration for `gh`, demonstrating L7 filtering and credential proxying.
- Add a link to the "Sandboxed Tool Execution" documentation for further reading.
- Also, slightly expand the description for `nono profile init`.

## Summary

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [x] Release note has been added to `CHANGELOG.md` if needed

