### PR TITLE
fix(profile): omit inheritable Option fields when None on save (#1400)

### DIFF
--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -2108,9 +2108,9 @@ pub struct Profile {
     /// ALIAS(canonical="env_credentials", introduced="v0.0.0", remove_by="indefinite", issue="#143")
     #[serde(default, alias = "secrets")]
     pub env_credentials: SecretsConfig,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub environment: Option<EnvironmentConfig>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub command_policies: Option<CommandPoliciesConfig>,
     #[serde(default)]
     pub credential_capture: HashMap<String, CredentialCaptureEntry>,
@@ -2134,22 +2134,22 @@ pub struct Profile {
     /// When `None` (absent from JSON), inherits from the base profile.
     /// When `Some`, replaces the base profile's config entirely, allowing
     /// derived profiles to narrow permissions.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub open_urls: Option<OpenUrlConfig>,
     /// Opt-in gate for temporary direct LaunchServices opens on macOS.
     /// Must be paired with the CLI flag `--allow-launch-services`.
     /// When `None`, inherits from the base profile.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allow_launch_services: Option<bool>,
     /// Opt-in gate for GPU access (Metal/IOKit on macOS, render nodes on Linux).
     /// Must be paired with the CLI flag `--allow-gpu`.
     /// When `None`, inherits from the base profile.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allow_gpu: Option<bool>,
     /// Opt-in to allow parent-of-protected-root grants on macOS.
     /// When `true` (and on macOS), `--allow ~` is permitted because Seatbelt deny
     /// rules protect `~/.nono`. Ignored on Linux. Default is `false`.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allow_parent_of_protected: Option<bool>,
     /// Deprecated: Parsed for backward compatibility but ignored.
     /// Supervised mode preserves TTY by default, making this unnecessary.
@@ -2166,7 +2166,7 @@ pub struct Profile {
     /// Binary path or command name to run when no trailing `-- <command>` is given.
     /// Resolved via `PATH` lookup or canonicalized if absolute. Only honoured
     /// for user-authored profiles (ignored for pack and built-in profiles).
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub binary: Option<String>,
     /// Extra arguments appended to the child command at launch.
     /// Supports variable expansion (e.g. `$NONO_PACKAGES`).
@@ -7322,6 +7322,46 @@ mod tests {
             err.to_string().contains("command_policies cannot be null"),
             "error should describe null rejection: {err}"
         );
+    }
+
+    /// Regression for https://github.com/nolabs-ai/nono/issues/1400.
+    ///
+    /// The post-run save flow serializes a resolved `Profile` and writes it
+    /// to disk. Inheritable `Option` fields whose `None` means "inherit from
+    /// base" must be OMITTED from the output, not serialized as `null`.
+    /// `command_policies` additionally rejects an explicit `null` on read
+    /// (see `test_command_policies_null_rejected`), so serializing `None` as
+    /// `null` produced a file that could never be reloaded — the user-visible
+    /// "saving throws an error, yet the profile is updated on disk" symptom.
+    #[test]
+    fn test_inheritable_options_omitted_when_none_and_round_trip() {
+        // A default Profile has every inheritable Option set to None.
+        let profile = Profile::default();
+
+        let json = serde_json::to_string(&profile).expect("serialize");
+
+        // None of these keys may appear in the serialized form; emitting any
+        // of them as `null` either breaks reload (command_policies) or
+        // wrongly clears an inherited value (the rest).
+        for key in [
+            "\"environment\"",
+            "\"command_policies\"",
+            "\"open_urls\"",
+            "\"allow_launch_services\"",
+            "\"allow_gpu\"",
+            "\"allow_parent_of_protected\"",
+            "\"binary\"",
+        ] {
+            assert!(
+                !json.contains(key),
+                "serialized Profile should omit {key} when None, got: {json}"
+            );
+        }
+
+        // The whole point: the saved file must reload successfully.
+        let reparsed: Profile = serde_json::from_str(&json).expect("saved profile must round-trip");
+        assert_eq!(reparsed.command_policies, None);
+        assert_eq!(reparsed.open_urls, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1400 — the post-run profile **save flow** writes files that fail to reload.

When a run triggers the "grant denied paths to a user profile" prompt, nono serializes a resolved `Profile` and writes it to disk (`profile_save_runtime.rs`). Seven inheritable `Option` fields on the `Profile` serialize struct had only `#[serde(default)]` and no `skip_serializing_if`, so `None` serialized to `null`:

```
environment, command_policies, open_urls, allow_launch_services,
allow_gpu, allow_parent_of_protected, binary
```

This is a write-then-fail-to-reparse round-trip bug. `command_policies` uses a custom deserializer that **intentionally rejects** an explicit `null` (`deserialize_command_policies`, guarded by `test_command_policies_null_rejected`). So every save where the active profile has no `command_policies` wrote `"command_policies": null` — a file the loader refuses. User-visible symptom: *"saving throws an error, yet the profile is updated on disk"* (the file is written via atomic rename, then fails to reparse). Reproduced via `nono profile validate` on a file produced by the save flow.

The other six fields parse fine on reload (plain `Option` + `default` maps `null` → `None`), but emitting `null` is semantically wrong for them too: their documented meaning is **"omit to inherit"**, while `null`/`Some` means "clear/replace". A saved profile emitting `null` would clear an inherited value rather than inherit it.

## Approach

Add `skip_serializing_if = "Option::is_none"` to all seven fields on the `Profile` serialize struct — matching `platform_overrides`, which already had it. This is a write-side-only change: the deserialize side and its null-rejection test are untouched, so the existing `test_command_policies_null_rejected` still enforces that an explicit `null` is a user error (the intent is to *omit* the field to inherit).

Minimal, mechanical diff: 7 attribute additions in `crates/nono-cli/src/profile/mod.rs`, plus a regression test.

## Verification

```
make build-cli          # ok (rustc 1.97)
make fmt-check          # ok
make clippy             # ok (-D warnings -D clippy::unwrap_used)
```

Targeted tests:
- `test_inheritable_options_omitted_when_none_and_round_trip` (new) — **ok**. Asserts a default `Profile` serializes without the seven keys and round-trips through `Profile::deserialize`.
- `test_command_policies_null_rejected` (existing) — **ok**. Null rejection on read unchanged.

Broader: `profile::*` (443), `profile_save_runtime::*` (40), and `learn::*` (35) test groups all pass, 0 failures — the serialization change does not regress the save/learn paths that consume it.

## Files consulted

- `crates/nono-cli/src/profile/mod.rs` — `Profile` serialize struct (line ~2085), `deserialize_command_policies` (line ~2065), null-rejection test (line ~7311).
- `crates/nono-cli/src/profile_save_runtime.rs` — `write_profile` serialize call (line ~606).
- `docs/cli/features/profile-authoring.mdx` — documented "omit to inherit" semantics for `open_urls` / `allow_launch_services` / `allow_gpu`.

---

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy — this is user-directed work on a real bug, not an OpenClaw/Pi contributor-presence campaign.
- [x] An issue already exists — #1400.
- [x] I described my intent and approach in the issue discussion — #1400 contains the repro, root cause, and proposed fix.
- [x] I reviewed repository coding and security rules for the affected area — read the project `AGENTS.md` (error handling, no `unwrap`/`expect`, surgical changes) and `docs/cli/features/profile-authoring.mdx`.
- [x] I provided required attribution for reused or adapted code — no external code adapted; all changes are newly written against the existing `Profile` struct and its existing `platform_overrides` precedent in the same file.
- [x] I did not use forbidden patterns such as unwrap/expect — no `.unwrap()`; the regression test uses `.expect("…")` in test code only, matching the established pattern in the surrounding `tests` module (e.g. existing `serde_json::from_str(json).expect("parse")`). `make clippy` (strict, `-D warnings -D clippy::unwrap_used`) passes clean.
- [x] I used NonoError where required — no error-handling code added; change is `#[serde(...)]` attributes only.
- [x] I validated and canonicalized all relevant paths — no path handling in this change.
- [x] This PR matches the approved or disclosed issue scope — #1400 proposes exactly this fix (skip-serialize on `command_policies`, plus the same for the sibling inheritable fields).

**Statement:** I am an AI coding agent (pi). This contribution was prepared at the explicit direction of the repository contributor (`dselivanov`) to fix a bug they personally encountered. It is not part of any contributor-presence campaign.
