### PR TITLE
feat: mediate vault login -method=oidc (custom inject header + per-command open_port)

### DIFF
--- a/crates/nono-cli/src/command_policy.rs
+++ b/crates/nono-cli/src/command_policy.rs
@@ -1023,6 +1023,14 @@ pub struct CommandNetworkConfig {
     pub tcp_connect_ports: Vec<u16>,
     #[serde(default)]
     pub tcp_bind_ports: Vec<u16>,
+    /// Localhost ports this command may bind (e.g. an OAuth callback listener).
+    /// Unlike `tcp_bind_ports` these are enforceable for tool-sandbox children
+    /// on macOS — they mirror the top-level `network.open_port`.
+    #[serde(default)]
+    pub open_port: Vec<u16>,
+    /// Localhost port ranges this command may bind, as `[start, end]` pairs.
+    #[serde(default)]
+    pub open_port_range: Vec<[u16; 2]>,
 }
 
 impl CommandNetworkConfig {
@@ -1032,6 +1040,8 @@ impl CommandNetworkConfig {
             allow_domain: dedup_append(&self.allow_domain, &child.allow_domain),
             tcp_connect_ports: dedup_append(&self.tcp_connect_ports, &child.tcp_connect_ports),
             tcp_bind_ports: dedup_append(&self.tcp_bind_ports, &child.tcp_bind_ports),
+            open_port: dedup_append(&self.open_port, &child.open_port),
+            open_port_range: dedup_append(&self.open_port_range, &child.open_port_range),
         }
     }
 }
@@ -3645,6 +3655,31 @@ mod tests {
             value.get("exec_paths").is_none(),
             "empty exec_paths should be omitted, got {value}"
         );
+    }
+
+    #[test]
+    fn command_network_open_port_merge_child_dedup_appends() {
+        let base = CommandNetworkConfig {
+            open_port: vec![8250],
+            open_port_range: vec![[3000, 3100]],
+            ..Default::default()
+        };
+        let child = CommandNetworkConfig {
+            open_port: vec![8250, 8251],
+            open_port_range: vec![[3000, 3100], [4000, 4100]],
+            ..Default::default()
+        };
+        let merged = base.merge_child(&child);
+        assert_eq!(merged.open_port, vec![8250, 8251]);
+        assert_eq!(merged.open_port_range, vec![[3000, 3100], [4000, 4100]]);
+    }
+
+    #[test]
+    fn command_network_open_port_round_trips() {
+        let json = r#"{"allow_domain":["vault.us1.ddbuild.io"],"open_port_range":[[8250,8255]]}"#;
+        let cfg: CommandNetworkConfig = serde_json::from_str(json).expect("parse");
+        assert_eq!(cfg.open_port_range, vec![[8250, 8255]]);
+        assert!(cfg.open_port.is_empty());
     }
 
     #[test]

--- a/crates/nono-cli/src/profile/credential_provider.rs
+++ b/crates/nono-cli/src/profile/credential_provider.rs
@@ -198,6 +198,17 @@ pub(super) fn validate_credential_provider_entries(profile: &Profile) -> Result<
                 "credential_providers.{name}.credential_format must contain the '{{}}' token placeholder"
             )));
         }
+        // Same raw header-value path as the header name; reject control chars
+        // to prevent header injection.
+        if provider
+            .credential_format
+            .as_deref()
+            .is_some_and(|format| format.bytes().any(|b| b.is_ascii_control() && b != b'\t'))
+        {
+            return Err(NonoError::ProfileParse(format!(
+                "credential_providers.{name}.credential_format must not contain control characters"
+            )));
+        }
         if provider
             .inject_header
             .as_deref()
@@ -483,6 +494,30 @@ mod tests {
             err.to_string().contains("credential_format"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn credential_format_with_control_chars_is_rejected() {
+        for bad in [
+            "{}\r\nEvil: 1",
+            "Bearer {}\n",
+            "{}\0",
+            "{}\x01",
+            "{}\x0b",
+            "{}\x0c",
+            "{}\x7f",
+        ] {
+            let profile = provider_with(Some("X-Vault-Token"), Some(bad));
+            let err = validate_credential_provider_entries(&profile)
+                .expect_err(&format!("must reject format {bad:?}"));
+            assert!(
+                err.to_string().contains("credential_format"),
+                "unexpected error for {bad:?}: {err}"
+            );
+        }
+        // Horizontal tab is a legal field-value character.
+        let ok = provider_with(Some("X-Vault-Token"), Some("Bearer\t{}"));
+        validate_credential_provider_entries(&ok).expect("tab is allowed");
     }
 
     #[test]

--- a/crates/nono-cli/src/profile/credential_provider.rs
+++ b/crates/nono-cli/src/profile/credential_provider.rs
@@ -15,6 +15,15 @@ pub struct CredentialProviderDef {
     /// API origins where phantom tokens are resolved on egress.
     #[serde(default)]
     pub api_hosts: Vec<String>,
+    /// Header the resolved credential is injected into on `api_hosts` egress.
+    /// Defaults to `Authorization` (OAuth Bearer APIs). Vault, for example,
+    /// needs `X-Vault-Token`.
+    #[serde(default)]
+    pub inject_header: Option<String>,
+    /// Format applied to the resolved credential before injection; `{}` is the
+    /// token. Defaults to `Bearer {}`. Use `{}` for a raw token (e.g. Vault).
+    #[serde(default)]
+    pub credential_format: Option<String>,
     /// Optional provider-specific logout/session detection.
     #[serde(default)]
     pub credential_store: Option<CredentialProviderStore>,
@@ -158,11 +167,10 @@ pub(super) fn validate_credential_provider_entries(profile: &Profile) -> Result<
                     &field.path,
                 )?;
             }
-            if endpoint.request_nonce_fields.is_empty() {
-                return Err(NonoError::ProfileParse(format!(
-                    "credential_providers.{name}.token_endpoints[{index}].request_nonce_fields must not be empty"
-                )));
-            }
+            // request_nonce_fields is only meaningful for refresh/exchange
+            // flows that re-send a phantom in the request body. Capture-only
+            // endpoints (e.g. Vault's OIDC callback, whose token is captured
+            // from the response and later sent in a header) leave it empty.
             for field in &endpoint.request_nonce_fields {
                 validate_provider_field(
                     &format!(
@@ -177,6 +185,27 @@ pub(super) fn validate_credential_provider_entries(profile: &Profile) -> Result<
                 &format!("credential_providers.{name}.api_hosts[{index}]"),
                 api_host,
             )?;
+        }
+        // A custom injection format must carry the `{}` token placeholder, or
+        // the redemption route would inject a constant header that never
+        // contains the resolved credential.
+        if provider
+            .credential_format
+            .as_deref()
+            .is_some_and(|format| !format.contains("{}"))
+        {
+            return Err(NonoError::ProfileParse(format!(
+                "credential_providers.{name}.credential_format must contain the '{{}}' token placeholder"
+            )));
+        }
+        if provider
+            .inject_header
+            .as_deref()
+            .is_some_and(|header| !is_valid_http_header_name(header))
+        {
+            return Err(NonoError::ProfileParse(format!(
+                "credential_providers.{name}.inject_header must be a valid HTTP header name (RFC 7230 token)"
+            )));
         }
         if let Some(store) = &provider.credential_store {
             validate_credential_provider_store(name, store)?;
@@ -386,4 +415,93 @@ fn validate_provider_field(context: &str, field: &str) -> Result<()> {
         )));
     }
     Ok(())
+}
+
+/// RFC 7230 `token`: the grammar for an HTTP header field name. Rejects
+/// whitespace, colons, and control characters so a malformed `inject_header`
+/// can't break the outbound request or smuggle extra header material.
+fn is_valid_http_header_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.bytes().all(|b| {
+            b.is_ascii_alphanumeric()
+                || matches!(
+                    b,
+                    b'!' | b'#'
+                        | b'$'
+                        | b'%'
+                        | b'&'
+                        | b'\''
+                        | b'*'
+                        | b'+'
+                        | b'-'
+                        | b'.'
+                        | b'^'
+                        | b'_'
+                        | b'`'
+                        | b'|'
+                        | b'~'
+                )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider_with(inject_header: Option<&str>, credential_format: Option<&str>) -> Profile {
+        let mut profile = Profile::default();
+        profile.credential_providers.insert(
+            "vault_oidc".to_string(),
+            CredentialProviderDef {
+                provider_type: CredentialProviderType::OauthCapture,
+                token_endpoints: vec![CredentialProviderTokenEndpoint {
+                    host: "https://vault.example.com".to_string(),
+                    path: "/v1/auth/oidc/oidc/callback".to_string(),
+                    response_fields: vec![CredentialProviderResponseField {
+                        path: "auth.client_token".to_string(),
+                        kind: CredentialProviderResponseFieldKind::Opaque,
+                    }],
+                    request_body: CredentialProviderRequestBodyFormat::Auto,
+                    // Capture-only endpoint: intentionally no request_nonce_fields.
+                    request_nonce_fields: vec![],
+                }],
+                api_hosts: vec!["https://vault.example.com".to_string()],
+                inject_header: inject_header.map(str::to_string),
+                credential_format: credential_format.map(str::to_string),
+                credential_store: None,
+                helpers: None,
+            },
+        );
+        profile
+    }
+
+    #[test]
+    fn credential_format_without_placeholder_is_rejected() {
+        let profile = provider_with(Some("X-Vault-Token"), Some("Bearer"));
+        let err = validate_credential_provider_entries(&profile).expect_err("must reject");
+        assert!(
+            err.to_string().contains("credential_format"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn invalid_inject_header_is_rejected() {
+        for bad in ["", "  ", "X Vault Token", "X-Vault-Token:", "X\r\nEvil"] {
+            let profile = provider_with(Some(bad), Some("{}"));
+            let err = validate_credential_provider_entries(&profile)
+                .expect_err(&format!("must reject header {bad:?}"));
+            assert!(
+                err.to_string().contains("inject_header"),
+                "unexpected error for {bad:?}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn custom_header_and_capture_only_endpoint_ok() {
+        // Raw-token header + empty request_nonce_fields (capture-only) is valid.
+        let profile = provider_with(Some("X-Vault-Token"), Some("{}"));
+        validate_credential_provider_entries(&profile).expect("valid provider");
+    }
 }

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -1234,6 +1234,8 @@ mod tests {
                 provider_type: profile::CredentialProviderType::OauthCapture,
                 token_endpoints: Vec::new(),
                 api_hosts: Vec::new(),
+                inject_header: None,
+                credential_format: None,
                 credential_store: Some(profile::CredentialProviderStore::FileJson {
                     path: "$HOME/.codex-nono-oauth/auth.json".to_string(),
                     phantom_fields: vec!["tokens.access_token".to_string()],
@@ -1287,6 +1289,8 @@ mod tests {
                 provider_type: profile::CredentialProviderType::OauthCapture,
                 token_endpoints: Vec::new(),
                 api_hosts: Vec::new(),
+                inject_header: None,
+                credential_format: None,
                 credential_store: Some(profile::CredentialProviderStore::FileJson {
                     path: "$HOME/.codex-nono-oauth/auth.json".to_string(),
                     phantom_fields: vec!["tokens.access_token".to_string()],

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -2503,8 +2503,16 @@ fn synthesize_credential_provider_proxy_config(
                 upstream: api_host.clone(),
                 credential_key: None,
                 inject_mode: InjectMode::Header,
-                inject_header: "Authorization".to_string(),
-                credential_format: Some("Bearer {}".to_string()),
+                inject_header: provider
+                    .inject_header
+                    .clone()
+                    .unwrap_or_else(|| "Authorization".to_string()),
+                credential_format: Some(
+                    provider
+                        .credential_format
+                        .clone()
+                        .unwrap_or_else(|| "Bearer {}".to_string()),
+                ),
                 path_pattern: None,
                 path_replacement: None,
                 query_param_name: None,
@@ -4867,6 +4875,8 @@ mod tests {
                     request_nonce_fields: vec!["refresh_token".to_string()],
                 }],
                 api_hosts: vec!["https://api.openai.com".to_string()],
+                inject_header: None,
+                credential_format: None,
                 credential_store: None,
                 helpers: None,
             },
@@ -4914,6 +4924,57 @@ mod tests {
             !route.endpoint_rules.is_empty(),
             "provider API routes must force L7 visibility even with allow-all policy"
         );
+        // Default injection is an OAuth Bearer Authorization header.
+        assert_eq!(route.inject_header, "Authorization");
+        assert_eq!(route.credential_format.as_deref(), Some("Bearer {}"));
+    }
+
+    #[test]
+    fn test_credential_provider_route_honors_custom_inject_header() {
+        // Vault authenticates with the raw token in `X-Vault-Token`, not an
+        // OAuth `Authorization: Bearer` header.
+        let mut providers = HashMap::new();
+        providers.insert(
+            "vault_oidc".to_string(),
+            crate::profile::CredentialProviderDef {
+                provider_type: crate::profile::CredentialProviderType::OauthCapture,
+                token_endpoints: vec![crate::profile::CredentialProviderTokenEndpoint {
+                    host: "https://vault.us1.ddbuild.io".to_string(),
+                    path: "/v1/auth/oidc/oidc/callback".to_string(),
+                    response_fields: vec![crate::profile::CredentialProviderResponseField {
+                        path: "auth.client_token".to_string(),
+                        kind: crate::profile::CredentialProviderResponseFieldKind::Opaque,
+                    }],
+                    request_body: crate::profile::CredentialProviderRequestBodyFormat::Auto,
+                    request_nonce_fields: vec![],
+                }],
+                api_hosts: vec!["https://vault.us1.ddbuild.io".to_string()],
+                inject_header: Some("X-Vault-Token".to_string()),
+                credential_format: Some("{}".to_string()),
+                credential_store: None,
+                helpers: None,
+            },
+        );
+        let proxy = ProxyLaunchOptions {
+            credential_providers: providers,
+            credential_routes: vec![crate::profile::CredentialRouteDef {
+                name: "vault".to_string(),
+                provider: "vault_oidc".to_string(),
+                env_var: None,
+                base_url_env_var: None,
+                endpoint_policy: None,
+            }],
+            ..ProxyLaunchOptions::default()
+        };
+
+        let config = build_proxy_config_from_flags(&proxy).expect("provider proxy config builds");
+        let route = config
+            .routes
+            .iter()
+            .find(|route| route.prefix == "vault")
+            .expect("API route must be synthesized");
+        assert_eq!(route.inject_header, "X-Vault-Token");
+        assert_eq!(route.credential_format.as_deref(), Some("{}"));
     }
 
     // Verify that a credential helper with `stdio: true` (interaction.stdio) does not

--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -3804,6 +3804,15 @@ fn add_policy_network(caps: &mut CapabilitySet, policy: &CommandSandboxConfig) -
     let Some(network) = &policy.network else {
         return Ok(());
     };
+    // Localhost bind grants (e.g. an OAuth callback listener) compose with
+    // ProxyOnly mode via localhost_port_ranges → proxy_bind_port_ranges. Only
+    // ranges are carried in the child spec, so singles are widened.
+    for &port in &network.open_port {
+        caps.add_localhost_port_range(port, port)?;
+    }
+    for &[start, end] in &network.open_port_range {
+        caps.add_localhost_port_range(start, end)?;
+    }
     if network.allow_all {
         caps.set_network_mode_mut(NetworkMode::AllowAll);
         return Ok(());
@@ -5813,6 +5822,34 @@ mod tests {
             caps.fs_capabilities().is_empty(),
             "uncovered path must grant nothing: {:?}",
             caps.fs_capabilities()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn open_port_grants_localhost_bind_ranges() -> Result<()> {
+        // A proxy-routed command's open_port must reach the child via
+        // localhost_port_ranges (→ proxy_bind_port_ranges), so an OAuth
+        // callback listener can bind. Singles are widened to [port, port].
+        let policy = CommandSandboxConfig {
+            network: Some(crate::command_policy::CommandNetworkConfig {
+                allow_domain: vec!["example.com".to_string()],
+                open_port: vec![8250],
+                open_port_range: vec![[8251, 8255]],
+                ..Default::default()
+            }),
+            ..CommandSandboxConfig::default()
+        };
+        let mut caps = CapabilitySet::new();
+        add_policy_network(&mut caps, &policy)?;
+        let ranges = caps.localhost_port_ranges();
+        assert!(
+            ranges.contains(&(8250, 8250)),
+            "single open_port widened to a range: {ranges:?}"
+        );
+        assert!(
+            ranges.contains(&(8251, 8255)),
+            "open_port_range preserved: {ranges:?}"
         );
         Ok(())
     }

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -3137,6 +3137,16 @@ fn add_policy_network(caps: &mut CapabilitySet, policy: &CommandSandboxConfig) -
     let Some(network) = &policy.network else {
         return Ok(());
     };
+    // Localhost bind grants (e.g. an OAuth callback listener) flow to the child
+    // via localhost_port_ranges → proxy_bind_port_ranges, so they compose with
+    // ProxyOnly mode. Only ranges are carried in the child spec, so singles are
+    // widened to [port, port].
+    for &port in &network.open_port {
+        caps.add_localhost_port_range(port, port)?;
+    }
+    for &[start, end] in &network.open_port_range {
+        caps.add_localhost_port_range(start, end)?;
+    }
     if network.allow_all {
         caps.set_network_mode_mut(NetworkMode::AllowAll);
         return Ok(());
@@ -6901,6 +6911,34 @@ mod tests {
         let selected = select_effective_policy(&config, "git", &Caller::Session)?;
 
         assert_eq!(selected.fs_read, sandbox.fs_read);
+        Ok(())
+    }
+
+    #[test]
+    fn open_port_grants_localhost_bind_ranges() -> Result<()> {
+        // A proxy-routed command's open_port must reach the child via
+        // localhost_port_ranges (→ proxy_bind_port_ranges), so an OAuth
+        // callback listener can bind. Singles are widened to [port, port].
+        let policy = CommandSandboxConfig {
+            network: Some(crate::command_policy::CommandNetworkConfig {
+                allow_domain: vec!["example.com".to_string()],
+                open_port: vec![8250],
+                open_port_range: vec![[8251, 8255]],
+                ..Default::default()
+            }),
+            ..CommandSandboxConfig::default()
+        };
+        let mut caps = CapabilitySet::new();
+        add_policy_network(&mut caps, &policy)?;
+        let ranges = caps.localhost_port_ranges();
+        assert!(
+            ranges.contains(&(8250, 8250)),
+            "single open_port widened to a range: {ranges:?}"
+        );
+        assert!(
+            ranges.contains(&(8251, 8255)),
+            "open_port_range preserved: {ranges:?}"
+        );
         Ok(())
     }
 

--- a/docs/cli/features/sandboxed-oauth-logins.mdx
+++ b/docs/cli/features/sandboxed-oauth-logins.mdx
@@ -220,6 +220,13 @@ a token refresh or exchange request.
 For JSON bodies, dotted paths are supported. For form bodies, use top-level
 field names.
 
+Optional. A *capture-only* endpoint — where the token arrives in the response
+and is never re-sent in a request body — leaves this empty. For example, the
+HashiCorp Vault CLI's `vault login -method=oidc` flow GETs
+`/v1/auth/<mount>/oidc/callback`, receives `auth.client_token` in the response,
+and thereafter sends it in a header; nothing is re-injected into a request
+body, so its token endpoint has no `request_nonce_fields`.
+
 ### `api_hosts` and `credential_routes`
 
 `api_hosts` declares where phantoms may be resolved:
@@ -241,6 +248,45 @@ field names.
 
 Only those routes can resolve the provider's phantoms. A random process cannot
 take `nono_<64hex>` and use it directly against the provider.
+
+### `inject_header` and `credential_format` (non-Bearer APIs)
+
+By default a resolved phantom is injected into the `Authorization` header as
+`Bearer <token>`. APIs that authenticate differently override this on the
+provider:
+
+```json
+"inject_header": "X-Vault-Token",
+"credential_format": "{}"
+```
+
+- `inject_header` — request header the resolved credential is injected into.
+  Defaults to `Authorization`. Must be a valid HTTP header name.
+- `credential_format` — value written to that header; `{}` is replaced with the
+  token. Defaults to `Bearer {}`. Must contain `{}`.
+
+For example, the HashiCorp Vault CLI sends the token as
+`X-Vault-Token: <raw token>`, so a `vault_oidc` provider sets
+`inject_header: "X-Vault-Token"` and `credential_format: "{}"`.
+
+### Binding the callback when the login CLI is a mediated command
+
+The examples above assume the sandboxed agent itself performs the login, using
+the top-level `network.open_port` grant for its loopback callback listener. If
+instead the login CLI runs as a mediated command (declared in
+`command_policies`), it must be granted its callback port on that command's
+network policy — the top-level grant does not extend to a tool-sandbox child:
+
+```json
+"network": {
+  "allow_domain": ["vault.example.com"],
+  "open_port_range": [[8250, 8255]]
+}
+```
+
+`vault login -method=oidc` binds `http://localhost:8250/oidc/callback` (and
+increments if busy). Use `open_port` / `open_port_range` rather than
+`tcp_bind_ports`, which cannot be enforced for tool-sandbox children on macOS.
 
 ## Add endpoint policy
 

--- a/docs/cli/features/tool-sandbox.mdx
+++ b/docs/cli/features/tool-sandbox.mdx
@@ -200,7 +200,9 @@ The `@git:common-dir` token runs `git rev-parse --git-common-dir` from nono's wo
 | `allow_all` | boolean | Allows unrestricted child network access. |
 | `allow_domain` | string array | Hostname allow-list. Valid only with an enforceable nono proxy/helper mode. |
 | `tcp_connect_ports` | port array | Raw TCP connect ports on Linux Landlock. Not hostname-filtered. |
-| `tcp_bind_ports` | port array | Raw TCP bind ports on Linux Landlock. |
+| `tcp_bind_ports` | port array | Raw TCP bind ports on Linux Landlock. Cannot be enforced for tool-sandbox children on macOS. |
+| `open_port` | port array | Localhost bind ports (e.g. an OAuth/OIDC loopback callback listener). Mirrors the top-level `network.open_port`; enforceable for children on macOS and Linux. |
+| `open_port_range` | `[start, end]` array | Inclusive localhost bind port ranges, e.g. `[[8250, 8255]]`. |
 
 `environment.allow_vars` accepts exact names such as `PATH`, trailing-prefix wildcards such as `AWS_*`, and the bare wildcard `*`. `environment.set_vars` injects static values after filtering; `PATH` and `NONO_*` are reserved.
 


### PR DESCRIPTION
## Linked Issue

Closes #1473

## Summary

Enables mediating HashiCorp Vault's `vault login -method=oidc` so the real Vault token never enters the sandbox — captured at the OIDC callback, replaced with a phantom, redeemed on egress to the Vault API. Three generic `oauth_capture`/policy gaps blocked the Vault CLI flow:

- **Optional `inject_header` / `credential_format` on `oauth_capture` providers** — Vault authenticates with `X-Vault-Token: <raw token>`, not `Authorization: Bearer {}`. Defaults unchanged; set `X-Vault-Token` / `{}` for Vault. Validated at parse time: `credential_format` must contain `{}`; `inject_header` must be a valid HTTP header token.
- **`request_nonce_fields` now optional** — the Vault OIDC callback (`/v1/auth/<mount>/oidc/callback`) is capture-only: the token arrives in the response and is never re-sent in a request body. The field only marks where to swap a phantom by value in an outbound refresh body — it does not gate capture, and `api_hosts` is mandatory, so omitting it is safe.
- **`open_port` / `open_port_range` on per-command network policies** — so the mediated `vault` command can bind its `localhost:8250` OIDC callback listener. Mirrors the top-level `network.open_port`, wired through `add_policy_network` (macOS + Linux) via the existing `localhost_port_ranges` path (enforceable on macOS, unlike `tcp_bind_ports`).

## Agent Disclosure

This PR was authored by an AI agent (disclosed on #1473).

- Consulted: `credential_provider.rs`, `proxy_runtime.rs`, `command_policy.rs`, `tool-sandbox/platform/{macos,linux}.rs`, `oauth_capture/{rewrite,endpoint}.rs`, and `CLAUDE.md`.
- Composes with existing mechanisms (`add_localhost_port_range` -> `proxy_bind_port_ranges`; the `api_hosts` route builder) rather than adding new machinery.
- No `unwrap`/`expect` in new code; uses `NonoError`; adds no new filesystem paths.

## Test Plan

- `make ci` clean (fmt, clippy -D warnings, tests) on a fresh rebase onto `upstream/main`.
- New unit tests: custom `inject_header` on the api_hosts route; `open_port` merge + parse round-trip; `open_port` -> localhost bind ranges (macOS + Linux); `credential_format` / `inject_header` validation.
- Verified end-to-end against a real `vault login -method=oidc`: `auth.client_token` captured at the callback and replaced with a phantom, the sandboxed `vault` only ever holds the phantom, and it is redeemed to the real token on egress to the Vault API.
- Docs updated: `sandboxed-oauth-logins.mdx` (new fields + Vault callback-bind note) and `tool-sandbox.mdx` (`open_port` reference).

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
- [ ] Release note has been added to `CHANGELOG.md` if needed

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope