### PR TITLE
fix(sandbox): allow exec in writable grant-dirs under command policies

### DIFF
--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -153,6 +153,9 @@ struct ResolvedToolSandboxPlan {
     deny_only: BTreeMap<String, ResolvedDenyOnlyCommand>,
     allowed_direct_bypasses: Vec<PathBuf>,
     allowed_direct_bypass_ids: HashSet<FileId>,
+    /// Writable dirs (cwd, etc.) get a subtree exec grant instead of the
+    /// per-file allow-list, since files can appear there after setup.
+    outer_exec_writable_dirs: Vec<PathBuf>,
 }
 
 #[derive(Debug, Clone)]
@@ -233,6 +236,7 @@ impl ResolvedToolSandboxPlan {
         let allowed_direct_bypasses =
             resolve_allowed_direct_bypasses(config, &resolved, &deny_only, &governance_denies)?;
         let allowed_direct_bypass_ids = resolve_file_ids(&allowed_direct_bypasses)?;
+        let outer_exec_writable_dirs = collect_outer_exec_writable_dirs(outer_caps, &search_dirs);
         Ok(Self {
             config: config.clone(),
             resolved,
@@ -241,6 +245,7 @@ impl ResolvedToolSandboxPlan {
             deny_only,
             allowed_direct_bypasses,
             allowed_direct_bypass_ids,
+            outer_exec_writable_dirs,
         })
     }
 }
@@ -471,6 +476,7 @@ impl PreparedToolSandboxRuntime {
     pub(crate) fn apply_outer_exec_gate(&self) -> Result<()> {
         apply_outer_exec_gate(
             &self.inner.allowed_outer_exec_files,
+            &self.inner.plan.outer_exec_writable_dirs,
             self.inner.landlock_abi,
         )
     }
@@ -2645,6 +2651,25 @@ fn reject_group_or_world_writable_path(
     Ok(())
 }
 
+/// Dirs the outer capability set grants write/readwrite to (e.g. cwd). Kept
+/// separate from `build_outer_exec_files`'s per-file enumeration since a
+/// writable dir's contents can change after setup.
+fn collect_outer_exec_writable_dirs(
+    caps: &CapabilitySet,
+    executable_dirs: &[PathBuf],
+) -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = caps
+        .fs_capabilities()
+        .iter()
+        .filter(|cap| !cap.is_file && cap.access.contains(AccessMode::Write))
+        .map(|cap| cap.resolved.clone())
+        .filter(|dir| !executable_dirs.contains(dir))
+        .collect();
+    dirs.sort();
+    dirs.dedup();
+    dirs
+}
+
 fn outer_caps_grant_write(caps: &CapabilitySet, path: &Path) -> bool {
     caps.fs_capabilities().iter().any(|cap| {
         cap.access.contains(AccessMode::Write)
@@ -2983,7 +3008,11 @@ fn add_outer_exec_file_with_deps(
     Ok(())
 }
 
-fn apply_outer_exec_gate(paths: &[PathBuf], abi: nono::DetectedAbi) -> Result<()> {
+fn apply_outer_exec_gate(
+    paths: &[PathBuf],
+    writable_dirs: &[PathBuf],
+    abi: nono::DetectedAbi,
+) -> Result<()> {
     if !abi.has_execute() {
         return Err(NonoError::SandboxInit(format!(
             "tool-sandbox outer exec gate requires Landlock ABI V3+; detected {}",
@@ -3020,6 +3049,24 @@ fn apply_outer_exec_gate(paths: &[PathBuf], abi: nono::DetectedAbi) -> Result<()
                 NonoError::SandboxInit(format!(
                     "tool-sandbox outer exec gate add_rule for {}: {err}",
                     path.display()
+                ))
+            })?;
+    }
+
+    // Subtree grant: files written into these dirs after setup must still run.
+    for dir in writable_dirs {
+        let fd = PathFd::new(dir).map_err(|err| {
+            NonoError::SandboxInit(format!(
+                "tool-sandbox outer exec gate cannot open {}: {err}",
+                dir.display()
+            ))
+        })?;
+        ruleset = ruleset
+            .add_rule(PathBeneath::new(fd, AccessFs::Execute))
+            .map_err(|err| {
+                NonoError::SandboxInit(format!(
+                    "tool-sandbox outer exec gate add_rule for {}: {err}",
+                    dir.display()
                 ))
             })?;
     }
@@ -5365,6 +5412,7 @@ mod tests {
                 deny_only: BTreeMap::new(),
                 allowed_direct_bypasses: Vec::new(),
                 allowed_direct_bypass_ids: HashSet::new(),
+                outer_exec_writable_dirs: Vec::new(),
             },
             shims_by_command: BTreeMap::from([("git".to_string(), shim.clone())]),
             credential_handles: BTreeMap::new(),

--- a/crates/nono-cli/tests/execution_strategy_run.rs
+++ b/crates/nono-cli/tests/execution_strategy_run.rs
@@ -13,6 +13,8 @@
 
 use std::fs;
 use std::net::TcpListener;
+#[cfg(target_os = "linux")]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
@@ -59,6 +61,15 @@ fn write_profile(home: &Path, name: &str, json: &str) -> PathBuf {
 fn python3_available() -> bool {
     Command::new("python3")
         .args(["-c", "import socket"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "linux")]
+fn cc_available() -> bool {
+    Command::new("cc")
+        .arg("--version")
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
@@ -421,5 +432,142 @@ fn env_credentials_with_command_policies_non_shim_entry_succeeds() {
     assert!(
         output.status.success(),
         "env_credentials + command_policies with a non-shim entry must succeed\nstdout: {stdout}\nstderr: {stderr}",
+    );
+}
+
+/// A script written into a writable grant-dir (cwd) must still execute under
+/// an active `command_policies` outer exec gate.
+#[test]
+#[cfg(target_os = "linux")]
+fn command_policies_allows_script_exec_in_writable_grant_dir() {
+    let (_tmp, home, workspace) = setup_isolated_home("cmd-policies-script-exec");
+
+    let script_path = workspace.join("s.sh");
+    fs::write(&script_path, "#!/usr/bin/env bash\necho ok\n").expect("write script");
+    fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755))
+        .expect("chmod script executable");
+
+    let profile_path = write_profile(
+        &home,
+        "cmd-policies-script-exec",
+        &format!(
+            r#"{{
+                "meta": {{ "name": "cmd-policies-script-exec-test" }},
+                "filesystem": {{ "allow": ["{workspace}"] }},
+                "network": {{ "block": true }},
+                "command_policies": {{
+                    "commands": {{
+                        "cat": {{
+                            "executable": "/bin/cat"
+                        }}
+                    }}
+                }}
+            }}"#,
+            workspace = workspace.display()
+        ),
+    );
+
+    let output = run_nono(
+        &[
+            "run",
+            "--profile",
+            profile_path.to_str().expect("profile path"),
+            "--no-rollback",
+            "--",
+            "bash",
+            "-c",
+            "./s.sh",
+        ],
+        &home,
+        &workspace,
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "a script in a writable grant-dir must still execute under command_policies\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    assert!(
+        stdout.contains("ok"),
+        "expected script output in stdout\nstdout: {stdout}\nstderr: {stderr}",
+    );
+}
+
+/// Same as above but for a binary compiled at runtime, so it wasn't on disk
+/// when the outer exec gate was set up.
+#[test]
+#[cfg(target_os = "linux")]
+fn command_policies_allows_compiled_binary_exec_in_writable_grant_dir() {
+    if !cc_available() {
+        eprintln!("skipping: cc not available");
+        return;
+    }
+
+    let (_tmp, home, workspace) = setup_isolated_home("cmd-policies-bin-exec");
+
+    let source_path = workspace.join("b.c");
+    fs::write(
+        &source_path,
+        "#include <stdio.h>\nint main(void) { printf(\"ok\\n\"); return 0; }\n",
+    )
+    .expect("write source");
+    let binary_path = workspace.join("b");
+    let compile_status = Command::new("cc")
+        .args([
+            "-o",
+            binary_path.to_str().expect("binary path"),
+            source_path.to_str().expect("source path"),
+        ])
+        .status()
+        .expect("run cc");
+    assert!(compile_status.success(), "cc must compile the test binary");
+
+    let profile_path = write_profile(
+        &home,
+        "cmd-policies-bin-exec",
+        &format!(
+            r#"{{
+                "meta": {{ "name": "cmd-policies-bin-exec-test" }},
+                "filesystem": {{ "allow": ["{workspace}"] }},
+                "network": {{ "block": true }},
+                "command_policies": {{
+                    "commands": {{
+                        "cat": {{
+                            "executable": "/bin/cat"
+                        }}
+                    }}
+                }}
+            }}"#,
+            workspace = workspace.display()
+        ),
+    );
+
+    let output = run_nono(
+        &[
+            "run",
+            "--profile",
+            profile_path.to_str().expect("profile path"),
+            "--no-rollback",
+            "--",
+            "bash",
+            "-c",
+            "./b",
+        ],
+        &home,
+        &workspace,
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "a freshly compiled binary in a writable grant-dir must still execute under command_policies\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    assert!(
+        stdout.contains("ok"),
+        "expected binary output in stdout\nstdout: {stdout}\nstderr: {stderr}",
     );
 }


### PR DESCRIPTION
## Linked Issue

Closes #1390

## Summary

Maybe there are better solutions, but without this, adding command policies breaks the main sandbox execution rules! This brings it inline with the default behavior on Linux without command policies, but might be unexpected. The original binary is there in the main sandbox, so it has the same restrictions as the agent itself....

NB: OSX has deny-within-allow, so blocking intercepted commands in the agent sandbox is easy.

The Landlock outer exec gate that `command_policies` installs allowed exec only
from read-only directories (PATH scan + `executable_dirs`), excluding every
directory the profile also grants write access to — including cwd. This adds
a directory-subtree `AccessFs::Execute` grant for those writable dirs, so
scripts and freshly compiled binaries written into them execute again, while
the real policed-command binaries stay blocked from direct exec (their
read-only search dirs are still enumerated per-file with controlled inodes
excluded).


## Agent Disclosure

I am an AI coding agent (Claude, via Claude Code) operating under human
supervision. Intent, approach, and residual-risk tradeoffs were disclosed and
discussed on the linked issue before this PR was opened:
https://github.com/nolabs-ai/nono/issues/1390#issuecomment-4919797717

Relevant files consulted/changed: `crates/nono-cli/src/tool-sandbox/platform/linux.rs`
(`ResolvedToolSandboxPlan::build`, `build_outer_exec_files`, `apply_outer_exec_gate`,
`outer_caps_grant_write`), `crates/nono-cli/tests/execution_strategy_run.rs`.

## Test Plan

- `make fmt` && `make ci` (clippy -D warnings + fmt-check + tests) — clean
- Added two Linux integration tests in `execution_strategy_run.rs`:
  `command_policies_allows_script_exec_in_writable_grant_dir` and
  `command_policies_allows_compiled_binary_exec_in_writable_grant_dir`
- Manually verified on a real Linux host (kernel 6.8.0, Landlock V4):
  - Pre-fix (`main`): script/binary in a writable grant-dir both fail with
    exit 126 (`bad interpreter: Permission denied`)
  - Post-fix (this branch): both execute successfully
  - Direct absolute-path exec of a policy-controlled binary is still denied
    (mediation unaffected)

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using DCO
- [x] All new code follows the project's coding standards (CLAUDE.md) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to CHANGELOG.md if needed

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (no reused/adapted code beyond existing repo helpers; new logic follows adjacent patterns in the same file)
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope