### PR TITLE
feat(profile): add platform_overrides field for per-OS profile patches

### DIFF
--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -67,6 +67,37 @@ Inherit from another profile by name:
 - `open_urls`: if the child provides the field (even as `{}`), it replaces the base entirely. If absent, the base value is inherited. Setting to `null` in JSON is equivalent to omitting it (both inherit the base).
 - `workdir`: child overrides base unless child is `"none"` (which inherits the base value instead).
 
+### platform_overrides
+
+Apply per-OS patches to the profile after `extends` resolution. Only the block matching the current platform is merged in; the others are ignored.
+
+```json
+{
+  "meta": { "name": "myprofile" },
+  "filesystem": {
+    "read": ["/tmp"]
+  },
+  "platform_overrides": {
+    "macos": {
+      "security": { "process_info_mode": "allow_all" },
+      "filesystem": { "read": ["/opt/homebrew", "~/Library/Caches"] }
+    },
+    "linux": {
+      "security": { "signal_mode": "isolated", "process_info_mode": "allow_same_sandbox" },
+      "filesystem": { "read": ["/usr/lib", "~/.cache"] }
+    }
+  }
+}
+```
+
+Merge semantics are identical to `extends`: array fields are dedup-appended, scalar fields are child-wins, deny-lists union. The override can only add or tighten — it cannot remove inherited paths or relax inherited deny rules.
+
+Valid platform keys are `macos`, `linux`, and `windows`. Unrecognised keys are a parse error.
+
+`extends` and `platform_overrides` are not allowed inside an override block. Nesting either is a parse error.
+
+Use `platform_overrides` when a single profile needs different paths or security modes per OS. Use group-level `when` predicates for package-level platform differences that are already handled by built-in groups.
+
 ### groups
 
 Controls which policy groups apply to the profile. Group definitions live in `policy.json`; list available groups with `nono profile groups`.
@@ -1045,6 +1076,7 @@ Supported predicate forms include `linux`, `macos`, `linux:fedora`, `linux:rhel-
 - `filesystem.suppress_save_prompt` only suppresses save-profile suggestions. It does not grant access, remove deny rules, or hide diagnostics.
 - `groups.exclude` removes groups from the resolved set. This weakens the sandbox. Use it only when you understand which protections you are removing.
 - `extends` chains resolve recursively up to depth 10. Circular inheritance is an error.
+- `platform_overrides` is applied after all `extends` inheritance is resolved. The override for the current platform is merged as a child, so its values win over inherited ones. Override blocks cannot themselves use `extends` or `platform_overrides`.
 - Prefer `when` predicates for package-specific platform differences. Put shared OS baseline paths in built-in policy groups instead.
 - `network.block: true` blocks all network access. It cannot be combined with proxy settings.
 - `custom_credentials` upstream URLs must use HTTPS. HTTP is only accepted for loopback addresses (localhost, 127.0.0.1, ::1).

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -149,6 +149,8 @@ pub struct ProfileDef {
     pub command_args: Vec<String>,
     #[serde(default)]
     pub unsafe_macos_seatbelt_rules: Vec<String>,
+    #[serde(default)]
+    pub platform_overrides: Option<profile::PlatformOverrides>,
 }
 
 impl ProfileDef {
@@ -187,7 +189,7 @@ impl ProfileDef {
             binary: None,
             command_args: self.command_args.clone(),
             unsafe_macos_seatbelt_rules: self.unsafe_macos_seatbelt_rules.clone(),
-            platform_overrides: None,
+            platform_overrides: self.platform_overrides.clone(),
         }
     }
 }

--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -187,6 +187,7 @@ impl ProfileDef {
             binary: None,
             command_args: self.command_args.clone(),
             unsafe_macos_seatbelt_rules: self.unsafe_macos_seatbelt_rules.clone(),
+            platform_overrides: None,
         }
     }
 }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -2181,6 +2181,69 @@ pub struct Profile {
     /// first-class capability.
     #[serde(default)]
     pub unsafe_macos_seatbelt_rules: Vec<String>,
+    /// Per-OS profile patches merged after `extends` resolution.
+    ///
+    /// Only the entry matching the current platform is applied; others are ignored.
+    /// The override block supports all profile fields except `extends` and
+    /// `platform_overrides` — nesting either is a parse error.
+    /// Merge semantics are identical to `extends`: deny-lists union, scalar fields
+    /// are child-wins, lists are dedup-appended.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub platform_overrides: Option<PlatformOverrides>,
+}
+
+/// Per-OS patches for [`Profile::platform_overrides`].
+///
+/// Unrecognised keys are rejected. Nesting `extends` or `platform_overrides`
+/// inside an override block is a parse error.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlatformOverrides {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub macos: Option<Box<PlatformOverride>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub linux: Option<Box<PlatformOverride>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub windows: Option<Box<PlatformOverride>>,
+}
+
+impl PlatformOverrides {
+    fn for_current_platform(self) -> Option<Box<PlatformOverride>> {
+        match crate::platform::current().os {
+            crate::platform::Os::Macos => self.macos,
+            crate::platform::Os::Linux => self.linux,
+            crate::platform::Os::Windows => self.windows,
+            crate::platform::Os::Unknown(_) => None,
+        }
+    }
+}
+
+/// A partial profile fragment used inside [`PlatformOverrides`].
+///
+/// Identical to [`Profile`] but rejects `extends` and `platform_overrides`
+/// during deserialization to prevent a second inheritance system from forming
+/// inside an override block.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct PlatformOverride(pub Profile);
+
+impl<'de> Deserialize<'de> for PlatformOverride {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let profile = Profile::deserialize(deserializer)?;
+        if profile.extends.is_some() {
+            return Err(serde::de::Error::custom(
+                "`extends` is not allowed inside `platform_overrides`",
+            ));
+        }
+        if profile.platform_overrides.is_some() {
+            return Err(serde::de::Error::custom(
+                "`platform_overrides` cannot be nested",
+            ));
+        }
+        Ok(Self(profile))
+    }
 }
 
 #[derive(Deserialize)]
@@ -2252,6 +2315,8 @@ struct ProfileDeserialize {
     command_args: Vec<String>,
     #[serde(default)]
     unsafe_macos_seatbelt_rules: Vec<String>,
+    #[serde(default)]
+    platform_overrides: Option<PlatformOverrides>,
 }
 
 impl From<ProfileDeserialize> for Profile {
@@ -2291,6 +2356,7 @@ impl From<ProfileDeserialize> for Profile {
             binary: raw.binary,
             command_args: raw.command_args,
             unsafe_macos_seatbelt_rules: raw.unsafe_macos_seatbelt_rules,
+            platform_overrides: raw.platform_overrides,
         };
 
         // Drain legacy keys into canonical sections (no-op unless the legacy
@@ -2846,6 +2912,7 @@ pub(crate) fn load_raw_profile_from_path(path: &Path) -> Result<Profile> {
 /// Resolve inheritance and apply implicit default-group merging for a raw profile.
 #[allow(deprecated)]
 pub(crate) fn finalize_profile(mut profile: Profile) -> Result<Profile> {
+    profile = apply_platform_overrides(profile)?;
     merge_implicit_default_groups(&mut profile)?;
     validate_credential_capture_resolved(&profile)?;
     validate_credential_provider_resolved(&profile)?;
@@ -3207,9 +3274,31 @@ fn load_base_profile_raw(
 /// The child's values take precedence for scalar fields. Collection fields
 /// are appended and deduplicated. The `extends` field is consumed (set to `None`).
 #[allow(deprecated)] // reads/writes commands.{allow,deny} (deprecated v0.33.0)
+/// Extract the current platform's override block and merge it into `profile`.
+///
+/// Called once during `finalize_profile`, after `extends` is fully resolved.
+/// The override is treated as a child in `merge_profiles` so deny-lists union
+/// and security modes are child-wins — an override can only tighten, not loosen.
+fn apply_platform_overrides(mut profile: Profile) -> Result<Profile> {
+    let Some(mut override_profile) = profile
+        .platform_overrides
+        .take()
+        .and_then(|po| po.for_current_platform())
+        .map(|o| o.0)
+    else {
+        return Ok(profile);
+    };
+    // Overrides don't carry meaningful meta; propagate the profile's own so
+    // merge_profiles' child-wins rule doesn't blank it out.
+    override_profile.meta = profile.meta.clone();
+    Ok(merge_profiles(profile, override_profile))
+}
+
+#[allow(deprecated)] // reads/writes commands.{allow,deny} (deprecated v0.33.0)
 fn merge_profiles(base: Profile, child: Profile) -> Profile {
     Profile {
         extends: None,
+        platform_overrides: None,
         meta: child.meta,
         security: SecurityConfig {
             signal_mode: child.security.signal_mode.or(base.security.signal_mode),
@@ -5724,6 +5813,7 @@ mod tests {
             binary: None,
             command_args: vec![],
             unsafe_macos_seatbelt_rules: vec![],
+            platform_overrides: None,
         }
     }
 
@@ -5811,6 +5901,7 @@ mod tests {
             binary: None,
             command_args: vec![],
             unsafe_macos_seatbelt_rules: vec![],
+            platform_overrides: None,
         }
     }
 
@@ -9557,5 +9648,121 @@ mod tests {
             ..aws_auth_cred_builder()
         };
         assert!(validate_custom_credential("apigw", &cred).is_ok());
+    }
+
+    // --- platform_overrides tests ---
+
+    #[test]
+    fn platform_overrides_parses_and_serializes() {
+        let json = r#"{
+            "meta": {"name": "test"},
+            "platform_overrides": {
+                "macos": { "filesystem": { "read": ["/opt/homebrew"] } },
+                "linux": { "filesystem": { "read": ["/usr/lib"] } }
+            }
+        }"#;
+        let profile: Profile = serde_json::from_str(json).expect("parse");
+        let po = profile.platform_overrides.as_ref().expect("has overrides");
+        assert!(po.macos.is_some());
+        assert!(po.linux.is_some());
+        assert!(po.windows.is_none());
+    }
+
+    #[test]
+    fn platform_overrides_rejects_nested_extends() {
+        let json = r#"{
+            "meta": {"name": "test"},
+            "platform_overrides": {
+                "linux": { "extends": "base", "filesystem": { "read": ["/usr/lib"] } }
+            }
+        }"#;
+        let err = serde_json::from_str::<Profile>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("extends"),
+            "expected error about `extends`, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn platform_overrides_rejects_nested_platform_overrides() {
+        let json = r#"{
+            "meta": {"name": "test"},
+            "platform_overrides": {
+                "linux": {
+                    "platform_overrides": { "linux": {} }
+                }
+            }
+        }"#;
+        let err = serde_json::from_str::<Profile>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("platform_overrides"),
+            "expected error about nesting, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn platform_overrides_merge_adds_filesystem_paths() {
+        // Build a profile whose override for the current platform adds a read path.
+        let current_os = crate::platform::current_os_name();
+        let json = format!(
+            r#"{{
+                "meta": {{"name": "test"}},
+                "filesystem": {{"read": ["/base/path"]}},
+                "platform_overrides": {{
+                    "{current_os}": {{ "filesystem": {{"read": ["/platform/path"]}} }}
+                }}
+            }}"#
+        );
+        let profile: Profile = serde_json::from_str(&json).expect("parse");
+        // finalize_profile applies platform_overrides
+        let finalized = finalize_profile(profile).expect("finalize");
+        assert!(
+            finalized.platform_overrides.is_none(),
+            "platform_overrides should be consumed after finalization"
+        );
+        assert!(
+            finalized
+                .filesystem
+                .read
+                .contains(&"/base/path".to_string()),
+            "base path must be present"
+        );
+        assert!(
+            finalized
+                .filesystem
+                .read
+                .contains(&"/platform/path".to_string()),
+            "platform override path must be present after merge"
+        );
+    }
+
+    #[test]
+    fn platform_overrides_other_platform_not_applied() {
+        // The override for the non-current platform must not bleed in.
+        let other_os = if crate::platform::current_os_name() == "macos" {
+            "linux"
+        } else {
+            "macos"
+        };
+        let json = format!(
+            r#"{{
+                "meta": {{"name": "test"}},
+                "filesystem": {{"read": ["/base/path"]}},
+                "platform_overrides": {{
+                    "{other_os}": {{ "filesystem": {{"read": ["/other/platform/path"]}} }}
+                }}
+            }}"#
+        );
+        let profile: Profile = serde_json::from_str(&json).expect("parse");
+        let finalized = finalize_profile(profile).expect("finalize");
+        assert!(
+            !finalized
+                .filesystem
+                .read
+                .contains(&"/other/platform/path".to_string()),
+            "other platform's paths must not be present"
+        );
     }
 }


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1347

## Summary

Adds a `platform_overrides` top-level field to the profile schema. After `extends` resolution, the block matching the current platform (`macos`, `linux`, or `windows`) is merged in as a child using the existing `merge_profiles` function. Merge semantics are identical to `extends`: deny-lists union, scalar fields are child-wins, arrays are dedup-appended.

`extends` and `platform_overrides` are rejected inside an override block at parse time to prevent a second inheritance system from forming inside the override.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
