### PR TITLE
fix(release): strip ./ prefix from SHA256SUMS.txt entries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
           find . -name "*.tar.gz" -exec mv {} . \;
           find . -name "*.deb" -exec mv {} . \;
           find . -name "*.rpm" -exec mv {} . \;
-          sha256sum ./*.tar.gz ./*.deb ./*.rpm > SHA256SUMS.txt
+          sha256sum -- *.tar.gz *.deb *.rpm > SHA256SUMS.txt
           cat SHA256SUMS.txt
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1351 

## Summary

sha256sum ./*.tar.gz expanded glob paths with a ./ prefix, causing install.sh awk lookup ($2 == bare_filename) to never match and aborting every install with no checksum found.

Switch to sha256sum -- *.tar.gz *.deb *.rpm so output uses bare filenames. The -- satisfies SC2035 (names with dashes wont become options) without reintroducing the prefix.
<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
