### PR TITLE
fix(proxy): skip credential_capture entries with missing helper binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -211,8 +211,17 @@ impl ProxyCredentialCaptureBackend {
                         "credential_capture.{name}.provider.command must not be empty"
                     )));
                 };
+                let command_path = match resolve_capture_command(command)? {
+                    CaptureCommandResolution::Resolved(path) => path,
+                    CaptureCommandResolution::Unavailable(reason) => {
+                        warn!(
+                            "credential_capture.{name}: {reason}; skipping (cmd://{name} routes are unavailable until the helper is installed)"
+                        );
+                        continue;
+                    }
+                };
                 ResolvedCredentialCaptureSource::Provider {
-                    command_path: resolve_capture_command(command)?,
+                    command_path,
                     args: provider
                         .command
                         .iter()
@@ -227,8 +236,17 @@ impl ProxyCredentialCaptureBackend {
                         "credential_capture.{name}.command must not be empty"
                     )));
                 };
+                let command_path = match resolve_capture_command(command)? {
+                    CaptureCommandResolution::Resolved(path) => path,
+                    CaptureCommandResolution::Unavailable(reason) => {
+                        warn!(
+                            "credential_capture.{name}: {reason}; skipping (cmd://{name} routes are unavailable until the helper is installed)"
+                        );
+                        continue;
+                    }
+                };
                 ResolvedCredentialCaptureSource::Command {
-                    command_path: resolve_capture_command(command)?,
+                    command_path,
                     args: entry
                         .command
                         .iter()
@@ -1290,7 +1308,18 @@ fn redacted_stderr(stderr: &[u8], policy: &nono::ScrubPolicy) -> Option<String> 
     Some(nono::scrub_value_with_policy(&text, policy).into_owned())
 }
 
-fn resolve_capture_command(command: &str) -> Result<PathBuf> {
+/// Outcome of resolving a `credential_capture` command's executable.
+///
+/// `Unavailable` covers helper binaries that are legitimately optional on a given
+/// machine (not on PATH, not executable, etc.) so the caller can skip the entry
+/// with a warning instead of aborting proxy startup entirely.
+#[derive(Debug)]
+enum CaptureCommandResolution {
+    Resolved(PathBuf),
+    Unavailable(String),
+}
+
+fn resolve_capture_command(command: &str) -> Result<CaptureCommandResolution> {
     let expanded = crate::policy::expand_env_vars(command);
     let command = expanded.as_str();
     let path = PathBuf::from(command);
@@ -1303,7 +1332,7 @@ fn resolve_capture_command(command: &str) -> Result<PathBuf> {
         )));
     }
     let Some(path_var) = std::env::var_os("PATH") else {
-        return Err(NonoError::ConfigParse(format!(
+        return Ok(CaptureCommandResolution::Unavailable(format!(
             "credential_capture command '{command}' could not be resolved because PATH is unset"
         )));
     };
@@ -1313,20 +1342,28 @@ fn resolve_capture_command(command: &str) -> Result<PathBuf> {
             return validate_capture_command_path(candidate);
         }
     }
-    Err(NonoError::ConfigParse(format!(
+    Ok(CaptureCommandResolution::Unavailable(format!(
         "credential_capture command '{command}' was not found in PATH"
     )))
 }
 
-fn validate_capture_command_path(path: PathBuf) -> Result<PathBuf> {
-    let canonical = path
-        .canonicalize()
-        .map_err(|source| NonoError::PathCanonicalization {
-            path: path.clone(),
-            source,
-        })?;
+fn validate_capture_command_path(path: PathBuf) -> Result<CaptureCommandResolution> {
+    let canonical = match path.canonicalize() {
+        Ok(canonical) => canonical,
+        Err(source) => {
+            return Ok(CaptureCommandResolution::Unavailable(
+                NonoError::PathCanonicalization {
+                    path: path.clone(),
+                    source,
+                }
+                .to_string(),
+            ));
+        }
+    };
     if !canonical.is_file() {
-        return Err(NonoError::ExpectedFile(canonical));
+        return Ok(CaptureCommandResolution::Unavailable(
+            NonoError::ExpectedFile(canonical).to_string(),
+        ));
     }
     #[cfg(unix)]
     {
@@ -1337,13 +1374,13 @@ fn validate_capture_command_path(path: PathBuf) -> Result<PathBuf> {
             .permissions()
             .mode();
         if mode & 0o111 == 0 {
-            return Err(NonoError::ConfigParse(format!(
+            return Ok(CaptureCommandResolution::Unavailable(format!(
                 "credential_capture command '{}' is not executable",
                 canonical.display()
             )));
         }
     }
-    Ok(canonical)
+    Ok(CaptureCommandResolution::Resolved(canonical))
 }
 
 pub(crate) fn prepare_proxy_launch_options(
@@ -3838,6 +3875,205 @@ mod tests {
 
         assert_capture_secret(&response, "browser-ok");
         assert_eq!(response.metadata.interactive, Some(true));
+        Ok(())
+    }
+
+    #[test]
+    fn credential_capture_backend_skips_missing_binary() -> Result<()> {
+        let entry = test_capture_entry_no_cache(vec!["nono-nonexistent-helper-xyz".to_string()]);
+        let mut entries = HashMap::new();
+        entries.insert("ghost".to_string(), entry);
+        let backend = ProxyCredentialCaptureBackend::new(&entries, "sess-ghost".to_string())?;
+
+        let err = nono_proxy::capture::CredentialCaptureBackend::capture(
+            &backend,
+            nono_proxy::capture::CredentialCaptureRequest {
+                credential_name: "ghost".to_string(),
+                route_id: "ghost".to_string(),
+                request_host: "example.com".to_string(),
+                request_path: "/".to_string(),
+                request_method: "GET".to_string(),
+                session_id: String::new(),
+                cache_scope: String::new(),
+            },
+        )
+        .expect_err("capture for a skipped entry should error");
+        assert_eq!(err.metadata.cache_action, "unknown_credential");
+        Ok(())
+    }
+
+    #[test]
+    fn credential_capture_backend_keeps_resolvable_entry_when_sibling_missing() -> Result<()> {
+        let resolvable = test_capture_entry_no_cache(vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            "printf ok".to_string(),
+        ]);
+        let missing = test_capture_entry_no_cache(vec!["nono-nonexistent-helper-xyz".to_string()]);
+        let mut entries = HashMap::new();
+        entries.insert("present".to_string(), resolvable);
+        entries.insert("ghost".to_string(), missing);
+        let backend = ProxyCredentialCaptureBackend::new(&entries, "sess-mixed".to_string())?;
+
+        let response = nono_proxy::capture::CredentialCaptureBackend::capture(
+            &backend,
+            nono_proxy::capture::CredentialCaptureRequest {
+                credential_name: "present".to_string(),
+                route_id: "present".to_string(),
+                request_host: "example.com".to_string(),
+                request_path: "/".to_string(),
+                request_method: "GET".to_string(),
+                session_id: String::new(),
+                cache_scope: String::new(),
+            },
+        )
+        .map_err(|err| NonoError::SandboxInit(err.to_string()))?;
+        assert_capture_secret(&response, "ok");
+
+        let err = nono_proxy::capture::CredentialCaptureBackend::capture(
+            &backend,
+            nono_proxy::capture::CredentialCaptureRequest {
+                credential_name: "ghost".to_string(),
+                route_id: "ghost".to_string(),
+                request_host: "example.com".to_string(),
+                request_path: "/".to_string(),
+                request_method: "GET".to_string(),
+                session_id: String::new(),
+                cache_scope: String::new(),
+            },
+        )
+        .expect_err("capture for a skipped entry should error");
+        assert_eq!(err.metadata.cache_action, "unknown_credential");
+        Ok(())
+    }
+
+    #[test]
+    fn credential_capture_backend_skips_missing_provider_binary() -> Result<()> {
+        let mut entry = test_capture_entry_no_cache(Vec::new());
+        entry.provider = Some(crate::profile::CredentialCaptureProvider {
+            command: vec!["nono-nonexistent-provider-xyz".to_string()],
+            config: serde_json::json!({}),
+        });
+        let mut entries = HashMap::new();
+        entries.insert("ghost_provider".to_string(), entry);
+        let backend =
+            ProxyCredentialCaptureBackend::new(&entries, "sess-ghost-provider".to_string())?;
+
+        let err = nono_proxy::capture::CredentialCaptureBackend::capture(
+            &backend,
+            nono_proxy::capture::CredentialCaptureRequest {
+                credential_name: "ghost_provider".to_string(),
+                route_id: "ghost_provider".to_string(),
+                request_host: "example.com".to_string(),
+                request_path: "/".to_string(),
+                request_method: "GET".to_string(),
+                session_id: String::new(),
+                cache_scope: String::new(),
+            },
+        )
+        .expect_err("capture for a skipped provider entry should error");
+        assert_eq!(err.metadata.cache_action, "unknown_credential");
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_capture_command_malformed_reference_still_errors() {
+        let result = resolve_capture_command("foo/bar");
+        assert!(
+            matches!(result, Err(NonoError::ConfigParse(_))),
+            "relative path with separator should still be a hard error, got {result:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn credential_capture_backend_skips_non_executable_binary() -> Result<()> {
+        let temp = tempfile::tempdir().map_err(NonoError::Io)?;
+        let path = temp.path().join("not-executable");
+        std::fs::write(&path, b"#!/bin/sh\necho hi\n").map_err(NonoError::Io)?;
+        let mut perms = std::fs::metadata(&path)
+            .map_err(NonoError::Io)?
+            .permissions();
+        {
+            use std::os::unix::fs::PermissionsExt;
+            perms.set_mode(0o644);
+        }
+        std::fs::set_permissions(&path, perms).map_err(NonoError::Io)?;
+
+        let entry = test_capture_entry_no_cache(vec![path.to_string_lossy().into_owned()]);
+        let mut entries = HashMap::new();
+        entries.insert("not_exec".to_string(), entry);
+        let backend = ProxyCredentialCaptureBackend::new(&entries, "sess-not-exec".to_string())?;
+
+        let err = nono_proxy::capture::CredentialCaptureBackend::capture(
+            &backend,
+            nono_proxy::capture::CredentialCaptureRequest {
+                credential_name: "not_exec".to_string(),
+                route_id: "not_exec".to_string(),
+                request_host: "example.com".to_string(),
+                request_path: "/".to_string(),
+                request_method: "GET".to_string(),
+                session_id: String::new(),
+                cache_scope: String::new(),
+            },
+        )
+        .expect_err("capture for a non-executable entry should error");
+        assert_eq!(err.metadata.cache_action, "unknown_credential");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn credential_capture_backend_skips_dangling_symlink() -> Result<()> {
+        let temp = tempfile::tempdir().map_err(NonoError::Io)?;
+        let link_path = temp.path().join("dangling-link");
+        std::os::unix::fs::symlink(temp.path().join("does-not-exist"), &link_path)
+            .map_err(NonoError::Io)?;
+
+        let entry = test_capture_entry_no_cache(vec![link_path.to_string_lossy().into_owned()]);
+        let mut entries = HashMap::new();
+        entries.insert("dangling".to_string(), entry);
+        let backend = ProxyCredentialCaptureBackend::new(&entries, "sess-dangling".to_string())?;
+
+        let err = nono_proxy::capture::CredentialCaptureBackend::capture(
+            &backend,
+            nono_proxy::capture::CredentialCaptureRequest {
+                credential_name: "dangling".to_string(),
+                route_id: "dangling".to_string(),
+                request_host: "example.com".to_string(),
+                request_path: "/".to_string(),
+                request_method: "GET".to_string(),
+                session_id: String::new(),
+                cache_scope: String::new(),
+            },
+        )
+        .expect_err("capture for a dangling-symlink entry should error");
+        assert_eq!(err.metadata.cache_action, "unknown_credential");
+        Ok(())
+    }
+
+    #[test]
+    fn credential_capture_backend_skips_directory_reference() -> Result<()> {
+        let temp = tempfile::tempdir().map_err(NonoError::Io)?;
+        let entry = test_capture_entry_no_cache(vec![temp.path().to_string_lossy().into_owned()]);
+        let mut entries = HashMap::new();
+        entries.insert("a_directory".to_string(), entry);
+        let backend = ProxyCredentialCaptureBackend::new(&entries, "sess-directory".to_string())?;
+
+        let err = nono_proxy::capture::CredentialCaptureBackend::capture(
+            &backend,
+            nono_proxy::capture::CredentialCaptureRequest {
+                credential_name: "a_directory".to_string(),
+                route_id: "a_directory".to_string(),
+                request_host: "example.com".to_string(),
+                request_path: "/".to_string(),
+                request_method: "GET".to_string(),
+                session_id: String::new(),
+                cache_scope: String::new(),
+            },
+        )
+        .expect_err("capture for a directory reference should error");
+        assert_eq!(err.metadata.cache_action, "unknown_credential");
         Ok(())
     }
 

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -1326,7 +1326,7 @@ fn resolve_capture_command(command: &str) -> Result<CaptureCommandResolution> {
     if path.is_absolute() {
         return validate_capture_command_path(path);
     }
-    if command.contains(std::path::MAIN_SEPARATOR) {
+    if command.contains('/') || command.contains('\\') {
         return Err(NonoError::ConfigParse(format!(
             "credential_capture command '{command}' must be an absolute path or bare command name"
         )));
@@ -3982,6 +3982,17 @@ mod tests {
         assert!(
             matches!(result, Err(NonoError::ConfigParse(_))),
             "relative path with separator should still be a hard error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_capture_command_rejects_non_native_separator() {
+        // A relative command embedding a backslash must be rejected on every
+        // platform, not just on Windows where `\` is the native separator.
+        let result = resolve_capture_command("foo\\bar");
+        assert!(
+            matches!(result, Err(NonoError::ConfigParse(_))),
+            "relative path with non-native separator should still be a hard error, got {result:?}"
         );
     }
 


### PR DESCRIPTION
## Linked Issue

Closes #1367

## Summary

A `credential_capture` (or `credential_capture.*.provider`) entry whose command binary can't be resolved (missing from `PATH`, dangling symlink, a directory, or not executable) now logs a startup warning and is skipped, instead of aborting proxy startup. The `cmd://<name>` route becomes unavailable and returns a normal per-request `unknown_credential` error only if actually used — no proxy-crate changes needed. Malformed config (empty command, relative path with a separator, invalid `cache_path_regex`) stays a hard error.

Also bumps `crossbeam-epoch` 0.9.18 → 0.9.20 (`cargo update -p crossbeam-epoch --precise 0.9.20`) to clear RUSTSEC-2026-0204, an unrelated advisory disclosed on 2026-07-06 that was failing `cargo audit` on `main` and blocking this PR's CI.

## Agent Disclosure

Authored by an AI coding agent (Claude Code) on behalf of @kipz, who reviewed and approved this PR before submission. Files consulted: `crates/nono-cli/src/proxy_runtime.rs` (`resolve_capture_command`, `validate_capture_command_path`, `ProxyCredentialCaptureBackend::new`/`::capture`), and the existing precedent in `command_policy.rs` (`resolve_policy_command_binaries`).

## Test Plan

- `make fmt && make ci` — fully clean (including `cargo audit`).
- New unit tests in `proxy_runtime.rs`: missing command/provider binary, resolvable-entry-kept-when-sibling-missing, non-executable, dangling symlink, directory reference, and malformed-reference-still-errors.
- Manual: built from this branch and from `main`; unpatched `main` aborts with "was not found in PATH", this branch starts and logs the skip warning.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

## Agent Compliance Check (Required for AI/Automated PRs)
- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope

