### PR TITLE
fix(cli): match intercept args after global options

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -1132,7 +1132,7 @@
         "args": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Contiguous argument sequence matched within argv[1..]. An empty list is a catch-all and must be last."
+          "description": "Contiguous argument sequence matched within argv[1..]. An empty list is a catch-all and must be last. Broad single-argument rules such as [\"--force\"] match anywhere in the invocation, not only at the subcommand position."
         },
         "action": { "$ref": "#/$defs/InterceptActionConfig" }
       }

--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -1132,7 +1132,7 @@
         "args": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Argument prefix matched against argv[1..]. An empty list is a catch-all and must be last."
+          "description": "Contiguous argument sequence matched within argv[1..]. An empty list is a catch-all and must be last."
         },
         "action": { "$ref": "#/$defs/InterceptActionConfig" }
       }
@@ -1233,7 +1233,7 @@
         "intercept": {
           "type": "array",
           "items": { "$ref": "#/$defs/InterceptRuleConfig" },
-          "description": "Ordered command argument-prefix intercept rules evaluated after invocation policy."
+          "description": "Ordered command argument-sequence intercept rules evaluated after invocation policy."
         },
         "allow_direct_exec_bypass": {
           "type": "array",

--- a/crates/nono-cli/src/command_policy.rs
+++ b/crates/nono-cli/src/command_policy.rs
@@ -427,7 +427,7 @@ pub enum InterceptActionConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct InterceptRuleConfig {
-    /// Argument prefix to match against argv[1..] of the shim invocation.
+    /// Contiguous argument sequence to match within argv[1..] of the shim invocation.
     /// An empty list is a catch-all.
     pub args: Vec<String>,
     /// Action to take when this rule matches.

--- a/crates/nono-cli/src/tool-sandbox/policy.rs
+++ b/crates/nono-cli/src/tool-sandbox/policy.rs
@@ -45,13 +45,7 @@ pub(super) fn resolve_intercept_action<'a>(
                 sandbox: rule.sandbox.as_ref(),
             };
         }
-        if shim_args.len() >= rule.args.len()
-            && rule
-                .args
-                .iter()
-                .zip(shim_args.iter())
-                .all(|(expected, actual)| expected.as_bytes() == *actual)
-        {
+        if intercept_args_match(&rule.args, &shim_args) {
             return ResolvedInterceptAction {
                 action: &rule.action,
                 rule_args: Some(&rule.args),
@@ -61,6 +55,18 @@ pub(super) fn resolve_intercept_action<'a>(
     }
 
     ResolvedInterceptAction::passthrough()
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn intercept_args_match(expected_args: &[String], shim_args: &[&[u8]]) -> bool {
+    expected_args.is_empty()
+        || (shim_args.len() >= expected_args.len()
+            && shim_args.windows(expected_args.len()).any(|window| {
+                expected_args
+                    .iter()
+                    .zip(window.iter())
+                    .all(|(expected, actual)| expected.as_bytes() == *actual)
+            }))
 }
 
 /// Resolve the env-expanded helper path and forwarded extra args for an `exec`
@@ -586,6 +592,60 @@ mod intercept_tests {
         assert!(matches!(
             resolved.action,
             InterceptActionConfig::Approve { .. }
+        ));
+    }
+
+    #[test]
+    fn resolve_intercept_action_matches_after_leading_global_args() {
+        let config = CommandPolicyConfig {
+            intercept: vec![InterceptRuleConfig {
+                args: vec!["push".to_string(), "--force".to_string()],
+                action: InterceptActionConfig::Approve { timeout_secs: None },
+                sandbox: None,
+            }],
+            ..CommandPolicyConfig::default()
+        };
+        let argv = vec![
+            b"git".to_vec(),
+            b"-c".to_vec(),
+            b"foo=bar".to_vec(),
+            b"push".to_vec(),
+            b"--force".to_vec(),
+        ];
+
+        let resolved = resolve_intercept_action(&config, &argv);
+
+        assert_eq!(resolved.rule_label(), "push --force");
+        assert!(matches!(
+            resolved.action,
+            InterceptActionConfig::Approve { .. }
+        ));
+    }
+
+    #[test]
+    fn resolve_intercept_action_falls_through_when_rule_sequence_is_absent() {
+        let config = CommandPolicyConfig {
+            intercept: vec![InterceptRuleConfig {
+                args: vec!["push".to_string(), "--force".to_string()],
+                action: InterceptActionConfig::Approve { timeout_secs: None },
+                sandbox: None,
+            }],
+            ..CommandPolicyConfig::default()
+        };
+        let argv = vec![
+            b"git".to_vec(),
+            b"-c".to_vec(),
+            b"foo=bar".to_vec(),
+            b"pull".to_vec(),
+            b"--force".to_vec(),
+        ];
+
+        let resolved = resolve_intercept_action(&config, &argv);
+
+        assert_eq!(resolved.rule_label(), "passthrough");
+        assert!(matches!(
+            resolved.action,
+            InterceptActionConfig::Passthrough
         ));
     }
 

--- a/crates/nono-cli/src/tool-sandbox/policy.rs
+++ b/crates/nono-cli/src/tool-sandbox/policy.rs
@@ -57,7 +57,6 @@ pub(super) fn resolve_intercept_action<'a>(
     ResolvedInterceptAction::passthrough()
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn intercept_args_match(expected_args: &[String], shim_args: &[&[u8]]) -> bool {
     expected_args.is_empty()
         || (shim_args.len() >= expected_args.len()

--- a/docs/cli/features/tool-sandbox.mdx
+++ b/docs/cli/features/tool-sandbox.mdx
@@ -63,7 +63,7 @@ Each entry under `commands` uses the command name as the key:
 | `can_use` | command-name array | Other commands this command may invoke through Tool Sandbox. If no self-invocation entry is configured, self-invocation keeps the current effective policy. |
 | `executable` | absolute path | Pin the command name to one executable file instead of the first `PATH` match. |
 | `allow_writable_executable` | boolean | Per-command trust downgrade for a pinned executable writable by the sandbox capability set. Requires absolute `executable`. |
-| `intercept` | array | Ordered argument-prefix mediation rules evaluated after invocation policy. |
+| `intercept` | array | Ordered argument-sequence mediation rules evaluated after invocation policy. |
 | `allow_direct_exec_bypass` | absolute path array | Compatibility escape hatch for direct canonical-path invocation. |
 | `allow_direct_exec_bypass_with_credentials` | boolean | Required when a credential-using command also allows direct exec bypass. |
 
@@ -111,7 +111,7 @@ An `intercept` rule may carry an optional `sandbox` (the same object described a
 
 ### Intercept Actions
 
-Each `intercept` entry is `{ "args": [...], "action": { "type": ... } }`. Rules are evaluated in order; the first whose `args` are a prefix of the invocation's arguments wins (an empty `args` is a catch-all). The `action.type` selects how the matched subcommand is handled:
+Each `intercept` entry is `{ "args": [...], "action": { "type": ... } }`. Rules are evaluated in order; the first whose `args` appear as a contiguous sequence in the invocation's arguments wins (an empty `args` is a catch-all). This lets subcommand rules match after command-global options, such as `git -c foo=bar push --force`. The `action.type` selects how the matched subcommand is handled:
 
 | `action.type` | Behavior |
 |---|---|

--- a/docs/cli/features/tool-sandbox.mdx
+++ b/docs/cli/features/tool-sandbox.mdx
@@ -111,7 +111,7 @@ An `intercept` rule may carry an optional `sandbox` (the same object described a
 
 ### Intercept Actions
 
-Each `intercept` entry is `{ "args": [...], "action": { "type": ... } }`. Rules are evaluated in order; the first whose `args` appear as a contiguous sequence in the invocation's arguments wins (an empty `args` is a catch-all). This lets subcommand rules match after command-global options, such as `git -c foo=bar push --force`. The `action.type` selects how the matched subcommand is handled:
+Each `intercept` entry is `{ "args": [...], "action": { "type": ... } }`. Rules are evaluated in order; the first whose `args` appear as a contiguous sequence in the invocation's arguments wins (an empty `args` is a catch-all). This lets subcommand rules match after command-global options, such as `git -c foo=bar push --force`. Broad single-argument rules like `["--force"]` match anywhere in the invocation, not only at the subcommand position. The `action.type` selects how the matched subcommand is handled:
 
 | `action.type` | Behavior |
 |---|---|


### PR DESCRIPTION
## Linked Issue

Closes #1328

## Summary

- Match intercept rule `args` as a contiguous sequence within `argv[1..]`, so command-global options before a subcommand do not bypass a configured intercept action.
- Add regression coverage for `git -c foo=bar push --force` against an intercept rule for `["push", "--force"]`.
- Update the Rust docs, profile schema descriptions, and Tool Sandbox guide from strict-prefix wording to contiguous argument-sequence wording.

## Agent Disclosure

This PR was prepared with assistance from an AI coding agent and reviewed by the human contributor before submission.

Relevant files and sections consulted:
- `AGENTS.md` Coding Agent Contribution Policy, coding standards, and security considerations.
- `NOGENT.md` tool-sandbox/security review guidance.
- `SECURITY.md` responsible disclosure guidance.
- `.github/pull_request_template.md` PR and agent-compliance requirements.
- `crates/nono-cli/src/tool-sandbox/policy.rs` intercept and invocation policy matching code.
- `crates/nono-cli/src/command_policy.rs` `InterceptRuleConfig` docs and validation context.
- `docs/cli/features/tool-sandbox.mdx` Tool Sandbox intercept documentation.
- `crates/nono-cli/data/nono-profile.schema.json` profile schema descriptions.

Compliance confirmation: this change is scoped to the existing public issue, follows the repository's coding and security requirements for the affected area, avoids forbidden `unwrap`/`expect` patterns, and does not change path handling or NonoError behavior.

## Test Plan

- `cargo test -p nono-cli resolve_intercept_action`
- `cargo fmt --all -- --check`
- `make test-cli`
  - Note: a managed-sandbox run failed in unrelated PTY/proxy tests with Unix-socket `Operation not permitted`; the same command passed when rerun outside that sandbox.
- `make clippy`
- `git diff --check`

## Scope / Caveat

This changes intercept `args` matching from strict index-0 prefix matching to command-agnostic contiguous sequence matching within `argv[1..]`. It intentionally does not add command-specific option parsing.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [x] Release note has been added to `CHANGELOG.md` if needed

## Agent Compliance Check (Required for AI/Automated PRs)

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope
