### PR TITLE
fix(tool-sandbox): skip missing fs_write_file grants instead of denying

### DIFF
--- a/crates/nono-cli/src/tool-sandbox/mod.rs
+++ b/crates/nono-cli/src/tool-sandbox/mod.rs
@@ -173,6 +173,54 @@ pub(crate) fn agent_can_write(
         && (path.starts_with(policy_root) || caps_grant(outer_caps, path, nono::AccessMode::Write))
 }
 
+// A policy's fs_write_file entries are best-effort: not every candidate
+// path exists on every machine (e.g. a log file some other tool creates
+// lazily). Skip a missing one rather than denying the whole command —
+// mirrors add_optional_dir/add_optional_read_file in each platform module.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) fn add_optional_write_file(
+    caps: &mut nono::CapabilitySet,
+    path: std::path::PathBuf,
+) -> nono::Result<()> {
+    match nono::FsCapability::new_file(&path, nono::AccessMode::ReadWrite) {
+        Ok(capability) => {
+            caps.add_fs(capability);
+            Ok(())
+        }
+        Err(nono::NonoError::PathNotFound(_)) => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(test)]
+mod add_optional_write_file_tests {
+    use super::add_optional_write_file;
+    use nono::CapabilitySet;
+    use std::path::PathBuf;
+
+    #[test]
+    fn missing_path_is_skipped_not_an_error() {
+        let mut caps = CapabilitySet::new();
+
+        let result = add_optional_write_file(&mut caps, PathBuf::from("/no/such/path.log"));
+
+        assert!(result.is_ok());
+        assert!(caps.fs_capabilities().is_empty());
+    }
+
+    #[test]
+    fn existing_path_is_granted() {
+        let mut caps = CapabilitySet::new();
+        let file = tempfile::NamedTempFile::new().expect("tempfile");
+
+        let result = add_optional_write_file(&mut caps, file.path().to_path_buf());
+
+        assert!(result.is_ok());
+        assert_eq!(caps.fs_capabilities().len(), 1);
+    }
+}
+
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[cfg(test)]
 mod agent_can_write_tests {

--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -3592,7 +3592,7 @@ fn add_policy_fs(
         if matches!(write_access(&path), AccessMode::Read) {
             add_optional_read_file(caps, path)?;
         } else {
-            caps.add_fs(FsCapability::new_file(path, AccessMode::ReadWrite)?);
+            super::add_optional_write_file(caps, path)?;
         }
     }
     Ok(())

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -3068,7 +3068,7 @@ fn add_policy_fs(
         if matches!(write_access(&path), AccessMode::Read) {
             add_optional_read_file(caps, path)?;
         } else {
-            caps.add_fs(FsCapability::new_file(path, AccessMode::ReadWrite)?);
+            super::add_optional_write_file(caps, path)?;
         }
     }
     Ok(())


### PR DESCRIPTION
## Linked Issue

Closes #1450

## Summary

A per-command `fs_write_file` grant for a missing path denied the whole
sandboxed command, unlike the sibling `fs_read`/`fs_write`/`fs_read_file`
grants which already skip missing paths. Adds a shared
`add_optional_write_file` helper (in `tool-sandbox/mod.rs`, alongside the
existing `agent_can_write`/`lexically_normalize` shared helpers) matching
that existing pattern, called from both the macOS and Linux platform
implementations instead of each defining its own copy.

## Agent Disclosure

Authored by an AI coding agent on behalf of @kipz. Consulted
`tool-sandbox/platform/{macos,linux}.rs` (`add_policy_fs` and its
`add_optional_*` siblings) and `capability.rs`/`capability_ext.rs` to
confirm this path lacks the missing-file tolerance the top-level session
sandbox already has. Disclosed on the linked issue before opening this PR.

## Test Plan

- `make ci` — clean.
- Added `add_optional_write_file_tests` (missing path is skipped, existing
  path is granted) — both pass.
- Rebuilt a downstream consumer against this branch and re-ran the issue's
  repro: denial is gone, command proceeds past sandbox construction.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

## Agent Compliance Check (Required for AI/Automated PRs)
- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope