### PR TITLE
fix(tool-sandbox): let allow_launch_services reach the open shim on macOS

### DIFF
--- a/crates/nono-cli/src/tool-sandbox/env.rs
+++ b/crates/nono-cli/src/tool-sandbox/env.rs
@@ -134,18 +134,22 @@ pub(crate) fn inject_chaining_control_env(
 }
 
 /// Inject the URL-open socket env var and `BROWSER` for a brokered child whose
-/// command declares `open_urls` and did not opt into direct LaunchServices.
+/// command declares `open_urls` or `allow_launch_services`.
 ///
 /// Both vars are stripped first (a child cannot smuggle its own) then set to
-/// the runtime's URL socket and the open shim path. No-op when URL opening is
-/// not enabled for this command.
+/// the runtime's URL socket and the open shim path. Needed for
+/// `allow_launch_services` too: the shim only recognizes itself as the
+/// URL-open relay when this env var is present, and a bare `open` in the
+/// child's $PATH always resolves to the shim, never straight to
+/// `/usr/bin/open`, once any command in the profile needs the shim. No-op
+/// when URL opening is not enabled for this command.
 pub(crate) fn inject_url_open_env(
     env: &mut Vec<Vec<u8>>,
     policy: &CommandSandboxConfig,
     url_socket_path: Option<&Path>,
     url_open_shim_path: Option<&Path>,
 ) {
-    if policy.open_urls.is_none() || policy.allow_launch_services {
+    if policy.open_urls.is_none() && !policy.allow_launch_services {
         return;
     }
     let (Some(url_socket_path), Some(shim_path)) = (url_socket_path, url_open_shim_path) else {
@@ -536,5 +540,47 @@ mod tests {
                 "{var} must be allowed so tool-sandbox children can verify TLS through the intercept proxy"
             );
         }
+    }
+
+    #[test]
+    fn inject_url_open_env_covers_allow_launch_services_without_open_urls() {
+        let policy = CommandSandboxConfig {
+            allow_launch_services: true,
+            ..Default::default()
+        };
+        let mut env = Vec::new();
+        inject_url_open_env(
+            &mut env,
+            &policy,
+            Some(Path::new("/tmp/url.sock")),
+            Some(Path::new("/tmp/shims/open")),
+        );
+
+        let socket_prefix = format!("{TOOL_SANDBOX_URL_SOCKET_ENV}=").into_bytes();
+        assert!(
+            env.iter().any(|e| e.starts_with(&socket_prefix)),
+            "allow_launch_services must get the URL socket env var, since the shim only \
+             recognizes itself as the URL-open relay when it's present"
+        );
+        assert!(
+            env.iter().any(|e| e.starts_with(b"BROWSER=")),
+            "allow_launch_services must get BROWSER pointed at the shim too"
+        );
+    }
+
+    #[test]
+    fn inject_url_open_env_noop_without_open_urls_or_launch_services() {
+        let policy = CommandSandboxConfig::default();
+        let mut env = Vec::new();
+        inject_url_open_env(
+            &mut env,
+            &policy,
+            Some(Path::new("/tmp/url.sock")),
+            Some(Path::new("/tmp/shims/open")),
+        );
+        assert!(
+            env.is_empty(),
+            "a command with neither policy must get no URL-open env vars"
+        );
     }
 }

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -872,8 +872,8 @@ fn handle_url_open_stream(
 }
 
 /// Resolve the requesting command from the connecting PID and validate the URL
-/// against that command's `open_urls` policy. Returns `Ok(())` if the open is
-/// permitted, or a denial reason otherwise. Does not open the browser.
+/// against that command's policy. Returns `Ok(())` if the open is permitted,
+/// or a denial reason otherwise. Does not open the browser.
 fn validate_url_open(
     state: &ToolSandboxState,
     peer_pid: u32,
@@ -890,6 +890,22 @@ fn validate_url_open(
 
     let policy = select_effective_policy(&state.plan.config, &command_name, &launch_caller)
         .map_err(|err| format!("policy resolution failed: {err}"))?;
+
+    check_url_open_policy(policy, &command_name, url)
+}
+
+/// Pure policy check, split out from [`validate_url_open`] for unit testing
+/// without a real process tree. `allow_launch_services` trusts the command to
+/// open any URL, matching a real exec of `/usr/bin/open`; otherwise the URL
+/// must pass `open_urls.allow_origins`.
+fn check_url_open_policy(
+    policy: &CommandSandboxConfig,
+    command_name: &str,
+    url: &str,
+) -> std::result::Result<(), String> {
+    if policy.allow_launch_services {
+        return Ok(());
+    }
 
     let open_urls = policy
         .open_urls
@@ -2675,15 +2691,15 @@ fn add_launch_services_caps(caps: &mut CapabilitySet, policy: &CommandSandboxCon
 }
 
 /// Grant the brokered child connect access to the URL listener socket and read
-/// access to the open shim, when the command declares `open_urls` and did not
-/// opt into direct LaunchServices. The shim is added to the exec gate by
+/// access to the open shim, when the command declares `open_urls` or
+/// `allow_launch_services`. The shim is added to the exec gate by
 /// [`add_child_process_exec_gate_with_policy`].
 fn add_url_open_caps(
     caps: &mut CapabilitySet,
     state: &ToolSandboxState,
     policy: &CommandSandboxConfig,
 ) -> Result<()> {
-    if policy.open_urls.is_none() || policy.allow_launch_services {
+    if policy.open_urls.is_none() && !policy.allow_launch_services {
         return Ok(());
     }
     let (Some(url_socket_path), Some(shim)) =
@@ -2854,15 +2870,16 @@ fn add_child_process_exec_gate_with_policy(
             .map(|identity| identity.path.clone()),
     );
     if let Some(policy) = policy {
-        // Allow execing the browser-open shim only when this command may open
-        // URLs without direct LaunchServices.
-        if policy.open_urls.is_some()
-            && !policy.allow_launch_services
+        // A bare `open` always resolves to this shim (mediated $PATH puts the
+        // shim dir first) once any command needs one, so both `open_urls` and
+        // `allow_launch_services` commands must be allowed to exec it.
+        if (policy.open_urls.is_some() || policy.allow_launch_services)
             && let Some(shim) = state.url_open_shim.as_ref()
         {
             allowed.push(shim.path.clone());
         }
-        // Direct LaunchServices opt-in: permit execing /usr/bin/open.
+        // Direct LaunchServices opt-in: also permit execing /usr/bin/open
+        // directly, for callers that resolve it by absolute path.
         if policy.allow_launch_services {
             let open_path = Path::new("/usr/bin/open");
             if open_path.exists() {
@@ -5399,6 +5416,166 @@ mod tests {
         assert!(
             rules.contains(&"(allow file-read* (literal \"/usr/bin/security\"))"),
             "unsafe file-read rule should be present"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn exec_gate_allows_open_shim_for_allow_launch_services_without_open_urls() -> Result<()> {
+        let temp = test_tempdir()?;
+        let command = temp.path().join("tool");
+        create_executable(&command)?;
+        let binary = test_binary("tool", &command)?;
+
+        let shim_path = temp.path().join("open");
+        create_executable(&shim_path)?;
+        let shim_path =
+            shim_path
+                .canonicalize()
+                .map_err(|source| NonoError::PathCanonicalization {
+                    path: shim_path,
+                    source,
+                })?;
+        let mut state = test_state();
+        state.url_open_shim = Some(ShimIdentity {
+            path: shim_path.clone(),
+            id: FileId { dev: 0, ino: 0 },
+        });
+
+        let policy = CommandSandboxConfig {
+            allow_launch_services: true,
+            ..Default::default()
+        };
+
+        let mut caps = CapabilitySet::new();
+        add_child_process_exec_gate_with_policy(&mut caps, &state, &binary, Some(&policy))?;
+
+        assert!(
+            has_exec_rule(&caps, &shim_path)?,
+            "allow_launch_services must let the command exec the open shim, since the \
+             mediated $PATH resolves `open` there rather than /usr/bin/open"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn url_open_policy_allows_launch_services_without_open_urls() {
+        let policy = CommandSandboxConfig {
+            allow_launch_services: true,
+            ..Default::default()
+        };
+        assert!(check_url_open_policy(&policy, "tool", "https://example.com/anything").is_ok());
+    }
+
+    #[test]
+    fn url_open_policy_denies_without_open_urls_or_launch_services() {
+        let policy = CommandSandboxConfig::default();
+        assert!(check_url_open_policy(&policy, "tool", "https://example.com").is_err());
+    }
+
+    #[test]
+    fn url_open_policy_still_enforces_allow_origins_without_launch_services() {
+        let policy = CommandSandboxConfig {
+            open_urls: Some(crate::profile::OpenUrlConfig {
+                allow_origins: vec!["https://example.com".to_string()],
+                allow_localhost: false,
+            }),
+            ..Default::default()
+        };
+        assert!(check_url_open_policy(&policy, "tool", "https://example.com/login").is_ok());
+        assert!(check_url_open_policy(&policy, "tool", "https://evil.example").is_err());
+    }
+
+    #[test]
+    fn url_open_caps_granted_for_allow_launch_services_without_open_urls() -> Result<()> {
+        let temp = test_tempdir()?;
+        let shim_path = temp.path().join("open");
+        create_executable(&shim_path)?;
+        let shim_path =
+            shim_path
+                .canonicalize()
+                .map_err(|source| NonoError::PathCanonicalization {
+                    path: shim_path,
+                    source,
+                })?;
+        let socket_path = temp.path().join("url.sock");
+        std::fs::File::create(&socket_path).map_err(|source| NonoError::ConfigRead {
+            path: socket_path.clone(),
+            source,
+        })?;
+        let socket_path =
+            socket_path
+                .canonicalize()
+                .map_err(|source| NonoError::PathCanonicalization {
+                    path: socket_path,
+                    source,
+                })?;
+
+        let mut state = test_state();
+        state.url_socket_path = Some(socket_path.clone());
+        state.url_open_shim = Some(ShimIdentity {
+            path: shim_path,
+            id: FileId { dev: 0, ino: 0 },
+        });
+
+        let policy = CommandSandboxConfig {
+            allow_launch_services: true,
+            ..Default::default()
+        };
+
+        let mut caps = CapabilitySet::new();
+        add_url_open_caps(&mut caps, &state, &policy)?;
+
+        assert!(
+            caps.unix_socket_capabilities()
+                .iter()
+                .any(|cap| cap.resolved == socket_path),
+            "allow_launch_services must get connect access to the URL listener socket, since \
+             the shim always relays through it rather than execing /usr/bin/open directly"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn url_open_caps_not_granted_without_open_urls_or_launch_services() -> Result<()> {
+        let temp = test_tempdir()?;
+        let shim_path = temp.path().join("open");
+        create_executable(&shim_path)?;
+        let shim_path =
+            shim_path
+                .canonicalize()
+                .map_err(|source| NonoError::PathCanonicalization {
+                    path: shim_path,
+                    source,
+                })?;
+        let socket_path = temp.path().join("url.sock");
+        std::fs::File::create(&socket_path).map_err(|source| NonoError::ConfigRead {
+            path: socket_path.clone(),
+            source,
+        })?;
+        let socket_path =
+            socket_path
+                .canonicalize()
+                .map_err(|source| NonoError::PathCanonicalization {
+                    path: socket_path,
+                    source,
+                })?;
+
+        let mut state = test_state();
+        state.url_socket_path = Some(socket_path.clone());
+        state.url_open_shim = Some(ShimIdentity {
+            path: shim_path,
+            id: FileId { dev: 0, ino: 0 },
+        });
+
+        let policy = CommandSandboxConfig::default();
+
+        let mut caps = CapabilitySet::new();
+        add_url_open_caps(&mut caps, &state, &policy)?;
+
+        assert!(
+            caps.unix_socket_capabilities().is_empty(),
+            "a command with neither policy must get no URL socket access"
         );
         Ok(())
     }


### PR DESCRIPTION
## Linked Issue

Closes #1463

## Summary

`allow_launch_services: true` only worked when no other command in the profile declared `open_urls`. Once any other command's edge set `open_urls`, three separate gaps combined to break it for every `allow_launch_services`-only command:

1. **Exec-gate** (`add_child_process_exec_gate_with_policy`): the browser-open shim's path was only admitted to the exec allowlist for `open_urls` edges, not `allow_launch_services` ones — even though a bare `open` in the mediated `$PATH` always resolves to the shim (never straight to `/usr/bin/open`) once any command in the profile needs it.
2. **Env injection** (`inject_url_open_env`): the URL-socket env var that lets the shim recognize itself as the relay was only set for `open_urls` edges — without it, the shim doesn't even attempt to connect to the supervisor.
3. **Socket capability** (`add_url_open_caps`): connect access to the URL listener socket was, again, only granted for `open_urls` edges — so even once the shim tried to connect, the sandbox denied the connection.
4. **Origin check** (`validate_url_open`): unconditionally required `open_urls` to be set, with no `allow_launch_services` check — so a relayed request would still be rejected.

This PR extends all four gates to also recognize `allow_launch_services`, scoped entirely to the macOS tool-sandbox path (Linux's `allow_launch_services` remains a documented no-op, unchanged).

## Agent Disclosure

This PR was authored by an AI agent (Claude Code). Files consulted/changed: `crates/nono-cli/src/tool-sandbox/platform/macos.rs` (`add_child_process_exec_gate_with_policy`, `validate_url_open`, `add_url_open_caps`), `crates/nono-cli/src/tool-sandbox/env.rs` (`inject_url_open_env`). Also read (unchanged): `crates/nono-cli/src/command_policy.rs` (`any_command_allows_url_open`), `crates/nono-cli/src/tool-sandbox/url_shim.rs`, `crates/nono-cli/src/url_open.rs`, and the Linux equivalent (`crates/nono-cli/src/tool-sandbox/platform/linux.rs`) to confirm `allow_launch_services` is intentionally a no-op there and left untouched. Consulted `CLAUDE.md` for the affected area. Confirms compliance with repository requirements.

## Test Plan

- `make ci` (clippy `-D warnings`, fmt-check, full test suite) — clean.
- 8 new unit tests covering each of the four fixed gates (exec-gate, env injection, socket capability, origin check) for both the `allow_launch_services`-without-`open_urls` case and the unaffected/no-op case.
- Reproduced the original failure and confirmed the full fix against a real downstream consumer: built this commit into a full profile with both `open_urls` (on one command) and `allow_launch_services` (on another), invoked through genuine tool-sandbox child mediation. Before: `fork/exec .../shims/open: operation not permitted`, then (after partial fixes) a LaunchServices dispatch failure. After all four fixes: the browser opens successfully. Also re-verified against the original real-world trigger (a CLI tool doing an interactive OAuth browser login through the sandbox) — confirmed the browser opens there too.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope