### PR TITLE
docs(codex): clarify codex docs around the optional login-shell hardening

### DIFF
--- a/docs/cli/clients/codex.mdx
+++ b/docs/cli/clients/codex.mdx
@@ -236,12 +236,32 @@ As a result:
 - when domain filtering is enabled, all network requests from commands executed by Codex are denied, regardless of the allowlist;
 - tool commands no longer appear to run inside nono.
 
+##### Option 1: Allow login shell in nono sandbox
+
 Because nono is already sandboxing the execution and filtering environment variables, you can start Codex with its own sandbox and optional hardening disabled.
 
 Recommended invocation:
 
 ```bash
 nono run --profile always-further/codex --network-profile codex -- codex --sandbox danger-full-access --ask-for-approval on-request --config allow_login_shell=true
+```
+
+##### Option 2: Explicit configration
+
+An alternative, more secure, and explicit approach is to keep optional hardening enabled and configure Codex’s `shell_environment_policy` so that required environment variables are passed to the subprocess.
+
+Set `allow_login_shell=false` in the Codex configuration, then add the `shell_environment_policy` block and list required exports:
+
+```toml
+[shell_environment_policy]
+inherit = "all"
+ignore_default_excludes = false
+include_only = [
+    "PATH", "HOME", "USER", "SHELL", "TERM", "COLORTERM", "LANG", "LC_*",
+    "NONO_CAP_FILE", "NONO_PROXY_TOKEN", "BROWSER",
+    "NO_PROXY", "HTTP_PROXY", "HTTPS_PROXY", "NODE_USE_ENV_PROXY",
+    "GIT_SSL_CAINFO", "CURL_CA_BUNDLE", "NODE_EXTRA_CA_CERTS", "REQUESTS_CA_BUNDLE", "SSL_CERT_FILE"
+]
 ```
 
 ### Additional Home-Directory Tools

--- a/docs/cli/clients/codex.mdx
+++ b/docs/cli/clients/codex.mdx
@@ -246,7 +246,7 @@ Recommended invocation:
 nono run --profile always-further/codex --network-profile codex -- codex --sandbox danger-full-access --ask-for-approval on-request --config allow_login_shell=true
 ```
 
-##### Option 2: Explicit configration
+##### Option 2: Explicit configuration
 
 An alternative, more secure, and explicit approach is to keep optional hardening enabled and configure Codex’s `shell_environment_policy` so that required environment variables are passed to the subprocess.
 

--- a/docs/cli/clients/codex.mdx
+++ b/docs/cli/clients/codex.mdx
@@ -227,6 +227,23 @@ If you want Codex limited to the built-in host allowlist for coding workflows:
 nono run --profile always-further/codex --network-profile codex -- codex --sandbox danger-full-access --ask-for-approval on-request
 ```
 
+#### Codex Shell-based Tools
+
+The `allow_login_shell` configuration key in Codex controls whether shell-based tools use login-shell semantics. When disabled, login-shell requests are rejected and the subprocess falls back to a non-login shell. This matters because, even with the Codex sandbox disabled, Codex subprocesses will have a narrow set of environment variables.
+
+As a result:
+
+- when domain filtering is enabled, all network requests from commands executed by Codex are denied, regardless of the allowlist;
+- tool commands no longer appear to run inside nono.
+
+Because nono is already sandboxing the execution and filtering environment variables, you can start Codex with its own sandbox and optional hardening disabled.
+
+Recommended invocation:
+
+```bash
+nono run --profile always-further/codex --network-profile codex -- codex --sandbox danger-full-access --ask-for-approval on-request --config allow_login_shell=true
+```
+
 ### Additional Home-Directory Tools
 
 The profile covers common Rust, Node.js, Python, and Nix runtime locations under `~/`, but some developer tools still install into other home-directory paths such as `~/go/bin` or `~/.bun/bin`.


### PR DESCRIPTION
## Linked Issue

Closes #1376 

## Summary

Documents how to handle the Codex login-shell optional hardening in nono sandbox by providing two approaches.

## Test Plan

Please see https://github.com/nolabs-ai/nono/discussions/1337 for the whole context.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [n/a] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [n/a] Public-facing changes are paired with documentation updates
- [n/a] Release note has been added to `CHANGELOG.md` if needed