### PR TITLE
fix: sigV4 URI generation errors for uri's that have encoded characters

### DIFF
--- a/crates/nono-proxy/src/aws/sign.rs
+++ b/crates/nono-proxy/src/aws/sign.rs
@@ -111,13 +111,25 @@ pub async fn sign_request(
     //   for all other services).
     // - `SessionTokenMode::Include`: include X-Amz-Security-Token in the
     //   canonical request when a session token is present (STS / IMDS / SSO).
-    // - `PercentEncodingMode::Single`: standard single-encode mode.
-    // - `UriPathNormalizationMode::Disabled`: required for S3 key correctness.
+    // - `PercentEncodingMode`: Almost all AWS services use double encoding, except S3
+    //   This means that a : character in the URL should encode once to %3A, and then again to %253A
+    //   Failing to do so will cause signing errors. The only exception to this rule is S3, which uses single encoding
+    // - `UriPathNormalizationMode` - Similarly, most uri's are normalized first (e.g. a path with ../.) before any encoding.
+    //   S3 is again the exception where these paths should be passed as-is
+    let is_s3 = route.service == "s3";
     let mut settings = SigningSettings::default();
     settings.payload_checksum_kind = PayloadChecksumKind::XAmzSha256;
     settings.session_token_mode = SessionTokenMode::Include;
-    settings.percent_encoding_mode = PercentEncodingMode::Single;
-    settings.uri_path_normalization_mode = UriPathNormalizationMode::Disabled;
+    settings.percent_encoding_mode = if is_s3 {
+        PercentEncodingMode::Single
+    } else {
+        PercentEncodingMode::Double
+    };
+    settings.uri_path_normalization_mode = if is_s3 {
+        UriPathNormalizationMode::Disabled
+    } else {
+        UriPathNormalizationMode::Enabled
+    };
 
     // Build signing parameters with pinned behavior version.
     let params = v4::SigningParams::builder()


### PR DESCRIPTION
## Linked Issue

Closes #1429

## Summary
This changes the AWS signing code to use double encoding and URI normalization for almost all routes, except S3

This is needed to fix e.g. URI's which have colons in their names (like for example bedrock models with a colon). Without this fix, AWS returns a signing error.

It's worth noting that AWS's documentation isn't the greatest here about what the expected behavior is supposed to be. I ended up looking mostly through SDK source code, and some wayback blog posts:
http://web.archive.org/web/20221210104029/https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
https://github.com/aws/aws-sdk-go/blob/main/aws/signer/v4/v4.go#L472

## Test Plan
This script succeeds only with the fix applied. It just makes a cURL command to bedrock (the haiku model with a `:` in it is what breaks)

```sh
set -euo pipefail
cd "$(dirname "${BASH_SOURCE[0]}")/.."

NONO_BIN="${NONO_BIN:-nono}"
HOST="https://bedrock-runtime.us-east-1.amazonaws.com"
BODY='{"messages":[{"role":"user","content":[{"text":"hi"}]}]}'

echo "# good model (no colon in id)"
"$NONO_BIN" run --profile ./profile.json --credential bedrock -- \
  curl -s -o /dev/null -w '%{http_code}\n' -X POST -H 'Content-Type: application/json' \
  -d "$BODY" "$HOST/model/us.anthropic.claude-sonnet-4-6/converse"

echo
echo "# bad model (colon in id -> percent-encoded to %3A on the wire)"
"$NONO_BIN" run --profile ./profile.json --credential bedrock -- \
  curl -s -X POST -H 'Content-Type: application/json' \
  -d "$BODY" "$HOST/model/global.anthropic.claude-haiku-4-5-20251001-v1:0/converse"
```

You can use this profile.json or anything else which configures bedrock for testing:
```
{
    "meta": {
        "name": "bedrock-sigv4-colon-repro",
        "description": "Repro for the AWS SigV4 percent-encoding bug:"
    },
    "filesystem": {
        "allow": [
            "."
        ]
    },
    "network": {
        "credentials": ["bedrock"],
        "custom_credentials": {
            "bedrock": {
                "upstream": "https://bedrock-runtime.us-east-1.amazonaws.com",
                "aws_auth": {},
                "endpoint_rules": [
                    { "method": "POST", "path": "/model/**" }
                ]
            }
        }
    },
    "environment": {
        "deny_vars": ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_PROFILE"],
        "set_vars": {
            "AWS_ACCESS_KEY_ID": "dummy-access-key",
            "AWS_SECRET_ACCESS_KEY": "dummy-secret-key",
            "HOME": "$HOME"
        }
    }
}
```

## Checklist

- [ ] An issue exists and is linked above
- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
