### PR TITLE
feat(proxy): add deny_domain to block domains through the proxy

### DIFF
--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -61,7 +61,7 @@ Inherit from another profile by name:
   selected profile as the final override layer. Inherited grants can widen
   sandbox permissions.
 - Scalar fields: child overrides base.
-- Array fields (`groups.include`, `groups.exclude`, `commands.allow`, `commands.deny`, `filesystem.*`, `allow_domain`, `open_port`, `listen_port`, `rollback.*`, `upstream_bypass`): child values are appended to base values and deduplicated. To remove inherited entries, use `groups.exclude` for groups; there is no mechanism to remove inherited filesystem paths. For `allow_domain` entries with endpoint rules, rules for the same domain are merged (appended) rather than replaced.
+- Array fields (`groups.include`, `groups.exclude`, `commands.allow`, `commands.deny`, `filesystem.*`, `allow_domain`, `deny_domain`, `open_port`, `listen_port`, `rollback.*`, `upstream_bypass`): child values are appended to base values and deduplicated. To remove inherited entries, use `groups.exclude` for groups; there is no mechanism to remove inherited filesystem paths. For `allow_domain` entries with endpoint rules, rules for the same domain are merged (appended) rather than replaced. `deny_domain` entries are additive — child profiles can only add more denies, never remove inherited ones.
 - Map fields (`env_credentials`, `hooks`, `custom_credentials`): child entries are merged into base; child keys override matching base keys.
 - `network_profile` supports three-state inheritance via `InheritableValue`: absent = inherit base value, `null` = explicitly clear, string = override. This is the only field that supports null-clearing.
 - `open_urls`: if the child provides the field (even as `{}`), it replaces the base entirely. If absent, the base value is inherited. Setting to `null` in JSON is equivalent to omitting it (both inherit the base).
@@ -282,6 +282,7 @@ All path fields support variable expansion (see Section 6).
 | `allow_http2`           | boolean                           | `false`  | Allow HTTP/2 to upstream servers via ALPN negotiation. Default is HTTP/1.1 with keep-alive. Equivalent to `--allow-http2`. |
 | `network_profile`       | string or null                    | inherit  | Name from `network-policy.json` for proxy filtering. Set to `null` to clear inherited value. |
 | `allow_domain`          | array of string or object         | `[]`     | Additional domains to allow through the proxy. Entries can be plain strings (CONNECT tunnel) or objects with endpoint rules (TLS-intercepted L7 filtering). Aliases: `proxy_allow`, `allow_proxy`. |
+| `deny_domain`           | array of string                   | `[]`     | Domains to block through the proxy regardless of the allowlist. Evaluated before `allow_domain`. Supports wildcard subdomains (`*.ads.example.com`). Equivalent to `--deny-domain`. |
 | `credentials`           | array of string                   | `[]`     | Credential services to enable via reverse proxy. Alias: `proxy_credentials`. |
 | `open_port`             | array of integer                  | `[]`     | Localhost TCP IPC. Aliases: `port_allow`, `allow_port`. Port **0**: macOS only (`localhost:*` outbound); Linux: explicit ports. |
 | `listen_port`           | array of integer                  | `[]`     | TCP ports the sandboxed child may listen on. |

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -1225,6 +1225,17 @@ pub struct SandboxArgs {
     )]
     pub allow_proxy: Vec<String>,
 
+    /// Block a domain through the proxy. Evaluated before the allowlist.
+    /// Supports wildcards (e.g. *.ads.example.com). Incompatible with --allow-net.
+    #[arg(
+        long = "deny-domain",
+        env = "NONO_DENY_DOMAIN",
+        value_name = "DOMAIN",
+        conflicts_with = "allow_net",
+        help_heading = "NETWORK"
+    )]
+    pub deny_proxy: Vec<String>,
+
     /// Allow the sandboxed child to listen on a TCP port (repeatable)
     /// ALIAS(canonical="--listen-port", introduced="v0.0.0", remove_by="indefinite", issue="#415")
     #[arg(
@@ -1538,6 +1549,16 @@ pub struct ProxyArgs {
         help_heading = "NETWORK"
     )]
     pub allow_proxy: Vec<String>,
+
+    /// Block a domain through the proxy. Evaluated before the allowlist.
+    /// Supports wildcards (e.g. *.ads.example.com).
+    #[arg(
+        long = "deny-domain",
+        env = "NONO_DENY_DOMAIN",
+        value_name = "DOMAIN",
+        help_heading = "NETWORK"
+    )]
+    pub deny_proxy: Vec<String>,
 
     /// Chain outbound traffic through an upstream proxy (host:port)
     /// ALIAS(canonical="--upstream-proxy", introduced="v0.0.0", remove_by="indefinite", issue="#415")
@@ -1900,6 +1921,7 @@ impl From<WrapSandboxArgs> for SandboxArgs {
             allow_net: false,
             network_profile: None,
             allow_proxy: Vec::new(),
+            deny_proxy: Vec::new(),
             allow_bind: args.allow_bind,
             allow_port: args.allow_port,
             allow_connect_port: args.allow_connect_port,

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -83,6 +83,8 @@ pub(crate) struct DomainFilterIntent {
     /// Only `AllowDomainEntry::Plain` entries — endpoint-bearing entries live in
     /// `EndpointFilterIntent`.
     pub(crate) allow_domain: Vec<profile::AllowDomainEntry>,
+    /// Domains to deny regardless of the allowlist.
+    pub(crate) deny_domain: Vec<String>,
 }
 
 /// `WithEndpoints` allow-domain entries that require TLS interception so the

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -288,6 +288,7 @@ mod tests {
             allow_domain: vec![profile::AllowDomainEntry::Plain(
                 "docs.python.org".to_string(),
             )],
+            deny_domain: Vec::new(),
             credentials: vec!["github".to_string()],
             custom_credentials: std::collections::HashMap::new(),
             credential_capture: std::collections::HashMap::new(),
@@ -329,6 +330,7 @@ mod tests {
             EffectiveProxySettings {
                 network_profile: None,
                 allow_domain: Vec::new(),
+                deny_domain: Vec::new(),
                 credentials: Vec::new(),
             }
         );
@@ -355,6 +357,7 @@ mod tests {
             allow_domain: vec![profile::AllowDomainEntry::Plain(
                 "docs.python.org".to_string(),
             )],
+            deny_domain: Vec::new(),
             credentials: vec!["github".to_string()],
             custom_credentials: std::collections::HashMap::new(),
             credential_capture: std::collections::HashMap::new(),
@@ -399,6 +402,7 @@ mod tests {
                     profile::AllowDomainEntry::Plain("docs.python.org".to_string()),
                     profile::AllowDomainEntry::Plain("example.com".to_string()),
                 ],
+                deny_domain: Vec::new(),
                 credentials: vec!["github".to_string(), "openai".to_string()],
             }
         );

--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -314,8 +314,12 @@ pub fn resolve_credentials(
 /// Build a complete `ProxyConfig` from a resolved network policy.
 ///
 /// Combines resolved hosts/suffixes with credential routes and optional
-/// CLI overrides (extra hosts).
-pub fn build_proxy_config(resolved: &ResolvedNetworkPolicy, extra_hosts: &[String]) -> ProxyConfig {
+/// CLI overrides (extra hosts and denied hosts).
+pub fn build_proxy_config(
+    resolved: &ResolvedNetworkPolicy,
+    extra_hosts: &[String],
+    denied_hosts: &[String],
+) -> ProxyConfig {
     let mut allowed_hosts = resolved.hosts.clone();
     // Convert suffixes to wildcard format for the proxy filter
     for suffix in &resolved.suffixes {
@@ -331,9 +335,37 @@ pub fn build_proxy_config(resolved: &ResolvedNetworkPolicy, extra_hosts: &[Strin
 
     ProxyConfig {
         allowed_hosts,
+        denied_hosts: denied_hosts.to_vec(),
         routes: resolved.routes.clone(),
         ..Default::default()
     }
+}
+
+/// Expand `--deny-domain` entries: if an entry matches a group name in the
+/// network policy, expand it to the group's hosts and suffixes. Otherwise
+/// treat it as a literal hostname.
+pub fn expand_proxy_deny(policy: &NetworkPolicy, entries: &[String]) -> Vec<String> {
+    let mut result = Vec::new();
+    for entry in entries {
+        if let Some(group) = policy.groups.get(entry.as_str()) {
+            result.extend(group.hosts.clone());
+            for suffix in &group.suffixes {
+                let wildcard = if suffix.starts_with('.') {
+                    format!("*{}", suffix)
+                } else {
+                    format!("*.{}", suffix)
+                };
+                result.push(wildcard);
+            }
+        } else {
+            let host = entry
+                .rsplit_once(':')
+                .and_then(|(h, p)| p.parse::<u16>().ok().map(|_| h))
+                .unwrap_or(entry.as_str());
+            result.push(host.to_string());
+        }
+    }
+    result
 }
 
 /// Expand `--allow-domain` entries: if an entry matches a group name in the
@@ -734,7 +766,7 @@ mod tests {
             routes: vec![],
             profile_credentials: vec![],
         };
-        let config = build_proxy_config(&resolved, &["extra.example.com".to_string()]);
+        let config = build_proxy_config(&resolved, &["extra.example.com".to_string()], &[]);
         assert!(config.allowed_hosts.contains(&"api.openai.com".to_string()));
         assert!(
             config
@@ -1415,5 +1447,36 @@ mod tests {
             "custom credential definitions should remain disabled until explicitly requested, got {} route(s)",
             routes.len()
         );
+    }
+
+    #[test]
+    fn test_expand_proxy_deny_plain_hostnames() {
+        let json = embedded_network_policy_json();
+        let policy = load_network_policy(json).unwrap();
+
+        let entries = vec!["evil.com".to_string(), "tracker.io".to_string()];
+        let denied = expand_proxy_deny(&policy, &entries);
+        assert_eq!(denied, vec!["evil.com", "tracker.io"]);
+    }
+
+    #[test]
+    fn test_expand_proxy_deny_strips_port() {
+        let json = embedded_network_policy_json();
+        let policy = load_network_policy(json).unwrap();
+
+        let entries = vec!["evil.com:443".to_string()];
+        let denied = expand_proxy_deny(&policy, &entries);
+        assert_eq!(denied, vec!["evil.com"]);
+    }
+
+    #[test]
+    fn test_build_proxy_config_denied_hosts_propagated() {
+        let json = embedded_network_policy_json();
+        let policy = load_network_policy(json).unwrap();
+        let profile_name = policy.profiles.keys().next().unwrap().clone();
+        let resolved = resolve_network_profile(&policy, &profile_name).unwrap();
+
+        let config = build_proxy_config(&resolved, &[], &["evil.com".to_string()]);
+        assert_eq!(config.denied_hosts, vec!["evil.com"]);
     }
 }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1489,6 +1489,10 @@ pub struct NetworkConfig {
         alias = "allow_proxy"
     )]
     pub allow_domain: Vec<AllowDomainEntry>,
+    /// Domains to deny through the proxy regardless of the allowlist.
+    /// Supports the same wildcard syntax as `allow_domain` (e.g. `*.ads.example.com`).
+    #[serde(default)]
+    pub deny_domain: Vec<String>,
     /// Credential services to enable via reverse proxy.
     /// Canonical profile key: `credentials` (legacy `proxy_credentials` accepted).
     ///
@@ -3284,6 +3288,7 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
                 &base.network.allow_domain,
                 &child.network.allow_domain,
             ),
+            deny_domain: dedup_append(&base.network.deny_domain, &child.network.deny_domain),
             open_port: dedup_append(&base.network.open_port, &child.network.open_port),
             listen_port: dedup_append(&base.network.listen_port, &child.network.listen_port),
             connect_port: dedup_append(&base.network.connect_port, &child.network.connect_port),
@@ -5677,6 +5682,7 @@ mod tests {
                 allow_http2: false,
                 network_profile: InheritableValue::Set("base-net".to_string()),
                 allow_domain: vec![AllowDomainEntry::Plain("base.example.com".to_string())],
+                deny_domain: vec![],
                 open_port: vec![3000],
                 listen_port: vec![4000],
                 connect_port: vec![],
@@ -5764,6 +5770,7 @@ mod tests {
                 allow_http2: false,
                 network_profile: InheritableValue::Inherit,
                 allow_domain: vec![AllowDomainEntry::Plain("child.example.com".to_string())],
+                deny_domain: vec![],
                 open_port: vec![3000, 5000],
                 listen_port: vec![4000, 6000],
                 connect_port: vec![],

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -22,6 +22,7 @@ pub(crate) struct PreparedProfile {
     pub(crate) rollback_exclude_globs: Vec<String>,
     pub(crate) network_profile: Option<String>,
     pub(crate) allow_domain: Vec<profile::AllowDomainEntry>,
+    pub(crate) deny_domain: Vec<String>,
     pub(crate) credentials: Vec<String>,
     pub(crate) custom_credentials: HashMap<String, profile::CustomCredentialDef>,
     pub(crate) credential_providers: HashMap<String, profile::CredentialProviderDef>,
@@ -801,6 +802,10 @@ fn prepare_profile_with_options(
         allow_domain: loaded_profile
             .as_ref()
             .map(|profile| profile.network.allow_domain.clone())
+            .unwrap_or_default(),
+        deny_domain: loaded_profile
+            .as_ref()
+            .map(|profile| profile.network.deny_domain.clone())
             .unwrap_or_default(),
         credentials: loaded_profile
             .as_ref()

--- a/crates/nono-cli/src/proxy_command.rs
+++ b/crates/nono-cli/src/proxy_command.rs
@@ -213,6 +213,9 @@ fn build_launch_options(args: &ProxyArgs) -> Result<ProxyLaunchOptions> {
             .map(|s| crate::proxy_runtime::parse_allow_domain_arg(s)),
     );
 
+    let mut deny_domain: Vec<String> = network.map(|n| n.deny_domain.clone()).unwrap_or_default();
+    deny_domain.extend(args.deny_proxy.iter().cloned());
+
     let mut credentials: Vec<String> = network
         .map(|n| n.resolved_credentials().to_vec())
         .unwrap_or_default();
@@ -267,14 +270,16 @@ fn build_launch_options(args: &ProxyArgs) -> Result<ProxyLaunchOptions> {
         .into_iter()
         .partition(|e| !matches!(e, profile::AllowDomainEntry::WithEndpoints { endpoints, .. } if !endpoints.is_empty()));
 
-    let domain_filter = if network_profile.is_some() || !plain_entries.is_empty() {
-        Some(DomainFilterIntent {
-            network_profile,
-            allow_domain: plain_entries,
-        })
-    } else {
-        None
-    };
+    let domain_filter =
+        if network_profile.is_some() || !plain_entries.is_empty() || !deny_domain.is_empty() {
+            Some(DomainFilterIntent {
+                network_profile,
+                allow_domain: plain_entries,
+                deny_domain,
+            })
+        } else {
+            None
+        };
 
     let endpoint_filter = if endpoint_entries.is_empty() {
         None

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -43,6 +43,7 @@ pub(crate) struct ActiveProxyRuntime {
 pub(crate) struct EffectiveProxySettings {
     pub(crate) network_profile: Option<String>,
     pub(crate) allow_domain: Vec<crate::profile::AllowDomainEntry>,
+    pub(crate) deny_domain: Vec<String>,
     pub(crate) credentials: Vec<String>,
 }
 
@@ -1357,6 +1358,7 @@ pub(crate) fn prepare_proxy_launch_options(
     let effective_proxy = resolve_effective_proxy_settings(args, prepared);
     let network_profile = effective_proxy.network_profile;
     let allow_domain = effective_proxy.allow_domain;
+    let deny_domain = effective_proxy.deny_domain;
     let mut credentials = effective_proxy.credentials;
     let mut custom_credentials = prepared.custom_credentials.clone();
     let mut proxy_source_env_vars = HashMap::new();
@@ -1391,7 +1393,8 @@ pub(crate) fn prepare_proxy_launch_options(
         bypass
     };
 
-    let has_domain_filter = network_profile.is_some() || !allow_domain.is_empty();
+    let has_domain_filter =
+        network_profile.is_some() || !allow_domain.is_empty() || !deny_domain.is_empty();
     let has_credentials = !credentials.is_empty();
     let would_activate = has_domain_filter || has_credentials || upstream_proxy_addr.is_some();
 
@@ -1420,14 +1423,16 @@ pub(crate) fn prepare_proxy_launch_options(
         .into_iter()
         .partition(|e| !matches!(e, crate::profile::AllowDomainEntry::WithEndpoints { endpoints, .. } if !endpoints.is_empty()));
 
-    let domain_filter = if network_profile.is_some() || !plain_entries.is_empty() {
-        Some(DomainFilterIntent {
-            network_profile,
-            allow_domain: plain_entries,
-        })
-    } else {
-        None
-    };
+    let domain_filter =
+        if network_profile.is_some() || !plain_entries.is_empty() || !deny_domain.is_empty() {
+            Some(DomainFilterIntent {
+                network_profile,
+                allow_domain: plain_entries,
+                deny_domain,
+            })
+        } else {
+            None
+        };
 
     let endpoint_filter = if !endpoint_entries.is_empty() {
         debug_assert!(
@@ -1617,6 +1622,7 @@ pub(crate) fn resolve_effective_proxy_settings(
         return EffectiveProxySettings {
             network_profile: None,
             allow_domain: Vec::new(),
+            deny_domain: Vec::new(),
             credentials: Vec::new(),
         };
     }
@@ -1627,12 +1633,15 @@ pub(crate) fn resolve_effective_proxy_settings(
         .or_else(|| prepared.network_profile.clone());
     let mut allow_domain = prepared.allow_domain.clone();
     allow_domain.extend(args.allow_proxy.iter().map(|s| parse_allow_domain_arg(s)));
+    let mut deny_domain = prepared.deny_domain.clone();
+    deny_domain.extend(args.deny_proxy.iter().cloned());
     let mut credentials = prepared.credentials.clone();
     credentials.extend(args.proxy_credential.clone());
 
     EffectiveProxySettings {
         network_profile,
         allow_domain,
+        deny_domain,
         credentials,
     }
 }
@@ -2258,7 +2267,15 @@ pub(crate) fn build_proxy_config_from_flags(
     routes.extend(endpoint_routes);
     resolved.routes = routes;
 
-    let mut proxy_config = network_policy::build_proxy_config(&resolved, &plain_hosts);
+    let deny_domain = proxy
+        .domain_filter
+        .as_ref()
+        .map(|d| d.deny_domain.as_slice())
+        .unwrap_or(&[]);
+    let denied_hosts = network_policy::expand_proxy_deny(&net_policy, deny_domain);
+
+    let mut proxy_config =
+        network_policy::build_proxy_config(&resolved, &plain_hosts, &denied_hosts);
     proxy_config.strict_filter = proxy.strict_filter;
 
     if let Some(ref upstream) = proxy.upstream_proxy {
@@ -3060,6 +3077,7 @@ mod tests {
             rollback_exclude_globs: Vec::new(),
             network_profile: None,
             allow_domain: Vec::new(),
+            deny_domain: Vec::new(),
             credentials: Vec::new(),
             custom_credentials,
             upstream_proxy: None,

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -428,6 +428,7 @@ pub(crate) struct PreparedSandbox {
     pub(crate) rollback_exclude_globs: Vec<String>,
     pub(crate) network_profile: Option<String>,
     pub(crate) allow_domain: Vec<profile::AllowDomainEntry>,
+    pub(crate) deny_domain: Vec<String>,
     pub(crate) credentials: Vec<String>,
     pub(crate) custom_credentials: HashMap<String, profile::CustomCredentialDef>,
     pub(crate) credential_capture: HashMap<String, profile::CredentialCaptureEntry>,
@@ -1271,6 +1272,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
                 rollback_exclude_globs,
                 network_profile: None,
                 allow_domain,
+                deny_domain: Vec::new(),
                 credentials,
                 custom_credentials: HashMap::new(),
                 credential_capture: HashMap::new(),
@@ -1328,6 +1330,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         rollback_exclude_globs: profile_rollback_globs,
         network_profile: profile_network_profile,
         allow_domain: profile_allow_domain,
+        deny_domain: profile_deny_domain,
         credentials: profile_credentials,
         custom_credentials: profile_custom_credentials,
         credential_providers: profile_credential_providers,
@@ -1379,6 +1382,8 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         .collect();
     print_allow_domain_port_warnings(&profile_allow_domain_strs, "profile allow_domain", silent);
     print_allow_domain_port_warnings(&args.allow_proxy, "--allow-domain", silent);
+    print_allow_domain_port_warnings(&profile_deny_domain, "profile deny_domain", silent);
+    print_allow_domain_port_warnings(&args.deny_proxy, "--deny-domain", silent);
 
     #[cfg(unix)]
     if args.profile.as_deref().is_some_and(is_claude_code_profile) {
@@ -1650,6 +1655,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
             rollback_exclude_globs: profile_rollback_globs,
             network_profile: profile_network_profile,
             allow_domain: profile_allow_domain,
+            deny_domain: profile_deny_domain,
             credentials: profile_credentials,
             custom_credentials: profile_custom_credentials,
             credential_capture: profile_credential_capture,
@@ -2238,6 +2244,7 @@ mod tests {
             rollback_exclude_globs: Vec::new(),
             network_profile: None,
             allow_domain: Vec::new(),
+            deny_domain: Vec::new(),
             credentials: Vec::new(),
             custom_credentials: std::collections::HashMap::new(),
             credential_capture: std::collections::HashMap::new(),

--- a/crates/nono-proxy/src/config.rs
+++ b/crates/nono-proxy/src/config.rs
@@ -41,6 +41,11 @@ pub struct ProxyConfig {
     #[serde(default)]
     pub allowed_hosts: Vec<String>,
 
+    /// Hosts to deny regardless of the allowlist (exact match + wildcards).
+    /// Evaluated before the allowlist.
+    #[serde(default)]
+    pub denied_hosts: Vec<String>,
+
     /// When `true`, an empty `allowed_hosts` denies every host instead of
     /// falling back to allow-all.
     #[serde(default)]
@@ -227,6 +232,7 @@ impl Default for ProxyConfig {
             bind_addr: default_bind_addr(),
             bind_port: 0,
             allowed_hosts: Vec::new(),
+            denied_hosts: Vec::new(),
             strict_filter: false,
             require_auth: default_require_auth(),
             strict_connect_auth: false,

--- a/crates/nono-proxy/src/filter.rs
+++ b/crates/nono-proxy/src/filter.rs
@@ -52,6 +52,19 @@ impl ProxyFilter {
         }
     }
 
+    /// Append user-configured deny entries. Evaluated before the allowlist.
+    ///
+    /// Supports the same wildcard syntax as the allowlist (`*.example.com`).
+    #[must_use]
+    pub fn with_denied_hosts(self, denied: &[String]) -> Self {
+        if denied.is_empty() {
+            return self;
+        }
+        Self {
+            inner: self.inner.with_denied_hosts(denied),
+        }
+    }
+
     /// Check a host against the filter with async DNS resolution.
     ///
     /// Resolves the hostname to IP addresses, then checks all resolved IPs
@@ -152,6 +165,31 @@ mod tests {
         let result = filter.check_host_result("metadata.google.internal", 443, &public_ip);
         assert!(!result.is_allowed());
         assert!(matches!(result, FilterResult::DenyHost { .. }));
+    }
+
+    #[test]
+    fn test_proxy_filter_with_denied_hosts() {
+        let filter = ProxyFilter::allow_all().with_denied_hosts(&["evil.com".to_string()]);
+        let public_ip = vec![IpAddr::V4(Ipv4Addr::new(104, 18, 7, 96))];
+
+        let result = filter.check_host_with_ips("evil.com", &public_ip);
+        assert!(!result.is_allowed());
+
+        let result = filter.check_host_with_ips("good.com", &public_ip);
+        assert!(result.is_allowed());
+    }
+
+    #[test]
+    fn test_proxy_filter_with_denied_hosts_wildcard() {
+        let filter = ProxyFilter::allow_all().with_denied_hosts(&["*.ads.example.com".to_string()]);
+        let public_ip = vec![IpAddr::V4(Ipv4Addr::new(104, 18, 7, 96))];
+
+        let result = filter.check_host_with_ips("tracker.ads.example.com", &public_ip);
+        assert!(!result.is_allowed());
+
+        // bare domain must NOT match wildcard
+        let result = filter.check_host_with_ips("ads.example.com", &public_ip);
+        assert!(result.is_allowed());
     }
 
     #[test]

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -171,7 +171,8 @@ impl ProxyHandle {
             crate::filter::ProxyFilter::allow_all()
         } else {
             crate::filter::ProxyFilter::new(&config.allowed_hosts)
-        };
+        }
+        .with_denied_hosts(&config.denied_hosts);
         // Hostname-only reachability: pass no resolved IPs so the link-local
         // SSRF check is skipped (that is a runtime DNS concern, not a config
         // one) and only the deny-list / allowlist hostname rules apply.
@@ -657,7 +658,8 @@ pub async fn start_with_nonce_resolver(
         ProxyFilter::allow_all()
     } else {
         ProxyFilter::new(&config.allowed_hosts)
-    };
+    }
+    .with_denied_hosts(&config.denied_hosts);
 
     // Build bypass matcher from external proxy config (once, not per-request)
     let bypass_matcher = config

--- a/crates/nono/src/net_filter.rs
+++ b/crates/nono/src/net_filter.rs
@@ -114,8 +114,10 @@ pub struct HostFilter {
     allowed_hosts: Vec<String>,
     /// Allowed wildcard suffixes (e.g., ".googleapis.com", lowercased)
     allowed_suffixes: Vec<String>,
-    /// Hostnames that are always denied
+    /// Exact hostnames that are always denied
     deny_hosts: Vec<String>,
+    /// Wildcard suffixes that are always denied (e.g., ".ads.example.com")
+    deny_suffixes: Vec<String>,
     /// When true, an empty allowlist denies instead of allowing.
     strict: bool,
 }
@@ -146,6 +148,7 @@ impl HostFilter {
             allowed_hosts: exact,
             allowed_suffixes: suffixes,
             deny_hosts: DENY_HOSTS.iter().map(|s| s.to_lowercase()).collect(),
+            deny_suffixes: Vec::new(),
             strict: false,
         }
     }
@@ -167,8 +170,26 @@ impl HostFilter {
             allowed_hosts: Vec::new(),
             allowed_suffixes: Vec::new(),
             deny_hosts: DENY_HOSTS.iter().map(|s| s.to_lowercase()).collect(),
+            deny_suffixes: Vec::new(),
             strict: false,
         }
+    }
+
+    /// Append user-configured deny entries on top of the hardcoded deny list.
+    ///
+    /// Supports the same wildcard syntax as the allowlist (`*.example.com`
+    /// matches `foo.example.com` but not `example.com` itself).
+    #[must_use]
+    pub fn with_denied_hosts(mut self, denied: &[String]) -> Self {
+        for entry in denied {
+            let lower = entry.to_lowercase();
+            if let Some(suffix) = lower.strip_prefix('*') {
+                self.deny_suffixes.push(suffix.to_string());
+            } else {
+                self.deny_hosts.push(lower);
+            }
+        }
+        self
     }
 
     /// Check a host against the filter.
@@ -188,11 +209,20 @@ impl HostFilter {
     pub fn check_host(&self, host: &str, resolved_ips: &[IpAddr]) -> FilterResult {
         let lower_host = host.to_lowercase();
 
-        // 1. Check deny hosts
+        // 1. Check deny hosts (exact match)
         if self.deny_hosts.contains(&lower_host) {
             return FilterResult::DenyHost {
                 host: host.to_string(),
             };
+        }
+
+        // 1b. Check deny suffixes (wildcard match, e.g. *.ads.example.com)
+        for suffix in &self.deny_suffixes {
+            if lower_host.ends_with(suffix.as_str()) && lower_host.len() > suffix.len() {
+                return FilterResult::DenyHost {
+                    host: host.to_string(),
+                };
+            }
         }
 
         // 2. Check resolved IPs for link-local addresses (cloud metadata protection)
@@ -423,6 +453,58 @@ mod tests {
             IpAddr::V4(Ipv4Addr::new(169, 254, 0, 1)),
         ];
         let result = filter.check_host("multi.example.com", &ips);
+        assert!(!result.is_allowed());
+    }
+
+    #[test]
+    fn test_user_deny_host_exact() {
+        let filter = HostFilter::allow_all().with_denied_hosts(&["evil.com".to_string()]);
+        let result = filter.check_host("evil.com", &public_ip());
+        assert!(!result.is_allowed());
+        assert!(matches!(result, FilterResult::DenyHost { .. }));
+    }
+
+    #[test]
+    fn test_user_deny_host_does_not_affect_others() {
+        let filter = HostFilter::allow_all().with_denied_hosts(&["evil.com".to_string()]);
+        let result = filter.check_host("good.com", &public_ip());
+        assert!(result.is_allowed());
+    }
+
+    #[test]
+    fn test_user_deny_host_wildcard() {
+        let filter = HostFilter::allow_all().with_denied_hosts(&["*.ads.example.com".to_string()]);
+        assert!(
+            !filter
+                .check_host("tracker.ads.example.com", &public_ip())
+                .is_allowed()
+        );
+        assert!(
+            !filter
+                .check_host("pixel.ads.example.com", &public_ip())
+                .is_allowed()
+        );
+        // bare domain must NOT match wildcard
+        assert!(
+            filter
+                .check_host("ads.example.com", &public_ip())
+                .is_allowed()
+        );
+    }
+
+    #[test]
+    fn test_user_deny_beats_allowlist() {
+        let filter =
+            HostFilter::new(&["evil.com".to_string()]).with_denied_hosts(&["evil.com".to_string()]);
+        let result = filter.check_host("evil.com", &public_ip());
+        assert!(!result.is_allowed());
+        assert!(matches!(result, FilterResult::DenyHost { .. }));
+    }
+
+    #[test]
+    fn test_user_deny_case_insensitive() {
+        let filter = HostFilter::allow_all().with_denied_hosts(&["Evil.COM".to_string()]);
+        let result = filter.check_host("evil.com", &public_ip());
         assert!(!result.is_allowed());
     }
 

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -464,6 +464,29 @@ nono run --allow-cwd --network-profile minimal --allow-domain custom-api.example
 
 When a URL with a path is provided, only requests matching that path pattern are permitted. Requests to other paths on the same domain are denied with `403 Forbidden`. Pattern syntax: `*` matches one path segment, `**` matches zero or more.
 
+#### `--deny-domain`
+
+Block a domain through the proxy even if it would otherwise be allowed. Can be specified multiple times. Activates proxy mode if not already active.
+
+Deny rules are evaluated before the allowlist, so a domain in both `--deny-domain` and `--allow-domain` (or a network profile) is always blocked.
+
+Accepts a plain hostname or a wildcard subdomain pattern:
+
+```bash
+# Block a specific host while allowing everything else
+nono run --allow-cwd --deny-domain ads.example.com -- my-agent
+
+# Block all subdomains of a domain
+nono run --allow-cwd --deny-domain '*.tracker.io' -- my-agent
+
+# Block telemetry while using a permissive profile
+nono run --allow-cwd --network-profile developer --deny-domain telemetry.vendor.com -- my-agent
+```
+
+Wildcard syntax (`*.example.com`) matches subdomains but not the bare domain itself. Cloud metadata endpoints (169.254.169.254, metadata.google.internal, etc.) are always denied regardless of this flag.
+
+Incompatible with `--allow-net` (which bypasses the proxy entirely, making deny rules ineffective).
+
 #### `--credential`
 
 Enable credential injection for a named service via the reverse proxy. The service must be either a preset service (`openai`, `anthropic`, `gemini`, `google-ai`) or defined as a custom credential in your profile. Credentials are loaded from the system keyring under the `nono` service name, from 1Password when `credential_key` is an `op://` URI, from Apple Passwords on macOS when `credential_key` is an `apple-password://` URI, from a file when `credential_key` is a `file://` URI, or from the host environment when `credential_key` is an `env://` URI.


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1330 

## Summary

Adds --deny-domain CLI flag and deny_domain profile key to complement allow_domain. Users can now say "allow everything except these domains" without enumerating an allowlist. Deny rules are evaluated before the allowlist, support wildcard subdomains (*.example.com), and activate the proxy on their own. Conflicts with --allow-net at parse time. Port-suffix warnings are emitted for deny entries consistent with allow-domain behavior.
<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
