### PR TITLE
fix(tool-sandbox): drop trailing newline from captured credential phantoms

### DIFF
--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -4341,10 +4341,10 @@ fn normalize_captured_credential(mut output: Vec<u8>) -> Vec<u8> {
     output
 }
 
+/// No appended newline: a caller that captures raw stdout and reuses it
+/// verbatim (e.g. in an HTTP header) would otherwise get a corrupted value.
 fn nonce_stdout(nonce: String) -> Vec<u8> {
-    let mut output = nonce.into_bytes();
-    output.push(b'\n');
-    output
+    nonce.into_bytes()
 }
 
 fn launch_child_with_capture(
@@ -6177,5 +6177,12 @@ mod tests {
         let result = apply_environment_set_vars(&mut env, &policy);
         assert!(result.is_ok());
         assert!(env.iter().any(|e| e == b"MY_APP_CONFIG=value"));
+    }
+
+    #[test]
+    fn nonce_stdout_appends_no_trailing_newline() {
+        let phantom = format!("nono_{}", "a".repeat(64));
+        let stdout = nonce_stdout(phantom.clone());
+        assert_eq!(stdout, phantom.into_bytes());
     }
 }

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -3614,10 +3614,10 @@ fn normalize_captured_credential(mut output: Vec<u8>) -> Vec<u8> {
     output
 }
 
+/// No appended newline: a caller that captures raw stdout and reuses it
+/// verbatim (e.g. in an HTTP header) would otherwise get a corrupted value.
 fn nonce_stdout(nonce: String) -> Vec<u8> {
-    let mut output = nonce.into_bytes();
-    output.push(b'\n');
-    output
+    nonce.into_bytes()
 }
 
 fn launch_child_with_capture(
@@ -6747,6 +6747,13 @@ mod tests {
         let without_override = crate::tool_sandbox::ResolvedInterceptAction::passthrough();
         let effective = without_override.sandbox.unwrap_or(&command_sandbox);
         assert_eq!(effective.fs_read, vec!["/command/path".to_string()]);
+    }
+
+    #[test]
+    fn nonce_stdout_appends_no_trailing_newline() {
+        let phantom = format!("nono_{}", "a".repeat(64));
+        let stdout = nonce_stdout(phantom.clone());
+        assert_eq!(stdout, phantom.into_bytes());
     }
 
     #[test]


### PR DESCRIPTION
## Linked Issue

Closes #1472

## Summary

`nonce_stdout()` (macOS and Linux tool-sandbox platform code) unconditionally appends a trailing `\n` to every `capture_credential` phantom before writing it to stdout. Any consumer that captures raw stdout bytes without trimming (e.g. Go's `exec.Command().Output()`) receives that extra byte as part of the credential value — which breaks it if the value is later placed in an HTTP header.

Real credential-fetching CLIs are inconsistent about a trailing newline — `gh auth token`, for instance, includes one, while other tools deliberately omit it precisely because their output is meant to be captured raw. `capture_credential` stands in for whichever specific command a profile intercepts, and nono has no way of knowing which convention that command follows. Unconditionally adding a byte is therefore unsafe in general: it's a no-op for callers that already trim, and a silent corruption for callers that don't, whenever the real command happens to be one of the many that omit it. `normalize_captured_credential` already reflects this on the *inbound* side, trimming a trailing newline off whatever the real command produced before storing it — this PR makes the *outbound* phantom follow the same principle: return exactly what was generated, nothing appended.

## Agent Disclosure

This PR was written by an AI coding agent (Claude Code) on behalf of the reporter, who reviewed and approved the change, the issue, and this PR description before submission.

Files consulted: `crates/nono-cli/src/tool-sandbox/platform/macos.rs` and `crates/nono-cli/src/tool-sandbox/platform/linux.rs` (both `nonce_stdout()` implementations, identical in shape).

## Test Plan

- Added `nonce_stdout_appends_no_trailing_newline` (macOS and Linux) asserting the returned bytes equal the input phantom exactly
- `make fmt` && `make ci` — clean (clippy `-D warnings`, fmt-check, full test suite, `cargo audit`, alias inventory, doc lint)
- Manual repro from the linked issue, before and after the fix, using a profile with a `capture_credential` intercept on `echo`:
  ```sh
  nono run --profile repro.json --allow-cwd --silent -- echo get-token | wc -c
  nono run --profile repro.json --allow-cwd --silent -- echo get-token | xxd | tail -2
  ```
  Before: 70 bytes, trailing `0a`. After this change: 69 bytes (`nono_` + 64 hex chars), no trailing newline.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope
