### PR TITLE
fix(tool-sandbox): preserve argv[0] for symlink-dispatched commands

### DIFF
--- a/crates/nono-cli/src/tool-sandbox/env.rs
+++ b/crates/nono-cli/src/tool-sandbox/env.rs
@@ -39,15 +39,15 @@ pub(crate) fn default_env_allow_patterns() -> Vec<String> {
         .collect()
 }
 
-/// Build the child argv: argv[0] is the binary's canonical path, then
-/// `extra_args` (the `exec` helper's fixed leading args, empty for normal
-/// commands), then the policy's `argv_prepend`, then the forwarded user args
-/// (`request.argv[1..]`). NUL bytes in `extra_args`/`argv_prepend` are rejected.
+/// `preserve_caller_argv0` keeps the caller's argv[0] so argv[0]-dispatch
+/// multi-call binaries (busybox, `docker-credential-*`) work; `exec` helpers
+/// pass false. argv[0] never selects the executed file (that stays `binary`).
 pub(crate) fn effective_argv_for_binary(
     binary: &ResolvedCommandBinary,
     request: &ToolSandboxShimRequest,
     policy: &CommandSandboxConfig,
     extra_args: &[Vec<u8>],
+    preserve_caller_argv0: bool,
 ) -> Result<Vec<Vec<u8>>> {
     if request.argv.is_empty() {
         return Err(NonoError::SandboxInit(
@@ -56,7 +56,11 @@ pub(crate) fn effective_argv_for_binary(
     }
     let mut argv =
         Vec::with_capacity(request.argv.len() + policy.argv_prepend.len() + extra_args.len());
-    argv.push(binary.canonical_path.as_os_str().as_bytes().to_vec());
+    if preserve_caller_argv0 {
+        argv.push(request.argv[0].clone());
+    } else {
+        argv.push(binary.canonical_path.as_os_str().as_bytes().to_vec());
+    }
     for arg in extra_args {
         if arg.contains(&0) {
             return Err(NonoError::ConfigParse(
@@ -442,7 +446,8 @@ mod tests {
         };
         let extra = vec![b"helperarg".to_vec()];
 
-        let argv = effective_argv_for_binary(&helper, &request, &policy, &extra).expect("argv");
+        let argv =
+            effective_argv_for_binary(&helper, &request, &policy, &extra, false).expect("argv");
         let rendered: Vec<String> = argv
             .iter()
             .map(|a| String::from_utf8_lossy(a).into_owned())
@@ -463,16 +468,48 @@ mod tests {
 
     #[test]
     fn effective_argv_normal_command_has_no_extra_args() {
-        // The non-exec path passes `&[]`, so argv is [binary, argv_prepend.., user_args].
         let binary = test_binary("/usr/bin/gh");
         let request = test_request(&["gh", "pr", "list"]);
         let policy = CommandSandboxConfig::default();
-        let argv = effective_argv_for_binary(&binary, &request, &policy, &[]).expect("argv");
+        let argv = effective_argv_for_binary(&binary, &request, &policy, &[], true).expect("argv");
         let rendered: Vec<String> = argv
             .iter()
             .map(|a| String::from_utf8_lossy(a).into_owned())
             .collect();
-        assert_eq!(rendered, vec!["/usr/bin/gh", "pr", "list"]);
+        assert_eq!(rendered, vec!["gh", "pr", "list"]);
+    }
+
+    #[test]
+    fn effective_argv_preserves_caller_argv0_for_symlink_dispatch() {
+        // Multi-call binary: the child must see the invoked name, not the path.
+        let binary = test_binary("/opt/homebrew/bin/docker-credential-helper");
+        let request = test_request(&["docker-credential-osxkeychain", "get"]);
+        let policy = CommandSandboxConfig::default();
+        let argv = effective_argv_for_binary(&binary, &request, &policy, &[], true).expect("argv");
+        let rendered: Vec<String> = argv
+            .iter()
+            .map(|a| String::from_utf8_lossy(a).into_owned())
+            .collect();
+        assert_eq!(rendered, vec!["docker-credential-osxkeychain", "get"]);
+        // argv[0] didn't change the executed file.
+        assert_eq!(
+            binary.canonical_path,
+            std::path::PathBuf::from("/opt/homebrew/bin/docker-credential-helper")
+        );
+    }
+
+    #[test]
+    fn effective_argv_helper_ignores_caller_argv0() {
+        // exec helper keeps its own argv[0], even with no extra_args.
+        let helper = test_binary("/opt/vendor/helper");
+        let request = test_request(&["git", "push"]);
+        let policy = CommandSandboxConfig::default();
+        let argv = effective_argv_for_binary(&helper, &request, &policy, &[], false).expect("argv");
+        let rendered: Vec<String> = argv
+            .iter()
+            .map(|a| String::from_utf8_lossy(a).into_owned())
+            .collect();
+        assert_eq!(rendered, vec!["/opt/vendor/helper", "push"]);
     }
 
     #[test]
@@ -481,7 +518,7 @@ mod tests {
         let request = test_request(&["gh", "auth", "switch"]);
         let policy = CommandSandboxConfig::default();
         let extra = vec![b"a\0b".to_vec()];
-        assert!(effective_argv_for_binary(&helper, &request, &policy, &extra).is_err());
+        assert!(effective_argv_for_binary(&helper, &request, &policy, &extra, false).is_err());
     }
 
     #[test]

--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -5387,6 +5387,45 @@ mod tests {
         })
     }
 
+    #[test]
+    fn verify_binary_identity_accepts_unchanged_binary() -> Result<()> {
+        let dir = test_tempdir()?;
+        let path = dir.path().join("multitool");
+        fs::write(&path, b"#!/bin/sh\nbasename \"$0\"\n").map_err(|source| {
+            NonoError::ConfigWrite {
+                path: path.clone(),
+                source,
+            }
+        })?;
+        let binary = test_binary("multitool", &path)?;
+        verify_binary_identity(&binary)?;
+        Ok(())
+    }
+
+    #[test]
+    fn verify_binary_identity_rejects_swapped_binary() -> Result<()> {
+        // Preserving argv[0] must not weaken the anti-swap guard.
+        let dir = test_tempdir()?;
+        let path = dir.path().join("multitool");
+        fs::write(&path, b"original").map_err(|source| NonoError::ConfigWrite {
+            path: path.clone(),
+            source,
+        })?;
+        let binary = test_binary("multitool", &path)?;
+
+        // swap the on-disk file (changes size + mtime)
+        fs::write(&path, b"swapped-larger-content").map_err(|source| NonoError::ConfigWrite {
+            path: path.clone(),
+            source,
+        })?;
+
+        assert!(
+            verify_binary_identity(&binary).is_err(),
+            "verify_binary_identity must reject a binary changed after resolution"
+        );
+        Ok(())
+    }
+
     fn symlink_path(target: &Path, link: &Path) -> Result<()> {
         std::os::unix::fs::symlink(target, link).map_err(|source| NonoError::ConfigWrite {
             path: link.to_path_buf(),

--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -1833,8 +1833,14 @@ fn handle_shim_stream_inner(
         let result = (|| {
             let (helper, extra_args) =
                 super::policy::resolve_exec_helper(&state.plan.exec_helpers, command)?;
-            let launch =
-                build_child_launch_spec_for_binary(state, &request, policy, helper, &extra_args)?;
+            let launch = build_child_launch_spec_for_binary(
+                state,
+                &request,
+                policy,
+                helper,
+                &extra_args,
+                false,
+            )?;
             launch_child(state, &request.command, &caller, launch, stdio)
         })();
         state.active_count.fetch_sub(1, Ordering::SeqCst);
@@ -3165,15 +3171,17 @@ fn build_child_launch_spec(
         .ok_or_else(|| {
             NonoError::SandboxInit(format!("missing resolved binary for {}", request.command))
         })?;
-    build_child_launch_spec_for_binary(state, request, policy, binary, &[])
+    build_child_launch_spec_for_binary(state, request, policy, binary, &[], true)
 }
 
 /// Build a child launch spec that runs `binary` (the command's real binary OR
 /// an `exec` intercept helper) inside the matched command's sandbox (`policy`).
 /// `extra_args` are inserted between argv[0] and the forwarded original args —
-/// used by the `exec` action for the helper's fixed leading args. The fs-read
-/// cap, Landlock execute allowlist (binary + its ELF/interpreter closure),
-/// runtime baseline, and identity expectations are all bound to `binary`, while
+/// used by the `exec` action for the helper's fixed leading args.
+/// `preserve_caller_argv0` is true for the command's own binary, false for
+/// `exec` helpers. The fs-read cap, Landlock execute
+/// allowlist (binary + its ELF/interpreter closure), runtime baseline, and
+/// identity expectations are all bound to `binary`, while
 /// network/credentials/proxy/fs/env come from `policy`.
 fn build_child_launch_spec_for_binary(
     state: &ToolSandboxState,
@@ -3181,6 +3189,7 @@ fn build_child_launch_spec_for_binary(
     policy: &CommandSandboxConfig,
     binary: &ResolvedCommandBinary,
     extra_args: &[Vec<u8>],
+    preserve_caller_argv0: bool,
 ) -> Result<ToolSandboxChildLaunchSpec> {
     let start_vbi = std::time::Instant::now();
     verify_binary_identity(binary)?;
@@ -3299,7 +3308,13 @@ fn build_child_launch_spec_for_binary(
             .as_ref()
             .map(|path| path.as_os_str().as_bytes().to_vec()),
         interpreter_args: binary.shape.interpreter_args.clone(),
-        argv: effective_argv_for_binary(binary, request, policy, extra_args)?,
+        argv: effective_argv_for_binary(
+            binary,
+            request,
+            policy,
+            extra_args,
+            preserve_caller_argv0,
+        )?,
         env,
         cwd: cwd.as_os_str().as_bytes().to_vec(),
         stdio_mode: selected_stdio_mode(request).to_string(),

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -708,6 +708,9 @@ fn run_child_launcher() -> Result<()> {
     // object but the final exec is still path-based. Default immutability
     // checks reject paths writable by the sandboxed agent; allowing writable
     // executable targets is therefore a deliberate trust downgrade.
+    //
+    // Preserving argv[0] doesn't widen it: argv[0] is only a string;
+    // `real_binary` (re-verified here) selects what runs.
     verify_launch_binary(&spec)?;
     let caps = caps_from_spec(&spec.caps)?;
     Sandbox::apply_auto(&caps)?;
@@ -1506,8 +1509,14 @@ fn handle_shim_stream_inner(
         let result = (|| {
             let (helper, extra_args) =
                 super::policy::resolve_exec_helper(&state.plan.exec_helpers, command)?;
-            let launch =
-                build_child_launch_spec_for_binary(state, &request, policy, helper, &extra_args)?;
+            let launch = build_child_launch_spec_for_binary(
+                state,
+                &request,
+                policy,
+                helper,
+                &extra_args,
+                false,
+            )?;
             launch_child(state, &request.command, &caller, launch, stdio)
         })();
         state.active_count.fetch_sub(1, Ordering::SeqCst);
@@ -1922,22 +1931,24 @@ fn build_child_launch_spec(
         .ok_or_else(|| {
             NonoError::SandboxInit(format!("missing resolved binary for {}", request.command))
         })?;
-    build_child_launch_spec_for_binary(state, request, policy, binary, &[])
+    build_child_launch_spec_for_binary(state, request, policy, binary, &[], true)
 }
 
 /// Build a child launch spec that runs `binary` (which may be the command's
 /// real binary OR an `exec` intercept helper) inside the matched command's
 /// sandbox (`policy`). `extra_args` are inserted between argv[0] and the
 /// forwarded original args (`request.argv[1..]`) — used by the `exec` action to
-/// pass the helper's fixed leading args. The fs-read cap, exec-gate, executable
-/// shape baseline, and identity expectations are all bound to `binary`, while
-/// network/credentials/proxy/fs/env come from `policy`.
+/// pass the helper's fixed leading args. `preserve_caller_argv0` is true for
+/// the command's own binary, false for `exec` helpers. The fs-read cap, exec-gate, executable shape baseline, and identity
+/// expectations are all bound to `binary`, while network/credentials/proxy/fs/env
+/// come from `policy`.
 fn build_child_launch_spec_for_binary(
     state: &ToolSandboxState,
     request: &ToolSandboxShimRequest,
     policy: &CommandSandboxConfig,
     binary: &ResolvedCommandBinary,
     extra_args: &[Vec<u8>],
+    preserve_caller_argv0: bool,
 ) -> Result<ToolSandboxChildLaunchSpec> {
     verify_binary_identity(binary)?;
     let cwd = PathBuf::from(OsString::from_vec(request.cwd.clone()));
@@ -1969,7 +1980,13 @@ fn build_child_launch_spec_for_binary(
             .as_ref()
             .map(|path| path.as_os_str().as_bytes().to_vec()),
         interpreter_args: binary.shape.interpreter_args.clone(),
-        argv: effective_argv_for_binary(binary, request, policy, extra_args)?,
+        argv: effective_argv_for_binary(
+            binary,
+            request,
+            policy,
+            extra_args,
+            preserve_caller_argv0,
+        )?,
         env: filter_child_env(state, request, policy)?,
         cwd: cwd.as_os_str().as_bytes().to_vec(),
         stdio_mode: selected_stdio_mode(request).to_string(),
@@ -5260,6 +5277,45 @@ mod tests {
     fn selected_stdio_mode_uses_supervisor_direct_fds() {
         let request = request_with_env(Vec::new());
         assert_eq!(selected_stdio_mode(&request), "direct_fds");
+    }
+
+    #[test]
+    fn verify_binary_identity_accepts_unchanged_binary() -> Result<()> {
+        let dir = test_tempdir()?;
+        let path = dir.path().join("multitool");
+        fs::write(&path, b"#!/bin/sh\nbasename \"$0\"\n").map_err(|source| {
+            NonoError::ConfigWrite {
+                path: path.clone(),
+                source,
+            }
+        })?;
+        let binary = test_binary("multitool", &path)?;
+        verify_binary_identity(&binary)?;
+        Ok(())
+    }
+
+    #[test]
+    fn verify_binary_identity_rejects_swapped_binary() -> Result<()> {
+        // Preserving argv[0] must not weaken the anti-swap guard.
+        let dir = test_tempdir()?;
+        let path = dir.path().join("multitool");
+        fs::write(&path, b"original").map_err(|source| NonoError::ConfigWrite {
+            path: path.clone(),
+            source,
+        })?;
+        let binary = test_binary("multitool", &path)?;
+
+        // swap the on-disk file (changes size + mtime)
+        fs::write(&path, b"swapped-larger-content").map_err(|source| NonoError::ConfigWrite {
+            path: path.clone(),
+            source,
+        })?;
+
+        assert!(
+            verify_binary_identity(&binary).is_err(),
+            "verify_binary_identity must reject a binary changed after resolution"
+        );
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Linked Issue

Closes #1411

## Summary

Tool Sandbox forced `argv[0]` to the symlink-resolved canonical path, so multi-call binaries that dispatch on `argv[0]` (busybox, `docker-credential-*`) took the wrong code path. The argv is built in shared code, so this affected both macOS and Linux. Preserve the invoked `argv[0]`; `exec` helpers keep their own. The executed file stays pinned by inode + SHA-256, so `argv[0]` never selects what runs.

## Agent Disclosure (if applicable)

- Authored by an AI agent (Claude), driven and reviewed by me.
- Touches `tool-sandbox/env.rs` and `platform/{macos,linux}.rs`.
- Complies with CLAUDE.md for the area: no unwrap/expect, `NonoError`, existing identity verification preserved; covered by tests.

## Test Plan

- `make ci` clean.
- Unit tests: `argv[0]` preserved for symlink dispatch, `exec` helpers unaffected, a swapped binary still rejected before launch.
- Verified on linux/arm64 (Apple `container` VM, Landlock kernel): unpatched nono gives `argv[0]` `/work/multitool` (resolved path), patched gives `asname` (invoked name) — matching the unsandboxed baseline.
- macOS: a symlinked multi-call binary run as a Tool Sandbox command now sees the invoked `argv[0]`, matching direct execution.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

## Agent Compliance Check (Required for AI/Automated PRs)

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope
