### PR TITLE
fix(registry): suppress X-Nono-UUID when update check is opted out

### DIFF
--- a/crates/nono-cli/src/pack_update_hint.rs
+++ b/crates/nono-cli/src/pack_update_hint.rs
@@ -299,13 +299,7 @@ fn is_opted_out() -> bool {
     if std::env::var(NO_PACK_UPDATE_HINTS_ENV).is_ok() {
         return true;
     }
-    if std::env::var("NONO_NO_UPDATE_CHECK").is_ok() {
-        return true;
-    }
-    match crate::config::user::load_user_config() {
-        Ok(Some(config)) => !config.updates.check,
-        _ => false,
-    }
+    crate::update_check::update_check_opted_out()
 }
 
 fn is_newer(installed: &str, latest: &str) -> bool {

--- a/crates/nono-cli/src/registry_client.rs
+++ b/crates/nono-cli/src/registry_client.rs
@@ -29,7 +29,9 @@ pub struct RegistryClient {
 /// Build the installation-context headers to attach to every registry request.
 ///
 /// Headers included:
-/// - `X-Nono-UUID`: installation UUID if a state file exists (omitted otherwise)
+/// - `X-Nono-UUID`: installation UUID (omitted when the update check is opted
+///   out via `NONO_NO_UPDATE_CHECK` or `[updates] check = false`, or when no
+///   state file exists)
 /// - `X-Nono-Platform`: OS name (`std::env::consts::OS`)
 /// - `X-Nono-Arch`: CPU architecture (`std::env::consts::ARCH`)
 /// - `X-Nono-CI`: `"true"` when a recognised CI environment is detected
@@ -507,6 +509,75 @@ mod tests {
             provider.map(|(_, v)| v.as_str()),
             Some("github_actions"),
             "X-Nono-CI-Provider should be 'github_actions'"
+        );
+    }
+
+    #[test]
+    fn context_headers_gate_uuid_on_opt_out() {
+        let _lock = match ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().join("home");
+        let state = tmp.path().join("state");
+        let config = tmp.path().join("config");
+        std::fs::create_dir_all(&home).expect("home dir");
+        std::fs::create_dir_all(state.join("nono")).expect("state dir");
+        std::fs::create_dir_all(&config).expect("config dir");
+        // A state file exists, so any absent UUID is attributable to the
+        // opt-out, not to a missing file.
+        let uuid = "22222222-2222-4222-8222-222222222222";
+        std::fs::write(
+            state.join("nono").join("update-check.json"),
+            format!(
+                r#"{{"uuid":"{uuid}","last_check":"1970-01-01T00:00:00Z","cached_result":null}}"#
+            ),
+        )
+        .expect("write state file");
+        let home_str = home.to_string_lossy().to_string();
+        let state_str = state.to_string_lossy().to_string();
+        let config_str = config.to_string_lossy().to_string();
+
+        let env = EnvVarGuard::set_all(&[
+            ("HOME", &home_str),
+            ("XDG_STATE_HOME", &state_str),
+            ("XDG_CONFIG_HOME", &config_str),
+            // Managed so we can force it absent for the opted-in case and still
+            // restore any ambient value on drop.
+            ("NONO_NO_UPDATE_CHECK", ""),
+        ]);
+        env.remove("NONO_NO_UPDATE_CHECK");
+
+        // Opted in: the UUID header is attached.
+        let headers = build_context_headers();
+        assert_eq!(
+            headers
+                .iter()
+                .find(|(k, _)| *k == "X-Nono-UUID")
+                .map(|(_, v)| v.as_str()),
+            Some(uuid),
+            "X-Nono-UUID should be present when not opted out"
+        );
+
+        // Opted out: the UUID header is omitted even though the state file
+        // still exists — this is the fix for the residual-identifier bug.
+        let _optout = EnvVarGuard::set_all(&[("NONO_NO_UPDATE_CHECK", "1")]);
+        let headers = build_context_headers();
+        assert!(
+            !headers.iter().any(|(k, _)| *k == "X-Nono-UUID"),
+            "X-Nono-UUID must be omitted when the update check is opted out"
+        );
+        // The coarse fingerprinting headers are intentionally still sent when
+        // opted out (out of scope for this fix; see the residual-identifiers
+        // note in the privacy documentation).
+        assert!(
+            headers.iter().any(|(k, _)| *k == "X-Nono-Platform"),
+            "X-Nono-Platform should still be sent when opted out"
+        );
+        assert!(
+            headers.iter().any(|(k, _)| *k == "X-Nono-Install-Source"),
+            "X-Nono-Install-Source should still be sent when opted out"
         );
     }
 

--- a/crates/nono-cli/src/update_check.rs
+++ b/crates/nono-cli/src/update_check.rs
@@ -18,7 +18,9 @@
 //! attached as HTTP headers to every `RegistryClient` request (see
 //! `registry_client.rs`). Version is conveyed via the `User-Agent` header
 //! rather than a dedicated field. The privacy posture is otherwise identical:
-//! the same anonymous installation identity, no PII.
+//! the same anonymous installation identity, no PII. When the update check is
+//! opted out (see [`update_check_opted_out`]) the `X-Nono-UUID` header is
+//! suppressed, so an opted-out install transmits no persistent identifier.
 //!
 //! To disable the update check, set `NONO_NO_UPDATE_CHECK=1` or add
 //! `[updates] check = false` to `$XDG_CONFIG_HOME/nono/config.toml` (default `~/.config/nono/config.toml`).
@@ -129,13 +131,7 @@ impl UpdateCheckHandle {
 ///   an update was found)
 /// - The state directory is unavailable
 pub fn start_background_check() -> Option<UpdateCheckHandle> {
-    // Check env var opt-out
-    if std::env::var("NONO_NO_UPDATE_CHECK").is_ok() {
-        return None;
-    }
-
-    // Check config file opt-out
-    if is_opted_out_via_config() {
+    if update_check_opted_out() {
         return None;
     }
 
@@ -191,8 +187,21 @@ pub fn start_background_check() -> Option<UpdateCheckHandle> {
     })
 }
 
-/// Check user config for update opt-out
-fn is_opted_out_via_config() -> bool {
+/// Whether the user has opted out of the update check.
+///
+/// Either source opts out:
+/// - the `NONO_NO_UPDATE_CHECK` environment variable is set — any value,
+///   including an empty string; presence alone opts out; or
+/// - the user config sets `[updates] check = false`.
+///
+/// This is the single authoritative opt-out predicate. It also gates the
+/// persistent installation identifier: when it returns `true`,
+/// [`read_installation_uuid`] returns `None`, so the `X-Nono-UUID` header is
+/// never attached to registry requests (see `registry_client.rs`).
+pub(crate) fn update_check_opted_out() -> bool {
+    if std::env::var("NONO_NO_UPDATE_CHECK").is_ok() {
+        return true;
+    }
     match crate::config::user::load_user_config() {
         Ok(Some(config)) => !config.updates.check,
         _ => false,
@@ -292,7 +301,13 @@ fn is_newer_version(current: &str, latest: &str) -> bool {
     }
 }
 
-/// Return the persisted installation UUID, or `None` if no state file exists yet. Never writes.
+/// Return the persisted installation UUID, or `None`. Never writes.
+///
+/// Returns `None` when the user has opted out of the update check (see
+/// [`update_check_opted_out`]) or when no state file exists yet. Gating on the
+/// opt-out here — rather than only at the call site — ensures the persistent
+/// identifier is suppressed for every consumer, so an opted-out install never
+/// transmits `X-Nono-UUID` even if a state file was written on an earlier run.
 ///
 /// Intentionally does not delegate to `load_or_create_state()` — that function
 /// creates the state file when none exists, which would violate this function's
@@ -300,6 +315,9 @@ fn is_newer_version(current: &str, latest: &str) -> bool {
 /// If `UpdateCheckState` changes (e.g. the `uuid` field is renamed), update
 /// both sites.
 pub(crate) fn read_installation_uuid() -> Option<String> {
+    if update_check_opted_out() {
+        return None;
+    }
     let path = state_file_path()?;
     if !path.exists() {
         return None;
@@ -490,6 +508,71 @@ mod tests {
         let _env = crate::test_env::EnvVarGuard::set_all(&[("NONO_NO_UPDATE_CHECK", "1")]);
         let handle = start_background_check();
         assert!(handle.is_none());
+    }
+
+    #[test]
+    fn test_read_installation_uuid_respects_opt_out() {
+        let _lock = match crate::test_env::ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().join("home");
+        let state = tmp.path().join("state");
+        let config = tmp.path().join("config");
+        std::fs::create_dir_all(&home).expect("home dir");
+        std::fs::create_dir_all(state.join("nono")).expect("state dir");
+        std::fs::create_dir_all(&config).expect("config dir");
+        let home_str = home.to_string_lossy().to_string();
+        let state_str = state.to_string_lossy().to_string();
+        let config_str = config.to_string_lossy().to_string();
+
+        // Write a valid state file with a known UUID.
+        let uuid = "11111111-1111-4111-8111-111111111111";
+        let state_json = serde_json::to_string(&UpdateCheckState {
+            uuid: uuid.to_string(),
+            last_check: DateTime::UNIX_EPOCH,
+            cached_result: None,
+        })
+        .expect("serialize state");
+        std::fs::write(state.join("nono").join(UPDATE_STATE_FILE), state_json)
+            .expect("write state file");
+
+        let env = crate::test_env::EnvVarGuard::set_all(&[
+            ("HOME", &home_str),
+            ("XDG_STATE_HOME", &state_str),
+            ("XDG_CONFIG_HOME", &config_str),
+            // Managed so we can force it absent below while still restoring any
+            // ambient value on drop.
+            ("NONO_NO_UPDATE_CHECK", ""),
+        ]);
+        // Force the opt-out env var absent for the opted-in assertion,
+        // independent of the developer's ambient environment.
+        env.remove("NONO_NO_UPDATE_CHECK");
+
+        // Not opted out: the stored UUID is returned.
+        assert_eq!(read_installation_uuid().as_deref(), Some(uuid));
+
+        // Opted out via env var: the UUID is suppressed even though the state
+        // file still exists on disk. This is the fix for the residual-identifier
+        // bug — an opted-out install must not transmit X-Nono-UUID.
+        let optout = crate::test_env::EnvVarGuard::set_all(&[("NONO_NO_UPDATE_CHECK", "1")]);
+        assert_eq!(read_installation_uuid(), None);
+        drop(optout);
+
+        // Opting back out via config also suppresses it, and the state file is
+        // left untouched on disk (transmission stops; we never delete it).
+        std::fs::create_dir_all(config.join("nono")).expect("config/nono dir");
+        std::fs::write(
+            config.join("nono").join("config.toml"),
+            "[updates]\ncheck = false\n",
+        )
+        .expect("write config");
+        assert_eq!(read_installation_uuid(), None);
+        assert!(
+            state.join("nono").join(UPDATE_STATE_FILE).exists(),
+            "state file must not be deleted by opt-out"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1507.

Registry requests to `registry.nono.sh` continued to send the persistent installation identifier `X-Nono-UUID` **even after the user opted out** of the update check, whenever the update-check state file already existed on disk (the default after the first `nono` run). The opt-out (`NONO_NO_UPDATE_CHECK` / `[updates] check = false`) gated only the `update.nono.sh` ping, not the registry header, so the documented opt-out was inaccurate in the common case.

## Approach

- Added a single authoritative opt-out predicate `update_check_opted_out()` in `crates/nono-cli/src/update_check.rs` (env `NONO_NO_UPDATE_CHECK` presence — any value — or config `[updates] check = false`).
- Routed `start_background_check()` through it (behaviour-preserving).
- **Gated `read_installation_uuid()` on the predicate** — it now returns `None` when opted out, suppressing `X-Nono-UUID` at the source for every consumer, even if a state file was written on an earlier run. The state file is intentionally **not** deleted (transmission stops; users still remove the file to erase the on-disk UUID).
- De-duplicated `pack_update_hint::is_opted_out()` to reuse the shared predicate.
- Corrected the header doc comment in `registry_client.rs`.

The coarse fingerprinting headers (`X-Nono-Platform`/`Arch`/`CI`/`Install-Source`) are intentionally **out of scope** — they remain gated by the separately-tracked master telemetry switch. This change is limited to the persistent identifier.

## Tests

- `update_check::test_read_installation_uuid_respects_opt_out` — reader returns the UUID when opted in; `None` under both the env-var and config opt-outs; state file left on disk.
- `registry_client::context_headers_gate_uuid_on_opt_out` — `X-Nono-UUID` present when opted in, absent when opted out, while `X-Nono-Platform`/`X-Nono-Install-Source` remain (pins the scope boundary).

Both tests are hermetic (serialized on `ENV_LOCK`, all env vars guard-managed, isolated temp `HOME`/`XDG_STATE_HOME`/`XDG_CONFIG_HOME`). `make ci` is clean locally.

## Files consulted

`crates/nono-cli/src/update_check.rs`, `crates/nono-cli/src/registry_client.rs`, `crates/nono-cli/src/pack_update_hint.rs`, `crates/nono-cli/src/config/user.rs`, `crates/nono-cli/src/state_paths.rs`, `crates/nono-cli/src/config/mod.rs`, `crates/nono-cli/src/test_env.rs`.

## Contributor disclosure

This PR was prepared by an AI-assisted contributor at the request of the maintainer, following the repository Coding Agent Contribution Policy (issue filed and disclosed before any code change).

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists (#1507)
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden `unwrap`/`expect` in production code (test code uses `.expect()` consistent with the repo's existing test convention; `clippy::unwrap_used` passes under `make ci`)
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope
