### PR TITLE
fix(registry): add X-Nono-Pull-Reason header to distinguish pull triggers (#1383)

### DIFF
--- a/crates/nono-cli/src/app_runtime.rs
+++ b/crates/nono-cli/src/app_runtime.rs
@@ -9,6 +9,7 @@ use crate::output;
 use crate::package_cmd;
 use crate::profile_cmd;
 use crate::proxy_command;
+use crate::registry_client::PullReason;
 use crate::rollback_commands;
 use crate::session_commands;
 use crate::setup;
@@ -97,9 +98,9 @@ fn dispatch_command(
         Commands::Profile(args) => {
             run_command_with_update(update_handle, silent, || profile_cmd::run_profile(args))
         }
-        Commands::Pull(args) => {
-            run_command_with_update(update_handle, silent, || package_cmd::run_pull(args))
-        }
+        Commands::Pull(args) => run_command_with_update(update_handle, silent, || {
+            package_cmd::run_pull(args, PullReason::Explicit)
+        }),
         Commands::Remove(args) => {
             run_command_with_update(update_handle, silent, || package_cmd::run_remove(args))
         }

--- a/crates/nono-cli/src/migration.rs
+++ b/crates/nono-cli/src/migration.rs
@@ -16,7 +16,7 @@
 use crate::cli::PullArgs;
 use crate::package::ProfileProvider;
 use crate::package_cmd;
-use crate::registry_client::{RegistryClient, resolve_registry_url};
+use crate::registry_client::{PullReason, RegistryClient, resolve_registry_url};
 use colored::Colorize;
 use nono::Result;
 use std::io::{self, BufRead, IsTerminal, Write};
@@ -291,17 +291,20 @@ fn write_field<W: Write>(out: &mut W, label: &str, value: &str, label_w: usize) 
 }
 
 fn run_pull(pack_ref: &str) -> Result<()> {
-    package_cmd::run_pull(PullArgs {
-        package_ref: pack_ref.to_string(),
-        registry: None,
-        // Migration only triggers when the resolver couldn't find the
-        // pack-provided profile. The lockfile may still claim "up to
-        // date" if the user wiped the pack dir manually — force
-        // re-install so the files actually exist before we retry.
-        force: true,
-        init: false,
-        help: None,
-    })?;
+    package_cmd::run_pull(
+        PullArgs {
+            package_ref: pack_ref.to_string(),
+            registry: None,
+            // Migration only triggers when the resolver couldn't find the
+            // pack-provided profile. The lockfile may still claim "up to
+            // date" if the user wiped the pack dir manually — force
+            // re-install so the files actually exist before we retry.
+            force: true,
+            init: false,
+            help: None,
+        },
+        PullReason::Migration,
+    )?;
     Ok(())
 }
 

--- a/crates/nono-cli/src/package_cmd.rs
+++ b/crates/nono-cli/src/package_cmd.rs
@@ -7,7 +7,7 @@ use crate::package::{
     self, ArtifactEntry, ArtifactType, LockedArtifact, LockedPackage, PackageManifest,
     PackageProvenance, PackageRef, PullResponse,
 };
-use crate::registry_client::{RegistryClient, resolve_registry_url};
+use crate::registry_client::{PullReason, RegistryClient, resolve_registry_url};
 use chrono::{DateTime, Local, Utc};
 use nono::{NonoError, Result, SignerIdentity};
 use semver::Version;
@@ -17,13 +17,13 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
-pub fn run_pull(args: PullArgs) -> Result<()> {
+pub fn run_pull(args: PullArgs, reason: PullReason) -> Result<()> {
     let package_ref = package::parse_package_ref(&args.package_ref)?;
     let registry_url = resolve_registry_url(args.registry.as_deref());
     let client = RegistryClient::new(registry_url.clone());
 
     let requested_version = package_ref.version.as_deref().unwrap_or("latest");
-    let pull = client.fetch_pull_response(&package_ref, requested_version)?;
+    let pull = client.fetch_pull_response(&package_ref, requested_version, reason)?;
     validate_pull_response(&package_ref, &pull)?;
 
     let lockfile = package::read_lockfile()?;
@@ -332,13 +332,16 @@ pub fn run_update(args: UpdateArgs) -> Result<()> {
                         );
                     }
                     eprintln!("  updating {key} {} → {latest}", pkg.version);
-                    match run_pull(PullArgs {
-                        package_ref: key.clone(),
-                        registry: args.registry.clone(),
-                        force: args.force,
-                        init: false,
-                        help: None,
-                    }) {
+                    match run_pull(
+                        PullArgs {
+                            package_ref: key.clone(),
+                            registry: args.registry.clone(),
+                            force: args.force,
+                            init: false,
+                            help: None,
+                        },
+                        PullReason::Update,
+                    ) {
                         Ok(()) => {
                             updated = updated.saturating_add(1);
                         }

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -2822,13 +2822,16 @@ fn load_registry_profile(name_or_path: &str, cli_extends: &[String]) -> Result<P
         eprintln!("Profile '{}' not found locally.", package_ref.key());
 
         // Auto-pull from registry
-        crate::package_cmd::run_pull(crate::cli::PullArgs {
-            package_ref: name_or_path.to_string(),
-            registry: None,
-            force: false,
-            init: false,
-            help: None,
-        })?;
+        crate::package_cmd::run_pull(
+            crate::cli::PullArgs {
+                package_ref: name_or_path.to_string(),
+                registry: None,
+                force: false,
+                init: false,
+                help: None,
+            },
+            crate::registry_client::PullReason::ProfileAuto,
+        )?;
     }
 
     // Read manifest to check pack type and find profile artifacts

--- a/crates/nono-cli/src/registry_client.rs
+++ b/crates/nono-cli/src/registry_client.rs
@@ -58,6 +58,35 @@ pub(crate) fn build_context_headers() -> Vec<(&'static str, String)> {
     headers
 }
 
+/// Why a `/pull` request was made. Sent only on that request via the
+/// `X-Nono-Pull-Reason` header, so the registry can distinguish a
+/// deliberate user-initiated install from a CI-driven or implicit one.
+/// Unlike the installation-context headers above, this doesn't apply to
+/// every registry call — only `/pull` has more than one possible trigger.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PullReason {
+    /// `nono pull <ns>/<name>` invoked directly.
+    Explicit,
+    /// `nono update` re-pulling an outdated pack.
+    Update,
+    /// First-run legacy-config migration auto-installing a suggested pack.
+    Migration,
+    /// Silent implicit pull because a `--profile <ns>/<name>` reference
+    /// (including an `extends` chain) wasn't installed locally.
+    ProfileAuto,
+}
+
+impl PullReason {
+    fn header_value(self) -> &'static str {
+        match self {
+            PullReason::Explicit => "explicit",
+            PullReason::Update => "update",
+            PullReason::Migration => "migration",
+            PullReason::ProfileAuto => "profile-auto",
+        }
+    }
+}
+
 impl RegistryClient {
     /// Build a registry client whose TLS verifier delegates to the OS-native
     /// trust store at handshake time (SecTrust on macOS, system CA stores on
@@ -127,6 +156,7 @@ impl RegistryClient {
         &self,
         package_ref: &PackageRef,
         version: &str,
+        reason: PullReason,
     ) -> Result<PullResponse> {
         let url = format!(
             "{}/api/v1/packages/{}/{}/versions/{version}/pull",
@@ -135,6 +165,7 @@ impl RegistryClient {
         let mut response = self
             .http
             .get(&url)
+            .header("X-Nono-Pull-Reason", reason.header_value())
             .config()
             .http_status_as_error(false)
             .build()
@@ -477,5 +508,13 @@ mod tests {
             Some("github_actions"),
             "X-Nono-CI-Provider should be 'github_actions'"
         );
+    }
+
+    #[test]
+    fn pull_reason_header_values_are_distinct_and_stable() {
+        assert_eq!(PullReason::Explicit.header_value(), "explicit");
+        assert_eq!(PullReason::Update.header_value(), "update");
+        assert_eq!(PullReason::Migration.header_value(), "migration");
+        assert_eq!(PullReason::ProfileAuto.header_value(), "profile-auto");
     }
 }


### PR DESCRIPTION
## Summary

Closes #1383.

`GET /api/v1/packages/{namespace}/{name}/versions/{version}/pull` is hit from four distinct CLI code paths, and the registry currently has no way to tell them apart. This adds an `X-Nono-Pull-Reason: explicit|update|migration|profile-auto` header sent only on the `/pull` request:

- **Explicit** — `nono pull <ns>/<name>` (`app_runtime.rs` → `package_cmd::run_pull`)
- **Update** — `nono update` re-pulling an outdated pack (`package_cmd.rs::run_update`)
- **Migration** — first-run legacy-config migration auto-installing a suggested pack (`migration.rs::run_pull`)
- **Profile-auto** — silent implicit pull when a `--profile` reference isn't installed locally (`profile/mod.rs::load_registry_profile`)

A `PullReason` enum is threaded from each of the four call sites through `package_cmd::run_pull` into `RegistryClient::fetch_pull_response`, which attaches the header on that single request only — not via the shared per-registry-host middleware used for `X-Nono-UUID`/`X-Nono-Platform`/etc., since those apply to every registry call and this only makes sense for `/pull`.

No change to the core `nono` library — entirely within `nono-cli` (`registry_client.rs`, `package_cmd.rs`, `migration.rs`, `profile/mod.rs`), consistent with the library/CLI boundary.

Server-side consumption of the header is out of scope for this repo — the registry service needs a paired change to read it.

## Agent disclosure

This PR was prepared by an AI coding agent (Claude Code) under the repository owner's direction, following the workflow and constraints in `AGENTS.md`.

## Files/sections consulted

- `AGENTS.md` (library/CLI boundary, error-handling, DCO requirements)
- `crates/nono-cli/src/registry_client.rs`
- `crates/nono-cli/src/package_cmd.rs`
- `crates/nono-cli/src/migration.rs`
- `crates/nono-cli/src/profile/mod.rs`
- `crates/nono-cli/src/app_runtime.rs`

## Testing

- Added a unit test for the `PullReason` → header-value mapping in `registry_client.rs`
- `make ci` — all tests pass except one pre-existing, unrelated failure (`capability_ext::tests::test_from_profile_filesystem_allow_expands_git_dynamic_token`), confirmed to fail identically on `main` with this diff stashed out (environment-specific, nested git-worktree behavior)
- `make fmt` — clean, no changes needed
- `make clippy` (`-D warnings -D clippy::unwrap_used`) — clean
- Independent multi-angle code review (correctness, reuse/simplification/efficiency, altitude, conventions) — no findings

## Agent Compliance Check (AGENTS.md)

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists (#1383)
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (none reused/adapted outside this repo)
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths (no path handling introduced by this change)
- [x] This PR matches the approved or disclosed issue scope