### PR TITLE
fix: missing ~/.cache on macOS

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -325,7 +325,8 @@
       "allow": {
         "readwrite": [
           "~/Library/Caches",
-          "~/Library/Logs"
+          "~/Library/Logs",
+          "~/.cache"
         ],
         "read": [
           "~/Library/Preferences"

--- a/crates/nono-cli/src/learn.rs
+++ b/crates/nono-cli/src/learn.rs
@@ -1371,10 +1371,9 @@ fn extract_path_from_syscall(line: &str, syscall: &str) -> Option<String> {
     // For openat, skip AT_FDCWD
     let path_start = if syscall == "openat" {
         // Skip "AT_FDCWD, " or similar
-        if let Some(comma_idx) = after_paren.find(',') {
+        {
+            let comma_idx = after_paren.find(',')?;
             comma_idx + 2 // Skip ", "
-        } else {
-            return None;
         }
     } else {
         0

--- a/crates/nono-cli/src/macos_trust.rs
+++ b/crates/nono-cli/src/macos_trust.rs
@@ -110,7 +110,7 @@ fn generate_and_trust_new_ca(validity: Duration) -> Result<Option<PreloadedCa>> 
     // Single atomic write — concurrent processes race, but the bundle is always
     // a coherent key+cert pair (second writer wins, no mismatch possible).
     let key_pem = ca.key_pem();
-    let combined = Zeroizing::new(format!("{}{}", &*key_pem, cert_pem));
+    let combined = Zeroizing::new(format!("{}{}", *key_pem, cert_pem));
     passwords::set_generic_password(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT, combined.as_bytes())
         .map_err(|e| {
             NonoError::SandboxInit(format!("failed to store CA bundle in Keychain: {e}"))
@@ -263,7 +263,7 @@ mod tests {
         use nono_proxy::tls_intercept::ca::split_key_cert_pem;
 
         let ca = generate_test_ca();
-        let combined = format!("{}{}", &*ca.key_pem(), ca.cert_pem());
+        let combined = format!("{}{}", *ca.key_pem(), ca.cert_pem());
 
         let (key_der, cert_pem) = split_key_cert_pem(&combined).unwrap();
         assert_eq!(&*key_der, ca.key_der());

--- a/crates/nono-cli/src/proxy_command.rs
+++ b/crates/nono-cli/src/proxy_command.rs
@@ -178,7 +178,7 @@ fn load_preloaded_ca(
 
     // `split_key_cert_pem` extracts the PKCS#8 key as DER and returns the cert
     // PEM; the key must come first in the combined bundle.
-    let combined = zeroize::Zeroizing::new(format!("{}{}", &*key_pem, cert_pem));
+    let combined = zeroize::Zeroizing::new(format!("{}{}", *key_pem, cert_pem));
     let (key_der, cert_pem) = nono_proxy::tls_intercept::ca::split_key_cert_pem(&combined)
         .map_err(|e| NonoError::ConfigParse(format!("invalid proxy CA material: {e}")))?;
 
@@ -387,17 +387,17 @@ fn print_connection_info(
         // userinfo). Surface it directly plus the raw token for Bearer clients.
         println!(
             "  proxy URL: {}",
-            format!("http://nono:{}@{}:{}", &*handle.token, addr, port).cyan()
+            format!("http://nono:{}@{}:{}", *handle.token, addr, port).cyan()
         );
         println!("  token:     {}", (*handle.token).dimmed());
         println!();
         println!(
             "  export HTTPS_PROXY=http://nono:{}@{}:{}",
-            &*handle.token, addr, port
+            *handle.token, addr, port
         );
         println!(
             "  export HTTP_PROXY=http://nono:{}@{}:{}",
-            &*handle.token, addr, port
+            *handle.token, addr, port
         );
     }
 

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -428,7 +428,7 @@ impl ProxyHandle {
     /// presented during interception.
     #[must_use]
     pub fn env_vars(&self) -> Vec<(String, String)> {
-        let proxy_url = format!("http://nono:{}@127.0.0.1:{}", &*self.token, self.port);
+        let proxy_url = format!("http://nono:{}@127.0.0.1:{}", *self.token, self.port);
 
         // Build NO_PROXY: always include loopback, plus non-credential
         // allowed hosts. Credential upstreams are excluded so their traffic

--- a/crates/nono-proxy/src/tls_intercept/ca.rs
+++ b/crates/nono-proxy/src/tls_intercept/ca.rs
@@ -438,7 +438,7 @@ mod tests {
     #[test]
     fn split_key_cert_pem_roundtrips() {
         let ca = EphemeralCa::generate_with_cn("nono-proxy-ca", CA_VALIDITY_DEFAULT).unwrap();
-        let combined = format!("{}{}", &*ca.key_pem(), ca.cert_pem());
+        let combined = format!("{}{}", *ca.key_pem(), ca.cert_pem());
 
         let (key_der, cert_pem) = split_key_cert_pem(&combined).unwrap();
         assert_eq!(&*key_der, ca.key_der());


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1377

## Summary

<!-- Briefly describe what this PR does and why. -->

Adding the missing readwrite access to `~/.cache` for macOS profile group `user_caches_macos` that some programs requires, e.g., uv.

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

Manually tested on macOS.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
