### PR TITLE
fix(why): respect proxy domain filter in --profile and --self host queries

### DIFF
--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -224,31 +224,48 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
         .iter()
         .chain(endpoint_domain_entries.iter())
         .collect();
-    // Expand network_profile hosts into the sandbox state so that `nono why --self`
-    // sees the same allowlist that the proxy enforces at runtime.
-    let mut allowed_domain_strs: Vec<String> = all_domain_entries
+    // Expand network_profile hosts and domain group aliases into the sandbox state
+    // so that `nono why --self` sees the same allowlist the proxy enforces at runtime.
+    let plain_domain_strs: Vec<String> = all_domain_entries
         .iter()
         .map(|e| e.domain().to_string())
         .collect();
-    if let Some(profile_name) = proxy
-        .and_then(|p| p.domain_filter.as_ref())
-        .and_then(|d| d.network_profile.as_deref())
-    {
+    let domain_filter = proxy.and_then(|p| p.domain_filter.as_ref());
+    let allowed_domain_strs: Vec<String> = if domain_filter.is_some() {
         let policy_json = config::embedded::embedded_network_policy_json();
-        if let Ok(net_policy) = network_policy::load_network_policy(policy_json)
-            && let Ok(resolved) = network_policy::resolve_network_profile(&net_policy, profile_name)
-        {
-            allowed_domain_strs.extend(resolved.hosts);
-            for suffix in &resolved.suffixes {
-                let wildcard = if suffix.starts_with('.') {
-                    format!("*{suffix}")
-                } else {
-                    format!("*.{suffix}")
-                };
-                allowed_domain_strs.push(wildcard);
+        match network_policy::load_network_policy(policy_json) {
+            Ok(net_policy) => {
+                let mut domains =
+                    network_policy::expand_proxy_allow(&net_policy, &plain_domain_strs);
+                if let Some(profile_name) = domain_filter.and_then(|d| d.network_profile.as_deref())
+                {
+                    match network_policy::resolve_network_profile(&net_policy, profile_name) {
+                        Ok(resolved) => {
+                            domains.extend(resolved.hosts);
+                            for suffix in &resolved.suffixes {
+                                let wildcard = if suffix.starts_with('.') {
+                                    format!("*{suffix}")
+                                } else {
+                                    format!("*.{suffix}")
+                                };
+                                domains.push(wildcard);
+                            }
+                        }
+                        Err(e) => {
+                            warn!("failed to resolve network_profile for sandbox state: {e}");
+                        }
+                    }
+                }
+                domains
+            }
+            Err(e) => {
+                warn!("failed to load network policy for sandbox state: {e}");
+                plain_domain_strs
             }
         }
-    }
+    } else {
+        plain_domain_strs
+    };
     let domain_endpoints: Vec<sandbox_state::DomainEndpointState> = all_domain_entries
         .iter()
         .filter_map(|e| match e {

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -5,8 +5,8 @@ use crate::launch_runtime::{LaunchPlan, select_threading_context};
 use crate::proxy_runtime::start_proxy_runtime;
 use crate::supervised_runtime::{SupervisedRuntimeContext, execute_supervised_runtime};
 use crate::{
-    DETACHED_SESSION_ID_ENV, command_blocking_deprecation, config, exec_strategy, output,
-    sandbox_state, session,
+    DETACHED_SESSION_ID_ENV, command_blocking_deprecation, config, exec_strategy, network_policy,
+    output, sandbox_state, session,
 };
 use nono::undo::{ContentHash, ExecutableIdentity};
 use nono::{CapabilitySet, NonoError, Result, Sandbox};
@@ -224,10 +224,31 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
         .iter()
         .chain(endpoint_domain_entries.iter())
         .collect();
-    let allowed_domain_strs: Vec<String> = all_domain_entries
+    // Expand network_profile hosts into the sandbox state so that `nono why --self`
+    // sees the same allowlist that the proxy enforces at runtime.
+    let mut allowed_domain_strs: Vec<String> = all_domain_entries
         .iter()
         .map(|e| e.domain().to_string())
         .collect();
+    if let Some(profile_name) = proxy
+        .and_then(|p| p.domain_filter.as_ref())
+        .and_then(|d| d.network_profile.as_deref())
+    {
+        let policy_json = config::embedded::embedded_network_policy_json();
+        if let Ok(net_policy) = network_policy::load_network_policy(policy_json)
+            && let Ok(resolved) = network_policy::resolve_network_profile(&net_policy, profile_name)
+        {
+            allowed_domain_strs.extend(resolved.hosts);
+            for suffix in &resolved.suffixes {
+                let wildcard = if suffix.starts_with('.') {
+                    format!("*{suffix}")
+                } else {
+                    format!("*.{suffix}")
+                };
+                allowed_domain_strs.push(wildcard);
+            }
+        }
+    }
     let domain_endpoints: Vec<sandbox_state::DomainEndpointState> = all_domain_entries
         .iter()
         .filter_map(|e| match e {

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -334,16 +334,47 @@ pub fn query_network(
                 },
             }
         }
-        nono::NetworkMode::AllowAll => QueryResult::Allowed {
-            reason: "network_allowed".to_string(),
-            granted_path: None,
-            access: Some(format!(
-                "Connection to {}:{} would be allowed",
-                domain, port
-            )),
-            source: None,
-            endpoint_rules: None,
-        },
+        nono::NetworkMode::AllowAll => {
+            // OS-level network is unrestricted, but a proxy domain filter may still
+            // apply. When allowed_domains is non-empty the proxy is active; check it.
+            if !allowed_domains.is_empty() {
+                let filter = nono::net_filter::HostFilter::new(allowed_domains);
+                match filter.check_host(&domain, &[]) {
+                    nono::net_filter::FilterResult::Allow => QueryResult::Allowed {
+                        reason: "proxy_allowed".to_string(),
+                        granted_path: None,
+                        access: Some(format!(
+                            "Connection to {}:{} would be allowed via proxy",
+                            domain, port
+                        )),
+                        source: Some("domain allowlist".to_string()),
+                        endpoint_rules: None,
+                    },
+                    _ => QueryResult::Denied {
+                        reason: "proxy_filtered".to_string(),
+                        details: Some(format!(
+                            "Domain filtering is active. host {} is not in the allowlist",
+                            domain
+                        )),
+                        policy_source: Some("proxy domain filter".to_string()),
+                        matching_capability: None,
+                        suggested_flag: Some(format!("--allow-domain {}", domain)),
+                        endpoint_rules: None,
+                    },
+                }
+            } else {
+                QueryResult::Allowed {
+                    reason: "network_allowed".to_string(),
+                    granted_path: None,
+                    access: Some(format!(
+                        "Connection to {}:{} would be allowed",
+                        domain, port
+                    )),
+                    source: None,
+                    endpoint_rules: None,
+                }
+            }
+        }
     }
 }
 

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -336,26 +336,75 @@ pub fn query_network(
         }
         nono::NetworkMode::AllowAll => {
             // OS-level network is unrestricted, but a proxy domain filter may still
-            // apply. When allowed_domains is non-empty the proxy is active; check it.
+            // apply. When allowed_domains is non-empty the proxy is active with
+            // default-deny semantics — check it the same way ProxyOnly does.
             if !allowed_domains.is_empty() {
                 let filter = nono::net_filter::HostFilter::new(allowed_domains);
                 match filter.check_host(&domain, &[]) {
-                    nono::net_filter::FilterResult::Allow => QueryResult::Allowed {
-                        reason: "proxy_allowed".to_string(),
-                        granted_path: None,
-                        access: Some(format!(
-                            "Connection to {}:{} would be allowed via proxy",
-                            domain, port
-                        )),
-                        source: Some("domain allowlist".to_string()),
-                        endpoint_rules: None,
-                    },
-                    _ => QueryResult::Denied {
+                    nono::net_filter::FilterResult::Allow => {
+                        let matching_endpoints = domain_endpoints
+                            .iter()
+                            .find(|de| de.domain.eq_ignore_ascii_case(&domain));
+
+                        match (matching_endpoints, &url_path) {
+                            (Some(de), Some(path)) => {
+                                if path_matches_endpoint_rules(path, &de.endpoints) {
+                                    QueryResult::Allowed {
+                                        reason: "proxy_allowed".to_string(),
+                                        granted_path: None,
+                                        access: Some(format!(
+                                            "Connection to {}:{} allowed via proxy \
+                                             (path {} matches endpoint rules)",
+                                            domain, port, path,
+                                        )),
+                                        source: Some("domain allowlist".to_string()),
+                                        endpoint_rules: Some(de.endpoints.clone()),
+                                    }
+                                } else {
+                                    QueryResult::Denied {
+                                        reason: "endpoint_restricted".to_string(),
+                                        details: Some(format!(
+                                            "{} is allowed but {} does not match any endpoint rule",
+                                            domain, path,
+                                        )),
+                                        policy_source: Some("endpoint rules".to_string()),
+                                        matching_capability: None,
+                                        suggested_flag: Some(format!(
+                                            "--allow-domain https://{}{}",
+                                            domain, path,
+                                        )),
+                                        endpoint_rules: Some(de.endpoints.clone()),
+                                    }
+                                }
+                            }
+                            (Some(de), None) => QueryResult::Allowed {
+                                reason: "proxy_allowed".to_string(),
+                                granted_path: None,
+                                access: Some(format!(
+                                    "Connection to {}:{} allowed via proxy \
+                                     (restricted to {} endpoint rules)",
+                                    domain,
+                                    port,
+                                    de.endpoints.len(),
+                                )),
+                                source: Some("domain allowlist".to_string()),
+                                endpoint_rules: Some(de.endpoints.clone()),
+                            },
+                            (None, _) => QueryResult::Allowed {
+                                reason: "proxy_allowed".to_string(),
+                                granted_path: None,
+                                access: Some(format!(
+                                    "Connection to {}:{} would be allowed via proxy",
+                                    domain, port,
+                                )),
+                                source: Some("domain allowlist".to_string()),
+                                endpoint_rules: None,
+                            },
+                        }
+                    }
+                    deny => QueryResult::Denied {
                         reason: "proxy_filtered".to_string(),
-                        details: Some(format!(
-                            "Domain filtering is active. host {} is not in the allowlist",
-                            domain
-                        )),
+                        details: Some(format!("Domain filtering is active. {}", deny.reason())),
                         policy_source: Some("proxy domain filter".to_string()),
                         matching_capability: None,
                         suggested_flag: Some(format!("--allow-domain {}", domain)),


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1365 
Closes #1366 

## Summary

Fixes two related diagnostic bugs:

- `nono why --profile` returned ALLOWED for arbitrary hosts on profiles using `network_profile` or `allow_domain`. The `AllowAll` OS-level network mode was treated as unconditionally allowed, skipping the proxy domain filter entirely. Fixed by checking `allowed_domains` against `HostFilter` in the `AllowAll` arm of `query_network` — a non-empty allowlist means the proxy is active with default-deny semantics.

- `nono why --self` reported DENIED for hosts allowed by `network_profile` because the sandbox state file only stored direct `allow_domain` entries. `network_profile` hosts were resolved lazily by the proxy at connection time but never written into the state. Fixed by expanding `network_profile` hosts at launch time in `execution_runtime.rs` before writing the capability state file, matching the resolution logic already used by `why --profile` and the proxy runtime.
<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
