### PR TITLE
fix: keep orphaned descendants in supervisor ancestry

### DIFF
--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -799,12 +799,20 @@ pub fn execute_supervised<F: FnMut(i32) -> bool>(
     // the parent hardens itself immediately after fork and the child hardens
     // itself after sandbox/filter setup whenever procfs inspection is not
     // required.
+
+    // Become a child-subreaper whenever the supervisor may need to read a
+    // descendant's /proc/<pid>/mem: tool-sandbox command mediation
+    // (`tool_sandbox_runtime`) or seccomp-notify mediation of network/AF_UNIX/
+    // openat (`child_requires_dumpable`). That read is ancestry-gated by
+    // ptrace_may_access under Yama ptrace_scope=1, so a descendant that
+    // daemonizes and reparents to pid 1 leaves our ancestry and gets its
+    // connect()/bind()/openat() denied with EPERM. Subreaping keeps it ours.
     #[cfg(target_os = "linux")]
-    if config.tool_sandbox_runtime.is_some() {
+    if config.tool_sandbox_runtime.is_some() || config.seccomp_policy.child_requires_dumpable() {
         let ret = unsafe { libc::prctl(libc::PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) };
         if ret != 0 {
             return Err(NonoError::SandboxInit(format!(
-                "Failed to set PR_SET_CHILD_SUBREAPER for tool-sandbox supervisor: {}",
+                "Failed to set PR_SET_CHILD_SUBREAPER for supervisor: {}",
                 std::io::Error::last_os_error()
             )));
         }
@@ -2718,6 +2726,34 @@ fn run_supervisor_loop(
     Ok((status, denials))
 }
 
+/// Reap descendants that reparented onto this supervisor (a child-subreaper),
+/// so short-lived detached processes don't linger as zombies for the session.
+///
+/// `waitpid(-1, WNOHANG)` returns only terminated children, so a live child is
+/// never consumed. If the primary `child` is reaped here, its status is
+/// returned rather than dropped.
+#[cfg(target_os = "linux")]
+fn reap_reparented_orphans(child: Pid) -> Option<WaitStatus> {
+    loop {
+        match waitpid(Some(Pid::from_raw(-1)), Some(WaitPidFlag::WNOHANG)) {
+            Ok(status @ (WaitStatus::Exited(pid, _) | WaitStatus::Signaled(pid, _, _))) => {
+                if pid == child {
+                    return Some(status);
+                }
+                debug!("Reaped reparented orphan {}", pid);
+            }
+            // Nothing reapable now; no WUNTRACED/WCONTINUED, so ignore stop/continue.
+            Ok(_) => return None,
+            Err(nix::errno::Errno::EINTR) => continue,
+            Err(nix::errno::Errno::ECHILD) => return None,
+            Err(e) => {
+                debug!("waitpid(-1) during orphan reap failed: {}", e);
+                return None;
+            }
+        }
+    }
+}
+
 /// Supervisor IPC event loop for capability expansion (Linux).
 ///
 /// Multiplexes between:
@@ -3023,6 +3059,12 @@ fn run_supervisor_loop(
             in_band_detach_requested,
         );
         handle_pty_suspension(pty.as_deref_mut(), child);
+
+        // Drain reparented orphans; if the primary child was among them,
+        // surface its status directly.
+        if let Some(status) = reap_reparented_orphans(child) {
+            return Ok((status, denials, ipc_denials));
+        }
 
         match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
             Ok(WaitStatus::StillAlive) => {

--- a/crates/nono-cli/tests/socket_access_run.rs
+++ b/crates/nono-cli/tests/socket_access_run.rs
@@ -56,21 +56,30 @@ fn short_tempdir() -> tempfile::TempDir {
         .expect("tempdir in /tmp")
 }
 
-fn python3_available() -> bool {
-    Command::new("python3")
-        .args(["-c", "import socket"])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+/// Absolute path to a system `python3` (under a default-allowed bin dir),
+/// preferred over a pyenv/asdf shim: shims re-exec the real interpreter from a
+/// dir the sandbox doesn't grant, so the child fails to exec (exit 127).
+fn python3_bin() -> Option<String> {
+    for cand in ["/usr/bin/python3", "/bin/python3", "/usr/local/bin/python3"] {
+        let runnable = Command::new(cand)
+            .args(["-c", "import socket"])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if runnable {
+            return Some(cand.to_string());
+        }
+    }
+    None
 }
 
 #[test]
 #[cfg(target_os = "linux")]
 fn af_unix_mediation_pathname_blocks_connect_to_unlisted_socket() {
-    if !python3_available() {
-        eprintln!("skipping: python3 not available");
+    let Some(py) = python3_bin() else {
+        eprintln!("skipping: no system python3 available");
         return;
-    }
+    };
 
     let (_tmp, home, workspace) = setup_isolated_home("af-unix-mediation");
     let sock_tmp = short_tempdir();
@@ -95,7 +104,7 @@ fn af_unix_mediation_pathname_blocks_connect_to_unlisted_socket() {
             "--profile",
             &profile_path.to_string_lossy(),
             "--",
-            "python3",
+            &py,
             "-c",
             &py_script,
         ],
@@ -125,10 +134,10 @@ fn af_unix_mediation_pathname_blocks_connect_to_unlisted_socket() {
 #[test]
 #[cfg(target_os = "linux")]
 fn af_unix_mediation_pathname_allows_connect_to_listed_socket() {
-    if !python3_available() {
-        eprintln!("skipping: python3 not available");
+    let Some(py) = python3_bin() else {
+        eprintln!("skipping: no system python3 available");
         return;
-    }
+    };
 
     let (_tmp, home, workspace) = setup_isolated_home("af-unix-mediation-allow");
     let sock_tmp = short_tempdir();
@@ -158,7 +167,7 @@ fn af_unix_mediation_pathname_allows_connect_to_listed_socket() {
             "--profile",
             &profile_path.to_string_lossy(),
             "--",
-            "python3",
+            &py,
             "-c",
             &py_script,
         ],
@@ -182,10 +191,10 @@ fn af_unix_mediation_pathname_allows_connect_to_listed_socket() {
 #[test]
 #[cfg(target_os = "macos")]
 fn filesystem_deny_blocks_unix_socket_connect_on_macos() {
-    if !python3_available() {
-        eprintln!("skipping: python3 not available");
+    let Some(py) = python3_bin() else {
+        eprintln!("skipping: no system python3 available");
         return;
-    }
+    };
 
     let (_tmp, home, workspace) = setup_isolated_home("macos-socket-deny");
     let sock_tmp = short_tempdir();
@@ -212,7 +221,7 @@ fn filesystem_deny_blocks_unix_socket_connect_on_macos() {
             "--profile",
             &profile_path.to_string_lossy(),
             "--",
-            "python3",
+            &py,
             "-c",
             &py_script,
         ],
@@ -230,5 +239,114 @@ fn filesystem_deny_blocks_unix_socket_connect_on_macos() {
     assert!(
         !stdout.contains("connected"),
         "connect must not complete\nstdout: {stdout}\nstderr: {stderr}",
+    );
+}
+
+/// Yama `ptrace_scope`, or `None` if it can't be read (non-Yama kernel).
+#[cfg(target_os = "linux")]
+fn yama_ptrace_scope() -> Option<i32> {
+    fs::read_to_string("/proc/sys/kernel/yama/ptrace_scope")
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+}
+
+/// Regression test for the AF_UNIX-pathname orphan `connect()` bug: a
+/// double-forked grandchild reparents to pid 1, and pre-fix the supervisor
+/// could no longer read its `/proc/<pid>/mem` to classify the syscall (the read
+/// is ancestry-gated under Yama `ptrace_scope=1`), so its allowed TCP connect
+/// was denied with `EPERM`. The child-subreaper fix keeps such descendants in
+/// the supervisor's ancestry. Only manifests under `ptrace_scope >= 1`.
+#[test]
+#[cfg(target_os = "linux")]
+fn af_unix_mediation_pathname_allows_orphaned_child_tcp_connect() {
+    let Some(py) = python3_bin() else {
+        eprintln!("skipping: no system python3 available");
+        return;
+    };
+    match yama_ptrace_scope() {
+        Some(0) => eprintln!(
+            "note: ptrace_scope=0, the orphan-reparent regression is not exercised \
+             (read succeeds regardless); asserting the positive path only"
+        ),
+        Some(n) => eprintln!("ptrace_scope={n}: regression is exercised"),
+        None => eprintln!("note: could not read ptrace_scope (non-Yama kernel?)"),
+    }
+
+    let (_tmp, home, workspace) = setup_isolated_home("af-unix-orphan");
+
+    // Live loopback listener so an authorized connect completes locally without
+    // egress (the handshake lands in the backlog; no accept() needed).
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
+    let port = listener.local_addr().expect("local_addr").port();
+
+    let profile_path = home.join("af-unix-orphan.json");
+    fs::write(
+        &profile_path,
+        r#"{"meta":{"name":"af-unix-orphan"},"workdir":{"access":"readwrite"},"network":{"block":false},"linux":{"af_unix_mediation":"pathname"}}"#,
+    )
+    .expect("write profile");
+
+    // Foreground connect (always in the supervisor's ancestry) then a
+    // double-forked orphan that reparents to pid 1 before it connects.
+    let py_script = format!(
+        r#"
+import os, socket
+PORT = {port}
+def attempt():
+    s = socket.socket(); s.settimeout(3)
+    try:
+        s.connect(("127.0.0.1", PORT)); return "OK"
+    except OSError as e:
+        return "errno=%d" % (e.errno,)
+    finally:
+        s.close()
+print("foreground " + attempt(), flush=True)
+r, w = os.pipe()
+if os.fork() == 0:
+    os.setsid()
+    if os.fork() == 0:
+        import time; time.sleep(0.5)  # let the intermediate exit -> reparent to pid 1
+        os.write(w, ("orphan " + attempt()).encode()); os._exit(0)
+    os._exit(0)
+os.close(w)
+print(os.read(r, 200).decode(), flush=True)
+"#
+    );
+
+    let output = run_nono(
+        &[
+            "run",
+            "--profile",
+            &profile_path.to_string_lossy(),
+            "--",
+            &py,
+            "-c",
+            &py_script,
+        ],
+        &home,
+        &workspace,
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Sanity: foreground connect is authorized and completes.
+    assert!(
+        stdout.contains("foreground OK"),
+        "foreground connect should be authorized and complete\nstdout: {stdout}\nstderr: {stderr}",
+    );
+
+    // The fix: the orphaned grandchild's connect is authorized too (pre-fix it
+    // was "orphan errno=1" under ptrace_scope>=1).
+    assert!(
+        stdout.contains("orphan OK"),
+        "orphaned grandchild connect must be authorized (was EPERM before the \
+         child-subreaper fix)\nstdout: {stdout}\nstderr: {stderr}",
+    );
+
+    // Fingerprint of the ancestry-gated /proc/<pid>/mem read failing.
+    assert!(
+        !stderr.contains("Failed to read sockaddr"),
+        "supervisor failed to classify the orphan's connect (ancestry lost)\nstderr: {stderr}",
     );
 }


### PR DESCRIPTION
## Linked Issue

Closes #1399 

## Summary
On Linux, set `PR_SET_CHILD_SUBREAPER` whenever the supervisor must read child memory (`child_requires_dumpable`), so such descendants reparent to the supervisor and stay in its ancestry, and reap them so they don't linger as zombies.

## Agent Disclosure (if applicable)
This PR was opened jointly by Claude and me. Claude wrote the code and I reviewed it and asked for changes to the comments. I filled the template manually.

## Test Plan

A new test is added which failed before the change and succeeded after. Furthermore, I manually executed the reproduction steps in the linked issue with the version 0.66.0 and the version built with these changes to verify that it fixes the issue.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests

Not applicable
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed