### PR TITLE
feat(tool-sandbox): caller-declared env pass-through via export_env

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -1291,6 +1291,11 @@
           "type": "array",
           "items": { "type": "string" },
           "description": "Governance list of canonical executable files that child profiles may not re-grant through allow_direct_exec_bypass."
+        },
+        "session_export_env": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Env vars the session forwards to commands whose resolved caller is the session (exact/PREFIX_*/*). Bypasses allow_vars and the dangerous-var blocklist. PATH/NONO_* and 1Password credentials are always excluded; LD_*/DYLD_* require an exact-name pattern. Mirrors the per-command export_env field for the session caller."
         }
       }
     },
@@ -1577,6 +1582,11 @@
         "daemon_pid_source": {
           "$ref": "#/$defs/DaemonPidSource",
           "description": "Helper nono runs to learn the pid of a daemon this command spawns (e.g. a tmux server that double-forks and reparents to pid 1). When a caller's process ancestry is severed by that reparenting, the lineage marker runs this helper and attributes the severed daemon to this command only if the reported pid matches. Prints one pid. Consumed on macOS only for now."
+        },
+        "export_env": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Env vars this command forwards to commands it invokes (exact/PREFIX_*/*). Bypasses allow_vars and the dangerous-var blocklist. PATH/NONO_* and 1Password credentials are always excluded; LD_*/DYLD_* require an exact-name pattern."
         }
       }
     },

--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -698,6 +698,53 @@ Controls which environment variables are passed to the sandboxed process. When `
 
 Inheritance: child `allow_vars` and `deny_vars` are appended to base values and deduplicated; `set_vars` merges as a map, with the child's value winning on key conflict.
 
+### export_env (caller-declared environment pass-through)
+
+`export_env` lets a **caller** declare which of its own live environment variables flow down, verbatim, to the commands it invokes — bypassing both the callee's `allow_vars` filtering and the built-in dangerous-variable blocklist (`LD_PRELOAD`, `NODE_OPTIONS`, `PYTHONPATH`, …). It is the escape hatch for tools that must forward an interpreter/tooling variable to the programs they launch (for example an interpreter-injection variable a wrapper sets before spawning a child interpreter).
+
+This is a **caller-declared** control: the field lives on the command doing the invoking (or on the session, for the top-level case), not on the command being invoked. When a command is intercepted, nono attributes it to its resolved caller, then copies the matching variables from that intercepted command's **immediate-parent environment** into the child. The caller's list is only the filter; the values always come from the live parent environment.
+
+- **Patterns:** exact names (`"TOOL_CONFIG"`), trailing-`*` prefixes (`"AWS_*"`), or a bare `"*"` (all). Mid-string wildcards are rejected at load time.
+- **`PATH` and any `NONO_*` key are always excluded** — nono manages those — even under `"*"`. A pattern that explicitly targets them (exact `PATH`, or the `NONO_` prefix) is rejected at load time.
+- Values are taken verbatim and are **not** run through the credential broker. Use `export_env` for tooling variables, not credentials — those flow through `use_credentials`/`allow_vars`.
+- Applied on both the macOS and Linux tool-sandbox paths, before PATH/chaining/`set_vars`/credential injection, so nono-injected variables still win. Merges by dedup-append across the inheritance chain.
+
+#### Per-command caller: `commands.<caller>.export_env`
+
+When the invoking command is itself mediated, declare `export_env` on that command. Example: `git` runs a hook that spawns `node`; `node`'s resolved caller is `git`, so `git`'s `export_env` decides what reaches `node`:
+
+```json
+{
+  "command_policies": {
+    "commands": {
+      "git": {
+        "can_use": ["node"],
+        "export_env": ["TOOL_CONFIG"]
+      }
+    }
+  }
+}
+```
+
+#### Session caller: `session_export_env`
+
+When the intercepted command's nearest mediated ancestor is the session itself — for example an **unmediated** wrapper spawns it, so the ancestry walk reaches the session root without crossing a mediated command — its caller is the session. Declare the top-level `session_export_env` to cover this case:
+
+```json
+{
+  "command_policies": {
+    "session_export_env": ["TOOL_CONFIG"],
+    "commands": {
+      "node": {
+        "from": { "session": { "fs_read": ["."] } }
+      }
+    }
+  }
+}
+```
+
+Here an unmediated wrapper invokes `node` while holding `TOOL_CONFIG` in its environment; `node`'s caller resolves to the session, so `session_export_env` copies `TOOL_CONFIG` into `node` verbatim.
+
 ### hooks
 
 Map of application name to hook configuration:

--- a/crates/nono-cli/src/command_policy.rs
+++ b/crates/nono-cli/src/command_policy.rs
@@ -258,6 +258,10 @@ pub struct CommandPoliciesConfig {
     pub commands: BTreeMap<String, CommandPolicyConfig>,
     #[serde(default)]
     pub deny_direct_exec_bypass: Vec<String>,
+    /// [`CommandPolicyConfig::export_env`] for commands whose resolved caller is
+    /// the session rather than another mediated command.
+    #[serde(default)]
+    pub session_export_env: Vec<String>,
 }
 
 impl CommandPoliciesConfig {
@@ -291,6 +295,7 @@ impl CommandPoliciesConfig {
             || self.approval_defaults.has_values()
             || !self.credentials.is_empty()
             || !self.deny_direct_exec_bypass.is_empty()
+            || !self.session_export_env.is_empty()
     }
 
     pub(crate) fn merge_child(&self, child: &Self) -> Self {
@@ -327,6 +332,7 @@ impl CommandPoliciesConfig {
                 &self.deny_direct_exec_bypass,
                 &child.deny_direct_exec_bypass,
             ),
+            session_export_env: dedup_append(&self.session_export_env, &child.session_export_env),
         }
     }
 }
@@ -599,6 +605,12 @@ pub struct CommandPolicyConfig {
     pub allow_writable_executable: bool,
     #[serde(default)]
     pub can_use: Vec<String>,
+    /// Env vars this command forwards verbatim to commands it invokes, bypassing
+    /// `allow_vars` and the dangerous-var blocklist — the caller-declared escape
+    /// hatch for tools that must pass an interpreter variable to what they launch.
+    /// Exact names, trailing-`*` prefixes, or bare `*`; never `PATH` or `NONO_*`.
+    #[serde(default)]
+    pub export_env: Vec<String>,
     #[serde(default)]
     pub sandbox: Option<CommandSandboxConfig>,
     #[serde(default)]
@@ -645,6 +657,7 @@ impl CommandPolicyConfig {
             allow_writable_executable: self.allow_writable_executable
                 || child.allow_writable_executable,
             can_use: dedup_append(&self.can_use, &child.can_use),
+            export_env: dedup_append(&self.export_env, &child.export_env),
             sandbox: merge_optional_sandbox(&self.sandbox, &child.sandbox),
             from,
             allow_direct_exec_bypass: dedup_append(
@@ -1148,6 +1161,11 @@ pub(crate) fn validate_command_policies(
         &config.deny_direct_exec_bypass,
         &mut report,
     );
+    validate_export_env(
+        "command_policies.session_export_env",
+        &config.session_export_env,
+        &mut report,
+    );
     if config.allow_writable_executables {
         report.warning(
             "writable_executables_trust_downgrade",
@@ -1556,6 +1574,12 @@ fn validate_command(
     validate_identifier_list(
         &format!("commands.{command_name}.can_use"),
         &command.can_use,
+        report,
+    );
+
+    validate_export_env(
+        &format!("command '{command_name}' export_env"),
+        &command.export_env,
         report,
     );
 
@@ -2647,6 +2671,41 @@ fn validate_environment(
             report.error(
                 "invalid_environment_set_var",
                 format!("command '{command_name}' from.{caller} set_vars value for '{name}' contains NUL"),
+            );
+        }
+    }
+}
+
+/// Validate an `export_env` pattern list. `field_label` names the field for
+/// diagnostics (e.g. `command 'git' export_env` or `session_export_env`).
+fn validate_export_env(
+    field_label: &str,
+    patterns: &[String],
+    report: &mut CommandPolicyValidationReport,
+) {
+    if let Some(error) = crate::exec_strategy::validate_env_var_patterns(patterns, "export_env") {
+        report.error("invalid_export_env", format!("{field_label}: {error}"));
+    }
+    for pattern in patterns {
+        if pattern.is_empty() {
+            report.error(
+                "invalid_export_env",
+                format!("{field_label} has an empty pattern"),
+            );
+            continue;
+        }
+        if pattern.matches('*').count() > 1 {
+            report.error(
+                "invalid_export_env",
+                format!("{field_label} pattern '{pattern}' contains multiple wildcards"),
+            );
+        }
+        // nono owns PATH/NONO_*, so naming them is an error. A broad pattern is
+        // fine — they are excluded at build time regardless.
+        if pattern == "PATH" || pattern.starts_with("NONO_") {
+            report.error(
+                "invalid_export_env",
+                format!("{field_label} pattern '{pattern}' targets reserved PATH/NONO_* variables"),
             );
         }
     }
@@ -3977,6 +4036,90 @@ mod tests {
                 .errors
                 .iter()
                 .any(|finding| finding.code == "invalid_environment_pattern")
+        );
+    }
+
+    #[test]
+    fn export_env_rejects_reserved_and_malformed_patterns() {
+        // A mid-string wildcard, exact PATH, and the NONO_* namespace must all
+        // be rejected on the caller-declared export list.
+        let mut config = active_git_config();
+        if let Some(git) = config.commands.get_mut("git") {
+            git.export_env = vec![
+                "A*B".to_string(),
+                "PATH".to_string(),
+                "NONO_FOO".to_string(),
+            ];
+        }
+
+        let report =
+            validate_command_policies(Some(&config), CommandPolicyValidationScope::Resolved);
+
+        assert!(
+            report
+                .errors
+                .iter()
+                .any(|finding| finding.code == "invalid_export_env")
+        );
+    }
+
+    #[test]
+    fn export_env_rejects_repeated_trailing_wildcards() {
+        // "A**" passes validate_env_var_patterns but matches_env_var_patterns
+        // treats it as unmatchable, silently excluding the var at runtime.
+        let mut config = active_git_config();
+        if let Some(git) = config.commands.get_mut("git") {
+            git.export_env = vec!["A**".to_string()];
+        }
+
+        let report =
+            validate_command_policies(Some(&config), CommandPolicyValidationScope::Resolved);
+
+        assert!(
+            report
+                .errors
+                .iter()
+                .any(|finding| finding.code == "invalid_export_env")
+        );
+    }
+
+    #[test]
+    fn export_env_accepts_valid_patterns() {
+        // Exact names, trailing-`*` prefixes, and a bare `*` (which still
+        // excludes PATH/NONO_* at build time) are all accepted.
+        let mut config = active_git_config();
+        if let Some(git) = config.commands.get_mut("git") {
+            git.export_env = vec![
+                "TOOL_CONFIG".to_string(),
+                "AWS_*".to_string(),
+                "*".to_string(),
+            ];
+        }
+
+        let report =
+            validate_command_policies(Some(&config), CommandPolicyValidationScope::Resolved);
+
+        assert!(
+            !report
+                .errors
+                .iter()
+                .any(|finding| finding.code == "invalid_export_env")
+        );
+    }
+
+    #[test]
+    fn session_export_env_rejects_reserved_patterns() {
+        let mut config = active_git_config();
+        config.session_export_env = vec!["NONO_CAP_FILE".to_string()];
+
+        let report =
+            validate_command_policies(Some(&config), CommandPolicyValidationScope::Resolved);
+
+        assert!(
+            report
+                .errors
+                .iter()
+                .any(|finding| finding.code == "invalid_export_env")
         );
     }
 

--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -42,6 +42,8 @@ use tracing::{debug, info, warn};
 pub(crate) use env_sanitization::is_dangerous_env_var;
 #[cfg(target_os = "linux")]
 pub(crate) use env_sanitization::is_env_var_allowed;
+#[cfg(any(test, target_os = "linux", target_os = "macos"))]
+pub(crate) use env_sanitization::matches_env_var_patterns;
 pub(crate) use env_sanitization::validate_env_var_patterns;
 pub(crate) use env_sanitization::validate_set_vars;
 

--- a/crates/nono-cli/src/exec_strategy/env_sanitization.rs
+++ b/crates/nono-cli/src/exec_strategy/env_sanitization.rs
@@ -12,9 +12,7 @@
 /// injection (BASH_ENV, PROMPT_COMMAND, IFS), and interpreter code/module injection
 /// (NODE_OPTIONS, PYTHONPATH, PERL5OPT, RUBYOPT, JAVA_TOOL_OPTIONS, etc.).
 pub(crate) fn is_dangerous_env_var(key: &str) -> bool {
-    // Linker injection
-    key.starts_with("LD_")
-        || key.starts_with("DYLD_")
+    is_loader_injection_env_var(key)
         // Shell injection
         || key == "BASH_ENV"
         || key == "ENV"
@@ -44,12 +42,22 @@ pub(crate) fn is_dangerous_env_var(key: &str) -> bool {
         || key == "DOTNET_STARTUP_HOOKS"
         // Go injection
         || key == "GOFLAGS"
-        // 1Password secrets and session tokens — meta-secrets used by
-        // the parent to authenticate `op` CLI, must never leak to sandboxed child
-        || key == "OP_SERVICE_ACCOUNT_TOKEN"
+        || is_forbidden_secret_env_var(key)
+}
+
+/// 1Password meta-secrets — credentials, not tooling vars, so `export_env`
+/// must never re-admit them even by exact name.
+pub(crate) fn is_forbidden_secret_env_var(key: &str) -> bool {
+    key == "OP_SERVICE_ACCOUNT_TOKEN"
         || key == "OP_CONNECT_TOKEN"
         || key == "OP_CONNECT_HOST"
         || key.starts_with("OP_SESSION_")
+}
+
+/// Loader vars hit any dynamically-linked child, not just an interpreter, so
+/// `export_env` requires an exact-name pattern for these — `*`/prefix isn't enough.
+pub(crate) fn is_loader_injection_env_var(key: &str) -> bool {
+    key.starts_with("LD_") || key.starts_with("DYLD_")
 }
 
 /// Returns true if `key` matches any pattern in `patterns`.
@@ -58,7 +66,7 @@ pub(crate) fn is_dangerous_env_var(key: &str) -> bool {
 /// (`"AWS_*"` matches `AWS_REGION`, `AWS_SECRET_ACCESS_KEY`, etc.).
 /// A bare `"*"` matches everything. The `*` wildcard is only valid as a
 /// trailing suffix — patterns like `"A*B"` or `"*X"` are skipped.
-fn matches_env_var_patterns(key: &str, patterns: &[String]) -> bool {
+pub(crate) fn matches_env_var_patterns(key: &str, patterns: &[String]) -> bool {
     for pattern in patterns {
         if let Some(prefix) = pattern.strip_suffix('*') {
             if prefix.contains('*') {

--- a/crates/nono-cli/src/tool-sandbox/env.rs
+++ b/crates/nono-cli/src/tool-sandbox/env.rs
@@ -116,6 +116,49 @@ pub(crate) fn apply_environment_set_vars(
     Ok(())
 }
 
+/// Copies `export_patterns`-matching vars from `request.env` into `env` verbatim,
+/// bypassing `allow_vars` and the dangerous-var blocklist. `PATH`/`NONO_*` and
+/// secrets are always excluded; loader vars need an exact-name pattern.
+pub(crate) fn apply_export_env(
+    env: &mut Vec<Vec<u8>>,
+    request: &ToolSandboxShimRequest,
+    export_patterns: &[String],
+) {
+    if export_patterns.is_empty() {
+        return;
+    }
+    for entry in &request.env {
+        let Some((key, value)) = split_env_entry(entry) else {
+            continue;
+        };
+        let Ok(key_str) = std::str::from_utf8(key) else {
+            continue;
+        };
+        // nono owns PATH and its own NONO_* namespace; never let the export
+        // list re-admit them, including under a bare `*`.
+        if key_str == "PATH" || key_str.starts_with("NONO_") {
+            continue;
+        }
+        if !crate::exec_strategy::matches_env_var_patterns(key_str, export_patterns) {
+            continue;
+        }
+        if crate::exec_strategy::env_sanitization::is_forbidden_secret_env_var(key_str) {
+            continue;
+        }
+        if crate::exec_strategy::env_sanitization::is_loader_injection_env_var(key_str)
+            && !export_patterns.iter().any(|pattern| pattern == key_str)
+        {
+            continue;
+        }
+        let mut prefix = key.to_vec();
+        prefix.push(b'=');
+        env.retain(|existing| !existing.starts_with(&prefix));
+        let mut new_entry = prefix;
+        new_entry.extend_from_slice(value);
+        env.push(new_entry);
+    }
+}
+
 pub(crate) fn inject_chaining_control_env(
     env: &mut Vec<Vec<u8>>,
     socket_path: &Path,
@@ -523,6 +566,142 @@ mod tests {
         let policy = CommandSandboxConfig::default();
         let extra = vec![b"a\0b".to_vec()];
         assert!(effective_argv_for_binary(&helper, &request, &policy, &extra, false).is_err());
+    }
+
+    fn patterns(list: &[&str]) -> Vec<String> {
+        list.iter().map(|v| v.to_string()).collect()
+    }
+
+    fn request_with(env: &[&str], cwd: &str) -> ToolSandboxShimRequest {
+        ToolSandboxShimRequest {
+            command: "node".to_string(),
+            argv: vec![b"node".to_vec()],
+            env: env.iter().map(|e| e.as_bytes().to_vec()).collect(),
+            cwd: cwd.as_bytes().to_vec(),
+            stdio_tty: [false; 3],
+        }
+    }
+
+    fn rendered(env: &[Vec<u8>]) -> Vec<String> {
+        env.iter()
+            .map(|e| String::from_utf8_lossy(e).into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn export_env_passes_blocklisted_var_from_parent() {
+        // A var on the dangerous blocklist still passes through when the caller
+        // exports it, carrying the intercepted command's parent value verbatim.
+        let request = request_with(&["PYTHONPATH=/opt/lib"], "/work");
+        let mut env: Vec<Vec<u8>> = Vec::new();
+        apply_export_env(&mut env, &request, &patterns(&["PYTHONPATH"]));
+        assert_eq!(rendered(&env), vec!["PYTHONPATH=/opt/lib"]);
+    }
+
+    #[test]
+    fn export_env_skips_var_not_matched_by_caller() {
+        // Only variables matching the caller's export list flow through.
+        let request = request_with(&["PYTHONPATH=/opt/lib", "TZ=UTC"], "/work");
+        let mut env: Vec<Vec<u8>> = Vec::new();
+        apply_export_env(&mut env, &request, &patterns(&["NODE_OPTIONS"]));
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn export_env_replaces_existing_entry() {
+        // A var already present in the (allow-filtered) env is overridden with
+        // the exported parent value rather than duplicated.
+        let request = request_with(&["NODE_TESTVAR=parent"], "/work");
+        let mut env: Vec<Vec<u8>> = vec![b"NODE_TESTVAR=stale".to_vec()];
+        apply_export_env(&mut env, &request, &patterns(&["NODE_TESTVAR"]));
+        assert_eq!(rendered(&env), vec!["NODE_TESTVAR=parent"]);
+    }
+
+    #[test]
+    fn export_env_noop_without_patterns() {
+        let request = request_with(&["PYTHONPATH=/opt/lib"], "/work");
+        let mut env: Vec<Vec<u8>> = Vec::new();
+        apply_export_env(&mut env, &request, &[]);
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn export_env_prefix_pattern_matches() {
+        let request = request_with(&["AWS_REGION=eu", "AWS_PROFILE=dev", "TZ=UTC"], "/work");
+        let mut env: Vec<Vec<u8>> = Vec::new();
+        apply_export_env(&mut env, &request, &patterns(&["AWS_*"]));
+        let out = rendered(&env);
+        assert!(out.contains(&"AWS_REGION=eu".to_string()));
+        assert!(out.contains(&"AWS_PROFILE=dev".to_string()));
+        assert!(!out.iter().any(|e| e.starts_with("TZ=")));
+    }
+
+    #[test]
+    fn export_env_star_excludes_path_and_nono() {
+        // A bare `*` forwards everything EXCEPT nono-managed PATH and NONO_*.
+        let request = request_with(
+            &["PATH=/evil", "NONO_CAP_FILE=/x", "NODE_OPTIONS=--require x"],
+            "/work",
+        );
+        let mut env: Vec<Vec<u8>> = Vec::new();
+        apply_export_env(&mut env, &request, &patterns(&["*"]));
+        let out = rendered(&env);
+        assert_eq!(out, vec!["NODE_OPTIONS=--require x".to_string()]);
+    }
+
+    #[test]
+    fn export_env_cannot_displace_the_chaining_control_env() {
+        // Naming a control var exactly must not beat the NONO_* exclusion: the
+        // child would otherwise point its shim at a socket of its own choosing.
+        let request = request_with(
+            &[
+                "NONO_TOOL_SANDBOX_SOCKET=/tmp/attacker.sock",
+                "PATH=/evil",
+                "TZ=UTC",
+            ],
+            "/work",
+        );
+        let mut env: Vec<Vec<u8>> = Vec::new();
+        apply_export_env(
+            &mut env,
+            &request,
+            &patterns(&["NONO_TOOL_SANDBOX_SOCKET", "PATH", "TZ"]),
+        );
+        assert_eq!(rendered(&env), vec!["TZ=UTC".to_string()]);
+    }
+
+    #[test]
+    fn export_env_never_forwards_1password_secrets() {
+        let request = request_with(
+            &["OP_SERVICE_ACCOUNT_TOKEN=ops_x", "OP_SESSION_my=y"],
+            "/work",
+        );
+        let mut env: Vec<Vec<u8>> = Vec::new();
+        apply_export_env(
+            &mut env,
+            &request,
+            &patterns(&["OP_SERVICE_ACCOUNT_TOKEN", "OP_SESSION_my", "*"]),
+        );
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn export_env_star_does_not_forward_loader_vars() {
+        let request = request_with(
+            &["LD_PRELOAD=/evil.so", "DYLD_INSERT_LIBRARIES=/evil.dylib"],
+            "/work",
+        );
+        let mut env: Vec<Vec<u8>> = Vec::new();
+        apply_export_env(&mut env, &request, &patterns(&["*", "LD_*", "DYLD_*"]));
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn export_env_exact_name_pattern_forwards_loader_var() {
+        let request = request_with(&["LD_PRELOAD=/trusted.so"], "/work");
+        let mut env: Vec<Vec<u8>> = Vec::new();
+        apply_export_env(&mut env, &request, &patterns(&["LD_PRELOAD"]));
+        assert_eq!(rendered(&env), vec!["LD_PRELOAD=/trusted.so".to_string()]);
     }
 
     #[test]

--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -11,9 +11,9 @@ use crate::lineage_cgroup::LineageMarker;
 use crate::profile;
 use crate::tool_sandbox::credentials::{ResolvedCredential, resolve_credentials};
 use crate::tool_sandbox::env::{
-    apply_environment_set_vars, default_env_allow_patterns, effective_argv_for_binary,
-    env_shebang_target_interpreter, inject_chaining_control_env, inject_url_open_env,
-    split_env_entry,
+    apply_environment_set_vars, apply_export_env, default_env_allow_patterns,
+    effective_argv_for_binary, env_shebang_target_interpreter, inject_chaining_control_env,
+    inject_url_open_env, split_env_entry,
 };
 use crate::tool_sandbox::launch::{
     exit_status_code, prepare_launcher_command, remove_launch_spec, write_launch_spec,
@@ -1358,7 +1358,7 @@ fn handle_shim_stream_inner(
     if let Some(invocation_policy) =
         select_invocation_policy(&state.plan.config, &request.command, &caller)
     {
-        let child_env = match filter_child_env(state, &request, policy) {
+        let child_env = match filter_child_env(state, &request, policy, &caller) {
             Ok(env) => env,
             Err(err) => {
                 record_command_policy_audit(
@@ -1545,7 +1545,7 @@ fn handle_shim_stream_inner(
     let intercept = match command_config {
         Some(cc) => {
             match super::resolve_intercept_action(cc, &request.argv, || {
-                filter_child_env(state, &request, policy)
+                filter_child_env(state, &request, policy, &caller)
             }) {
                 Ok(intercept) => intercept,
                 Err(err) => {
@@ -1713,7 +1713,7 @@ fn handle_shim_stream_inner(
             ));
         }
         let result = (|| {
-            let launch = build_child_launch_spec(state, &request, effective_sandbox)?;
+            let launch = build_child_launch_spec(state, &request, effective_sandbox, &caller)?;
             launch_child_with_capture(state, &request.command, &caller, launch, stdio)
         })();
         state.active_count.fetch_sub(1, Ordering::SeqCst);
@@ -1801,7 +1801,7 @@ fn handle_shim_stream_inner(
             ));
         }
         let result = (|| {
-            let launch = build_child_launch_spec(state, &request, effective_sandbox)?;
+            let launch = build_child_launch_spec(state, &request, effective_sandbox, &caller)?;
             launch_child_with_capture(state, &request.command, &caller, launch, stdio)
         })();
         state.active_count.fetch_sub(1, Ordering::SeqCst);
@@ -1882,6 +1882,7 @@ fn handle_shim_stream_inner(
                 helper,
                 &extra_args,
                 false,
+                &caller,
             )?;
             launch_child(state, &request.command, &caller, launch, stdio)
         })();
@@ -1961,7 +1962,7 @@ fn handle_shim_stream_inner(
     }
 
     let result = (|| {
-        let launch = build_child_launch_spec(state, &request, effective_sandbox)?;
+        let launch = build_child_launch_spec(state, &request, effective_sandbox, &caller)?;
         launch_child(state, &request.command, &caller, launch, stdio)
     })();
     state.active_count.fetch_sub(1, Ordering::SeqCst);
@@ -2270,6 +2271,22 @@ fn select_effective_policy<'a>(
                 }),
             }
         }
+    }
+}
+
+/// The export list the resolved caller declares: its own `export_env`, or the
+/// top-level `session_export_env`. An unknown caller command exports nothing.
+fn caller_export_env<'a>(config: &'a CommandPoliciesConfig, caller: &Caller) -> &'a [String] {
+    match caller {
+        Caller::Session { .. } => &config.session_export_env,
+        Caller::Command {
+            command: caller_name,
+            ..
+        } => config
+            .commands
+            .get(caller_name)
+            .map(|command| command.export_env.as_slice())
+            .unwrap_or(&[]),
     }
 }
 
@@ -3267,6 +3284,7 @@ fn build_child_launch_spec(
     state: &ToolSandboxState,
     request: &ToolSandboxShimRequest,
     policy: &CommandSandboxConfig,
+    caller: &Caller,
 ) -> Result<ToolSandboxChildLaunchSpec> {
     let binary = state
         .plan
@@ -3276,7 +3294,7 @@ fn build_child_launch_spec(
         .ok_or_else(|| {
             NonoError::SandboxInit(format!("missing resolved binary for {}", request.command))
         })?;
-    build_child_launch_spec_for_binary(state, request, policy, binary, &[], true)
+    build_child_launch_spec_for_binary(state, request, policy, binary, &[], true, caller)
 }
 
 /// Build a child launch spec that runs `binary` (the command's real binary OR
@@ -3295,6 +3313,7 @@ fn build_child_launch_spec_for_binary(
     binary: &ResolvedCommandBinary,
     extra_args: &[Vec<u8>],
     preserve_caller_argv0: bool,
+    caller: &Caller,
 ) -> Result<ToolSandboxChildLaunchSpec> {
     let start_vbi = std::time::Instant::now();
     verify_binary_identity(binary)?;
@@ -3327,7 +3346,7 @@ fn build_child_launch_spec_for_binary(
     tool_sandbox_profile_log!("build_child_caps total: {:?}", start_caps.elapsed());
     caps.deduplicate();
 
-    let env = filter_child_env(state, request, policy)?;
+    let env = filter_child_env(state, request, policy, caller)?;
 
     // Build the execute allowlist. AccessMode::Read includes
     // AccessFs::Execute in the Landlock mapping; without an explicit
@@ -4056,6 +4075,7 @@ fn filter_child_env(
     state: &ToolSandboxState,
     request: &ToolSandboxShimRequest,
     policy: &CommandSandboxConfig,
+    caller: &Caller,
 ) -> Result<Vec<Vec<u8>>> {
     let allowed_patterns: Vec<String> = policy
         .environment
@@ -4097,6 +4117,12 @@ fn filter_child_env(
         }
     }
     drop(broker);
+    // Runs before PATH/chaining/set_vars/creds so nono-injected vars still win.
+    apply_export_env(
+        &mut env,
+        request,
+        caller_export_env(&state.plan.config, caller),
+    );
     if !has_path {
         env.push(format!("PATH={}", state.session_path).into_bytes());
     } else {
@@ -6115,6 +6141,48 @@ mod tests {
         let denied = resolve_caller_with(DAEMONIZED_PEER, UNRELATED_ROOT, &state, "git", |_| None);
         assert!(matches!(denied, Err(NonoError::SandboxInit(_))));
         Ok(())
+    }
+
+    #[test]
+    fn caller_export_env_selects_the_resolved_callers_own_list() {
+        let mut config = CommandPoliciesConfig {
+            session_export_env: vec!["SESSION_*".to_string()],
+            ..Default::default()
+        };
+        config.commands.insert(
+            "git".to_string(),
+            CommandPolicyConfig {
+                export_env: vec!["GIT_*".to_string()],
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            caller_export_env(&config, &Caller::Session { pid: 1 }),
+            ["SESSION_*".to_string()]
+        );
+        assert_eq!(
+            caller_export_env(
+                &config,
+                &Caller::Command {
+                    command: "git".to_string(),
+                    pid: 2,
+                }
+            ),
+            ["GIT_*".to_string()]
+        );
+        // A caller with no policy of its own must not fall back to the session
+        // list, or an unmediated wrapper would inherit the session's exports.
+        assert!(
+            caller_export_env(
+                &config,
+                &Caller::Command {
+                    command: "unknown".to_string(),
+                    pid: 3,
+                }
+            )
+            .is_empty()
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -8,9 +8,9 @@ use crate::command_policy::{
 };
 use crate::tool_sandbox::credentials::{ResolvedCredential, resolve_credentials};
 use crate::tool_sandbox::env::{
-    apply_environment_set_vars, default_env_allow_patterns, effective_argv_for_binary,
-    env_shebang_target_interpreter, inject_chaining_control_env, inject_url_open_env,
-    split_env_entry,
+    apply_environment_set_vars, apply_export_env, default_env_allow_patterns,
+    effective_argv_for_binary, env_shebang_target_interpreter, inject_chaining_control_env,
+    inject_url_open_env, split_env_entry,
 };
 use crate::tool_sandbox::launch::{
     exit_status_code, prepare_launcher_command, remove_launch_spec, write_launch_spec,
@@ -1052,7 +1052,7 @@ fn handle_shim_stream_inner(
     if let Some(invocation_policy) =
         select_invocation_policy(&state.plan.config, &request.command, &caller)
     {
-        let child_env = match filter_child_env(state, &request, policy) {
+        let child_env = match filter_child_env(state, &request, policy, &caller) {
             Ok(env) => env,
             Err(err) => {
                 record_command_policy_audit(
@@ -1243,7 +1243,7 @@ fn handle_shim_stream_inner(
         })?;
 
     let intercept = match super::resolve_intercept_action(command_config, &request.argv, || {
-        filter_child_env(state, &request, policy)
+        filter_child_env(state, &request, policy, &caller)
     }) {
         Ok(intercept) => intercept,
         Err(err) => {
@@ -1400,7 +1400,7 @@ fn handle_shim_stream_inner(
             ));
         }
         let result = (|| {
-            let launch = build_child_launch_spec(state, &request, effective_sandbox)?;
+            let launch = build_child_launch_spec(state, &request, effective_sandbox, &caller)?;
             launch_child_with_capture(state, &request.command, &caller, launch, stdio)
         })();
         state.active_count.fetch_sub(1, Ordering::SeqCst);
@@ -1486,7 +1486,7 @@ fn handle_shim_stream_inner(
             ));
         }
         let result = (|| {
-            let launch = build_child_launch_spec(state, &request, effective_sandbox)?;
+            let launch = build_child_launch_spec(state, &request, effective_sandbox, &caller)?;
             launch_child_with_capture(state, &request.command, &caller, launch, stdio)
         })();
         state.active_count.fetch_sub(1, Ordering::SeqCst);
@@ -1568,6 +1568,7 @@ fn handle_shim_stream_inner(
                 helper,
                 &extra_args,
                 false,
+                &caller,
             )?;
             launch_child(state, &request.command, &caller, launch, stdio)
         })();
@@ -1647,7 +1648,7 @@ fn handle_shim_stream_inner(
         ));
     }
     let result = (|| {
-        let launch = build_child_launch_spec(state, &request, effective_sandbox)?;
+        let launch = build_child_launch_spec(state, &request, effective_sandbox, &caller)?;
         launch_child(state, &request.command, &caller, launch, stdio)
     })();
     state.active_count.fetch_sub(1, Ordering::SeqCst);
@@ -2518,6 +2519,7 @@ fn build_child_launch_spec(
     state: &ToolSandboxState,
     request: &ToolSandboxShimRequest,
     policy: &CommandSandboxConfig,
+    caller: &Caller,
 ) -> Result<ToolSandboxChildLaunchSpec> {
     let binary = state
         .plan
@@ -2527,7 +2529,7 @@ fn build_child_launch_spec(
         .ok_or_else(|| {
             NonoError::SandboxInit(format!("missing resolved binary for {}", request.command))
         })?;
-    build_child_launch_spec_for_binary(state, request, policy, binary, &[], true)
+    build_child_launch_spec_for_binary(state, request, policy, binary, &[], true, caller)
 }
 
 /// Build a child launch spec that runs `binary` (which may be the command's
@@ -2545,6 +2547,7 @@ fn build_child_launch_spec_for_binary(
     binary: &ResolvedCommandBinary,
     extra_args: &[Vec<u8>],
     preserve_caller_argv0: bool,
+    caller: &Caller,
 ) -> Result<ToolSandboxChildLaunchSpec> {
     verify_binary_identity(binary)?;
     let cwd = PathBuf::from(OsString::from_vec(request.cwd.clone()));
@@ -2583,7 +2586,7 @@ fn build_child_launch_spec_for_binary(
             extra_args,
             preserve_caller_argv0,
         )?,
-        env: filter_child_env(state, request, policy)?,
+        env: filter_child_env(state, request, policy, caller)?,
         cwd: cwd.as_os_str().as_bytes().to_vec(),
         stdio_mode: selected_stdio_mode(request).to_string(),
         stdio_limits: stdio_limits_from_policy(policy),
@@ -3272,6 +3275,7 @@ fn filter_child_env(
     state: &ToolSandboxState,
     request: &ToolSandboxShimRequest,
     policy: &CommandSandboxConfig,
+    caller: &Caller,
 ) -> Result<Vec<Vec<u8>>> {
     let allowed_patterns: Vec<String> = policy
         .environment
@@ -3309,6 +3313,12 @@ fn filter_child_env(
         }
     }
 
+    // Runs before PATH/chaining/set_vars/creds so nono-injected vars still win.
+    apply_export_env(
+        &mut result,
+        request,
+        caller_export_env(&state.plan.config, caller),
+    );
     result.retain(|entry| !entry.starts_with(b"PATH="));
     result.push(format!("PATH={}", state.session_path).into_bytes());
     inject_chaining_control_env(&mut result, &state.socket_path, &state.shim_dir);
@@ -4022,6 +4032,19 @@ fn select_effective_policy<'a>(
                 }),
             }
         }
+    }
+}
+
+/// The export list the resolved caller declares: its own `export_env`, or the
+/// top-level `session_export_env`. An unknown caller command exports nothing.
+fn caller_export_env<'a>(config: &'a CommandPoliciesConfig, caller: &Caller) -> &'a [String] {
+    match caller {
+        Caller::Session => &config.session_export_env,
+        Caller::Command { name: caller_name } => config
+            .commands
+            .get(caller_name)
+            .map(|command| command.export_env.as_slice())
+            .unwrap_or(&[]),
     }
 }
 
@@ -5669,6 +5692,46 @@ mod tests {
     }
 
     #[test]
+    fn caller_export_env_selects_the_resolved_callers_own_list() {
+        let mut config = CommandPoliciesConfig {
+            session_export_env: vec!["SESSION_*".to_string()],
+            ..Default::default()
+        };
+        config.commands.insert(
+            "git".to_string(),
+            CommandPolicyConfig {
+                export_env: vec!["GIT_*".to_string()],
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            caller_export_env(&config, &Caller::Session),
+            ["SESSION_*".to_string()]
+        );
+        assert_eq!(
+            caller_export_env(
+                &config,
+                &Caller::Command {
+                    name: "git".to_string()
+                }
+            ),
+            ["GIT_*".to_string()]
+        );
+        // A caller with no policy of its own must not fall back to the session
+        // list, or an unmediated wrapper would inherit the session's exports.
+        assert!(
+            caller_export_env(
+                &config,
+                &Caller::Command {
+                    name: "unknown".to_string()
+                }
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
     fn writable_policy_command_override_is_explicit_for_sandbox_writable_paths() -> Result<()> {
         let temp = test_tempdir()?;
         let bin_dir = temp.path().join("bin");
@@ -6776,7 +6839,12 @@ mod tests {
             b"NONO_TOOL_SANDBOX_LAUNCH_SPEC=/old.json".to_vec(),
         ]);
 
-        let env = filter_child_env(&state, &request, &CommandSandboxConfig::default())?;
+        let env = filter_child_env(
+            &state,
+            &request,
+            &CommandSandboxConfig::default(),
+            &Caller::Session,
+        )?;
 
         assert!(contains_entry(&env, b"HOME=/Users/test"));
         assert!(contains_entry(
@@ -6815,7 +6883,12 @@ mod tests {
             b"UNRELATED=should-be-stripped".to_vec(),
         ]);
 
-        let env = filter_child_env(&state, &request, &CommandSandboxConfig::default())?;
+        let env = filter_child_env(
+            &state,
+            &request,
+            &CommandSandboxConfig::default(),
+            &Caller::Session,
+        )?;
 
         assert!(contains_entry(
             &env,
@@ -6855,7 +6928,7 @@ mod tests {
         let request = request_with_env(vec![nonce_entry.clone()]);
         let policy = policy_with_env(Some(vec!["API_TOKEN".to_string()]), BTreeMap::new());
 
-        let env = filter_child_env(&state, &request, &policy)?;
+        let env = filter_child_env(&state, &request, &policy, &Caller::Session)?;
 
         assert!(contains_entry(&env, b"API_TOKEN=s3cr3t"));
         assert!(!contains_entry(&env, &nonce_entry));
@@ -6883,7 +6956,7 @@ mod tests {
         };
         let request = request_with_env(Vec::new());
 
-        let env = filter_child_env(&state, &request, &policy)?;
+        let env = filter_child_env(&state, &request, &policy, &Caller::Session)?;
 
         assert!(contains_entry(
             &env,

--- a/crates/nono-cli/tests/schema_shape.rs
+++ b/crates/nono-cli/tests/schema_shape.rs
@@ -107,6 +107,7 @@ fn test_schema_command_policies_match_tool_sandbox_guide_shape() {
             "deny_direct_exec_bypass",
             "entrypoint",
             "executable_dirs",
+            "session_export_env",
         ],
     );
     assert_schema_properties(
@@ -150,6 +151,7 @@ fn test_schema_command_policies_match_tool_sandbox_guide_shape() {
             "can_use",
             "daemon_pid_source",
             "executable",
+            "export_env",
             "from",
             "intercept",
             "sandbox",

--- a/docs/cli/features/tool-sandbox.mdx
+++ b/docs/cli/features/tool-sandbox.mdx
@@ -532,6 +532,52 @@ Pattern syntax is intentionally small:
 
 `PATH` and `NONO_*` are reserved and cannot be set with `set_vars`.
 
+### Forwarding Caller Variables
+
+`allow_vars` filters the environment nono builds. It does not let a calling command pass its own variables through to a command it invokes — that is what `export_env` is for:
+
+```json
+{
+  "npm": {
+    "export_env": ["NODE_OPTIONS", "NPM_CONFIG_*"]
+  }
+}
+```
+
+`session_export_env` does the same for commands whose resolved caller is the session itself:
+
+```json
+{
+  "tool_sandbox": {
+    "session_export_env": ["PYTHONPATH"]
+  }
+}
+```
+
+Both accept the same three pattern forms as `allow_vars`, and both deliberately bypass `allow_vars` and the dangerous-variable blocklist. That is the point of the feature — `NODE_OPTIONS` and `PYTHONPATH` are on the blocklist precisely because an untrusted process should not be able to set them, but a legitimate build tool often must.
+
+<Warning>
+Values forwarded by `export_env` come from the **calling command's environment**, not from the profile. Anything that can set a variable in that process controls what the child receives. Forward the narrowest set that works, and prefer exact names over `*`.
+</Warning>
+
+Three classes of variable are treated differently, regardless of how broad your pattern is:
+
+| Class | Examples | Behaviour |
+|---|---|---|
+| Reserved | `PATH`, `NONO_*` | Never forwarded. nono owns these. |
+| Credentials | `OP_SERVICE_ACCOUNT_TOKEN`, `OP_CONNECT_TOKEN`, `OP_CONNECT_HOST`, `OP_SESSION_*` | Never forwarded. Use a broker credential instead. |
+| Loader injection | `LD_*`, `DYLD_*` | Forwarded only when named exactly. `*` and `LD_*` skip them. |
+
+The loader rule exists because `LD_PRELOAD` and friends load code into *any* dynamically-linked child, not just an interpreter, and that child may hold an injected credential socket. Preloading is legitimate for sanitizers and similar tools, so it stays possible — but it has to be deliberate:
+
+```json
+{
+  "make": {
+    "export_env": ["LD_PRELOAD"]
+  }
+}
+```
+
 ## Mandatory Arguments
 
 Use `argv_prepend` when a selected child policy needs mandatory mode flags. The arguments are inserted after the synthesized `argv[0]` and before caller-provided arguments.


### PR DESCRIPTION
## Linked Issue

Closes nolabs-ai/nono#1439

## Summary

Caller-declared env pass-through: per-command `export_env` + top-level `session_export_env`. A command's named vars are copied verbatim to commands it invokes, bypassing `allow_vars` filtering and the dangerous-var blocklist. Patterns: exact, `PREFIX_*`, `*`. `PATH`/`NONO_*` always excluded.

## Agent Disclosure (if applicable)

Authored by an AI agent (code, tests, PR, issue). No `unwrap`/`expect`/`panic` in new non-test code; covered by tests.

## Test Plan

* `make ci` passes (clippy `-D warnings`, fmt, tests, doc lint).
* Unit tests: verbatim pass-through; `PREFIX_*` and `*` matching; `PATH`/`NONO_*` excluded under `*`; reserved/malformed patterns rejected.
* Verified end-to-end on Linux: `session_export_env` and a mediated command's `export_env` each deliver a named var downstream that default filtering would drop.

## Checklist

- [X] An issue exists and is linked above
- [X] All commits are signed-off, using [DCO](<https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin>)
- [X] All new code follows the project's coding standards ([CLAUDE.md](<CLAUDE.md>)) and is covered by tests
- [X] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

## Agent Compliance Check (Required for AI/Automated PRs)

- [X] I am not prohibited from contributing under this policy
- [X] An issue already exists
- [X] I disclosed that I am an agent in the issue discussion
- [X] I described my intent and approach in the issue discussion
- [X] I reviewed repository coding and security rules for the affected area
- [X] I provided required attribution for reused or adapted code
- [X] I did not use forbidden patterns such as unwrap/expect
- [X] I used NonoError where required
- [X] I validated and canonicalized all relevant paths
- [X] This PR matches the approved or disclosed issue scope