### PR TITLE
fix(tool-sandbox): grant command interpreter read of its script

### DIFF
--- a/crates/nono-cli/src/command_policy.rs
+++ b/crates/nono-cli/src/command_policy.rs
@@ -2905,7 +2905,10 @@ fn read_command_prefix(path: &Path, max_bytes: usize) -> nono::Result<Vec<u8>> {
 }
 
 #[cfg(any(test, target_os = "linux", target_os = "macos"))]
-fn classify_executable_shape(path: &Path, bytes: &[u8]) -> nono::Result<ResolvedExecutableShape> {
+pub(crate) fn classify_executable_shape(
+    path: &Path,
+    bytes: &[u8],
+) -> nono::Result<ResolvedExecutableShape> {
     if bytes.starts_with(b"\x7fELF") {
         return Ok(ResolvedExecutableShape {
             kind: ResolvedExecutableKind::Elf,

--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -4,7 +4,8 @@ use crate::audit_integrity::{
 };
 use crate::command_policy::{
     CommandFromConfig, CommandPoliciesConfig, CommandSandboxConfig, ResolvedCommandBinaries,
-    ResolvedCommandBinary, ResolvedExecutableKind, has_explicit_self_invocation_entry,
+    ResolvedCommandBinary, ResolvedExecutableKind, classify_executable_shape,
+    has_explicit_self_invocation_entry,
 };
 use crate::lineage_cgroup::LineageMarker;
 use crate::profile;
@@ -3451,6 +3452,7 @@ fn build_child_caps(
     )?);
     add_runtime_baseline(&mut caps, &state.baseline_cache, &binary.canonical_path)?;
     add_executable_shape_baseline(&mut caps, state, binary)?;
+    add_interpreted_script_read(&mut caps, state, binary, request)?;
     add_chaining_control_caps(&mut caps, state)?;
     add_policy_fs(
         &mut caps,
@@ -3523,6 +3525,116 @@ fn add_executable_shape_baseline(
     {
         caps.add_fs(FsCapability::new_file(&canonical_real, AccessMode::Read)?);
         add_runtime_baseline(caps, &state.baseline_cache, &canonical_real)?;
+    }
+    Ok(())
+}
+
+/// Grant a re-exec'd interpreter read of the shebang script it is running.
+///
+/// A `#!/usr/bin/env <interp>` script re-exec's `<interp>` (e.g. `node`),
+/// which the exec gate launches as its own binary with the script as an argv
+/// path — not `binary.canonical_path`. Its child domain therefore never grants
+/// the script, and module runtimes fail to read the script and its co-located
+/// dependency tree (`EACCES`).
+///
+/// Scope is deliberately narrow: an argv path is treated as the interpreter's
+/// script only when it is a shebang script whose resolved interpreter is the
+/// launched binary. This excludes ordinary file arguments to non-interpreter
+/// commands (e.g. `curl /path/file`), which must not gain a read grant or the
+/// proxy trust bundle. For a matched script, re-grant the covering outer read
+/// grant(s) so the dependency tree resolves — bounded by `outer_caps`, so the
+/// interpreter never gains read access the caller did not already have — plus
+/// the session TLS-intercept trust bundle (otherwise granted only to commands
+/// with their own proxy route) so the interpreter can make the caller's HTTPS
+/// calls.
+fn add_interpreted_script_read(
+    caps: &mut CapabilitySet,
+    state: &ToolSandboxState,
+    binary: &ResolvedCommandBinary,
+    request: &ToolSandboxShimRequest,
+) -> Result<()> {
+    add_interpreted_script_read_inner(
+        caps,
+        &state.outer_caps,
+        &binary.canonical_path,
+        &request.argv,
+        &state.proxy_trust_bundle_paths,
+    )
+}
+
+/// Read up to the first 256 bytes of `path` for shebang classification.
+fn read_executable_header(path: &Path) -> Option<Vec<u8>> {
+    use std::io::Read;
+    let mut file = fs::File::open(path).ok()?;
+    let mut buf = [0u8; 256];
+    let n = file.read(&mut buf).ok()?;
+    Some(buf[..n].to_vec())
+}
+
+/// True when `arg_path` is a shebang script whose resolved interpreter shares a
+/// file name with `binary_path` (the binary being launched to run it).
+fn is_shebang_script_for(binary_path: &Path, arg_path: &Path) -> bool {
+    let Some(header) = read_executable_header(arg_path) else {
+        return false;
+    };
+    let Ok(shape) = classify_executable_shape(arg_path, &header) else {
+        return false;
+    };
+    if shape.kind != ResolvedExecutableKind::ShebangScript {
+        return false;
+    }
+    let Some(shebang_interp) = shape.interpreter.as_ref() else {
+        return false;
+    };
+    // `#!/usr/bin/env <interp>` records `env`; resolve the real target.
+    let resolved = env_shebang_target_interpreter(shebang_interp, &shape.interpreter_args)
+        .unwrap_or_else(|| shebang_interp.clone());
+    resolved.file_name().is_some() && resolved.file_name() == binary_path.file_name()
+}
+
+fn add_interpreted_script_read_inner(
+    caps: &mut CapabilitySet,
+    outer_caps: &CapabilitySet,
+    binary_path: &Path,
+    argv: &[Vec<u8>],
+    proxy_trust_bundle_paths: &[PathBuf],
+) -> Result<()> {
+    let mut granted_script = false;
+    for arg in argv {
+        let raw = PathBuf::from(OsString::from_vec(arg.clone()));
+        if !raw.is_absolute() {
+            continue;
+        }
+        let Ok(canon) = raw.canonicalize() else {
+            continue;
+        };
+        if !canon.is_file() || !is_shebang_script_for(binary_path, &canon) {
+            continue;
+        }
+        for outer in outer_caps.fs_capabilities() {
+            if !matches!(outer.access, AccessMode::Read | AccessMode::ReadWrite) {
+                continue;
+            }
+            let covers = if outer.is_file {
+                outer.resolved == canon
+            } else {
+                canon.starts_with(&outer.resolved)
+            };
+            if !covers {
+                continue;
+            }
+            if outer.is_file {
+                caps.add_fs(FsCapability::new_file(&outer.resolved, AccessMode::Read)?);
+            } else {
+                caps.add_fs(FsCapability::new_dir(&outer.resolved, AccessMode::Read)?);
+            }
+            granted_script = true;
+        }
+    }
+    if granted_script {
+        for path in proxy_trust_bundle_paths {
+            caps.add_fs(FsCapability::new_file(path, AccessMode::Read)?);
+        }
     }
     Ok(())
 }
@@ -5450,6 +5562,112 @@ mod tests {
         assert!(
             !resolved.iter().any(|p| p == &missing),
             "missing exec_path must be skipped, not fatal: {resolved:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn interpreted_script_read_grants_covered_script_and_trust_bundle() -> Result<()> {
+        let tmp = test_tempdir()?;
+        let pkg = tmp.path().join("pkg");
+        create_dir(&pkg)?;
+        // A shebang script whose interpreter basename is `myinterp` (direct
+        // path, no PATH resolution needed).
+        let script = pkg.join("cli.js");
+        fs::write(&script, b"#!/opt/tools/bin/myinterp\n// script").map_err(|source| {
+            NonoError::ConfigWrite {
+                path: script.clone(),
+                source,
+            }
+        })?;
+        let ca = tmp.path().join("intercept-ca.pem");
+        fs::write(&ca, b"cert").map_err(|source| NonoError::ConfigWrite {
+            path: ca.clone(),
+            source,
+        })?;
+        // Outer sandbox grants the package tree (read) — but nothing outside it.
+        let outer = CapabilitySet::new().allow_path(tmp.path(), AccessMode::Read)?;
+        let tmp_canon = tmp.path().canonicalize().expect("canonicalize tmp");
+        let ca_canon = ca.canonicalize().expect("canonicalize ca");
+        let binary = PathBuf::from("/opt/tools/bin/myinterp");
+
+        // Interpreter (myinterp) invoked with its shebang script under the tree.
+        let mut caps = CapabilitySet::new();
+        let argv = vec![
+            b"myinterp".to_vec(),
+            script.to_string_lossy().into_owned().into_bytes(),
+        ];
+        add_interpreted_script_read_inner(
+            &mut caps,
+            &outer,
+            &binary,
+            &argv,
+            std::slice::from_ref(&ca),
+        )?;
+        let granted: Vec<_> = caps
+            .fs_capabilities()
+            .iter()
+            .map(|c| c.resolved.clone())
+            .collect();
+        assert!(
+            granted.contains(&tmp_canon),
+            "covering outer read subtree must be re-granted: {granted:?}"
+        );
+        assert!(
+            granted.contains(&ca_canon),
+            "trust bundle must be granted when a shebang script is matched: {granted:?}"
+        );
+
+        // Not a shebang script for this interpreter: a plain data file arg (the
+        // `curl /path/file` case) must grant nothing — no read, no trust bundle.
+        let data = pkg.join("data.txt");
+        fs::write(&data, b"plain data").map_err(|source| NonoError::ConfigWrite {
+            path: data.clone(),
+            source,
+        })?;
+        let mut caps_data = CapabilitySet::new();
+        let argv_data = vec![
+            b"myinterp".to_vec(),
+            data.to_string_lossy().into_owned().into_bytes(),
+        ];
+        add_interpreted_script_read_inner(
+            &mut caps_data,
+            &outer,
+            &binary,
+            &argv_data,
+            std::slice::from_ref(&ca),
+        )?;
+        assert!(
+            caps_data.fs_capabilities().is_empty(),
+            "non-shebang file arg must grant nothing: {:?}",
+            caps_data.fs_capabilities()
+        );
+
+        // A shebang script for a DIFFERENT interpreter must not match this
+        // binary (prevents unrelated commands gaining the grant / trust bundle).
+        let other = pkg.join("other.sh");
+        fs::write(&other, b"#!/bin/otherinterp\necho hi").map_err(|source| {
+            NonoError::ConfigWrite {
+                path: other.clone(),
+                source,
+            }
+        })?;
+        let mut caps_other = CapabilitySet::new();
+        let argv_other = vec![
+            b"myinterp".to_vec(),
+            other.to_string_lossy().into_owned().into_bytes(),
+        ];
+        add_interpreted_script_read_inner(
+            &mut caps_other,
+            &outer,
+            &binary,
+            &argv_other,
+            std::slice::from_ref(&ca),
+        )?;
+        assert!(
+            caps_other.fs_capabilities().is_empty(),
+            "shebang script for a different interpreter must grant nothing: {:?}",
+            caps_other.fs_capabilities()
         );
         Ok(())
     }

--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -3553,11 +3553,13 @@ fn add_interpreted_script_read(
     binary: &ResolvedCommandBinary,
     request: &ToolSandboxShimRequest,
 ) -> Result<()> {
+    let cwd = PathBuf::from(OsString::from_vec(request.cwd.clone()));
     add_interpreted_script_read_inner(
         caps,
         &state.outer_caps,
         &binary.canonical_path,
         &request.argv,
+        &cwd,
         &state.proxy_trust_bundle_paths,
     )
 }
@@ -3597,32 +3599,43 @@ fn add_interpreted_script_read_inner(
     outer_caps: &CapabilitySet,
     binary_path: &Path,
     argv: &[Vec<u8>],
+    cwd: &Path,
     proxy_trust_bundle_paths: &[PathBuf],
 ) -> Result<()> {
     let mut granted_script = false;
     for arg in argv {
         let raw = PathBuf::from(OsString::from_vec(arg.clone()));
-        if !raw.is_absolute() {
-            continue;
-        }
+        let raw = if raw.is_absolute() {
+            raw
+        } else {
+            cwd.join(raw)
+        };
         let Ok(canon) = raw.canonicalize() else {
             continue;
         };
-        if !canon.is_file() || !is_shebang_script_for(binary_path, &canon) {
+        if !canon.is_file() {
             continue;
         }
-        for outer in outer_caps.fs_capabilities() {
-            if !matches!(outer.access, AccessMode::Read | AccessMode::ReadWrite) {
-                continue;
-            }
-            let covers = if outer.is_file {
-                outer.resolved == canon
-            } else {
-                canon.starts_with(&outer.resolved)
-            };
-            if !covers {
-                continue;
-            }
+        // Determine the covering outer read grant(s) before reading the file's
+        // header, so a path outside `outer_caps` is never opened by the
+        // unsandboxed supervisor on the strength of argv alone.
+        let covering: Vec<FsCapability> = outer_caps
+            .fs_capabilities()
+            .iter()
+            .filter(|outer| {
+                matches!(outer.access, AccessMode::Read | AccessMode::ReadWrite)
+                    && if outer.is_file {
+                        outer.resolved == canon
+                    } else {
+                        canon.starts_with(&outer.resolved)
+                    }
+            })
+            .cloned()
+            .collect();
+        if covering.is_empty() || !is_shebang_script_for(binary_path, &canon) {
+            continue;
+        }
+        for outer in covering {
             if outer.is_file {
                 caps.add_fs(FsCapability::new_file(&outer.resolved, AccessMode::Read)?);
             } else {
@@ -5602,6 +5615,7 @@ mod tests {
             &outer,
             &binary,
             &argv,
+            tmp.path(),
             std::slice::from_ref(&ca),
         )?;
         let granted: Vec<_> = caps
@@ -5635,6 +5649,7 @@ mod tests {
             &outer,
             &binary,
             &argv_data,
+            tmp.path(),
             std::slice::from_ref(&ca),
         )?;
         assert!(
@@ -5662,12 +5677,80 @@ mod tests {
             &outer,
             &binary,
             &argv_other,
+            tmp.path(),
             std::slice::from_ref(&ca),
         )?;
         assert!(
             caps_other.fs_capabilities().is_empty(),
             "shebang script for a different interpreter must grant nothing: {:?}",
             caps_other.fs_capabilities()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn interpreted_script_read_resolves_relative_argv_against_cwd() -> Result<()> {
+        let tmp = test_tempdir()?;
+        let pkg = tmp.path().join("pkg");
+        create_dir(&pkg)?;
+        let script = pkg.join("cli.js");
+        fs::write(&script, b"#!/opt/tools/bin/myinterp\n// script").map_err(|source| {
+            NonoError::ConfigWrite {
+                path: script.clone(),
+                source,
+            }
+        })?;
+        let outer = CapabilitySet::new().allow_path(tmp.path(), AccessMode::Read)?;
+        let pkg_canon = pkg.canonicalize().expect("canonicalize pkg");
+        let binary = PathBuf::from("/opt/tools/bin/myinterp");
+
+        // Interpreter invoked with a script path relative to the request cwd
+        // (e.g. `node cli.js`), not an absolute argv path.
+        let mut caps = CapabilitySet::new();
+        let argv = vec![b"myinterp".to_vec(), b"cli.js".to_vec()];
+        add_interpreted_script_read_inner(&mut caps, &outer, &binary, &argv, &pkg, &[])?;
+        let granted: Vec<_> = caps
+            .fs_capabilities()
+            .iter()
+            .map(|c| c.resolved.clone())
+            .collect();
+        assert!(
+            granted.contains(&pkg_canon) || granted.iter().any(|p| pkg_canon.starts_with(p)),
+            "relative script path must resolve against cwd and be granted: {granted:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn interpreted_script_read_grants_nothing_for_an_uncovered_script() -> Result<()> {
+        // A path outside `outer_caps` must never be classified, let alone
+        // granted, regardless of whether it looks like a matching shebang
+        // script — the coverage check must gate the file read, not follow it.
+        let tmp = test_tempdir()?;
+        let allowed = tmp.path().join("allowed");
+        create_dir(&allowed)?;
+        let outside = tmp.path().join("outside");
+        create_dir(&outside)?;
+        let script = outside.join("cli.js");
+        fs::write(&script, b"#!/opt/tools/bin/myinterp\n// script").map_err(|source| {
+            NonoError::ConfigWrite {
+                path: script.clone(),
+                source,
+            }
+        })?;
+
+        let outer = CapabilitySet::new().allow_path(&allowed, AccessMode::Read)?;
+        let binary = PathBuf::from("/opt/tools/bin/myinterp");
+        let mut caps = CapabilitySet::new();
+        let argv = vec![
+            b"myinterp".to_vec(),
+            script.to_string_lossy().into_owned().into_bytes(),
+        ];
+        add_interpreted_script_read_inner(&mut caps, &outer, &binary, &argv, tmp.path(), &[])?;
+        assert!(
+            caps.fs_capabilities().is_empty(),
+            "uncovered path must grant nothing: {:?}",
+            caps.fs_capabilities()
         );
         Ok(())
     }


### PR DESCRIPTION
## Linked Issue

Closes #1466

## Summary

On Linux, when the tool-sandbox is engaged, a `#!/usr/bin/env <interp>` script's interpreter is launched to run the script inside a per-exec child sandbox that grants the interpreter + its runtime baseline but not the **script** — which is an argv path, not the launched binary — so the interpreter gets `EACCES` reading its own script (and its module tree), even when the caller's session already grants the script's directory. This grants the child read of argv paths the agent's **outer** sandbox already permits, re-using the covering outer read grant so dependency trees resolve; bounded by `outer_caps`, so the child gains nothing the caller lacked. When such a script is matched, it also grants the session TLS-intercept trust bundle (otherwise given only to commands with their own proxy route), so the interpreter can make the caller's HTTPS calls.

## Agent Disclosure (if applicable)

- This PR was authored by an AI agent (Claude) on behalf of the repository owner.
- Areas changed: `crates/nono-cli/src/tool-sandbox/platform/linux.rs` (`build_child_caps` + new `add_interpreted_script_read`/`_inner`); reviewed `CLAUDE.md` coding/security rules and the sibling handling from #1394.
- The grant is bounded by `outer_caps` (`path_covered_with_access`) so it never widens the child beyond the caller's own read set; argv paths are canonicalized before use.

## Test Plan

- New unit test `interpreted_script_read_grants_covered_script_and_trust_bundle` (Linux): asserts a covered script's enclosing outer read grant + the trust bundle are granted, and that an argv path **outside** `outer_caps` is not granted. Passes (`cargo test -p nono-cli`, Linux container).
- Built `nono` for Linux and verified manually: a `#!/usr/bin/env node` script run under a profile with command policies now executes (was `EACCES` on the script before); reads outside the caller's grants remain denied.
- Change is `#[cfg(target_os = "linux")]`; host `make ci` clippy/fmt/tests pass (one unrelated attestation-signing test is a known parallel-run flake — passes in isolation).

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

## Agent Compliance Check (Required for AI/Automated PRs)

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope