### PR TITLE
fix(tool-sandbox): attribute daemonized callers to their command (cgroup on linux, verified daemon-pid on macos)

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -1500,6 +1500,27 @@
         "allow_direct_exec_bypass_with_credentials": {
           "type": "boolean",
           "description": "Second opt-in required before a credential-using command may have direct exec bypass."
+        },
+        "daemon_pid_source": {
+          "$ref": "#/$defs/DaemonPidSource",
+          "description": "Helper nono runs to learn the pid of a daemon this command spawns (e.g. a tmux server that double-forks and reparents to pid 1). When a caller's process ancestry is severed by that reparenting, the lineage marker runs this helper and attributes the severed daemon to this command only if the reported pid matches. Prints one pid. Consumed on macOS only for now."
+        }
+      }
+    },
+    "DaemonPidSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["argv"],
+      "properties": {
+        "argv": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Helper program and args. The program is expanded (~, $WORKDIR, $TMPDIR, $UID, XDG) and must then be an absolute path. nono passes the daemon's context as a JSON object on stdin and reads the pid the helper prints on stdout."
+        },
+        "env": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Allowlist of the daemon's environment keys nono may forward into the helper's JSON input. Credential-named keys are dropped regardless."
         }
       }
     },

--- a/crates/nono-cli/src/command_policy.rs
+++ b/crates/nono-cli/src/command_policy.rs
@@ -529,6 +529,24 @@ pub struct CommandPolicyConfig {
     pub allow_direct_exec_bypass_with_credentials: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub intercept: Vec<InterceptRuleConfig>,
+    /// Helper that reports the pid of a daemon this command spawns (e.g. a tmux
+    /// server that reparents to pid 1), letting the lineage marker attribute a
+    /// severed caller back to this command. Consumed on macOS only for now.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_pid_source: Option<DaemonPidSource>,
+}
+
+/// The helper the lineage marker runs to attribute a severed daemon back to a
+/// command, plus the daemon-env keys it may see.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct DaemonPidSource {
+    /// Helper program + args. The program is expanded (`~`, `$WORKDIR`, `$TMPDIR`,
+    /// `$UID`, XDG) and must then be an absolute path.
+    pub argv: Vec<String>,
+    /// Daemon-env keys nono may forward into the helper's JSON `daemon_env`.
+    #[serde(default)]
+    pub env: Vec<String>,
 }
 
 impl CommandPolicyConfig {
@@ -568,6 +586,11 @@ impl CommandPolicyConfig {
                 }
                 rules
             },
+            // Child (more-derived) replaces the base helper: replace, not merge.
+            daemon_pid_source: child
+                .daemon_pid_source
+                .clone()
+                .or_else(|| self.daemon_pid_source.clone()),
         }
     }
 }
@@ -4464,6 +4487,83 @@ mod tests {
         };
         let merged = parent.merge_child(&child);
         assert_eq!(merged.intercept.len(), 1);
+    }
+
+    #[test]
+    fn daemon_pid_source_child_replaces_parent() {
+        let parent = CommandPolicyConfig {
+            daemon_pid_source: Some(DaemonPidSource {
+                argv: vec!["parent-helper".to_string()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let child = CommandPolicyConfig {
+            daemon_pid_source: Some(DaemonPidSource {
+                argv: vec!["child-helper".to_string()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            parent.merge_child(&child).daemon_pid_source,
+            Some(DaemonPidSource {
+                argv: vec!["child-helper".to_string()],
+                ..Default::default()
+            })
+        );
+    }
+
+    #[test]
+    fn daemon_pid_source_inherited_when_child_omits_it() {
+        let parent = CommandPolicyConfig {
+            daemon_pid_source: Some(DaemonPidSource {
+                argv: vec!["parent-helper".to_string()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let child = CommandPolicyConfig::default();
+        assert_eq!(
+            parent.merge_child(&child).daemon_pid_source,
+            Some(DaemonPidSource {
+                argv: vec!["parent-helper".to_string()],
+                ..Default::default()
+            })
+        );
+        // Child adds it where the parent has none.
+        assert_eq!(
+            child.merge_child(&parent).daemon_pid_source,
+            Some(DaemonPidSource {
+                argv: vec!["parent-helper".to_string()],
+                ..Default::default()
+            })
+        );
+    }
+
+    #[test]
+    fn daemon_pid_source_round_trips_through_serde() {
+        let config = CommandPolicyConfig {
+            daemon_pid_source: Some(DaemonPidSource {
+                argv: vec!["tmux-server-pid".to_string(), "--workspace".to_string()],
+                env: vec!["BAZEL_OUTPUT_USER_ROOT".to_string()],
+            }),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&config).expect("serialize");
+        assert!(
+            json.contains("daemon_pid_source"),
+            "field must serialize: {json}"
+        );
+        let parsed: CommandPolicyConfig = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed.daemon_pid_source, config.daemon_pid_source);
+
+        // Omitted by default (skip_serializing_if) and parses back as None.
+        let empty = serde_json::to_string(&CommandPolicyConfig::default()).expect("serialize");
+        assert!(
+            !empty.contains("daemon_pid_source"),
+            "absent by default: {empty}"
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/command_policy.rs
+++ b/crates/nono-cli/src/command_policy.rs
@@ -1384,6 +1384,75 @@ pub(crate) fn resolve_policy_exec_helpers(
     Ok(helpers)
 }
 
+/// Pre-resolve every command's `daemon_pid_source` helper, keyed by command
+/// name (each command declares at most one), exactly like `exec` intercept
+/// helpers: identity (dev/ino/size/mtime/sha256) is captured up front for
+/// TOCTOU protection, rather than only checking the helper path is absolute
+/// at dispatch time. A declared helper that fails to resolve is a hard error —
+/// a daemon_pid_source that can never run would silently fail closed on every
+/// severed-daemon check, which should surface at profile-build time instead.
+#[cfg(any(test, target_os = "linux", target_os = "macos"))]
+pub(crate) fn resolve_policy_daemon_pid_source_helpers(
+    config: &CommandPoliciesConfig,
+) -> nono::Result<BTreeMap<String, ResolvedCommandBinary>> {
+    let mut helpers = BTreeMap::new();
+    for (command_name, command) in &config.commands {
+        let Some(source) = &command.daemon_pid_source else {
+            continue;
+        };
+        let Some(helper_raw) = source.argv.first() else {
+            continue;
+        };
+        let helper_path = crate::policy::expand_path(helper_raw).map_err(|err| {
+            nono::NonoError::ProfileParse(format!(
+                "command '{command_name}' daemon_pid_source helper '{helper_raw}' could not be expanded: {err}"
+            ))
+        })?;
+        if !helper_path.is_absolute() {
+            return Err(nono::NonoError::ProfileParse(format!(
+                "command '{command_name}' daemon_pid_source helper must be an absolute path; got '{}'",
+                helper_path.display()
+            )));
+        }
+        // Not scoped by the command-hash cache, same rationale as exec helpers above.
+        let (resolved, _) = candidate_command_match(&helper_path, &HashMap::new())?
+            .ok_or_else(|| {
+                nono::NonoError::ProfileParse(format!(
+                    "command '{command_name}' daemon_pid_source helper '{}' not found or not executable",
+                    helper_path.display()
+                ))
+            })?;
+        helpers.insert(
+            command_name.clone(),
+            ResolvedCommandBinary {
+                name: format!("{command_name}.daemon_pid_source"),
+                canonical_path: resolved.canonical_path,
+                dev: resolved.dev,
+                ino: resolved.ino,
+                size: resolved.size,
+                mtime_nanos: resolved.mtime_nanos,
+                sha256: resolved.sha256,
+                duplicate_paths: Vec::new(),
+                shape: resolved.shape,
+            },
+        );
+    }
+    Ok(helpers)
+}
+
+/// True if the named command's `daemon_pid_source` helper opts into
+/// `allow_writable_executable`. Mirrors `command_referencing_exec_helper_allows_writable`.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) fn command_daemon_pid_source_helper_allows_writable(
+    config: &CommandPoliciesConfig,
+    command_name: &str,
+) -> bool {
+    config
+        .commands
+        .get(command_name)
+        .is_some_and(|command| command.allow_writable_executable)
+}
+
 fn validate_command(
     command_name: &str,
     command: &CommandPolicyConfig,
@@ -1509,7 +1578,27 @@ fn validate_command(
         }
     }
 
+    if let Some(source) = &command.daemon_pid_source {
+        validate_daemon_pid_source(command_name, source, report);
+    }
+
     validate_intercept_rules(command_name, &command.intercept, config, scope, report);
+}
+
+/// An empty `argv` fails closed at runtime (`argv.first()` is `None`, so the
+/// command's severed-daemon attribution is silently disabled) rather than
+/// surfacing a clear error, so reject it at profile-load time instead.
+fn validate_daemon_pid_source(
+    command_name: &str,
+    source: &DaemonPidSource,
+    report: &mut CommandPolicyValidationReport,
+) {
+    if source.argv.is_empty() {
+        report.error(
+            "daemon_pid_source_empty_argv",
+            format!("command '{command_name}' daemon_pid_source.argv must not be empty"),
+        );
+    }
 }
 
 fn validate_intercept_rules(
@@ -4383,6 +4472,114 @@ mod tests {
             err.to_string().contains("absolute path"),
             "expected absolute-path rejection, got: {err}"
         );
+    }
+
+    fn git_config_with_daemon_pid_source(argv: Vec<String>) -> CommandPoliciesConfig {
+        let mut config = active_git_config();
+        let git = config.commands.get_mut("git").expect("git command");
+        git.daemon_pid_source = Some(DaemonPidSource {
+            argv,
+            env: Vec::new(),
+        });
+        config
+    }
+
+    #[test]
+    fn daemon_pid_source_rejects_empty_argv() {
+        let config = git_config_with_daemon_pid_source(vec![]);
+        let report =
+            validate_command_policies(Some(&config), CommandPolicyValidationScope::Resolved);
+        assert!(
+            report
+                .errors
+                .iter()
+                .any(|finding| finding.code == "daemon_pid_source_empty_argv"),
+            "{:?}",
+            report.errors
+        );
+    }
+
+    #[test]
+    fn daemon_pid_source_accepts_nonempty_argv() {
+        let config = git_config_with_daemon_pid_source(vec!["/usr/bin/true".to_string()]);
+        let report =
+            validate_command_policies(Some(&config), CommandPolicyValidationScope::Resolved);
+        assert!(
+            !report
+                .errors
+                .iter()
+                .any(|finding| finding.code == "daemon_pid_source_empty_argv"),
+            "{:?}",
+            report.errors
+        );
+    }
+
+    #[test]
+    fn daemon_pid_source_helper_resolution_captures_identity() {
+        let helper = ["/usr/bin/true", "/bin/true"]
+            .into_iter()
+            .map(PathBuf::from)
+            .find(|p| p.exists());
+        let Some(helper) = helper else {
+            return; // no stable helper available; skip rather than fail spuriously.
+        };
+        let config = git_config_with_daemon_pid_source(vec![helper.display().to_string()]);
+        let helpers = resolve_policy_daemon_pid_source_helpers(&config).expect("resolve helpers");
+        let resolved = helpers.get("git").expect("helper resolved for git");
+        assert!(!resolved.sha256.is_empty());
+        assert!(resolved.canonical_path.is_absolute());
+    }
+
+    #[test]
+    fn resolve_policy_daemon_pid_source_helpers_rejects_relative_helper() {
+        let config = git_config_with_daemon_pid_source(vec!["relative/helper".to_string()]);
+        let err = resolve_policy_daemon_pid_source_helpers(&config)
+            .expect_err("must reject relative helper");
+        assert!(
+            err.to_string().contains("absolute path"),
+            "expected absolute-path rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_policy_daemon_pid_source_helpers_rejects_missing_helper() {
+        let config =
+            git_config_with_daemon_pid_source(vec!["/nonexistent/nono-test-helper".to_string()]);
+        let err = resolve_policy_daemon_pid_source_helpers(&config)
+            .expect_err("must reject a helper that does not exist");
+        assert!(
+            err.to_string().contains("not found or not executable"),
+            "expected not-found rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_policy_daemon_pid_source_helpers_expands_vars_in_program_path() {
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let dir = std::env::temp_dir().join(format!(
+            "nono-daemon-pid-source-expand-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).expect("mkdir");
+        let helper = dir.join("helper.sh");
+        fs::write(&helper, "#!/bin/sh\necho 1\n").expect("write");
+        fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        let dir_str = dir.to_string_lossy().into_owned();
+        let _env = crate::test_env::EnvVarGuard::set_all(&[("NONO_TEST_HELPER_DIR", &dir_str)]);
+
+        let config =
+            git_config_with_daemon_pid_source(vec!["$NONO_TEST_HELPER_DIR/helper.sh".to_string()]);
+        let helpers = resolve_policy_daemon_pid_source_helpers(&config).expect("resolve helpers");
+        let resolved = helpers.get("git").expect("helper resolved for git");
+        assert_eq!(
+            resolved.canonical_path,
+            helper.canonicalize().expect("canonicalize")
+        );
+
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/nono-cli/src/command_policy.rs
+++ b/crates/nono-cli/src/command_policy.rs
@@ -1391,7 +1391,10 @@ pub(crate) fn resolve_policy_exec_helpers(
 /// at dispatch time. A declared helper that fails to resolve is a hard error —
 /// a daemon_pid_source that can never run would silently fail closed on every
 /// severed-daemon check, which should surface at profile-build time instead.
-#[cfg(any(test, target_os = "linux", target_os = "macos"))]
+// daemon_pid_source is consumed on macOS only for now (see CommandPolicyConfig
+// doc comment); unlike exec_helpers this isn't wired up on Linux, so keep the
+// cfg gate macOS-only or `-D warnings` flags it as dead code there.
+#[cfg(any(test, target_os = "macos"))]
 pub(crate) fn resolve_policy_daemon_pid_source_helpers(
     config: &CommandPoliciesConfig,
 ) -> nono::Result<BTreeMap<String, ResolvedCommandBinary>> {
@@ -1442,7 +1445,7 @@ pub(crate) fn resolve_policy_daemon_pid_source_helpers(
 
 /// True if the named command's `daemon_pid_source` helper opts into
 /// `allow_writable_executable`. Mirrors `command_referencing_exec_helper_allows_writable`.
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(target_os = "macos")]
 pub(crate) fn command_daemon_pid_source_helper_allows_writable(
     config: &CommandPoliciesConfig,
     command_name: &str,

--- a/crates/nono-cli/src/lineage_cgroup.rs
+++ b/crates/nono-cli/src/lineage_cgroup.rs
@@ -1,0 +1,556 @@
+//! Linux cgroup v2 lineage marker for tool-sandbox caller attribution.
+//!
+//! A daemonized caller (setsid + double-fork, reparented to pid 1) severs
+//! `resolve_caller`'s parent-pid walk. Each Tool Sandbox command instead self-attaches,
+//! pre-exec, to a per-command cgroup; membership survives reparenting and a
+//! sandboxed command can never write `/sys/fs/cgroup` (Landlock grants none), so
+//! reading a severed caller's `/proc/<pid>/cgroup` attributes it unforgeably to its
+//! command. No controllers are enabled — membership only, sidestepping the EBUSY
+//! no-internal-process constraint.
+//!
+//! No writable base -> fail closed (deny). No env-based degrade: an inherited env
+//! token is forgeable via a same-uid `/proc/<pid>/environ` read.
+
+use crate::resource_cgroup::{delegated_base, pid_is_alive, teardown as remove_cgroup};
+use nix::libc;
+use nono::{NonoError, Result};
+use std::collections::HashMap;
+use std::fs::{self, OpenOptions};
+use std::os::fd::OwnedFd;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+const CGROUP_ROOT: &str = "/sys/fs/cgroup";
+const SESSION_PREFIX: &str = "nono.session.";
+const CMD_PREFIX: &str = "cmd_";
+
+/// The chosen attribution mechanism.
+enum LineageKind {
+    /// Writable cgroup base found; attribution is unforgeable.
+    Cgroup(CgroupLineage),
+    /// No writable base; severed callers are denied (fail closed).
+    Disabled,
+}
+
+/// The session's lineage-attribution mechanism, built lazily on first use.
+///
+/// SECURITY (fail-closed): the cgroup tree is created on first attribution — never
+/// eagerly at supervisor start. Building it does blocking `/sys/fs/cgroup` I/O
+/// (mkdir probes, readdir), and doing that before the supervisor forks the
+/// sandboxed top-level child perturbs the still-live proxy async runtime's worker
+/// threads, so the fork races them and the child's Landlock exec gate can fail to
+/// enforce (an unlisted command would run). First use only ever happens while
+/// mediating a sub-command, which is after that fork, so the marker never touches
+/// the fork's quiescence.
+pub(crate) struct LineageMarker {
+    supervisor_pid: u32,
+    kind: OnceLock<LineageKind>,
+}
+
+impl LineageMarker {
+    /// Defer the cgroup work; no filesystem I/O here. See the type's security note.
+    pub(crate) fn deferred(supervisor_pid: u32) -> Self {
+        Self {
+            supervisor_pid,
+            kind: OnceLock::new(),
+        }
+    }
+
+    fn kind(&self) -> &LineageKind {
+        self.kind.get_or_init(|| build_kind(self.supervisor_pid))
+    }
+
+    /// Attribute a severed caller to its command, or `None` to deny. Never the session.
+    pub(crate) fn resolve_severed_command(&self, pid: u32) -> Option<String> {
+        match self.kind() {
+            LineageKind::Cgroup(marker) => marker.match_command(&read_process_cgroup(pid)?),
+            LineageKind::Disabled => None,
+        }
+    }
+
+    /// `cgroup.procs` write handle the child self-attaches through, pre-exec;
+    /// `None` when disabled.
+    pub(crate) fn command_procs_fd(&self, command: &str) -> Result<Option<OwnedFd>> {
+        match self.kind() {
+            LineageKind::Cgroup(marker) => marker.ensure_command_procs(command).map(Some),
+            LineageKind::Disabled => Ok(None),
+        }
+    }
+
+    /// Kill survivors in each command cgroup and remove the session tree. Idempotent.
+    /// Never forces a build: nothing to tear down if the marker was never used.
+    pub(crate) fn teardown(&self) {
+        if let Some(LineageKind::Cgroup(marker)) = self.kind.get() {
+            marker.teardown();
+        }
+    }
+
+    #[cfg(test)]
+    fn from_kind_for_test(kind: LineageKind) -> Self {
+        let cell = OnceLock::new();
+        let _ = cell.set(kind);
+        Self {
+            supervisor_pid: 0,
+            kind: cell,
+        }
+    }
+
+    /// A pre-resolved `Disabled` marker for tests that want the fail-closed path
+    /// without touching a real cgroup base.
+    #[cfg(test)]
+    pub(crate) fn disabled_for_test() -> Self {
+        Self::from_kind_for_test(LineageKind::Disabled)
+    }
+}
+
+/// Choose the mechanism: writable cgroup base -> unforgeable cgroup attribution;
+/// otherwise disabled (fail closed). Runs the blocking cgroup I/O, so it is only
+/// ever called from `LineageMarker::kind` on first use (post-fork).
+fn build_kind(supervisor_pid: u32) -> LineageKind {
+    if let Some(base) = discover_writable_base() {
+        match CgroupLineage::init(base, supervisor_pid) {
+            Ok(marker) => return LineageKind::Cgroup(marker),
+            Err(err) => tracing::warn!("cgroup lineage marker unavailable: {err}"),
+        }
+    } else {
+        tracing::debug!("no writable cgroup v2 base for the lineage marker");
+    }
+    LineageKind::Disabled
+}
+
+/// A command's cgroup dir (open/teardown) plus its namespace-relative path
+/// (matching `/proc/<pid>/cgroup`).
+struct CommandCgroup {
+    dir: PathBuf,
+    rel: String,
+}
+
+pub(crate) struct CgroupLineage {
+    session_dir: PathBuf,
+    commands: Mutex<HashMap<String, CommandCgroup>>,
+}
+
+impl CgroupLineage {
+    fn init(base: PathBuf, supervisor_pid: u32) -> Result<Self> {
+        // A prior supervisor may have been SIGKILL'd before teardown; sweep its dead sessions.
+        sweep_stale_sessions(&base);
+        let session_dir = base.join(format!("{SESSION_PREFIX}{supervisor_pid}"));
+        if let Err(err) = fs::create_dir(&session_dir)
+            && err.kind() != std::io::ErrorKind::AlreadyExists
+        {
+            return Err(NonoError::SandboxInit(format!(
+                "cgroup lineage: cannot create {}: {err}",
+                session_dir.display()
+            )));
+        }
+        Ok(Self {
+            session_dir,
+            commands: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Lazily create `cmd_<command>` (session-lived), then open a fresh `O_CLOEXEC`
+    /// `cgroup.procs` the child self-attaches through pre-exec.
+    fn ensure_command_procs(&self, command: &str) -> Result<OwnedFd> {
+        if command.is_empty() || command.contains('/') {
+            return Err(NonoError::SandboxInit(format!(
+                "cgroup lineage: invalid command name '{command}'"
+            )));
+        }
+        let dir = self.session_dir.join(format!("{CMD_PREFIX}{command}"));
+        {
+            let mut map = self.commands.lock().map_err(|_| lock_err())?;
+            if !map.contains_key(command) {
+                if let Err(err) = fs::create_dir(&dir)
+                    && err.kind() != std::io::ErrorKind::AlreadyExists
+                {
+                    return Err(NonoError::SandboxInit(format!(
+                        "cgroup lineage: cannot create {}: {err}",
+                        dir.display()
+                    )));
+                }
+                map.insert(
+                    command.to_string(),
+                    CommandCgroup {
+                        rel: namespace_relative(&dir),
+                        dir: dir.clone(),
+                    },
+                );
+            }
+        }
+        // O_CLOEXEC is load-bearing: it must vanish at execve or the sandboxed program
+        // inherits a writable cgroup.procs and could attach arbitrary same-uid pids to
+        // forge lineage (Landlock gates open(), not writes on an already-open fd).
+        let procs = OpenOptions::new()
+            .write(true)
+            .custom_flags(libc::O_CLOEXEC)
+            .open(dir.join("cgroup.procs"))
+            .map_err(|err| {
+                NonoError::SandboxInit(format!(
+                    "cgroup lineage: cannot open cgroup.procs in {}: {err}",
+                    dir.display()
+                ))
+            })?;
+        Ok(OwnedFd::from(procs))
+    }
+
+    /// Command whose cgroup contains `observed`, whole-segment matched. Lock
+    /// poisoning denies.
+    fn match_command(&self, observed: &str) -> Option<String> {
+        let map = self.commands.lock().ok()?;
+        map.iter()
+            .find(|(_, cgroup)| cgroup_within(&cgroup.rel, observed))
+            .map(|(name, _)| name.clone())
+    }
+
+    fn teardown(&self) {
+        if let Ok(map) = self.commands.lock() {
+            for cgroup in map.values() {
+                remove_cgroup(&cgroup.dir);
+            }
+        }
+        let _ = fs::remove_dir(&self.session_dir);
+    }
+}
+
+fn lock_err() -> NonoError {
+    NonoError::SandboxInit("cgroup lineage: command map lock poisoned".to_string())
+}
+
+/// systemd `user@<uid>.service`, else the deepest ancestor of our own cgroup leaf
+/// an unprivileged mkdir can create under.
+fn discover_writable_base() -> Option<PathBuf> {
+    if let Ok(base) = delegated_base()
+        && dir_allows_child_cgroups(&base)
+    {
+        return Some(base);
+    }
+    probe_writable_base()
+}
+
+fn probe_writable_base() -> Option<PathBuf> {
+    let raw = fs::read_to_string("/proc/self/cgroup").ok()?;
+    let rel = raw
+        .lines()
+        .find_map(|line| line.strip_prefix("0::"))?
+        .trim();
+    let mut leaf = PathBuf::from(CGROUP_ROOT);
+    for segment in rel.split('/').filter(|s| !s.is_empty()) {
+        leaf.push(segment);
+    }
+    let mut candidate = leaf.as_path();
+    loop {
+        if dir_allows_child_cgroups(candidate) {
+            return Some(candidate.to_path_buf());
+        }
+        if candidate == Path::new(CGROUP_ROOT) {
+            return None;
+        }
+        candidate = candidate.parent()?;
+    }
+}
+
+/// The only reliable delegation test is an actual mkdir; probe with a throwaway.
+fn dir_allows_child_cgroups(dir: &Path) -> bool {
+    let probe = dir.join(format!("nono.lineage-probe.{}", std::process::id()));
+    match fs::create_dir(&probe) {
+        Ok(()) => {
+            let _ = fs::remove_dir(&probe);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+/// `/proc/<pid>/cgroup` paths are namespace-relative; strip the mount prefix so
+/// both sides compare in the same rooting.
+fn namespace_relative(abs: &Path) -> String {
+    abs.strip_prefix(CGROUP_ROOT)
+        .map(|rest| format!("/{}", rest.display()))
+        .unwrap_or_else(|_| abs.display().to_string())
+}
+
+/// True if `observed` is `recorded` or a descendant, whole-segment only — a
+/// `starts_with` check would accept `cmd_tmuxX` for `cmd_tmux`.
+fn cgroup_within(recorded: &str, observed: &str) -> bool {
+    let rec: Vec<&str> = recorded.split('/').filter(|s| !s.is_empty()).collect();
+    let obs: Vec<&str> = observed.split('/').filter(|s| !s.is_empty()).collect();
+    !rec.is_empty() && obs.len() >= rec.len() && obs.iter().zip(&rec).all(|(a, b)| a == b)
+}
+
+fn read_process_cgroup(pid: u32) -> Option<String> {
+    let raw = fs::read_to_string(format!("/proc/{pid}/cgroup")).ok()?;
+    raw.lines()
+        .find_map(|line| line.strip_prefix("0::"))
+        .map(|s| s.trim().to_string())
+}
+
+fn sweep_stale_sessions(base: &Path) {
+    let Ok(entries) = fs::read_dir(base) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(pid) = name.to_str().and_then(parse_session_pid) else {
+            continue;
+        };
+        if !pid_is_alive(pid) {
+            teardown_session_tree(&entry.path());
+        }
+    }
+}
+
+fn teardown_session_tree(session_dir: &Path) {
+    if let Ok(entries) = fs::read_dir(session_dir) {
+        for entry in entries.flatten() {
+            remove_cgroup(&entry.path());
+        }
+    }
+    let _ = fs::remove_dir(session_dir);
+}
+
+fn parse_session_pid(name: &str) -> Option<u32> {
+    name.strip_prefix(SESSION_PREFIX)?.parse::<u32>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::fd::AsRawFd;
+
+    fn cgroup_with(command: &str, rel: &str) -> CgroupLineage {
+        let mut map = HashMap::new();
+        map.insert(
+            command.to_string(),
+            CommandCgroup {
+                dir: PathBuf::from(format!("{CGROUP_ROOT}{rel}")),
+                rel: rel.to_string(),
+            },
+        );
+        CgroupLineage {
+            session_dir: PathBuf::from("/unused"),
+            commands: Mutex::new(map),
+        }
+    }
+
+    #[test]
+    fn cgroup_marker_attributes_severed_caller_to_its_command() {
+        let marker = cgroup_with(
+            "tmux",
+            "/user.slice/user@1000.service/nono.session.42/cmd_tmux",
+        );
+        assert_eq!(
+            marker.match_command("/user.slice/user@1000.service/nono.session.42/cmd_tmux"),
+            Some("tmux".to_string())
+        );
+        // A descendant cgroup still attributes to the command.
+        assert_eq!(
+            marker.match_command("/user.slice/user@1000.service/nono.session.42/cmd_tmux/child"),
+            Some("tmux".to_string())
+        );
+    }
+
+    #[test]
+    fn cgroup_marker_denies_non_matching_and_lookalike_paths() {
+        let marker = cgroup_with("tmux", "/user.slice/nono.session.42/cmd_tmux");
+        // Unrelated cgroup: denied.
+        assert_eq!(marker.match_command("/user.slice/other.scope"), None);
+        // SECURITY: whole-segment matching rejects a substring look-alike segment;
+        // a `starts_with` bug would accept these and impersonate `tmux`.
+        assert_eq!(
+            marker.match_command("/user.slice/nono.session.42/cmd_tmuxX"),
+            None
+        );
+        assert_eq!(
+            marker.match_command("/user.slice/nono.session.42/cmd_tmux-evil"),
+            None
+        );
+        // A prefix (an ancestor of the command cgroup) is not a member.
+        assert_eq!(marker.match_command("/user.slice/nono.session.42"), None);
+    }
+
+    #[test]
+    fn disabled_marker_denies_severed_caller() {
+        // No writable cgroup base -> Disabled -> fail closed (deny), never a
+        // command and never the session.
+        assert_eq!(
+            LineageMarker::disabled_for_test().resolve_severed_command(std::process::id()),
+            None
+        );
+    }
+
+    #[test]
+    fn cgroup_within_is_whole_segment() {
+        assert!(cgroup_within("/a/b", "/a/b"));
+        assert!(cgroup_within("/a/b", "/a/b/c"));
+        assert!(!cgroup_within("/a/b", "/a/bx"));
+        assert!(!cgroup_within("/a/b", "/a"));
+        assert!(!cgroup_within("/a/b", "/x/a/b"));
+        // Empty recorded path never matches (guards a bug that would match all).
+        assert!(!cgroup_within("", "/a/b"));
+    }
+
+    #[test]
+    fn parse_session_pid_only_matches_our_sessions() {
+        assert_eq!(parse_session_pid("nono.session.42"), Some(42));
+        assert_eq!(parse_session_pid("nono.session.0"), Some(0));
+        assert_eq!(parse_session_pid("nono.session."), None);
+        assert_eq!(parse_session_pid("nono.session.abc"), None);
+        assert_eq!(parse_session_pid("nono.42"), None);
+        assert_eq!(parse_session_pid("cmd_tmux"), None);
+    }
+
+    #[test]
+    fn namespace_relative_strips_mount_prefix() {
+        assert_eq!(
+            namespace_relative(Path::new(
+                "/sys/fs/cgroup/user.slice/nono.session.1/cmd_tmux"
+            )),
+            "/user.slice/nono.session.1/cmd_tmux"
+        );
+    }
+
+    /// LIVE: a sandboxed child must never write `cgroup.procs` — the property the
+    /// marker's unforgeability rests on. `#[ignore]`: needs a live cgroup base +
+    /// Landlock and restricts the test process itself, so run it alone.
+    #[test]
+    #[ignore = "requires live cgroup v2 delegation + Landlock; run with --ignored"]
+    fn live_landlock_denies_child_write_to_cgroup_procs() {
+        use landlock::{
+            ABI, Access, AccessFs, CompatLevel, Compatible, PathBeneath, PathFd, Ruleset,
+            RulesetAttr, RulesetCreatedAttr, RulesetStatus,
+        };
+
+        let base = discover_writable_base().expect("a writable cgroup base");
+        let marker = CgroupLineage::init(base, std::process::id()).expect("init lineage");
+        let procs = marker
+            .ensure_command_procs("tmux")
+            .expect("open cmd cgroup.procs");
+        // The supervisor (this process, outside the sandbox) can write it.
+        drop(procs);
+        let procs_path = marker.session_dir.join("cmd_tmux/cgroup.procs");
+
+        let tmp = std::env::temp_dir();
+        let abi = ABI::V3;
+        // Restrict this process like a child: write allowed only under a temp dir,
+        // nothing under /sys/fs/cgroup.
+        let status = Ruleset::default()
+            .set_compatibility(CompatLevel::BestEffort)
+            .handle_access(AccessFs::from_all(abi))
+            .expect("handle fs access")
+            .create()
+            .expect("create ruleset")
+            .add_rule(PathBeneath::new(
+                PathFd::new(&tmp).expect("open tmp"),
+                AccessFs::from_all(abi),
+            ))
+            .expect("add tmp rule")
+            .restrict_self()
+            .expect("restrict self");
+
+        // Landlock must actually be enforced for the denial to mean anything; on a
+        // kernel without it (e.g. a minimal VM), skip rather than pass vacuously.
+        if !matches!(status.ruleset, RulesetStatus::FullyEnforced) {
+            eprintln!(
+                "Landlock not fully enforced on this kernel ({:?}); \
+                 cannot validate cgroup.procs denial",
+                status.ruleset
+            );
+            marker.teardown();
+            return;
+        }
+
+        // Now sandboxed like a child: writing the cmd cgroup.procs must be denied.
+        let err = OpenOptions::new()
+            .write(true)
+            .open(&procs_path)
+            .expect_err("sandboxed write to cgroup.procs must be denied");
+        assert_eq!(
+            err.raw_os_error(),
+            Some(nix::libc::EACCES),
+            "expected EACCES writing {}, got {err:?}",
+            procs_path.display()
+        );
+        marker.teardown();
+    }
+
+    /// LIVE: the property the marker exists for. A daemon setsid+double-forked to
+    /// pid 1 still carries its command's cgroup, so it attributes to `tmux`, never
+    /// the session. `#[ignore]`: needs live cgroup v2 delegation and forks; run alone.
+    #[test]
+    #[ignore = "requires live cgroup v2 delegation; run with --ignored"]
+    fn live_daemonized_caller_attributed_to_its_command() {
+        use nix::libc;
+        use nix::sys::wait::waitpid;
+        use nix::unistd::{ForkResult, fork};
+
+        let base = discover_writable_base().expect("a writable cgroup base");
+        let cgroup = CgroupLineage::init(base, std::process::id()).expect("init lineage");
+        let procs = cgroup
+            .ensure_command_procs("tmux")
+            .expect("open cmd cgroup.procs");
+        let procs_fd = procs.as_raw_fd();
+
+        // Pipe: the reparented daemon reports its own pid back to us.
+        let mut fds = [0i32; 2];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0, "pipe");
+        let [read_fd, write_fd] = fds;
+
+        // SAFETY: post-fork children use only async-signal-safe libc calls.
+        match unsafe { fork() }.expect("fork") {
+            ForkResult::Child => {
+                if !crate::resource_cgroup::child_self_attach(procs_fd) {
+                    unsafe { libc::_exit(126) };
+                }
+                // setsid + double-fork: the grandchild reparents to pid 1.
+                unsafe { libc::setsid() };
+                match unsafe { fork() }.expect("fork") {
+                    ForkResult::Child => {
+                        let pid = unsafe { libc::getpid() };
+                        let bytes = pid.to_ne_bytes();
+                        unsafe {
+                            libc::write(write_fd, bytes.as_ptr().cast(), bytes.len());
+                        }
+                        // Park so the parent can read our cgroup while we live.
+                        unsafe { libc::usleep(500_000) };
+                        unsafe { libc::_exit(0) };
+                    }
+                    // Middle process exits immediately, orphaning the grandchild.
+                    ForkResult::Parent { .. } => unsafe { libc::_exit(0) },
+                }
+            }
+            ForkResult::Parent { child } => {
+                unsafe { libc::close(write_fd) };
+                let _ = waitpid(child, None); // reap the middle process
+                let mut buf = [0u8; 4];
+                let n = unsafe { libc::read(read_fd, buf.as_mut_ptr().cast(), buf.len()) };
+                assert_eq!(n, 4, "expected the daemon's pid");
+                unsafe { libc::close(read_fd) };
+                let daemon_pid = u32::from_ne_bytes(buf);
+
+                // Precondition: the daemon is reparented (severed ancestry).
+                let ppid = parent_pid_of(daemon_pid);
+                assert_eq!(ppid, Some(1), "daemon must be reparented to pid 1");
+
+                let marker = LineageMarker::from_kind_for_test(LineageKind::Cgroup(cgroup));
+                assert_eq!(
+                    marker.resolve_severed_command(daemon_pid),
+                    Some("tmux".to_string()),
+                    "daemonized caller must attribute to its command"
+                );
+                // Control: this process never self-attached, so it is not a member.
+                assert_eq!(marker.resolve_severed_command(std::process::id()), None);
+                marker.teardown();
+            }
+        }
+    }
+
+    fn parent_pid_of(pid: u32) -> Option<u32> {
+        let status = fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+        status
+            .lines()
+            .find_map(|line| line.strip_prefix("PPid:"))
+            .and_then(|rest| rest.trim().parse::<u32>().ok())
+    }
+}

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -34,6 +34,8 @@ mod launch_runtime;
 mod learn;
 mod learn_runtime;
 mod legacy_cleanup;
+#[cfg(target_os = "linux")]
+mod lineage_cgroup;
 #[cfg(target_os = "macos")]
 mod macos_trust;
 mod migration;

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -9927,6 +9927,112 @@ mod tests {
     }
 
     #[test]
+    fn platform_overrides_merge_adds_command_daemon_pid_source() {
+        // `daemon_pid_source` declared only in the current platform's override must
+        // land on the command's effective policy, alongside the base's fields.
+        let current_os = crate::platform::current_os_name();
+        let json = format!(
+            r#"{{
+                "meta": {{"name": "test"}},
+                "command_policies": {{"commands": {{"tmux": {{"sandbox": {{"exec_paths": ["/base/exec"]}}}}}}}},
+                "platform_overrides": {{
+                    "{current_os}": {{"command_policies": {{"commands": {{"tmux": {{"daemon_pid_source": {{"argv": ["tmux-pid"]}}}}}}}}}}
+                }}
+            }}"#
+        );
+        let profile: Profile = serde_json::from_str(&json).expect("parse");
+        let finalized = finalize_profile(profile).expect("finalize");
+        let tmux = &finalized
+            .command_policies
+            .expect("command_policies")
+            .commands["tmux"];
+        assert_eq!(
+            tmux.daemon_pid_source
+                .as_ref()
+                .map(|source| source.argv.clone()),
+            Some(vec!["tmux-pid".to_string()]),
+            "current-OS override must add daemon_pid_source"
+        );
+        assert_eq!(
+            tmux.sandbox.as_ref().expect("sandbox").exec_paths,
+            vec!["/base/exec".to_string()],
+            "base sandbox must survive the override merge"
+        );
+    }
+
+    #[test]
+    fn platform_overrides_other_platform_daemon_pid_source_not_applied() {
+        // A `daemon_pid_source` override for the non-current platform must not leak in.
+        let other_os = if crate::platform::current_os_name() == "macos" {
+            "linux"
+        } else {
+            "macos"
+        };
+        let json = format!(
+            r#"{{
+                "meta": {{"name": "test"}},
+                "command_policies": {{"commands": {{"tmux": {{"sandbox": {{"exec_paths": ["/base/exec"]}}}}}}}},
+                "platform_overrides": {{
+                    "{other_os}": {{"command_policies": {{"commands": {{"tmux": {{"daemon_pid_source": {{"argv": ["tmux-pid"]}}}}}}}}}}
+                }}
+            }}"#
+        );
+        let profile: Profile = serde_json::from_str(&json).expect("parse");
+        let finalized = finalize_profile(profile).expect("finalize");
+        assert_eq!(
+            finalized
+                .command_policies
+                .expect("command_policies")
+                .commands["tmux"]
+                .daemon_pid_source,
+            None,
+            "other platform's daemon_pid_source must not be present"
+        );
+    }
+
+    #[test]
+    fn extends_child_daemon_pid_source_replaces_base() {
+        // resolve_extends folds `merge_profiles(base, child)`; the child (more
+        // derived) helper wins.
+        let base: Profile = serde_json::from_str(
+            r#"{"meta":{"name":"base"},"command_policies":{"commands":{"tmux":{"daemon_pid_source":{"argv":["base-pid"]}}}}}"#,
+        )
+        .expect("parse base");
+        let child: Profile = serde_json::from_str(
+            r#"{"meta":{"name":"child"},"command_policies":{"commands":{"tmux":{"daemon_pid_source":{"argv":["child-pid"]}}}}}"#,
+        )
+        .expect("parse child");
+        let merged = merge_profiles(base, child);
+        assert_eq!(
+            merged.command_policies.expect("command_policies").commands["tmux"]
+                .daemon_pid_source
+                .as_ref()
+                .map(|source| source.argv.clone()),
+            Some(vec!["child-pid".to_string()])
+        );
+    }
+
+    #[test]
+    fn extends_inherits_base_daemon_pid_source_when_child_omits() {
+        let base: Profile = serde_json::from_str(
+            r#"{"meta":{"name":"base"},"command_policies":{"commands":{"tmux":{"daemon_pid_source":{"argv":["base-pid"]}}}}}"#,
+        )
+        .expect("parse base");
+        let child: Profile = serde_json::from_str(
+            r#"{"meta":{"name":"child"},"command_policies":{"commands":{"tmux":{}}}}"#,
+        )
+        .expect("parse child");
+        let merged = merge_profiles(base, child);
+        assert_eq!(
+            merged.command_policies.expect("command_policies").commands["tmux"]
+                .daemon_pid_source
+                .as_ref()
+                .map(|source| source.argv.clone()),
+            Some(vec!["base-pid".to_string()])
+        );
+    }
+
+    #[test]
     fn platform_overrides_other_platform_not_applied() {
         // The override for the non-current platform must not bleed in.
         let other_os = if crate::platform::current_os_name() == "macos" {

--- a/crates/nono-cli/src/resource_cgroup.rs
+++ b/crates/nono-cli/src/resource_cgroup.rs
@@ -264,7 +264,7 @@ const REAP_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis
 
 /// Kill anything left in the leaf, then remove it. Best-effort — a leftover empty
 /// directory isn't worth failing a finished run over.
-fn teardown(path: &Path) {
+pub(crate) fn teardown(path: &Path) {
     // cgroup.kill (Linux 5.14+) kills everything in the leaf at once. If it isn't
     // available we ignore it; a single process that already exited leaves the leaf
     // empty anyway.
@@ -314,7 +314,7 @@ fn parse_leaf_pid(name: &str) -> Option<u32> {
 }
 
 /// Whether `pid` still exists (`/proc/<pid>` present), in any state including zombie.
-fn pid_is_alive(pid: u32) -> bool {
+pub(crate) fn pid_is_alive(pid: u32) -> bool {
     Path::new("/proc").join(pid.to_string()).exists()
 }
 
@@ -323,7 +323,7 @@ fn pid_is_alive(pid: u32) -> bool {
 /// systemd delegates each user session a subtree under `.../user@<uid>.service` it
 /// can manage without root — the one place we can reliably create child cgroups. We
 /// read `/proc/self/cgroup` and walk up to it.
-fn delegated_base() -> Result<PathBuf> {
+pub(crate) fn delegated_base() -> Result<PathBuf> {
     let raw = fs::read_to_string("/proc/self/cgroup")
         .map_err(|e| resource_err(format!("cannot read /proc/self/cgroup: {e}")))?;
     let uid = nix::unistd::Uid::current().as_raw();

--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -6,6 +6,7 @@ use crate::command_policy::{
     CommandFromConfig, CommandPoliciesConfig, CommandSandboxConfig, ResolvedCommandBinaries,
     ResolvedCommandBinary, ResolvedExecutableKind, has_explicit_self_invocation_entry,
 };
+use crate::lineage_cgroup::LineageMarker;
 use crate::profile;
 use crate::tool_sandbox::credentials::{ResolvedCredential, resolve_credentials};
 use crate::tool_sandbox::env::{
@@ -44,8 +45,9 @@ use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
 use std::os::unix::net::{UnixListener, UnixStream};
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -125,6 +127,8 @@ struct ToolSandboxState {
     baseline_cache: BaselineCache,
     proxy_trust_bundle_paths: Vec<PathBuf>,
     active_children: Mutex<HashMap<u32, ActiveChild>>,
+    /// Attributes severed-ancestry callers to their spawning command. See `lineage_cgroup`.
+    lineage: LineageMarker,
     active_count: AtomicUsize,
     queued_requests: AtomicUsize,
     emitted_error_response: AtomicBool,
@@ -367,6 +371,10 @@ impl PreparedToolSandboxRuntime {
         );
 
         let approval_backends = crate::approval_runtime::build_approval_registry(&plan.config)?;
+        // Deferred: the cgroup marker builds itself on first use (post-fork), never
+        // now — eager cgroup I/O here would perturb the supervised fork. See
+        // `LineageMarker`'s security note.
+        let lineage = LineageMarker::deferred(std::process::id());
         let runtime = Self {
             inner: Arc::new(ToolSandboxState {
                 runtime_dir,
@@ -388,6 +396,7 @@ impl PreparedToolSandboxRuntime {
                 baseline_cache,
                 proxy_trust_bundle_paths: proxy_trust_bundle_paths.to_vec(),
                 active_children: Mutex::new(HashMap::new()),
+                lineage,
                 active_count: AtomicUsize::new(0),
                 queued_requests: AtomicUsize::new(0),
                 emitted_error_response: AtomicBool::new(false),
@@ -408,6 +417,8 @@ impl PreparedToolSandboxRuntime {
     /// `process::exit` (which bypasses Drop chains); on Rust unwind paths
     /// `ToolSandboxState::Drop` provides a fallback that finds a stale dir already gone.
     pub(crate) fn cleanup_runtime_dir(&self) {
+        // Also here, not just Drop: `process::exit` bypasses Drop chains. Idempotent.
+        self.inner.lineage.teardown();
         if let Err(err) = guarded_remove_runtime_dir(&self.inner.runtime_dir) {
             debug!(
                 "tool-sandbox runtime dir cleanup skipped for {}: {}",
@@ -637,6 +648,8 @@ impl PreparedToolSandboxRuntime {
 
 impl Drop for ToolSandboxState {
     fn drop(&mut self) {
+        // Fallback for unwind paths; `cleanup_runtime_dir` handles normal exit. Idempotent.
+        self.lineage.teardown();
         if let Err(err) = guarded_remove_runtime_dir(&self.runtime_dir) {
             debug!(
                 "tool-sandbox runtime dir cleanup skipped for {}: {err}",
@@ -2026,6 +2039,23 @@ fn resolve_caller(
     state: &ToolSandboxState,
     command_name: &str,
 ) -> Result<Caller> {
+    resolve_caller_with(peer_pid, session_root_pid, state, command_name, |pid| {
+        state
+            .lineage
+            .resolve_severed_command(pid)
+            .map(|command| Caller::Command { command, pid })
+    })
+}
+
+/// `resolve_severed` is a parameter so tests can drive the fallback without a
+/// real reparented process.
+fn resolve_caller_with(
+    peer_pid: u32,
+    session_root_pid: u32,
+    state: &ToolSandboxState,
+    command_name: &str,
+    resolve_severed: impl Fn(u32) -> Option<Caller>,
+) -> Result<Caller> {
     let mut pid = peer_pid;
     for _ in 0..ANCESTRY_DEPTH_LIMIT {
         if let Some((command, launch_caller)) = live_active_child(pid, state)? {
@@ -2045,6 +2075,11 @@ fn resolve_caller(
             break;
         }
         pid = parent_pid(pid)?;
+    }
+    // Walk stopped short of the root: an ancestor daemonized (reparented to pid 1).
+    // Attribute to the spawning command via the lineage marker, never the session.
+    if let Some(caller) = resolve_severed(peer_pid) {
+        return Ok(caller);
     }
     Err(NonoError::SandboxInit(
         "tool-sandbox caller ancestry could not be trusted".to_string(),
@@ -3917,6 +3952,30 @@ fn filter_child_env(
     Ok(env)
 }
 
+/// Make the child self-attach to its command's cgroup pre-exec, so every descendant
+/// (including a daemon reparented to pid 1) carries the marker. No-op when disabled.
+fn install_lineage_attach(
+    state: &ToolSandboxState,
+    command_name: &str,
+    command: &mut Command,
+) -> Result<()> {
+    let Some(procs_fd) = state.lineage.command_procs_fd(command_name)? else {
+        return Ok(());
+    };
+    // SAFETY: runs post-fork/pre-exec, so must be async-signal-safe; child_self_attach
+    // is (getpid + itoa + write) and _exit(126)s on failure (fail closed). procs_fd is
+    // O_CLOEXEC so it never reaches the sandboxed program.
+    unsafe {
+        command.pre_exec(move || {
+            if !crate::resource_cgroup::child_self_attach(procs_fd.as_raw_fd()) {
+                libc::_exit(126);
+            }
+            Ok(())
+        });
+    }
+    Ok(())
+}
+
 fn launch_child(
     state: &ToolSandboxState,
     command_name: &str,
@@ -3975,6 +4034,7 @@ fn launch_child_with_direct_fds(
         .stdin(Stdio::from(File::from(stdio.stdin)))
         .stdout(Stdio::from(File::from(stdio.stdout)))
         .stderr(Stdio::from(File::from(stdio.stderr)));
+    install_lineage_attach(state, command_name, &mut command)?;
     let mut child = command.spawn().map_err(NonoError::CommandExecution)?;
     drop(command);
     let exit_code = wait_for_tracked_child(state, command_name, launch_caller, &mut child)?;
@@ -4009,6 +4069,7 @@ fn launch_child_with_brokered_stdio(
         .stdin(Stdio::from(File::from(stdin)))
         .stdout(Stdio::from(File::from(stdout_write)))
         .stderr(Stdio::from(File::from(stderr_write)));
+    install_lineage_attach(state, command_name, &mut command)?;
 
     let mut child = command.spawn().map_err(NonoError::CommandExecution)?;
     drop(command);
@@ -4268,6 +4329,7 @@ fn launch_child_with_capture(
         .stderr(Stdio::from(File::from(stdio.stderr)));
     // stdio.stdout is not used for capture; drop it so the fd is closed.
     drop(stdio.stdout);
+    install_lineage_attach(state, command_name, &mut command)?;
 
     let mut child = command.spawn().map_err(NonoError::CommandExecution)?;
     drop(command);
@@ -4325,6 +4387,7 @@ fn launch_child_with_pty(
         .stdin(Stdio::from(File::from(stdin_slave)))
         .stdout(Stdio::from(File::from(stdout_slave)))
         .stderr(Stdio::from(File::from(stderr_slave)));
+    install_lineage_attach(state, command_name, &mut command)?;
     let mut child = command.spawn().map_err(NonoError::CommandExecution)?;
     drop(command);
     drop(pty.slave);
@@ -5477,6 +5540,7 @@ mod tests {
             },
             proxy_trust_bundle_paths: Vec::new(),
             active_children: Mutex::new(HashMap::new()),
+            lineage: LineageMarker::disabled_for_test(),
             active_count: AtomicUsize::new(0),
             queued_requests: AtomicUsize::new(0),
             emitted_error_response: AtomicBool::new(false),
@@ -5558,6 +5622,50 @@ mod tests {
         let caller = resolve_caller(pid, pid, &state, "git")?;
 
         assert!(matches!(caller, Caller::Command { command, .. } if command == "git"));
+        Ok(())
+    }
+
+    fn test_state_for_membership(socket_path: PathBuf) -> ToolSandboxState {
+        let runtime_dir = PathBuf::from("/tmp/nono-tool-sandbox-test");
+        test_state_with_chaining_paths(
+            runtime_dir.clone(),
+            socket_path,
+            runtime_dir.join("shims"),
+            ShimIdentity {
+                path: runtime_dir.join("shims/git"),
+                id: FileId { dev: 1, ino: 1 },
+            },
+        )
+    }
+
+    // Peer pid 1 with an unrelated root: the walk ends before the root (as after a
+    // daemonized reparent), forcing the severed-ancestry fallback.
+    const DAEMONIZED_PEER: u32 = 1;
+    const UNRELATED_ROOT: u32 = 2;
+
+    #[test]
+    fn resolve_caller_attributes_daemonized_caller_to_its_command() -> Result<()> {
+        let state =
+            test_state_for_membership(PathBuf::from("/tmp/nono-tool-sandbox-test/supervisor.sock"));
+        // Marker resolves the severed caller to its command, never the session.
+        let caller = resolve_caller_with(DAEMONIZED_PEER, UNRELATED_ROOT, &state, "git", |_| {
+            Some(Caller::Command {
+                command: "tmux".to_string(),
+                pid: DAEMONIZED_PEER,
+            })
+        })?;
+
+        assert!(matches!(caller, Caller::Command { command, .. } if command == "tmux"));
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_caller_blocks_daemonized_caller_the_marker_cannot_attribute() -> Result<()> {
+        let state =
+            test_state_for_membership(PathBuf::from("/tmp/nono-tool-sandbox-test/supervisor.sock"));
+        // Marker cannot attribute: fail closed rather than fall back to the session.
+        let denied = resolve_caller_with(DAEMONIZED_PEER, UNRELATED_ROOT, &state, "git", |_| None);
+        assert!(matches!(denied, Err(NonoError::SandboxInit(_))));
         Ok(())
     }
 

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -2118,7 +2118,10 @@ fn parse_procargs2(buf: &[u8]) -> Option<DaemonArgvEnv> {
     while pos < buf.len() && buf[pos] == 0 {
         pos += 1; // exec-path alignment padding
     }
-    let mut argv = Vec::with_capacity(argc as usize);
+    // `argc` comes from the target process's raw KERN_PROCARGS2 buffer, so an
+    // untrusted/manipulated process can report an enormous value; cap the
+    // allocation by the buffer we actually read to avoid an OOM panic.
+    let mut argv = Vec::with_capacity(std::cmp::min(argc as usize, buf.len()));
     for _ in 0..argc {
         if pos >= buf.len() {
             break;
@@ -6421,5 +6424,22 @@ mod tests {
         let without_override = crate::tool_sandbox::ResolvedInterceptAction::passthrough();
         let effective = without_override.sandbox.unwrap_or(&command_sandbox);
         assert_eq!(effective.fs_read, vec!["/command/path".to_string()]);
+    }
+
+    #[test]
+    fn parse_procargs2_bounds_argv_capacity_to_buffer_len() {
+        // `argc` is read from the target process's own KERN_PROCARGS2 buffer, so an
+        // untrusted/manipulated process can report an argc far larger than the
+        // buffer actually holds. Before the fix this drove an unbounded
+        // `Vec::with_capacity(argc as usize)`, which panics with an OOM abort
+        // rather than returning an error.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&i32::MAX.to_ne_bytes()); // argc
+        buf.push(0); // empty exec path, NUL-terminated
+        buf.extend_from_slice(b"one\0two\0");
+
+        let (argv, env) = parse_procargs2(&buf).expect("buffer is well-formed enough to parse");
+        assert_eq!(argv, vec!["one".to_string(), "two".to_string()]);
+        assert!(env.is_empty());
     }
 }

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -173,6 +173,9 @@ struct ResolvedToolSandboxPlan {
     /// as written in the profile. Identity expectations are captured here so
     /// the helper launch is TOCTOU-protected like a command binary.
     exec_helpers: BTreeMap<PathBuf, ResolvedCommandBinary>,
+    /// Pre-resolved `daemon_pid_source` helpers, keyed by command name.
+    /// Identity is captured here for the same TOCTOU protection as `exec_helpers`.
+    daemon_pid_source_helpers: BTreeMap<String, ResolvedCommandBinary>,
     deny_only: BTreeMap<String, ResolvedDenyOnlyCommand>,
     allowed_direct_bypass_ids: HashSet<FileId>,
 }
@@ -214,6 +217,13 @@ impl ResolvedToolSandboxPlan {
         }
         let exec_helpers = crate::command_policy::resolve_policy_exec_helpers(config)?;
         validate_controlled_exec_helper_immutability(config, &exec_helpers, outer_caps)?;
+        let daemon_pid_source_helpers =
+            crate::command_policy::resolve_policy_daemon_pid_source_helpers(config)?;
+        validate_controlled_daemon_pid_source_helper_immutability(
+            config,
+            &daemon_pid_source_helpers,
+            outer_caps,
+        )?;
         let search_dirs = command_search_dirs(config, path_env, outer_caps)?;
         validate_trusted_executable_dirs(&search_dirs, outer_caps)?;
         // BMETE command policies are scoped to command_policies.commands.
@@ -230,6 +240,7 @@ impl ResolvedToolSandboxPlan {
             config: config.clone(),
             resolved,
             exec_helpers,
+            daemon_pid_source_helpers,
             deny_only,
             allowed_direct_bypass_ids,
         })
@@ -307,7 +318,7 @@ impl PreparedToolSandboxRuntime {
 
         let approval_backends = crate::approval_runtime::build_approval_registry(&plan.config)?;
         // Verify severed daemons if any command declares a helper, else disabled (fail closed).
-        let lineage = LineageMarker::build(&plan.config);
+        let lineage = LineageMarker::build(&plan.config, plan.daemon_pid_source_helpers.clone());
         let runtime = Self {
             inner: Arc::new(ToolSandboxState {
                 runtime_dir,
@@ -1836,13 +1847,19 @@ enum LineageMarker {
 }
 
 impl LineageMarker {
-    fn build(config: &CommandPoliciesConfig) -> Self {
+    fn build(
+        config: &CommandPoliciesConfig,
+        helpers: BTreeMap<String, ResolvedCommandBinary>,
+    ) -> Self {
         if config
             .commands
             .values()
             .any(|command| command.daemon_pid_source.is_some())
         {
-            Self::DaemonPid(DaemonPidLineage::default())
+            Self::DaemonPid(DaemonPidLineage {
+                helpers,
+                ..Default::default()
+            })
         } else {
             Self::Disabled
         }
@@ -1872,11 +1889,25 @@ struct DaemonIdentity {
     start_usec: u64,
 }
 
+/// A severed daemon that matched no declared `daemon_pid_source` is re-checked
+/// against every helper (each up to `DAEMON_PID_SOURCE_TIMEOUT`) on every call
+/// without this bound: a same-user process that rapidly forks/reparents could
+/// force a full helper sweep per attempt and exhaust the supervisor's thread
+/// pool. Short enough that a helper's own startup race (e.g. server not fully
+/// up yet) self-heals quickly; long enough to blunt a tight fork loop.
+const DAEMON_PID_NEGATIVE_CACHE_TTL: Duration = Duration::from_secs(2);
+
 /// Verifies severed daemons against declared `daemon_pid_source` helpers and
 /// caches each result, keyed by pid and pinned by kernel identity.
 #[derive(Default)]
 struct DaemonPidLineage {
     cache: Mutex<HashMap<u32, (DaemonIdentity, String)>>,
+    /// Unmatched severed daemons, pinned by kernel identity so a recycled pid
+    /// can't inherit a stale denial, expired after `DAEMON_PID_NEGATIVE_CACHE_TTL`.
+    negative_cache: Mutex<HashMap<u32, (DaemonIdentity, Instant)>>,
+    /// Pre-resolved helper identity (dev/ino/size/mtime/sha256), keyed by
+    /// command name, captured at plan-build time for TOCTOU protection.
+    helpers: BTreeMap<String, ResolvedCommandBinary>,
 }
 
 impl DaemonPidLineage {
@@ -1885,6 +1916,21 @@ impl DaemonPidLineage {
         daemon_pid: u32,
         config: &CommandPoliciesConfig,
         policy_root: &Path,
+    ) -> Option<String> {
+        self.attribute_with_negative_ttl(
+            daemon_pid,
+            config,
+            policy_root,
+            DAEMON_PID_NEGATIVE_CACHE_TTL,
+        )
+    }
+
+    fn attribute_with_negative_ttl(
+        &self,
+        daemon_pid: u32,
+        config: &CommandPoliciesConfig,
+        policy_root: &Path,
+        negative_ttl: Duration,
     ) -> Option<String> {
         if daemon_pid == 0 || daemon_pid == 1 {
             return None;
@@ -1897,12 +1943,28 @@ impl DaemonPidLineage {
             trace!("tool-sandbox: severed daemon {daemon_pid} -> command {name} (cache hit)");
             return Some(name.clone());
         }
+        if let Ok(negative_cache) = self.negative_cache.lock()
+            && let Some((cached_id, at)) = negative_cache.get(&daemon_pid)
+            && *cached_id == identity
+            && at.elapsed() < negative_ttl
+        {
+            trace!(
+                "tool-sandbox: severed daemon {daemon_pid} denied (negative cache hit, no helper re-run)"
+            );
+            return None;
+        }
         // `D`'s kernel-read context is the same for every helper, so read it once.
         let daemon_cwd = daemon_cwd(daemon_pid);
         let daemon_argv_env = daemon_argv_env(daemon_pid);
         let daemon_argv = daemon_argv_env.as_ref().map(|(argv, _)| argv.clone());
         for (name, command) in &config.commands {
             let Some(source) = &command.daemon_pid_source else {
+                continue;
+            };
+            // Resolved at plan-build time; absent means the helper failed to
+            // resolve there and plan build would have already errored, so this
+            // is defensive (e.g. a config mutated after build in a test).
+            let Some(resolved) = self.helpers.get(name) else {
                 continue;
             };
             let daemon_env = daemon_argv_env
@@ -1917,9 +1979,13 @@ impl DaemonPidLineage {
                 daemon_argv: daemon_argv.clone(),
                 daemon_env,
             };
-            let Some(server_pid) =
-                run_daemon_pid_source(name, &source.argv, &context, DAEMON_PID_SOURCE_TIMEOUT)
-            else {
+            let Some(server_pid) = run_daemon_pid_source(
+                name,
+                &source.argv,
+                resolved,
+                &context,
+                DAEMON_PID_SOURCE_TIMEOUT,
+            ) else {
                 continue;
             };
             // A match counts only if `D`'s kernel identity is unchanged across the
@@ -1933,6 +1999,13 @@ impl DaemonPidLineage {
                 debug!("tool-sandbox: severed daemon {daemon_pid} attributed to command {name}");
                 return Some(name.clone());
             }
+        }
+        if let Ok(mut negative_cache) = self.negative_cache.lock() {
+            negative_cache.insert(daemon_pid, (identity, Instant::now()));
+            // Bound the cache: drop entries whose pid died, was reused, or expired.
+            negative_cache.retain(|pid, (id, at)| {
+                at.elapsed() < negative_ttl && daemon_identity(*pid) == Some(*id)
+            });
         }
         debug!("tool-sandbox: severed daemon {daemon_pid} matched no daemon_pid_source; denying");
         None
@@ -2177,28 +2250,28 @@ const DAEMON_PID_SOURCE_TIMEOUT: Duration = Duration::from_secs(5);
 ///
 /// SECURITY: the helper runs UNSANDBOXED in the supervisor, so it MUST only read and
 /// emit a pid, never execute workspace-controlled code. nono hardens the launch
-/// (absolute-path program, cleared env, neutral cwd, hard timeout) but cannot vet
-/// the helper itself.
+/// (pinned, TOCTOU-verified identity resolved at plan-build time; cleared env,
+/// neutral cwd, hard timeout) but cannot vet the helper's own behavior.
 fn run_daemon_pid_source(
     command_name: &str,
     argv: &[String],
+    resolved: &ResolvedCommandBinary,
     context: &DaemonHelperContext,
     timeout: Duration,
 ) -> Option<u32> {
-    let (prog, args) = argv.split_first()?;
-    // Resolve `~`/`$VAR` (e.g. an install-prefix env var) from the supervisor env,
-    // then require the result absolute — the helper is exec'd directly, not via PATH.
-    let prog = crate::policy::expand_path(prog)
-        .map_err(|err| warn!("tool-sandbox: {command_name}.daemon_pid_source path expand: {err}"))
-        .ok()?;
-    if !prog.is_absolute() {
-        warn!("tool-sandbox: {command_name}.daemon_pid_source program must be absolute; ignoring");
+    let (_, args) = argv.split_first()?;
+    // `resolved` was resolved and immutability-checked at plan-build time; re-verify
+    // its identity now, right before spawn, to close the TOCTOU window between then
+    // and dispatch (mirrors verify_binary_identity's use for command binaries).
+    if let Err(err) = verify_binary_identity(resolved) {
+        warn!("tool-sandbox: {command_name}.daemon_pid_source helper identity check failed: {err}");
         return None;
     }
+    let prog = &resolved.canonical_path;
     let payload = serde_json::to_vec(context)
         .map_err(|err| debug!("tool-sandbox: {command_name}.daemon_pid_source serialize: {err}"))
         .ok()?;
-    let mut command = std::process::Command::new(&prog);
+    let mut command = std::process::Command::new(prog);
     command
         .args(args)
         .current_dir("/")
@@ -2216,12 +2289,18 @@ fn run_daemon_pid_source(
         .map_err(|err| debug!("tool-sandbox: {command_name}.daemon_pid_source spawn failed: {err}"))
         .ok()?;
 
-    // The JSON is far under the pipe buffer, so this one blocking write can't
-    // deadlock against a helper that reads stdin to EOF. Drop closes it (signals EOF).
-    if let Some(mut stdin) = child.stdin.take()
-        && let Err(err) = stdin.write_all(&payload)
-    {
-        debug!("tool-sandbox: {command_name}.daemon_pid_source stdin write failed: {err}");
+    // `D`'s argv/env is untrusted and unbounded (read straight from the kernel), so
+    // the JSON payload can exceed the pipe buffer. Write it on its own thread so a
+    // helper that doesn't drain stdin before doing other work can't wedge this
+    // thread's write and skip the deadline loop below; killing the child on timeout
+    // closes its stdin fd, unblocking the writer.
+    if let Some(mut stdin) = child.stdin.take() {
+        let command_name = command_name.to_string();
+        std::thread::spawn(move || {
+            if let Err(err) = stdin.write_all(&payload) {
+                debug!("tool-sandbox: {command_name}.daemon_pid_source stdin write failed: {err}");
+            }
+        });
     }
 
     // Poll to a deadline; kill a wedged helper so it can't hang the shim thread.
@@ -4316,6 +4395,36 @@ fn validate_controlled_exec_helper_immutability(
     Ok(())
 }
 
+/// Apply the same non-writable-executable trust gate to resolved
+/// `daemon_pid_source` helpers as to `exec` intercept helpers: the helper
+/// binary must not be writable (nor replaceable via a writable parent)
+/// through the outer session capability set unless the declaring command
+/// opted into `allow_writable_executable` (or the global
+/// `allow_writable_executables`). Without this, a command whose own
+/// capability grant covers the helper's path could let the sandboxed
+/// workspace process substitute a malicious binary that then runs
+/// unsandboxed in the supervisor.
+fn validate_controlled_daemon_pid_source_helper_immutability(
+    config: &CommandPoliciesConfig,
+    daemon_pid_source_helpers: &BTreeMap<String, ResolvedCommandBinary>,
+    outer_caps: &CapabilitySet,
+) -> Result<()> {
+    for (command_name, binary) in daemon_pid_source_helpers {
+        let allow_writable_path = config.allow_writable_executables
+            || crate::command_policy::command_daemon_pid_source_helper_allows_writable(
+                config,
+                command_name,
+            );
+        validate_controlled_file(
+            &binary.canonical_path,
+            outer_caps,
+            "daemon_pid_source helper",
+            allow_writable_path,
+        )?;
+    }
+    Ok(())
+}
+
 fn command_allows_writable_executable(
     command: &crate::command_policy::CommandPolicyConfig,
 ) -> bool {
@@ -4803,6 +4912,7 @@ mod tests {
                     warnings: Vec::new(),
                 },
                 exec_helpers: BTreeMap::new(),
+                daemon_pid_source_helpers: BTreeMap::new(),
                 deny_only: BTreeMap::new(),
                 allowed_direct_bypass_ids: HashSet::new(),
             },
@@ -5515,6 +5625,66 @@ mod tests {
     }
 
     #[test]
+    fn writable_daemon_pid_source_helper_override_is_explicit_for_sandbox_writable_paths()
+    -> Result<()> {
+        let temp = test_tempdir()?;
+        let bin_dir = temp.path().join("bin");
+        create_dir(&bin_dir)?;
+        let helper = bin_dir.join("helper");
+        create_executable(&helper)?;
+
+        let mut config = CommandPoliciesConfig::default();
+        config.commands.insert(
+            "tmux".to_string(),
+            CommandPolicyConfig {
+                daemon_pid_source: Some(DaemonPidSource {
+                    argv: vec![helper.to_string_lossy().into_owned()],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+
+        let mut helpers = BTreeMap::new();
+        helpers.insert(
+            "tmux".to_string(),
+            test_binary("tmux.daemon_pid_source", &helper)?,
+        );
+
+        let caps = CapabilitySet::new();
+        validate_controlled_daemon_pid_source_helper_immutability(&config, &helpers, &caps)?;
+
+        let mut file_write_caps = CapabilitySet::new();
+        file_write_caps.add_fs(FsCapability::new_file(&helper, AccessMode::ReadWrite)?);
+        let err = validate_controlled_daemon_pid_source_helper_immutability(
+            &config,
+            &helpers,
+            &file_write_caps,
+        )
+        .err()
+        .ok_or_else(|| {
+            NonoError::SandboxInit("expected sandbox-writable helper rejection".to_string())
+        })?;
+        assert!(
+            err.to_string()
+                .contains("writable by the outer session capability set")
+        );
+
+        config
+            .commands
+            .get_mut("tmux")
+            .ok_or_else(|| NonoError::SandboxInit("missing test command policy".to_string()))?
+            .allow_writable_executable = true;
+        validate_controlled_daemon_pid_source_helper_immutability(
+            &config,
+            &helpers,
+            &file_write_caps,
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
     fn exec_gate_allows_non_controlled_initial_exec() {
         let id = FileId { dev: 42, ino: 7 };
         let result = check_exec_gate(
@@ -5908,12 +6078,12 @@ mod tests {
     #[test]
     fn lineage_build_enabled_only_when_a_command_declares_a_helper() {
         assert!(matches!(
-            LineageMarker::build(&CommandPoliciesConfig::default()),
+            LineageMarker::build(&CommandPoliciesConfig::default(), BTreeMap::new()),
             LineageMarker::Disabled
         ));
         let config = config_with_helper("tmux", vec!["/bin/echo".to_string()]);
         assert!(matches!(
-            LineageMarker::build(&config),
+            LineageMarker::build(&config, BTreeMap::new()),
             LineageMarker::DaemonPid(_)
         ));
     }
@@ -5950,7 +6120,12 @@ mod tests {
         // Helper echoes our own pid, so attribution matches and pins by kernel identity.
         let pid = std::process::id();
         let config = config_with_helper("tmux", vec!["/bin/echo".to_string(), pid.to_string()]);
-        let lineage = DaemonPidLineage::default();
+        let helper = test_binary("tmux.daemon_pid_source", Path::new("/bin/echo"))
+            .expect("resolve /bin/echo");
+        let lineage = DaemonPidLineage {
+            helpers: BTreeMap::from([("tmux".to_string(), helper)]),
+            ..Default::default()
+        };
         assert_eq!(
             lineage.attribute(pid, &config, Path::new("/tmp")),
             Some("tmux".to_string())
@@ -5962,22 +6137,119 @@ mod tests {
         // Helper reports a pid that is not the one being resolved -> no match -> deny.
         let other = std::process::id().wrapping_add(1).max(2);
         let config = config_with_helper("tmux", vec!["/bin/echo".to_string(), other.to_string()]);
-        let lineage = DaemonPidLineage::default();
+        let helper = test_binary("tmux.daemon_pid_source", Path::new("/bin/echo"))
+            .expect("resolve /bin/echo");
+        let lineage = DaemonPidLineage {
+            helpers: BTreeMap::from([("tmux".to_string(), helper)]),
+            ..Default::default()
+        };
         assert_eq!(
             lineage.attribute(std::process::id(), &config, Path::new("/tmp")),
             None
         );
     }
 
+    /// A helper script that appends one byte to `counter_path` per invocation, so
+    /// tests can assert how many times it actually ran, then echoes `reported_pid`.
+    fn counting_helper_argv(counter_path: &Path, reported_pid: u32) -> Vec<String> {
+        vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            format!(
+                "printf x >> {} && echo {reported_pid}",
+                counter_path.display()
+            ),
+        ]
+    }
+
     #[test]
-    fn run_daemon_pid_source_rejects_relative_program() {
-        // A non-absolute helper program is misconfiguration: never PATH-resolve it.
+    fn daemon_pid_lineage_negative_cache_suppresses_helper_rerun_within_ttl() {
         let pid = std::process::id();
-        let argv = vec!["echo".to_string(), pid.to_string()];
+        let other = pid.wrapping_add(1).max(2);
+        let dir = std::env::temp_dir().join(format!("nono-neg-cache-{pid}"));
+        fs::create_dir_all(&dir).expect("mkdir");
+        let counter = dir.join("count");
+
+        let config = config_with_helper("tmux", counting_helper_argv(&counter, other));
+        let helper =
+            test_binary("tmux.daemon_pid_source", Path::new("/bin/sh")).expect("resolve /bin/sh");
+        let lineage = DaemonPidLineage {
+            helpers: BTreeMap::from([("tmux".to_string(), helper)]),
+            ..Default::default()
+        };
+
+        // First call: no match, helper runs once, negative-cached.
         assert_eq!(
-            run_daemon_pid_source("tmux", &argv, &test_context(pid), Duration::from_secs(5)),
+            lineage.attribute_with_negative_ttl(
+                pid,
+                &config,
+                Path::new("/tmp"),
+                Duration::from_secs(30)
+            ),
             None
         );
+        // Second call within the TTL: must hit the negative cache, not re-run the helper.
+        assert_eq!(
+            lineage.attribute_with_negative_ttl(
+                pid,
+                &config,
+                Path::new("/tmp"),
+                Duration::from_secs(30)
+            ),
+            None
+        );
+        let invocations = fs::read(&counter).expect("read counter").len();
+        assert_eq!(
+            invocations, 1,
+            "helper must run once, not once per attribute() call, within the negative-cache TTL"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn daemon_pid_lineage_negative_cache_expires_and_rechecks_helper() {
+        let pid = std::process::id();
+        let other = pid.wrapping_add(1).max(2);
+        let dir = std::env::temp_dir().join(format!("nono-neg-cache-expire-{pid}"));
+        fs::create_dir_all(&dir).expect("mkdir");
+        let counter = dir.join("count");
+
+        let config = config_with_helper("tmux", counting_helper_argv(&counter, other));
+        let helper =
+            test_binary("tmux.daemon_pid_source", Path::new("/bin/sh")).expect("resolve /bin/sh");
+        let lineage = DaemonPidLineage {
+            helpers: BTreeMap::from([("tmux".to_string(), helper)]),
+            ..Default::default()
+        };
+
+        let tiny_ttl = Duration::from_millis(1);
+        assert_eq!(
+            lineage.attribute_with_negative_ttl(pid, &config, Path::new("/tmp"), tiny_ttl),
+            None
+        );
+        std::thread::sleep(Duration::from_millis(50));
+        assert_eq!(
+            lineage.attribute_with_negative_ttl(pid, &config, Path::new("/tmp"), tiny_ttl),
+            None
+        );
+        let invocations = fs::read(&counter).expect("read counter").len();
+        assert_eq!(
+            invocations, 2,
+            "an expired negative-cache entry must let the helper re-run, so a since-started \
+             server can still be attributed"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn daemon_pid_lineage_denies_when_helper_not_pre_resolved() {
+        // Defensive: a command declares daemon_pid_source but no matching entry made
+        // it into the pre-resolved helpers map (shouldn't happen outside tests, since
+        // plan build would have errored) -> skip that command, fail closed overall.
+        let pid = std::process::id();
+        let config = config_with_helper("tmux", vec!["/bin/echo".to_string(), pid.to_string()]);
+        let lineage = DaemonPidLineage::default(); // helpers empty
+        assert_eq!(lineage.attribute(pid, &config, Path::new("/tmp")), None);
     }
 
     #[test]
@@ -5988,11 +6260,14 @@ mod tests {
             "-c".to_string(),
             "sleep 30".to_string(),
         ];
+        let resolved =
+            test_binary("tmux.daemon_pid_source", Path::new("/bin/sh")).expect("resolve /bin/sh");
         let start = Instant::now();
         assert_eq!(
             run_daemon_pid_source(
                 "tmux",
                 &argv,
+                &resolved,
                 &test_context(std::process::id()),
                 Duration::from_millis(200)
             ),
@@ -6001,6 +6276,40 @@ mod tests {
         assert!(
             start.elapsed() < Duration::from_secs(5),
             "must not block on the helper"
+        );
+    }
+
+    #[test]
+    fn run_daemon_pid_source_does_not_deadlock_on_large_daemon_argv() {
+        // A severed daemon's argv is untrusted and unbounded (read straight from the
+        // kernel, see daemon_argv_env), so it can exceed the OS pipe buffer (~16KB on
+        // macOS). A helper that doesn't drain stdin before blocking (e.g. it only reads
+        // once it's done its own work) must not be able to wedge the write and skip the
+        // timeout loop entirely.
+        let mut context = test_context(std::process::id());
+        context.daemon_argv = Some(vec!["x".repeat(4096); 64]); // ~256KB, well over 16KB
+        let argv = vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            "sleep 3".to_string(),
+        ];
+        let resolved =
+            test_binary("tmux.daemon_pid_source", Path::new("/bin/sh")).expect("resolve /bin/sh");
+        let start = Instant::now();
+        assert_eq!(
+            run_daemon_pid_source(
+                "tmux",
+                &argv,
+                &resolved,
+                &context,
+                Duration::from_millis(200)
+            ),
+            None
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "blocking stdin write let a non-draining helper skip the timeout deadline: took {:?}",
+            start.elapsed()
         );
     }
 
@@ -6014,36 +6323,43 @@ mod tests {
             "-c".to_string(),
             "plutil -extract candidate_pid raw -o - -".to_string(),
         ];
+        let resolved =
+            test_binary("tmux.daemon_pid_source", Path::new("/bin/sh")).expect("resolve /bin/sh");
         assert_eq!(
-            run_daemon_pid_source("tmux", &argv, &test_context(pid), Duration::from_secs(5)),
+            run_daemon_pid_source(
+                "tmux",
+                &argv,
+                &resolved,
+                &test_context(pid),
+                Duration::from_secs(5)
+            ),
             Some(pid)
         );
     }
 
     #[test]
-    fn run_daemon_pid_source_expands_vars_in_program_path() {
-        // A `$VAR/helper` path must expand from the env and run, so profiles need
-        // not hard-code an install prefix.
-        let _guard = match crate::test_env::ENV_LOCK.lock() {
-            Ok(g) => g,
-            Err(p) => p.into_inner(),
-        };
+    fn run_daemon_pid_source_rejects_helper_whose_identity_changed_since_resolution() {
+        // TOCTOU: the resolved identity (dev/ino/size/mtime) no longer matches the live
+        // file -> deny rather than exec a possibly-substituted binary.
         let pid = std::process::id();
-        let dir = std::env::temp_dir().join(format!("nono-pid-expand-{pid}"));
-        fs::create_dir_all(&dir).expect("mkdir");
-        let helper = dir.join("helper.sh");
-        fs::write(&helper, format!("#!/bin/sh\necho {pid}\n")).expect("write");
-        fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o755)).expect("chmod");
-        let dir_str = dir.to_string_lossy().into_owned();
-        let _env = crate::test_env::EnvVarGuard::set_all(&[("NONO_TEST_HELPER_DIR", &dir_str)]);
-
-        let context = test_context(pid);
-        let argv = vec!["$NONO_TEST_HELPER_DIR/helper.sh".to_string()];
+        let mut resolved =
+            test_binary("tmux.daemon_pid_source", Path::new("/bin/sh")).expect("resolve /bin/sh");
+        resolved.ino = resolved.ino.wrapping_add(1);
+        let argv = vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            format!("echo {pid}"),
+        ];
         assert_eq!(
-            run_daemon_pid_source("tmux", &argv, &context, Duration::from_secs(5)),
-            Some(pid)
+            run_daemon_pid_source(
+                "tmux",
+                &argv,
+                &resolved,
+                &test_context(pid),
+                Duration::from_secs(5)
+            ),
+            None
         );
-        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -6094,7 +6410,12 @@ mod tests {
         // its recorded identity, so the cache can't grow unbounded.
         let pid = std::process::id();
         let config = config_with_helper("tmux", vec!["/bin/echo".to_string(), pid.to_string()]);
-        let lineage = DaemonPidLineage::default();
+        let helper = test_binary("tmux.daemon_pid_source", Path::new("/bin/echo"))
+            .expect("resolve /bin/echo");
+        let lineage = DaemonPidLineage {
+            helpers: BTreeMap::from([("tmux".to_string(), helper)]),
+            ..Default::default()
+        };
         {
             let mut cache = lineage.cache.lock().expect("lock");
             cache.insert(
@@ -6183,7 +6504,9 @@ mod tests {
         fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o755)).expect("chmod");
 
         let config = config_with_helper("tmux", vec![helper.to_string_lossy().into_owned()]);
-        let marker = LineageMarker::build(&config);
+        let helpers = crate::command_policy::resolve_policy_daemon_pid_source_helpers(&config)
+            .expect("resolve daemon_pid_source helpers");
+        let marker = LineageMarker::build(&config, helpers);
 
         assert_eq!(
             marker.resolve_severed_command(daemon, &config, &dir),

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -42,8 +42,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
-use tracing::{debug, warn};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tracing::{debug, trace, warn};
 use zeroize::Zeroizing;
 
 // ── Constants ────────────────────────────────────────────────────────────
@@ -156,6 +156,9 @@ struct ToolSandboxState {
     credential_handles: BTreeMap<String, ResolvedCredential>,
     proxy_trust_bundle_paths: Vec<PathBuf>,
     active_children: Mutex<HashMap<u32, ActiveChild>>,
+    /// Attributes severed-ancestry callers to their spawning command. See the
+    /// daemon-lineage section below.
+    lineage: LineageMarker,
     active_count: AtomicUsize,
     queued_requests: AtomicUsize,
     emitted_error_response: AtomicBool,
@@ -303,6 +306,8 @@ impl PreparedToolSandboxRuntime {
         seal_shim_dir(&shim_dir)?;
 
         let approval_backends = crate::approval_runtime::build_approval_registry(&plan.config)?;
+        // Verify severed daemons if any command declares a helper, else disabled (fail closed).
+        let lineage = LineageMarker::build(&plan.config);
         let runtime = Self {
             inner: Arc::new(ToolSandboxState {
                 runtime_dir,
@@ -322,6 +327,7 @@ impl PreparedToolSandboxRuntime {
                 credential_handles,
                 proxy_trust_bundle_paths: proxy_trust_bundle_paths.to_vec(),
                 active_children: Mutex::new(HashMap::new()),
+                lineage,
                 active_count: AtomicUsize::new(0),
                 queued_requests: AtomicUsize::new(0),
                 emitted_error_response: AtomicBool::new(false),
@@ -1743,7 +1749,37 @@ fn resolve_caller(
     state: &ToolSandboxState,
     command_name: &str,
 ) -> Result<Caller> {
+    resolve_caller_with(
+        peer_pid,
+        session_root_pid,
+        state,
+        command_name,
+        |daemon_pid| {
+            // Only a genuinely reparented daemon (ppid 1) is a valid severed anchor.
+            if parent_pid(daemon_pid).ok() != Some(1) {
+                return None;
+            }
+            state
+                .lineage
+                .resolve_severed_command(daemon_pid, &state.plan.config, &state.policy_root)
+                .map(|name| Caller::Command { name })
+        },
+    )
+}
+
+/// `resolve_severed` receives the daemon pid `D` (last non-init pid in the walk);
+/// a parameter so tests can drive the severed branch without a real reparented
+/// process. Mirrors the Linux `lineage_cgroup` seam.
+fn resolve_caller_with(
+    peer_pid: u32,
+    session_root_pid: u32,
+    state: &ToolSandboxState,
+    command_name: &str,
+    resolve_severed: impl Fn(u32) -> Option<Caller>,
+) -> Result<Caller> {
     let mut pid = peer_pid;
+    // On a severed walk this ends as the reparented daemon `D` (ppid 1).
+    let mut last_non_init = peer_pid;
     for _ in 0..ANCESTRY_DEPTH_LIMIT {
         if let Some((cmd, launch_caller)) = live_active_child(pid, state)? {
             if cmd == command_name
@@ -1759,6 +1795,7 @@ fn resolve_caller(
         if pid == 0 || pid == 1 {
             break;
         }
+        last_non_init = pid;
         pid = match parent_pid(pid) {
             Ok(p) => p,
             // If proc_pidinfo fails partway up the chain the process likely
@@ -1766,10 +1803,452 @@ fn resolve_caller(
             Err(_) => break,
         };
     }
+    // Walk stopped short of the root: an ancestor daemonized (reparented to pid 1).
+    // Fail closed unless the marker verifies `last_non_init` by pid identity.
+    if let Some(caller) = resolve_severed(last_non_init) {
+        return Ok(caller);
+    }
     Err(NonoError::BlockedCommand {
         command: "unknown".to_string(),
         reason: "caller ancestry did not reach session root".to_string(),
     })
+}
+
+// ── Daemon lineage ─────────────────────────────────────────────────────────
+//
+// A daemonized caller (setsid + double-fork, reparented to pid 1) severs the
+// parent-pid walk above. The marker re-establishes attribution by running each
+// command's declared `daemon_pid_source` helper and matching the pid it reports
+// against the severed daemon `D`, pinned by kernel identity so a recycled pid
+// cannot inherit a stale attribution. Fail closed: no helper naming `D` -> deny,
+// never the session.
+//
+// Mirrors the Linux `lineage_cgroup::LineageMarker` seam (verified pid vs.
+// unforgeable cgroup membership). Lives here, not a standalone module, to reuse
+// the `proc_pidinfo` FFI and `ProcBsdInfo` layout defined above.
+
+/// The session's lineage-attribution mechanism, chosen once at supervisor start.
+enum LineageMarker {
+    /// A command declares a `daemon_pid_source`; severed daemons are verified against it.
+    DaemonPid(DaemonPidLineage),
+    /// No helper declared; severed callers are denied (fail closed).
+    Disabled,
+}
+
+impl LineageMarker {
+    fn build(config: &CommandPoliciesConfig) -> Self {
+        if config
+            .commands
+            .values()
+            .any(|command| command.daemon_pid_source.is_some())
+        {
+            Self::DaemonPid(DaemonPidLineage::default())
+        } else {
+            Self::Disabled
+        }
+    }
+
+    /// Attribute a severed daemon `D` to the command that declared it, or `None`
+    /// to deny. Never the session.
+    fn resolve_severed_command(
+        &self,
+        daemon_pid: u32,
+        config: &CommandPoliciesConfig,
+        policy_root: &Path,
+    ) -> Option<String> {
+        match self {
+            Self::DaemonPid(lineage) => lineage.attribute(daemon_pid, config, policy_root),
+            Self::Disabled => None,
+        }
+    }
+}
+
+/// Kernel identity of a pid: `p_uniqueid` (monotonic per boot, never recycled)
+/// plus BSD process start time. Pins a cached `D -> command` attribution so a
+/// recycled pid cannot inherit it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct DaemonIdentity {
+    uniqueid: u64,
+    start_usec: u64,
+}
+
+/// Verifies severed daemons against declared `daemon_pid_source` helpers and
+/// caches each result, keyed by pid and pinned by kernel identity.
+#[derive(Default)]
+struct DaemonPidLineage {
+    cache: Mutex<HashMap<u32, (DaemonIdentity, String)>>,
+}
+
+impl DaemonPidLineage {
+    fn attribute(
+        &self,
+        daemon_pid: u32,
+        config: &CommandPoliciesConfig,
+        policy_root: &Path,
+    ) -> Option<String> {
+        if daemon_pid == 0 || daemon_pid == 1 {
+            return None;
+        }
+        let identity = daemon_identity(daemon_pid)?;
+        if let Ok(cache) = self.cache.lock()
+            && let Some((cached_id, name)) = cache.get(&daemon_pid)
+            && *cached_id == identity
+        {
+            trace!("tool-sandbox: severed daemon {daemon_pid} -> command {name} (cache hit)");
+            return Some(name.clone());
+        }
+        // `D`'s kernel-read context is the same for every helper, so read it once.
+        let daemon_cwd = daemon_cwd(daemon_pid);
+        let daemon_argv_env = daemon_argv_env(daemon_pid);
+        let daemon_argv = daemon_argv_env.as_ref().map(|(argv, _)| argv.clone());
+        for (name, command) in &config.commands {
+            let Some(source) = &command.daemon_pid_source else {
+                continue;
+            };
+            let daemon_env = daemon_argv_env
+                .as_ref()
+                .map(|(_, env)| filter_daemon_env(env, &source.env, name));
+            let context = DaemonHelperContext {
+                schema_version: DAEMON_HELPER_SCHEMA_VERSION,
+                command: name.clone(),
+                candidate_pid: daemon_pid,
+                workdir: policy_root.to_string_lossy().into_owned(),
+                daemon_cwd: daemon_cwd.clone(),
+                daemon_argv: daemon_argv.clone(),
+                daemon_env,
+            };
+            let Some(server_pid) =
+                run_daemon_pid_source(name, &source.argv, &context, DAEMON_PID_SOURCE_TIMEOUT)
+            else {
+                continue;
+            };
+            // A match counts only if `D`'s kernel identity is unchanged across the
+            // helper run, so a pid reused mid-check can't be mis-attributed.
+            if server_pid == daemon_pid && daemon_identity(daemon_pid) == Some(identity) {
+                if let Ok(mut cache) = self.cache.lock() {
+                    cache.insert(daemon_pid, (identity, name.clone()));
+                    // Bound the cache: drop entries whose pid died or was reused.
+                    cache.retain(|pid, (id, _)| daemon_identity(*pid) == Some(*id));
+                }
+                debug!("tool-sandbox: severed daemon {daemon_pid} attributed to command {name}");
+                return Some(name.clone());
+            }
+        }
+        debug!("tool-sandbox: severed daemon {daemon_pid} matched no daemon_pid_source; denying");
+        None
+    }
+}
+
+const PROC_PIDUNIQIDENTIFIERINFO: i32 = 17;
+
+#[repr(C)]
+struct ProcUniqIdentifierInfo {
+    p_uuid: [u8; 16],
+    p_uniqueid: u64,
+    p_puniqueid: u64,
+    p_reserve2: u64,
+    p_reserve3: u64,
+    p_reserve4: u64,
+}
+
+fn daemon_identity(pid: u32) -> Option<DaemonIdentity> {
+    let mut uinfo: ProcUniqIdentifierInfo = unsafe { std::mem::zeroed() };
+    let usize_bytes = std::mem::size_of::<ProcUniqIdentifierInfo>() as i32;
+    // SAFETY: proc_pidinfo writes exactly `usize_bytes` into uinfo on success and
+    // the flavor-sized return is checked before any field is read.
+    let ret = unsafe {
+        proc_pidinfo(
+            pid as i32,
+            PROC_PIDUNIQIDENTIFIERINFO,
+            0,
+            (&mut uinfo as *mut ProcUniqIdentifierInfo).cast::<libc::c_void>(),
+            usize_bytes,
+        )
+    };
+    if ret != usize_bytes {
+        return None;
+    }
+    let mut binfo: ProcBsdInfo = unsafe { std::mem::zeroed() };
+    let bsize = std::mem::size_of::<ProcBsdInfo>() as i32;
+    // SAFETY: as above, for the BSD-info flavor.
+    let ret = unsafe {
+        proc_pidinfo(
+            pid as i32,
+            PROC_PIDTBSDINFO,
+            0,
+            (&mut binfo as *mut ProcBsdInfo).cast::<libc::c_void>(),
+            bsize,
+        )
+    };
+    if ret != bsize {
+        return None;
+    }
+    Some(DaemonIdentity {
+        uniqueid: uinfo.p_uniqueid,
+        start_usec: binfo.pbi_start_tvsec * 1_000_000 + binfo.pbi_start_tvusec,
+    })
+}
+
+/// Bumped only on an incompatible change to the helper's JSON input.
+const DAEMON_HELPER_SCHEMA_VERSION: u32 = 1;
+
+/// Credential-named keys never forwarded into `daemon_env`, even if allowlisted:
+/// a backstop against a profile leaking a secret to an unsandboxed helper.
+const DAEMON_ENV_CREDENTIAL_DENYLIST: &[&str] = &[
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    "GITLAB_TOKEN",
+    "OAUTH_TOKEN",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "ANTHROPIC_API_KEY",
+];
+
+/// The daemon context nono hands a `daemon_pid_source` helper as a JSON object on
+/// stdin. `candidate_pid` is the kernel-pinned severed daemon `D`; the helper
+/// prints the pid it believes is its server and nono accepts only if it equals `D`.
+#[derive(serde::Serialize)]
+struct DaemonHelperContext {
+    schema_version: u32,
+    command: String,
+    candidate_pid: u32,
+    workdir: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    daemon_cwd: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    daemon_argv: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    daemon_env: Option<BTreeMap<String, String>>,
+}
+
+/// Keep only the allowlisted keys present in `D`'s env, minus the credential-name
+/// backstop. Logs each backstop drop so a misconfigured allowlist is visible.
+fn filter_daemon_env(
+    daemon_env: &[(String, String)],
+    allowlist: &[String],
+    command_name: &str,
+) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    for key in allowlist {
+        if DAEMON_ENV_CREDENTIAL_DENYLIST
+            .iter()
+            .any(|denied| denied.eq_ignore_ascii_case(key))
+        {
+            debug!(
+                "tool-sandbox: {command_name}.daemon_pid_source dropped credential-named env key {key}"
+            );
+            continue;
+        }
+        if let Some((_, value)) = daemon_env.iter().find(|(k, _)| k == key) {
+            out.insert(key.clone(), value.clone());
+        }
+    }
+    out
+}
+
+/// A daemon's argv plus its env as `(key, value)` pairs.
+type DaemonArgvEnv = (Vec<String>, Vec<(String, String)>);
+
+/// `D`'s argv and env (`KEY=VALUE` split on the first `=`), read from the kernel.
+/// `None` on any failure; callers omit the fields rather than fail attribution.
+fn daemon_argv_env(pid: u32) -> Option<DaemonArgvEnv> {
+    let argmax = kern_argmax()?;
+    let mut buf = vec![0u8; argmax];
+    let mut mib = [libc::CTL_KERN, libc::KERN_PROCARGS2, pid as libc::c_int];
+    let mut len = buf.len();
+    // SAFETY: sysctl writes at most `len` bytes into `buf` and updates `len` to the
+    // count actually written, which we honor before parsing.
+    let ret = unsafe {
+        libc::sysctl(
+            mib.as_mut_ptr(),
+            mib.len() as libc::c_uint,
+            buf.as_mut_ptr().cast::<libc::c_void>(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if ret != 0 {
+        return None;
+    }
+    buf.truncate(len);
+    parse_procargs2(&buf)
+}
+
+fn kern_argmax() -> Option<usize> {
+    let mut mib = [libc::CTL_KERN, libc::KERN_ARGMAX];
+    let mut argmax: libc::c_int = 0;
+    let mut len = std::mem::size_of::<libc::c_int>();
+    // SAFETY: sysctl writes one `c_int` into `argmax`; `len` bounds the write.
+    let ret = unsafe {
+        libc::sysctl(
+            mib.as_mut_ptr(),
+            mib.len() as libc::c_uint,
+            (&mut argmax as *mut libc::c_int).cast::<libc::c_void>(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if ret != 0 || argmax <= 0 {
+        return None;
+    }
+    Some(argmax as usize)
+}
+
+/// Parse a `KERN_PROCARGS2` buffer: `argc` (i32), the exec path, NUL padding, then
+/// `argc` NUL-terminated argv strings, then NUL-terminated `KEY=VALUE` env strings.
+/// All reads are bounds-checked against the returned length.
+fn parse_procargs2(buf: &[u8]) -> Option<DaemonArgvEnv> {
+    let argc = i32::from_ne_bytes(buf.get(0..4)?.try_into().ok()?);
+    if argc < 0 {
+        return None;
+    }
+    let read_cstr = |pos: &mut usize| -> &[u8] {
+        let start = *pos;
+        while *pos < buf.len() && buf[*pos] != 0 {
+            *pos += 1;
+        }
+        let s = &buf[start..*pos];
+        *pos += 1; // step over the NUL (or past the end)
+        s
+    };
+    let mut pos = 4;
+    read_cstr(&mut pos); // exec path
+    while pos < buf.len() && buf[pos] == 0 {
+        pos += 1; // exec-path alignment padding
+    }
+    let mut argv = Vec::with_capacity(argc as usize);
+    for _ in 0..argc {
+        if pos >= buf.len() {
+            break;
+        }
+        argv.push(String::from_utf8_lossy(read_cstr(&mut pos)).into_owned());
+    }
+    let mut env = Vec::new();
+    while pos < buf.len() && buf[pos] != 0 {
+        let entry = read_cstr(&mut pos);
+        if let Some(eq) = entry.iter().position(|&b| b == b'=') {
+            env.push((
+                String::from_utf8_lossy(&entry[..eq]).into_owned(),
+                String::from_utf8_lossy(&entry[eq + 1..]).into_owned(),
+            ));
+        }
+    }
+    Some((argv, env))
+}
+
+/// `D`'s current working directory, read from the kernel. `None` on failure.
+fn daemon_cwd(pid: u32) -> Option<String> {
+    let mut info: libc::proc_vnodepathinfo = unsafe { std::mem::zeroed() };
+    let size = std::mem::size_of::<libc::proc_vnodepathinfo>() as i32;
+    // SAFETY: proc_pidinfo writes exactly `size` bytes into `info` on success.
+    let ret = unsafe {
+        proc_pidinfo(
+            pid as i32,
+            libc::PROC_PIDVNODEPATHINFO,
+            0,
+            (&mut info as *mut libc::proc_vnodepathinfo).cast::<libc::c_void>(),
+            size,
+        )
+    };
+    if ret != size {
+        return None;
+    }
+    let raw = &info.pvi_cdir.vip_path;
+    // SAFETY: `vip_path` is a fixed NUL-terminated C-string buffer; read it as bytes.
+    let bytes = unsafe {
+        std::slice::from_raw_parts(raw.as_ptr().cast::<u8>(), std::mem::size_of_val(raw))
+    };
+    let end = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
+    if end == 0 {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&bytes[..end]).into_owned())
+}
+
+const DAEMON_PID_SOURCE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Run a command's `daemon_pid_source` helper, feeding `context` as a JSON object
+/// on stdin; parse the first whitespace-delimited integer of stdout as the daemon pid.
+///
+/// SECURITY: the helper runs UNSANDBOXED in the supervisor, so it MUST only read and
+/// emit a pid, never execute workspace-controlled code. nono hardens the launch
+/// (absolute-path program, cleared env, neutral cwd, hard timeout) but cannot vet
+/// the helper itself.
+fn run_daemon_pid_source(
+    command_name: &str,
+    argv: &[String],
+    context: &DaemonHelperContext,
+    timeout: Duration,
+) -> Option<u32> {
+    let (prog, args) = argv.split_first()?;
+    // Resolve `~`/`$VAR` (e.g. an install-prefix env var) from the supervisor env,
+    // then require the result absolute — the helper is exec'd directly, not via PATH.
+    let prog = crate::policy::expand_path(prog)
+        .map_err(|err| warn!("tool-sandbox: {command_name}.daemon_pid_source path expand: {err}"))
+        .ok()?;
+    if !prog.is_absolute() {
+        warn!("tool-sandbox: {command_name}.daemon_pid_source program must be absolute; ignoring");
+        return None;
+    }
+    let payload = serde_json::to_vec(context)
+        .map_err(|err| debug!("tool-sandbox: {command_name}.daemon_pid_source serialize: {err}"))
+        .ok()?;
+    let mut command = std::process::Command::new(&prog);
+    command
+        .args(args)
+        .current_dir("/")
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    // HOME lets a helper expand `~` to a pid file; not credential-bearing.
+    if let Some(home) = std::env::var_os("HOME") {
+        command.env("HOME", home);
+    }
+    let mut child = command
+        .spawn()
+        .map_err(|err| debug!("tool-sandbox: {command_name}.daemon_pid_source spawn failed: {err}"))
+        .ok()?;
+
+    // The JSON is far under the pipe buffer, so this one blocking write can't
+    // deadlock against a helper that reads stdin to EOF. Drop closes it (signals EOF).
+    if let Some(mut stdin) = child.stdin.take()
+        && let Err(err) = stdin.write_all(&payload)
+    {
+        debug!("tool-sandbox: {command_name}.daemon_pid_source stdin write failed: {err}");
+    }
+
+    // Poll to a deadline; kill a wedged helper so it can't hang the shim thread.
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                warn!("tool-sandbox: {command_name}.daemon_pid_source timed out; denying");
+                return None;
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(20)),
+            Err(err) => {
+                debug!("tool-sandbox: {command_name}.daemon_pid_source wait failed: {err}");
+                return None;
+            }
+        }
+    };
+    if !status.success() {
+        debug!(
+            "tool-sandbox: {command_name}.daemon_pid_source exited {:?}",
+            status.code()
+        );
+        return None;
+    }
+    let mut stdout = String::new();
+    child.stdout.take()?.read_to_string(&mut stdout).ok()?;
+    stdout.split_whitespace().next()?.parse::<u32>().ok()
 }
 
 fn parent_pid(pid: u32) -> Result<u32> {
@@ -4266,8 +4745,9 @@ fn is_tty(fd: i32) -> bool {
 mod tests {
     use super::*;
     use crate::command_policy::{
-        CommandEnvironmentConfig, CommandFromConfig, CommandPolicyConfig, InterceptActionConfig,
-        InterceptRuleConfig, ResolvedExecutableKind, ResolvedExecutableShape,
+        CommandEnvironmentConfig, CommandFromConfig, CommandPolicyConfig, DaemonPidSource,
+        InterceptActionConfig, InterceptRuleConfig, ResolvedExecutableKind,
+        ResolvedExecutableShape,
     };
 
     fn test_binary(name: &str, path: &Path) -> Result<ResolvedCommandBinary> {
@@ -4328,6 +4808,7 @@ mod tests {
             credential_handles: BTreeMap::new(),
             proxy_trust_bundle_paths: Vec::new(),
             active_children: Mutex::new(HashMap::new()),
+            lineage: LineageMarker::Disabled,
             active_count: AtomicUsize::new(0),
             queued_requests: AtomicUsize::new(0),
             emitted_error_response: AtomicBool::new(false),
@@ -5364,6 +5845,356 @@ mod tests {
 
         assert!(matches!(caller, Caller::Command { name } if name == "git"));
         Ok(())
+    }
+
+    // Peer pid 1 with an unrelated root: the walk ends before the root (as after a
+    // daemonized reparent), forcing the severed-daemon branch.
+    const DAEMONIZED_PEER: u32 = 1;
+    const UNRELATED_ROOT: u32 = 2;
+
+    fn config_with_helper(command: &str, argv: Vec<String>) -> CommandPoliciesConfig {
+        let mut config = CommandPoliciesConfig::default();
+        config.commands.insert(
+            command.to_string(),
+            CommandPolicyConfig {
+                daemon_pid_source: Some(DaemonPidSource {
+                    argv,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+        config
+    }
+
+    fn test_context(candidate_pid: u32) -> DaemonHelperContext {
+        DaemonHelperContext {
+            schema_version: DAEMON_HELPER_SCHEMA_VERSION,
+            command: "tmux".to_string(),
+            candidate_pid,
+            workdir: "/tmp".to_string(),
+            daemon_cwd: None,
+            daemon_argv: None,
+            daemon_env: None,
+        }
+    }
+
+    #[test]
+    fn resolve_caller_attributes_severed_daemon_to_verified_command() -> Result<()> {
+        let state = test_state();
+        // Stand in for a positive daemon_pid_source match; drives the severed branch.
+        let caller = resolve_caller_with(DAEMONIZED_PEER, UNRELATED_ROOT, &state, "git", |_| {
+            Some(Caller::Command {
+                name: "tmux".to_string(),
+            })
+        })?;
+
+        assert!(matches!(caller, Caller::Command { name } if name == "tmux"));
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_caller_blocks_severed_daemon_without_match() -> Result<()> {
+        let state = test_state();
+        // Fail-closed: no declared helper identifies the severed daemon.
+        let blocked = resolve_caller_with(DAEMONIZED_PEER, UNRELATED_ROOT, &state, "git", |_| None);
+        assert!(matches!(blocked, Err(NonoError::BlockedCommand { .. })));
+        Ok(())
+    }
+
+    #[test]
+    fn lineage_build_enabled_only_when_a_command_declares_a_helper() {
+        assert!(matches!(
+            LineageMarker::build(&CommandPoliciesConfig::default()),
+            LineageMarker::Disabled
+        ));
+        let config = config_with_helper("tmux", vec!["/bin/echo".to_string()]);
+        assert!(matches!(
+            LineageMarker::build(&config),
+            LineageMarker::DaemonPid(_)
+        ));
+    }
+
+    #[test]
+    fn disabled_lineage_denies_severed_daemon() {
+        // Disabled -> deny, never a command, never the session.
+        assert_eq!(
+            LineageMarker::Disabled.resolve_severed_command(
+                std::process::id(),
+                &CommandPoliciesConfig::default(),
+                Path::new("/tmp"),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn daemon_pid_lineage_denies_reserved_and_dead_pids() {
+        let lineage = DaemonPidLineage::default();
+        let config = config_with_helper("tmux", vec!["/bin/echo".to_string()]);
+        // init / kernel pids are never attributed.
+        assert_eq!(lineage.attribute(0, &config, Path::new("/tmp")), None);
+        assert_eq!(lineage.attribute(1, &config, Path::new("/tmp")), None);
+        // A pid with no live process yields no kernel identity -> deny.
+        assert_eq!(
+            lineage.attribute(u32::MAX, &config, Path::new("/tmp")),
+            None
+        );
+    }
+
+    #[test]
+    fn daemon_pid_lineage_attributes_when_helper_names_the_daemon() {
+        // Helper echoes our own pid, so attribution matches and pins by kernel identity.
+        let pid = std::process::id();
+        let config = config_with_helper("tmux", vec!["/bin/echo".to_string(), pid.to_string()]);
+        let lineage = DaemonPidLineage::default();
+        assert_eq!(
+            lineage.attribute(pid, &config, Path::new("/tmp")),
+            Some("tmux".to_string())
+        );
+    }
+
+    #[test]
+    fn daemon_pid_lineage_denies_when_helper_names_a_different_pid() {
+        // Helper reports a pid that is not the one being resolved -> no match -> deny.
+        let other = std::process::id().wrapping_add(1).max(2);
+        let config = config_with_helper("tmux", vec!["/bin/echo".to_string(), other.to_string()]);
+        let lineage = DaemonPidLineage::default();
+        assert_eq!(
+            lineage.attribute(std::process::id(), &config, Path::new("/tmp")),
+            None
+        );
+    }
+
+    #[test]
+    fn run_daemon_pid_source_rejects_relative_program() {
+        // A non-absolute helper program is misconfiguration: never PATH-resolve it.
+        let pid = std::process::id();
+        let argv = vec!["echo".to_string(), pid.to_string()];
+        assert_eq!(
+            run_daemon_pid_source("tmux", &argv, &test_context(pid), Duration::from_secs(5)),
+            None
+        );
+    }
+
+    #[test]
+    fn run_daemon_pid_source_times_out_wedged_helper() {
+        // A helper that never exits is killed at the deadline -> no pid (fail-closed).
+        let argv = vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            "sleep 30".to_string(),
+        ];
+        let start = Instant::now();
+        assert_eq!(
+            run_daemon_pid_source(
+                "tmux",
+                &argv,
+                &test_context(std::process::id()),
+                Duration::from_millis(200)
+            ),
+            None
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "must not block on the helper"
+        );
+    }
+
+    #[test]
+    fn run_daemon_pid_source_verify_mode_round_trips_candidate_pid() {
+        // Verify-mode helper: echo back the candidate_pid it read from stdin JSON.
+        // plutil ships in /usr/bin, so it works under the helper's minimal PATH.
+        let pid = std::process::id();
+        let argv = vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            "plutil -extract candidate_pid raw -o - -".to_string(),
+        ];
+        assert_eq!(
+            run_daemon_pid_source("tmux", &argv, &test_context(pid), Duration::from_secs(5)),
+            Some(pid)
+        );
+    }
+
+    #[test]
+    fn run_daemon_pid_source_expands_vars_in_program_path() {
+        // A `$VAR/helper` path must expand from the env and run, so profiles need
+        // not hard-code an install prefix.
+        let _guard = match crate::test_env::ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let pid = std::process::id();
+        let dir = std::env::temp_dir().join(format!("nono-pid-expand-{pid}"));
+        fs::create_dir_all(&dir).expect("mkdir");
+        let helper = dir.join("helper.sh");
+        fs::write(&helper, format!("#!/bin/sh\necho {pid}\n")).expect("write");
+        fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        let dir_str = dir.to_string_lossy().into_owned();
+        let _env = crate::test_env::EnvVarGuard::set_all(&[("NONO_TEST_HELPER_DIR", &dir_str)]);
+
+        let context = test_context(pid);
+        let argv = vec!["$NONO_TEST_HELPER_DIR/helper.sh".to_string()];
+        assert_eq!(
+            run_daemon_pid_source("tmux", &argv, &context, Duration::from_secs(5)),
+            Some(pid)
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn filter_daemon_env_honors_allowlist_and_credential_backstop() {
+        let daemon_env = vec![
+            ("BAZEL_OUTPUT_USER_ROOT".to_string(), "/custom".to_string()),
+            ("GH_TOKEN".to_string(), "secret".to_string()),
+            ("PATH".to_string(), "/usr/bin".to_string()),
+        ];
+        // Allowlist BAZEL_OUTPUT_USER_ROOT (kept), a credential-named key (dropped by
+        // the backstop), and a key absent from `D` (omitted). PATH is not allowlisted.
+        let allowlist = vec![
+            "BAZEL_OUTPUT_USER_ROOT".to_string(),
+            "gh_token".to_string(), // case-insensitive denylist match
+            "ABSENT".to_string(),
+        ];
+        let filtered = filter_daemon_env(&daemon_env, &allowlist, "tmux");
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(
+            filtered.get("BAZEL_OUTPUT_USER_ROOT"),
+            Some(&"/custom".to_string())
+        );
+        assert!(!filtered.contains_key("GH_TOKEN"));
+        assert!(!filtered.contains_key("PATH"));
+    }
+
+    #[test]
+    fn parse_procargs2_extracts_argv_and_env() {
+        // argc(=2) | exec path + NUL | pad NUL | argv0 | argv1 | env0 | env1
+        let mut buf = 2i32.to_ne_bytes().to_vec();
+        buf.extend_from_slice(b"/path/to/prog\0\0");
+        buf.extend_from_slice(b"/path/to/prog\0--flag\0");
+        buf.extend_from_slice(b"KEY=VALUE\0BAZEL_OUTPUT_USER_ROOT=/custom\0");
+        let (argv, env) = parse_procargs2(&buf).expect("parse");
+        assert_eq!(argv, vec!["/path/to/prog", "--flag"]);
+        assert_eq!(
+            env,
+            vec![
+                ("KEY".to_string(), "VALUE".to_string()),
+                ("BAZEL_OUTPUT_USER_ROOT".to_string(), "/custom".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn daemon_pid_lineage_cache_prunes_dead_entries() {
+        // A successful attribution prunes cache entries whose pid no longer carries
+        // its recorded identity, so the cache can't grow unbounded.
+        let pid = std::process::id();
+        let config = config_with_helper("tmux", vec!["/bin/echo".to_string(), pid.to_string()]);
+        let lineage = DaemonPidLineage::default();
+        {
+            let mut cache = lineage.cache.lock().expect("lock");
+            cache.insert(
+                u32::MAX, // dead pid: no live identity
+                (
+                    DaemonIdentity {
+                        uniqueid: 1,
+                        start_usec: 1,
+                    },
+                    "stale".to_string(),
+                ),
+            );
+        }
+        assert_eq!(
+            lineage.attribute(pid, &config, Path::new("/tmp")),
+            Some("tmux".to_string())
+        );
+        let cache = lineage.cache.lock().expect("lock");
+        assert!(!cache.contains_key(&u32::MAX), "dead entry must be pruned");
+        assert!(cache.contains_key(&pid), "live attribution must remain");
+        assert_eq!(cache.len(), 1);
+    }
+
+    /// LIVE: the property the marker exists for. A real setsid+double-fork daemon
+    /// reparented to pid 1, named by a `daemon_pid_source` helper, resolves to
+    /// `Command{tmux}`; an unnamed reparented daemon is denied. `#[ignore]`: forks
+    /// real processes; run with --ignored.
+    #[test]
+    #[ignore = "forks real reparented daemons; run with --ignored"]
+    fn live_severed_daemon_attributed_to_its_command() {
+        use nix::sys::wait::waitpid;
+        use nix::unistd::{ForkResult, fork};
+
+        // Spawn a setsid + double-fork daemon; returns the reparented grandchild pid.
+        fn spawn_reparented_daemon() -> u32 {
+            let mut fds = [0i32; 2];
+            assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0, "pipe");
+            let [read_fd, write_fd] = fds;
+            // SAFETY: post-fork children use only async-signal-safe libc calls.
+            match unsafe { fork() }.expect("fork") {
+                ForkResult::Child => {
+                    unsafe { libc::setsid() };
+                    match unsafe { fork() }.expect("fork") {
+                        ForkResult::Child => {
+                            let pid = unsafe { libc::getpid() };
+                            let bytes = pid.to_ne_bytes();
+                            unsafe {
+                                libc::write(write_fd, bytes.as_ptr().cast(), bytes.len());
+                                libc::usleep(800_000);
+                                libc::_exit(0);
+                            }
+                        }
+                        ForkResult::Parent { .. } => unsafe { libc::_exit(0) },
+                    }
+                }
+                ForkResult::Parent { child } => {
+                    unsafe { libc::close(write_fd) };
+                    let _ = waitpid(child, None); // reap the middle process
+                    let mut buf = [0u8; 4];
+                    let n = unsafe { libc::read(read_fd, buf.as_mut_ptr().cast(), buf.len()) };
+                    assert_eq!(n, 4, "expected the daemon's pid");
+                    unsafe { libc::close(read_fd) };
+                    i32::from_ne_bytes(buf) as u32
+                }
+            }
+        }
+
+        let daemon = spawn_reparented_daemon();
+        let other = spawn_reparented_daemon();
+        assert_eq!(
+            parent_pid(daemon).ok(),
+            Some(1),
+            "daemon must reparent to 1"
+        );
+        assert_eq!(
+            parent_pid(other).ok(),
+            Some(1),
+            "control must reparent to 1"
+        );
+
+        // Throwaway helper that echoes the daemon's pid.
+        let dir = std::env::temp_dir().join(format!("nono-daemon-pid-{}", std::process::id()));
+        fs::create_dir_all(&dir).expect("mkdir");
+        let helper = dir.join("pid_source.sh");
+        fs::write(&helper, format!("#!/bin/sh\necho {daemon}\n")).expect("write helper");
+        fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+        let config = config_with_helper("tmux", vec![helper.to_string_lossy().into_owned()]);
+        let marker = LineageMarker::build(&config);
+
+        assert_eq!(
+            marker.resolve_severed_command(daemon, &config, &dir),
+            Some("tmux".to_string()),
+            "reparented daemon must attribute to its command"
+        );
+        // A reparented daemon the helper does not name is denied (fail-closed).
+        assert_eq!(
+            marker.resolve_severed_command(other, &config, &dir),
+            None,
+            "non-matching reparented daemon must be denied"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/nono-cli/tests/schema_shape.rs
+++ b/crates/nono-cli/tests/schema_shape.rs
@@ -147,12 +147,14 @@ fn test_schema_command_policies_match_tool_sandbox_guide_shape() {
             "allow_direct_exec_bypass_with_credentials",
             "allow_writable_executable",
             "can_use",
+            "daemon_pid_source",
             "executable",
             "from",
             "intercept",
             "sandbox",
         ],
     );
+    assert_schema_properties(&schema, "DaemonPidSource", &["argv", "env"]);
     assert_schema_properties(
         &schema,
         "CommandEdgeConfig",

--- a/docs/cli/features/tool-sandbox.mdx
+++ b/docs/cli/features/tool-sandbox.mdx
@@ -66,6 +66,7 @@ Each entry under `commands` uses the command name as the key:
 | `intercept` | array | Ordered argument-sequence mediation rules evaluated after invocation policy. |
 | `allow_direct_exec_bypass` | absolute path array | Compatibility escape hatch for direct canonical-path invocation. |
 | `allow_direct_exec_bypass_with_credentials` | boolean | Required when a credential-using command also allows direct exec bypass. |
+| `daemon_pid_source` | `{ argv: string[], env?: string[] }` | macOS only. Helper nono runs to learn the pid of a daemon this command spawns that double-forks and reparents to pid 1 (e.g. a tmux server), so a request from that daemon can still be attributed to this command. `argv` is the helper program (expanded, then must be absolute); `env` allowlists daemon-env keys forwarded to it. See [Daemon Attribution](#daemon-attribution). |
 
 `from` entries accept three value shapes:
 
@@ -241,6 +242,33 @@ This is broader than `commands.<name>.allow_writable_executable`: it also covers
 Linux launches the verified executable object by file descriptor. macOS verifies the pinned file before sandboxing but must still call `execve()` by path, so a sandbox-writable executable or parent directory remains replaceable before launch. Avoid `allow_writable_executable` for high-assurance macOS policies.
 
 Interpreter-packaged tools, such as a Python `aws` entrypoint, are classified as shebang scripts. Tool Sandbox grants the selected script, its interpreter, and the interpreter's ELF loader closure. Language package directories, virtualenvs, SDK homes, and tool-specific data are not guessed by Tool Sandbox; grant those explicitly with `fs_read`, `fs_read_file`, `fs_write`, or `fs_write_file`.
+
+## Daemon Attribution
+
+Tool Sandbox authorizes a request by walking the caller's process ancestry to the session. A daemon that double-forks and reparents to pid 1 (a tmux server, for example) severs that chain, so a request from it can no longer be tied to the command that spawned it. Rather than fall back to something replayable, Tool Sandbox attributes such a caller by a platform lineage marker, or denies it:
+
+- **Linux** places each Tool Sandbox command in a per-command cgroup that survives reparenting; a severed caller is attributed by reading its cgroup. No writable cgroup base means severed callers are denied.
+- **macOS** uses `commands.<name>.daemon_pid_source`: a helper nono runs to learn the pid of the daemon the command spawns. When a caller reparented to pid 1 is seen, nono runs each declared helper and attributes the caller to a command only if the reported pid matches, pinned by the daemon's kernel identity. No declared helper means severed callers are denied.
+
+Either way a severed caller resolves only to the command that spawned it, never the session, and is denied on any mismatch.
+
+The macOS helper is declared as `{ "argv": [...], "env": [...] }`. nono passes the daemon's context as a single JSON object on **stdin**:
+
+```json
+{
+  "schema_version": 1,
+  "command": "<command name>",
+  "candidate_pid": 48213,
+  "workdir": "/abs/session/workdir",
+  "daemon_cwd": "/abs/daemon/cwd",
+  "daemon_argv": ["/path/to/daemon", "..."],
+  "daemon_env": { "SOME_KEY": "value" }
+}
+```
+
+`candidate_pid` is the severed daemon nono walked to; `daemon_cwd`, `daemon_argv`, and `daemon_env` describe it, read from the kernel, and are omitted when unreadable. `daemon_env` carries only the keys named in `env` that are present in the daemon's environment; credential-named keys are always dropped. The helper prints the pid it believes is its server on stdout; nono accepts only if that equals `candidate_pid`.
+
+The helper runs **unsandboxed** in the supervisor. It MUST only read and emit a single pid (for example, the pid file the daemon writes) and MUST NOT execute workspace-controlled code. nono hardens the launch — the `argv` program is expanded (`~`, `$WORKDIR`, `$TMPDIR`, `$UID`, XDG) and must then be an absolute path, its environment is cleared to a minimal set, its working directory is neutral, and it is killed if it exceeds a short timeout — but cannot vet what the declared helper itself does.
 
 ## Examples
 


### PR DESCRIPTION
## Linked Issue

Closes #1412

## Summary

- Tool Sandbox authorizes a command by walking the caller's process ancestry back to the session. A daemonized ancestor (`setsid` + double-fork → reparented to pid 1) severs that walk, so a caller that legitimately descends from a session command is blocked (`caller ancestry did not reach session root`).
- This PR attributes such a severed caller to the command that spawned the daemon (gated by that command's from-edges), or leaves it blocked if it can't be attributed — never the session. An in-sandbox process cannot forge the attribution.
- **Linux:** an unforgeable per-command cgroup marker, self-attached pre-exec, survives reparenting; Landlock denies in-sandbox cgroupfs writes. Needs cgroup delegation; where absent, severed callers stay blocked (unchanged).
- **macOS** (no unprivileged kernel marker): a command-declared `daemon_pid_source` helper reports the daemon's pid, accepted only if it matches the walked-to daemon, pinned by kernel identity. The helper receives the daemon's own argv/env/cwd (read from the kernel) as a JSON object on stdin so it can locate or verify its server.
- Security caveat: the macOS helper runs unsandboxed, so its launch is hardened (absolute-path program, cleared env, neutral cwd, hard timeout) and a declared helper must only read and emit a pid — never run workspace-controlled code.

## Agent Disclosure (if applicable)

Authored by an AI agent, driven and reviewed by me. Area: `tool-sandbox/platform/{macos,linux}.rs`, `lineage_cgroup.rs`, `command_policy.rs`, `profile/mod.rs`, the profile schema, and the Tool Sandbox docs. Complies with CLAUDE.md for the area: no unwrap/expect, `NonoError`, bounds-checked FFI.

## Test Plan

- `make ci` clean (check, test, audit, lint-aliases, lint-docs).
- Unit, both platforms: severed caller → spawning command; deny on non-match / dead / reused pid; `platform_overrides` + `extends` merge; schema shape; `daemon_pid_source` serde/merge.
- macOS: `KERN_PROCARGS2` parse; helper stdin-context round-trip (verify mode); env allowlist honoured + credential-name denylist enforced.
- Live (`#[ignore]`, run with `--ignored`): real `setsid`+double-fork daemon attributes to its command; Linux child `cgroup.procs` write → `EACCES`.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

## Agent Compliance Check (Required for AI/Automated PRs)

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope
