### PR TITLE
fix(policy): survive atomic replacement of resolv.conf; report stale …

### DIFF
--- a/crates/nono-cli/data/policy.json
+++ b/crates/nono-cli/data/policy.json
@@ -211,6 +211,7 @@
           "/usr/local/lib",
           "/usr/local/lib64",
           "/etc/resolv.conf",
+          "/run/systemd/resolve",
           "/etc/hosts",
           "/etc/nsswitch.conf",
           "/etc/gai.conf",

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -55,6 +55,10 @@ pub enum QueryResult {
         source: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         endpoint_rules: Option<Vec<crate::sandbox_state::EndpointRuleState>>,
+        /// Advisory caveat: policy allows the operation, but enforcement may
+        /// still deny it (e.g. a sibling file grant went stale).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        warning: Option<String>,
     },
     /// The operation is denied
     #[serde(rename = "denied")]
@@ -181,6 +185,7 @@ pub fn query_path(
             access: Some(cap.access.to_string()),
             source: Some(cap.source.to_string()),
             endpoint_rules: None,
+            warning: None,
         });
     }
 
@@ -271,6 +276,7 @@ pub fn query_network(
                                     )),
                                     source: Some("domain allowlist".to_string()),
                                     endpoint_rules: Some(de.endpoints.clone()),
+                                    warning: None,
                                 }
                             } else {
                                 QueryResult::Denied {
@@ -301,6 +307,7 @@ pub fn query_network(
                             )),
                             source: Some("domain allowlist".to_string()),
                             endpoint_rules: Some(de.endpoints.clone()),
+                            warning: None,
                         },
                         (None, _) => QueryResult::Allowed {
                             reason: "proxy_allowed".to_string(),
@@ -321,6 +328,7 @@ pub fn query_network(
                                 "domain allowlist".to_string()
                             }),
                             endpoint_rules: None,
+                            warning: None,
                         },
                     }
                 }
@@ -359,6 +367,7 @@ pub fn query_network(
                                         )),
                                         source: Some("domain allowlist".to_string()),
                                         endpoint_rules: Some(de.endpoints.clone()),
+                                        warning: None,
                                     }
                                 } else {
                                     QueryResult::Denied {
@@ -389,6 +398,7 @@ pub fn query_network(
                                 )),
                                 source: Some("domain allowlist".to_string()),
                                 endpoint_rules: Some(de.endpoints.clone()),
+                                warning: None,
                             },
                             (None, _) => QueryResult::Allowed {
                                 reason: "proxy_allowed".to_string(),
@@ -399,6 +409,7 @@ pub fn query_network(
                                 )),
                                 source: Some("domain allowlist".to_string()),
                                 endpoint_rules: None,
+                                warning: None,
                             },
                         }
                     }
@@ -421,6 +432,7 @@ pub fn query_network(
                     )),
                     source: None,
                     endpoint_rules: None,
+                    warning: None,
                 }
             }
         }
@@ -569,6 +581,7 @@ pub fn print_result(result: &QueryResult) {
             access,
             source,
             endpoint_rules,
+            warning,
         } => {
             println!("{}", "ALLOWED".green().bold());
             println!("  Reason: {}", reason);
@@ -586,6 +599,9 @@ pub fn print_result(result: &QueryResult) {
                 for rule in rules {
                     println!("    {} {}", rule.method, rule.path);
                 }
+            }
+            if let Some(warn) = warning {
+                println!("  {} {}", "Warning:".yellow().bold(), warn);
             }
         }
         QueryResult::Denied {

--- a/crates/nono-cli/src/sandbox_state.rs
+++ b/crates/nono-cli/src/sandbox_state.rs
@@ -92,23 +92,23 @@ pub struct FsCapState {
 }
 
 /// Stat the resolved path of a file-level grant so its identity at sandbox
-/// start can be recorded. Landlock is the only backend that binds rules to
+/// start can be recorded, as a `(dev, ino)` pair — one is meaningless
+/// without the other. Landlock is the only backend that binds rules to
 /// inodes (macOS Seatbelt rules are path-based), so this is Linux-only.
 #[cfg(target_os = "linux")]
-fn grant_time_inode(cap: &nono::FsCapability) -> (Option<u64>, Option<u64>) {
+fn grant_time_inode(cap: &nono::FsCapability) -> Option<(u64, u64)> {
     use std::os::unix::fs::MetadataExt;
     if !cap.is_file {
-        return (None, None);
+        return None;
     }
-    match std::fs::metadata(&cap.resolved) {
-        Ok(md) => (Some(md.dev()), Some(md.ino())),
-        Err(_) => (None, None),
-    }
+    std::fs::metadata(&cap.resolved)
+        .ok()
+        .map(|md| (md.dev(), md.ino()))
 }
 
 #[cfg(not(target_os = "linux"))]
-fn grant_time_inode(_cap: &nono::FsCapability) -> (Option<u64>, Option<u64>) {
-    (None, None)
+fn grant_time_inode(_cap: &nono::FsCapability) -> Option<(u64, u64)> {
+    None
 }
 
 impl SandboxState {
@@ -124,7 +124,7 @@ impl SandboxState {
                 .fs_capabilities()
                 .iter()
                 .map(|c| {
-                    let (dev, ino) = grant_time_inode(c);
+                    let inode = grant_time_inode(c);
                     FsCapState {
                         original: c.original.display().to_string(),
                         path: c.resolved.display().to_string(),
@@ -135,8 +135,8 @@ impl SandboxState {
                         },
                         is_file: c.is_file,
                         source: Some(c.source.to_string()),
-                        dev,
-                        ino,
+                        dev: inode.map(|(dev, _)| dev),
+                        ino: inode.map(|(_, ino)| ino),
                     }
                 })
                 .collect(),

--- a/crates/nono-cli/src/sandbox_state.rs
+++ b/crates/nono-cli/src/sandbox_state.rs
@@ -78,6 +78,37 @@ pub struct FsCapState {
     /// Capability source for diagnostics (`user`, `profile`, `group:<name>`, `system`)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
+    /// Device number of the resolved path at sandbox start (Linux file grants
+    /// only). Landlock rules bind to the inode that was open at ruleset build
+    /// time, not to the path, so a file replaced via write-temp-then-rename
+    /// carries no rule even though the grant still names it. `nono why`
+    /// compares this against a fresh stat to surface such stale grants.
+    /// Absent in states written by older builds and on non-Linux platforms.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dev: Option<u64>,
+    /// Inode number of the resolved path at sandbox start (see `dev`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ino: Option<u64>,
+}
+
+/// Stat the resolved path of a file-level grant so its identity at sandbox
+/// start can be recorded. Landlock is the only backend that binds rules to
+/// inodes (macOS Seatbelt rules are path-based), so this is Linux-only.
+#[cfg(target_os = "linux")]
+fn grant_time_inode(cap: &nono::FsCapability) -> (Option<u64>, Option<u64>) {
+    use std::os::unix::fs::MetadataExt;
+    if !cap.is_file {
+        return (None, None);
+    }
+    match std::fs::metadata(&cap.resolved) {
+        Ok(md) => (Some(md.dev()), Some(md.ino())),
+        Err(_) => (None, None),
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn grant_time_inode(_cap: &nono::FsCapability) -> (Option<u64>, Option<u64>) {
+    (None, None)
 }
 
 impl SandboxState {
@@ -92,16 +123,21 @@ impl SandboxState {
             fs: caps
                 .fs_capabilities()
                 .iter()
-                .map(|c| FsCapState {
-                    original: c.original.display().to_string(),
-                    path: c.resolved.display().to_string(),
-                    access: match c.access {
-                        AccessMode::Read => "read".to_string(),
-                        AccessMode::Write => "write".to_string(),
-                        AccessMode::ReadWrite => "readwrite".to_string(),
-                    },
-                    is_file: c.is_file,
-                    source: Some(c.source.to_string()),
+                .map(|c| {
+                    let (dev, ino) = grant_time_inode(c);
+                    FsCapState {
+                        original: c.original.display().to_string(),
+                        path: c.resolved.display().to_string(),
+                        access: match c.access {
+                            AccessMode::Read => "read".to_string(),
+                            AccessMode::Write => "write".to_string(),
+                            AccessMode::ReadWrite => "readwrite".to_string(),
+                        },
+                        is_file: c.is_file,
+                        source: Some(c.source.to_string()),
+                        dev,
+                        ino,
+                    }
                 })
                 .collect(),
             net_blocked: caps.is_network_blocked(),
@@ -560,6 +596,68 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "linux")]
+    fn test_from_caps_records_inode_for_file_grants_only() {
+        use std::os::unix::fs::MetadataExt;
+
+        let dir = tempdir().expect("tempdir");
+        let file_path = dir.path().join("granted.txt");
+        std::fs::write(&file_path, b"ok").expect("write test file");
+
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability::new_file(&file_path, AccessMode::Read).expect("file cap"));
+        caps.add_fs(FsCapability::new_dir(dir.path(), AccessMode::Read).expect("dir cap"));
+
+        let state = SandboxState::from_caps(&caps, &[], &[], &[]);
+        let file_state = state.fs.iter().find(|c| c.is_file).expect("file grant");
+        let dir_state = state.fs.iter().find(|c| !c.is_file).expect("dir grant");
+
+        let md = std::fs::metadata(&file_path).expect("stat");
+        assert_eq!(file_state.dev, Some(md.dev()));
+        assert_eq!(file_state.ino, Some(md.ino()));
+        assert_eq!(dir_state.dev, None);
+        assert_eq!(dir_state.ino, None);
+
+        // Directory grants must omit the keys entirely so states stay readable
+        // by older builds that don't know the fields.
+        let json = serde_json::to_string(&state).expect("serialize");
+        let v: serde_json::Value = serde_json::from_str(&json).expect("parse");
+        let dir_obj = v["fs"]
+            .as_array()
+            .expect("fs array")
+            .iter()
+            .find(|c| c["is_file"] == serde_json::Value::Bool(false))
+            .expect("dir entry");
+        assert!(dir_obj.get("ino").is_none());
+        assert!(dir_obj.get("dev").is_none());
+    }
+
+    #[test]
+    fn test_state_without_inode_fields_still_loads() {
+        // States written by older builds have no dev/ino keys on fs entries;
+        // strip them from a freshly serialized state to reproduce that shape.
+        let dir = tempdir().expect("tempdir");
+        let file_path = dir.path().join("granted.txt");
+        std::fs::write(&file_path, b"ok").expect("write test file");
+
+        let mut caps = CapabilitySet::new();
+        caps.add_fs(FsCapability::new_file(&file_path, AccessMode::Read).expect("file cap"));
+        let state = SandboxState::from_caps(&caps, &[], &[], &[]);
+
+        let mut v = serde_json::to_value(&state).expect("serialize state");
+        for entry in v["fs"].as_array_mut().expect("fs array") {
+            let obj = entry.as_object_mut().expect("fs entry object");
+            obj.remove("dev");
+            obj.remove("ino");
+        }
+
+        let legacy: SandboxState = serde_json::from_value(v).expect("legacy state loads");
+        assert_eq!(legacy.fs[0].dev, None);
+        assert_eq!(legacy.fs[0].ino, None);
+        legacy.to_caps().expect("legacy state converts to caps");
+    }
+
+    #[test]
     fn test_sandbox_state_roundtrip_preserves_source() {
         let dir = tempdir().expect("tempdir");
         let file_path = dir.path().join("granted.txt");
@@ -664,6 +762,8 @@ mod tests {
                 access: "readwrite".to_string(),
                 is_file: true,
                 source: Some("profile".to_string()),
+                dev: None,
+                ino: None,
             }],
             net_blocked: false,
             allowed_commands: vec![],

--- a/crates/nono-cli/src/sandbox_state.rs
+++ b/crates/nono-cli/src/sandbox_state.rs
@@ -443,6 +443,48 @@ fn validate_cap_file_path(path_str: &str) -> Result<PathBuf> {
     Ok(canonical)
 }
 
+/// Lenient variant of [`load_sandbox_state`] for opportunistic consumers,
+/// such as the stale-file-grant hints in non-`--self` `nono why` queries.
+///
+/// Returns `None` on any failure (unset env var, validation failure,
+/// unreadable file, parse error) instead of exiting. Callers of this variant
+/// worked without the state file before it was consulted and must not grow a
+/// hard dependency on its readability — inside a sandbox the state file is
+/// frequently not covered by any read grant. The fallback only means fewer
+/// diagnostics; enforcement is unaffected. `--self` queries, whose whole
+/// answer comes from the state file, keep the strict fail-loud loader.
+pub fn try_load_sandbox_state() -> Option<SandboxState> {
+    let cap_file_str = std::env::var("NONO_CAP_FILE").ok()?;
+
+    let validated_path = match validate_cap_file_path(&cap_file_str) {
+        Ok(path) => path,
+        Err(e) => {
+            debug!("Skipping sandbox state for diagnostics: {}", e);
+            return None;
+        }
+    };
+
+    let content = match std::fs::read_to_string(&validated_path) {
+        Ok(content) => content,
+        Err(e) => {
+            debug!(
+                "Skipping sandbox state for diagnostics: cannot read {}: {}",
+                validated_path.display(),
+                e
+            );
+            return None;
+        }
+    };
+
+    match serde_json::from_str(&content) {
+        Ok(state) => Some(state),
+        Err(e) => {
+            debug!("Skipping sandbox state for diagnostics: parse error: {}", e);
+            None
+        }
+    }
+}
+
 /// Load sandbox state from NONO_CAP_FILE environment variable
 ///
 /// Returns None if not running inside a nono sandbox (env var not set).
@@ -934,6 +976,52 @@ mod cap_file_validation_tests {
             msg.contains("regular file") || msg.contains(".nono-"),
             "directory should be rejected: {msg}"
         );
+    }
+
+    #[test]
+    fn test_try_load_returns_none_instead_of_exiting_on_bad_cap_file() {
+        // Non-`--self` `nono why` consults the state only for staleness hints;
+        // a NONO_CAP_FILE that fails validation or cannot be read must degrade
+        // to None (pre-hint behavior), not abort the query like the strict
+        // loader does.
+        let _lock = match ENV_LOCK.lock() {
+            Ok(lock) => lock,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        // Unset: not in a sandbox.
+        {
+            let env = EnvVarGuard::set_all(&[("NONO_CAP_FILE", "placeholder")]);
+            env.remove("NONO_CAP_FILE");
+            assert!(try_load_sandbox_state().is_none());
+        }
+
+        // Validation failure (wrong location / pattern).
+        {
+            let _env = EnvVarGuard::set_all(&[("NONO_CAP_FILE", "/etc/hosts")]);
+            assert!(try_load_sandbox_state().is_none());
+        }
+
+        // Nonexistent file under a valid root.
+        {
+            let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
+            let missing = dir.path().join(".nono-0000000000000000.json");
+            let missing_str = missing.to_str().expect("utf8");
+            let _env = EnvVarGuard::set_all(&[("NONO_CAP_FILE", missing_str)]);
+            assert!(try_load_sandbox_state().is_none());
+        }
+
+        // And a valid file still loads. Use env::temp_dir() rather than the
+        // /tmp anchor the other tests use: this case reads the file's
+        // contents (not just metadata), and sandboxed dev environments may
+        // grant /tmp write-only. Holding ENV_LOCK keeps TMPDIR stable here.
+        {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = write_cap_file(dir.path());
+            let path_str = path.to_str().expect("utf8");
+            let _env = EnvVarGuard::set_all(&[("NONO_CAP_FILE", path_str)]);
+            assert!(try_load_sandbox_state().is_some());
+        }
     }
 
     #[test]

--- a/crates/nono-cli/src/why_runtime.rs
+++ b/crates/nono-cli/src/why_runtime.rs
@@ -95,7 +95,17 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
     // that inode, so a grant whose file was since replaced is enforced against
     // the wrong (old) inode — detect those up front so path queries can report
     // them instead of a misleading plain ALLOWED.
-    let sandbox_state = load_sandbox_state();
+    //
+    // `--self` answers entirely from the state file, so it keeps the strict
+    // loader (fail loud on a bad NONO_CAP_FILE). All other modes only use the
+    // state for staleness hints and worked without it before — they use the
+    // lenient loader so an unreadable state file (common inside the sandbox)
+    // degrades to "no hints" instead of breaking the query.
+    let sandbox_state = if args.self_query {
+        load_sandbox_state()
+    } else {
+        sandbox_state::try_load_sandbox_state()
+    };
     let stale_file_grants = sandbox_state
         .as_ref()
         .map(detect_stale_file_grants)

--- a/crates/nono-cli/src/why_runtime.rs
+++ b/crates/nono-cli/src/why_runtime.rs
@@ -90,8 +90,19 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
     use query_ext::{QueryResult, print_result, query_network, query_path, query_scope};
     use sandbox_state::load_sandbox_state;
 
+    // When running inside a sandbox, the state file records the inode each
+    // file-level grant resolved to at sandbox start. Landlock rules bind to
+    // that inode, so a grant whose file was since replaced is enforced against
+    // the wrong (old) inode — detect those up front so path queries can report
+    // them instead of a misleading plain ALLOWED.
+    let sandbox_state = load_sandbox_state();
+    let stale_file_grants = sandbox_state
+        .as_ref()
+        .map(detect_stale_file_grants)
+        .unwrap_or_default();
+
     let ctx: WhyContext = if args.self_query {
-        match load_sandbox_state() {
+        match sandbox_state {
             Some(state) => {
                 let paths = state.bypass_protection_as_paths();
                 let domain_endpoints = state.domain_endpoints.clone();
@@ -207,7 +218,15 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
             Some(WhyOp::ReadWrite) => AccessMode::ReadWrite,
             None => AccessMode::Read,
         };
-        query_path(path, op, &ctx.caps, &ctx.overridden_paths)?
+        let result = query_path(path, op, &ctx.caps, &ctx.overridden_paths)?;
+        apply_file_grant_staleness(
+            result,
+            path,
+            op,
+            &ctx.caps,
+            &ctx.overridden_paths,
+            &stale_file_grants,
+        )?
     } else if let Some(ref host) = args.host {
         query_network(
             host,
@@ -233,6 +252,155 @@ pub(crate) fn run_why(args: WhyArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// A file-level grant whose Landlock rule no longer matches the file at the
+/// granted path: the file was replaced (new inode) or removed after sandbox
+/// start, so the kernel rule — bound to the old inode — no longer applies.
+struct StaleFileGrant {
+    /// Resolved path of the grant (as recorded in the state file).
+    path: String,
+    /// Access mode string of the grant ("read", "write", "readwrite").
+    access: String,
+    /// Capability source of the grant, for attribution.
+    source: Option<String>,
+    /// (dev, ino) recorded at sandbox start.
+    grant_id: (u64, u64),
+    /// Current (dev, ino) at the granted path; `None` if the path is gone.
+    current_id: Option<(u64, u64)>,
+}
+
+impl StaleFileGrant {
+    fn describe(&self) -> String {
+        match self.current_id {
+            Some((dev, ino)) => format!(
+                "the file at {} was replaced after sandbox start \
+                 (inode {}:{} when the sandbox started, {}:{} now)",
+                self.path, self.grant_id.0, self.grant_id.1, dev, ino
+            ),
+            None => format!("the file at {} was removed after sandbox start", self.path),
+        }
+    }
+}
+
+/// Compare each file-level grant's recorded (dev, ino) against a fresh stat of
+/// the granted path. Only meaningful on Linux, where Landlock binds rules to
+/// inodes; macOS Seatbelt rules are path-based and never go stale this way.
+#[cfg(target_os = "linux")]
+fn detect_stale_file_grants(state: &sandbox_state::SandboxState) -> Vec<StaleFileGrant> {
+    use std::os::unix::fs::MetadataExt;
+
+    state
+        .fs
+        .iter()
+        .filter_map(|cap| {
+            if !cap.is_file {
+                return None;
+            }
+            let grant_id = (cap.dev?, cap.ino?);
+            let current_id = std::fs::metadata(&cap.path)
+                .ok()
+                .map(|md| (md.dev(), md.ino()));
+            if current_id == Some(grant_id) {
+                return None;
+            }
+            Some(StaleFileGrant {
+                path: cap.path.clone(),
+                access: cap.access.clone(),
+                source: cap.source.clone(),
+                grant_id,
+                current_id,
+            })
+        })
+        .collect()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn detect_stale_file_grants(_state: &sandbox_state::SandboxState) -> Vec<StaleFileGrant> {
+    Vec::new()
+}
+
+/// Correct a path-query verdict for stale file grants.
+///
+/// If the query was answered by a file-level grant whose inode changed since
+/// sandbox start, the kernel will deny the access despite the grant. Re-query
+/// without the stale file grants: another (directory) grant may still cover
+/// the path with a live rule — then the answer stays ALLOWED via that grant,
+/// with a warning about the stale one. Otherwise report a denial that names
+/// the real cause instead of a misleading ALLOWED.
+fn apply_file_grant_staleness(
+    result: query_ext::QueryResult,
+    path: &std::path::Path,
+    op: AccessMode,
+    caps: &CapabilitySet,
+    overridden_paths: &[std::path::PathBuf],
+    stale_grants: &[StaleFileGrant],
+) -> Result<query_ext::QueryResult> {
+    let query_ext::QueryResult::Allowed {
+        granted_path: Some(ref granted),
+        ..
+    } = result
+    else {
+        return Ok(result);
+    };
+    let Some(stale) = stale_grants.iter().find(|g| g.path == *granted) else {
+        return Ok(result);
+    };
+
+    let mut fresh_caps = CapabilitySet::new();
+    for cap in caps.fs_capabilities() {
+        let cap_is_stale = cap.is_file
+            && stale_grants
+                .iter()
+                .any(|g| std::path::Path::new(&g.path) == cap.resolved);
+        if !cap_is_stale {
+            fresh_caps.add_fs(cap.clone());
+        }
+    }
+
+    match query_ext::query_path(path, op, &fresh_caps, overridden_paths)? {
+        query_ext::QueryResult::Allowed {
+            reason,
+            granted_path,
+            access,
+            source,
+            endpoint_rules,
+            ..
+        } => Ok(query_ext::QueryResult::Allowed {
+            reason,
+            granted_path,
+            access,
+            source,
+            endpoint_rules,
+            warning: Some(format!(
+                "A more specific file grant is stale: {}. Landlock rules bind to the inode \
+                 that was open when the sandbox started, so that grant no longer applies; \
+                 access works only through the grant shown above.",
+                stale.describe()
+            )),
+        }),
+        _ => Ok(query_ext::QueryResult::Denied {
+            reason: "stale_file_grant".to_string(),
+            details: Some(format!(
+                "The sandbox granted this file, but {}. Landlock rules bind to the inode, \
+                 not the path, so the kernel still enforces the rule against the old inode \
+                 and access at this path fails with EACCES despite the grant. Restart the \
+                 sandbox to re-apply the grant to the current file.",
+                stale.describe()
+            )),
+            policy_source: stale.source.clone(),
+            matching_capability: Some(query_ext::CapabilityMatch {
+                path: stale.path.clone(),
+                access: stale.access.clone(),
+                source: stale
+                    .source
+                    .clone()
+                    .unwrap_or_else(|| "unknown".to_string()),
+            }),
+            suggested_flag: None,
+            endpoint_rules: None,
+        }),
+    }
 }
 
 fn query_command_policy(
@@ -308,6 +476,7 @@ fn query_command_policy(
             )),
             source: Some(format!("command_policies.commands.{command}.from.{caller}")),
             endpoint_rules: None,
+            warning: None,
         };
     };
 
@@ -326,6 +495,7 @@ fn query_command_policy(
                 "command_policies.commands.{command}.from.{caller}.invocation_policy"
             )),
             endpoint_rules: None,
+            warning: None,
         },
         Ok(WhyInvocationPolicyOutcome::Deny { reason }) => query_ext::QueryResult::Denied {
             reason,
@@ -538,6 +708,189 @@ mod tests {
                 );
             }
             other => panic!("expected denied command-policy result, got {other:?}"),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    mod stale_file_grants {
+        use super::super::*;
+        use nono::FsCapability;
+        use tempfile::tempdir;
+
+        /// Build a file grant + state, then atomically replace the file
+        /// (write temp + rename), the same pattern systemd-resolved uses on
+        /// /run/systemd/resolve/stub-resolv.conf.
+        fn replaced_file_fixture() -> (
+            tempfile::TempDir,
+            std::path::PathBuf,
+            CapabilitySet,
+            sandbox_state::SandboxState,
+        ) {
+            let dir = tempdir().expect("tempdir");
+            let target = dir.path().join("conf");
+            std::fs::write(&target, "generation-1").expect("write target");
+
+            let mut caps = CapabilitySet::new();
+            caps.add_fs(FsCapability::new_file(&target, AccessMode::Read).expect("file cap"));
+            let state = sandbox_state::SandboxState::from_caps(&caps, &[], &[], &[]);
+
+            let tmp = dir.path().join("conf.tmp");
+            std::fs::write(&tmp, "generation-2").expect("write tmp");
+            std::fs::rename(&tmp, &target).expect("atomic replace");
+
+            (dir, target, caps, state)
+        }
+
+        #[test]
+        fn detect_ignores_fresh_and_in_place_rewritten_grants() {
+            let dir = tempdir().expect("tempdir");
+            let target = dir.path().join("conf");
+            std::fs::write(&target, "generation-1").expect("write target");
+
+            let mut caps = CapabilitySet::new();
+            caps.add_fs(FsCapability::new_file(&target, AccessMode::Read).expect("file cap"));
+            let state = sandbox_state::SandboxState::from_caps(&caps, &[], &[], &[]);
+
+            assert!(detect_stale_file_grants(&state).is_empty());
+
+            // In-place rewrite keeps the inode; the Landlock rule still applies.
+            std::fs::write(&target, "generation-2").expect("rewrite in place");
+            assert!(detect_stale_file_grants(&state).is_empty());
+        }
+
+        #[test]
+        fn detect_flags_atomically_replaced_grant() {
+            let (_dir, _target, _caps, state) = replaced_file_fixture();
+
+            let stale = detect_stale_file_grants(&state);
+            assert_eq!(stale.len(), 1);
+            assert!(
+                stale[0].current_id.is_some(),
+                "replaced file still exists, just with a new inode"
+            );
+            assert_ne!(Some(stale[0].grant_id), stale[0].current_id);
+        }
+
+        #[test]
+        fn detect_flags_removed_grant_target() {
+            let dir = tempdir().expect("tempdir");
+            let target = dir.path().join("conf");
+            std::fs::write(&target, "generation-1").expect("write target");
+
+            let mut caps = CapabilitySet::new();
+            caps.add_fs(FsCapability::new_file(&target, AccessMode::Read).expect("file cap"));
+            let state = sandbox_state::SandboxState::from_caps(&caps, &[], &[], &[]);
+
+            std::fs::remove_file(&target).expect("remove target");
+
+            let stale = detect_stale_file_grants(&state);
+            assert_eq!(stale.len(), 1);
+            assert_eq!(stale[0].current_id, None);
+        }
+
+        #[test]
+        fn stale_grant_with_no_other_coverage_becomes_denied() {
+            let (_dir, target, caps, state) = replaced_file_fixture();
+            let stale = detect_stale_file_grants(&state);
+
+            let result =
+                query_ext::query_path(&target, AccessMode::Read, &caps, &[]).expect("query");
+            assert!(
+                matches!(result, query_ext::QueryResult::Allowed { .. }),
+                "path-spec reasoning alone reports ALLOWED — the misleading answer"
+            );
+
+            let corrected =
+                apply_file_grant_staleness(result, &target, AccessMode::Read, &caps, &[], &stale)
+                    .expect("staleness pass");
+
+            match corrected {
+                query_ext::QueryResult::Denied {
+                    reason,
+                    details,
+                    matching_capability,
+                    ..
+                } => {
+                    assert_eq!(reason, "stale_file_grant");
+                    assert!(
+                        details
+                            .as_deref()
+                            .is_some_and(|d| d.contains("replaced after sandbox start"))
+                    );
+                    assert!(matching_capability.is_some());
+                }
+                other => panic!("expected stale_file_grant denial, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn stale_grant_covered_by_directory_grant_stays_allowed_with_warning() {
+            let (dir, target, mut caps, state) = replaced_file_fixture();
+            // The proposed policy fix: a directory grant survives replacement.
+            caps.add_fs(FsCapability::new_dir(dir.path(), AccessMode::Read).expect("dir cap"));
+            let stale = detect_stale_file_grants(&state);
+
+            let result =
+                query_ext::query_path(&target, AccessMode::Read, &caps, &[]).expect("query");
+            let corrected =
+                apply_file_grant_staleness(result, &target, AccessMode::Read, &caps, &[], &stale)
+                    .expect("staleness pass");
+
+            match corrected {
+                query_ext::QueryResult::Allowed {
+                    granted_path,
+                    warning,
+                    ..
+                } => {
+                    let dir_canonical = dir
+                        .path()
+                        .canonicalize()
+                        .expect("canonicalize dir")
+                        .display()
+                        .to_string();
+                    assert_eq!(granted_path.as_deref(), Some(dir_canonical.as_str()));
+                    assert!(
+                        warning.as_deref().is_some_and(|w| w.contains("stale")),
+                        "warning must mention the stale file grant, got {warning:?}"
+                    );
+                }
+                other => panic!("expected allowed-with-warning, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn results_not_matching_a_stale_grant_pass_through_unchanged() {
+            let (_dir, target, caps, _state) = replaced_file_fixture();
+
+            let result =
+                query_ext::query_path(&target, AccessMode::Read, &caps, &[]).expect("query");
+            let corrected = apply_file_grant_staleness(
+                result.clone(),
+                &target,
+                AccessMode::Read,
+                &caps,
+                &[],
+                &[], // nothing stale
+            )
+            .expect("staleness pass");
+
+            match (result, corrected) {
+                (
+                    query_ext::QueryResult::Allowed {
+                        granted_path: before,
+                        ..
+                    },
+                    query_ext::QueryResult::Allowed {
+                        granted_path: after,
+                        warning,
+                        ..
+                    },
+                ) => {
+                    assert_eq!(before, after);
+                    assert!(warning.is_none());
+                }
+                other => panic!("expected allowed passthrough, got {other:?}"),
+            }
         }
     }
 

--- a/docs/cli/internals/landlock.mdx
+++ b/docs/cli/internals/landlock.mdx
@@ -79,6 +79,8 @@ AccessFs::Truncate    // ABI v3+
 
 Note: `RemoveFile` and `RemoveDir` are both included because `rename()` requires removal rights on the source. This enables atomic write patterns (write to `.tmp` then rename to target) for both files and directories.
 
+Note: Landlock rules bind to the inode that was open when the ruleset was applied, not to the path. A *file-level* grant therefore goes stale if the file is replaced via such an atomic write from outside the sandbox — the new inode carries no rule and access fails with `EACCES`. `nono why` reports this as `stale_file_grant` (see [Troubleshooting](/cli/usage/troubleshooting)). Directory grants are not affected: a directory rule covers all children, including files created after the sandbox started.
+
 ### Full Access (`--allow`)
 
 Both read and write access rights combined.

--- a/docs/cli/usage/troubleshooting.mdx
+++ b/docs/cli/usage/troubleshooting.mdx
@@ -38,6 +38,7 @@ Command fails with "Permission denied" or "Operation not permitted" errors.
 | Sensitive path blocked | Use `--bypass-protection` with your grant (see below) |
 | Relative path resolved differently | Use absolute paths |
 | Symlink target outside sandbox | Grant access to the symlink target |
+| File replaced after sandbox start (Linux) | Grant the containing directory, or restart the sandbox (see below) |
 
 ### Sensitive Paths
 
@@ -64,6 +65,25 @@ To intentionally access a blocked path, use `--bypass-protection` alongside your
 ```bash
 nono run --allow ~/.gnupg --bypass-protection ~/.gnupg -- gpg --list-keys
 ```
+
+### Stale File Grants (Linux)
+
+On Linux, a file-level grant (`--read-file`, `--write-file`, `--allow-file`, or profile `read_file`/`write_file`/`allow_file`) attaches to the file's *inode* at sandbox start, not to its path. If the file is later replaced atomically — the write-temp-then-`rename()` pattern used by editors, `git config`, systemd-resolved, and most config tools — the path points to a new inode that carries no rule, and access fails with `EACCES` for the rest of the session even though the grant still names the path.
+
+`nono why` detects this from inside the sandbox and reports it:
+
+```
+DENIED
+  Reason: stale_file_grant
+  Details: The sandbox granted this file, but the file at ... was replaced
+  after sandbox start (inode 39:175234 when the sandbox started, 39:175245
+  now). ...
+```
+
+Remedies:
+
+- Restart the sandbox session — grants re-resolve to the current file.
+- If the file is rewritten routinely, grant its containing directory instead: directory rules cover files created after sandbox start, so they survive atomic replacement (at the cost of a broader grant).
 
 ---
 


### PR DESCRIPTION
## Linked Issue

References #986 — a partial fix by design (diagnostics plus one built-in policy instance, per the disclosure comment on the issue), so intentionally not `Closes`.

## Summary

Landlock rules bind to the inode open at ruleset build, so a file-level grant goes stale when the file is atomically replaced (write-temp + `rename(2)`). This PR:

1. **Policy** (`data/policy.json`): `system_read_linux_core` additionally grants the directory `/run/systemd/resolve` (read). Its `/etc/resolv.conf` file grant canonicalizes to `stub-resolv.conf`, which systemd-resolved replaces on any resolver-config change, breaking DNS for the rest of the session. Directory rules cover children created later, so they survive; non-systemd systems skip the missing path.
2. **Diagnostics**: the capability state file records `(dev, ino)` per file grant at sandbox start (Linux only; optional fields, compatible both ways). `nono why` re-stats the granted path and reports `DENIED / stale_file_grant` with grant-time vs. current inode and a restart hint — or ALLOWED with a warning when a directory grant still covers the path. Non-`--self` queries load the state leniently (unreadable state ⇒ no hints, never an error); `--self` stays strict.
3. **Docs**: troubleshooting entry + Landlock-internals note.

```
DENIED
  Reason: stale_file_grant
  Details: The sandbox granted this file, but the file at ... was replaced
  after sandbox start (inode 39:175234 when the sandbox started, 39:175245
  now). Landlock rules bind to the inode, not the path, ... Restart the
  sandbox to re-apply the grant to the current file.
```

**Deliberately not done:** Landlock has no path-based rules, so the only way a file grant can survive replacement is granting its parent directory. We did not apply that automatically to all file grants — it silently widens each to its whole directory, a posture change maintainers should make explicitly, per grant (as done here). The issue's repro still reproduces for user/profile file grants, now diagnosable. Other rename-prone builtin file grants (`/etc/ld.so.cache`, `/etc/hosts`, …) remain — their parent `/etc` is too broad. `/run/systemd/resolve` is systemd-specific in-tree policy; per NOGENT.md a nono package may be the longer-term home — guidance welcome.

## Agent Disclosure

- Agent-assisted contribution (Claude Fable 5 via Claude Code), directed and reviewed by @maufl; intent disclosed on #986 before opening this PR.
- Consulted: `AGENTS.md`, `NOGENT.md`, `sandbox/linux.rs` (PathFd inode binding), `capability.rs` (grant-time canonicalization), `policy.rs`, `sandbox_state.rs`, `why_runtime.rs`, `query_ext.rs`, the profile authoring guide, and this template. All code newly written; nothing reused or adapted.
- Confirmed compliant with repository coding and security requirements: NonoError propagation, no unwrap/expect in production code, paths canonicalized, fail-closed behavior preserved (the lenient loader affects diagnostics only, never enforcement).

## Test Plan

- New unit tests: staleness detection (fresh / in-place / replaced / removed), both `why` verdicts, pass-through, inode recording, legacy-state compatibility, lenient-loader failure modes.
- `make check`, `make test`, `cargo audit`, `make lint-aliases`, `make lint-docs` pass locally (remaining failures are pre-existing PTY/AF_UNIX tests needing permissions the sandboxed dev env lacks, all in untouched files).
- Verified end-to-end on Arch/zen (Landlock ABI v6): resolv.conf reads survive stub replacement under the new grant; the output above is from a live session; non-`--self` `why` still answers with an unreadable state file.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [x] Release note has been added to `CHANGELOG.md` if needed (generated via git-cliff from conventional commits)

## Agent Compliance Check (Required for AI/Automated PRs)

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope
