### PR TITLE
fix(audit): record and show seccomp capability decisions

### DIFF
--- a/crates/nono-cli/src/audit_commands.rs
+++ b/crates/nono-cli/src/audit_commands.rs
@@ -3,7 +3,7 @@
 //! Handles `nono audit list|show` for viewing the audit trail of sandboxed sessions.
 
 use crate::audit_attestation::verify_audit_attestation;
-use crate::audit_event_reader::command_policy_events_json;
+use crate::audit_event_reader::{command_policy_events_json, load_capability_decisions};
 use crate::audit_integrity::verify_audit_log;
 use crate::audit_ledger::verify_session_in_ledger;
 use crate::audit_session::{
@@ -422,7 +422,43 @@ fn cmd_show(args: AuditShowArgs) -> Result<()> {
         }
     }
 
+    let capability_decisions = load_capability_decisions(&session.dir)?;
+    if !capability_decisions.is_empty() {
+        eprintln!();
+        eprintln!("  Capability Decisions: {}", capability_decisions.len());
+        for record in &capability_decisions {
+            print_capability_decision(record);
+        }
+    }
+
     Ok(())
+}
+
+fn print_capability_decision(entry: &nono::supervisor::AuditEntry) {
+    use nono::supervisor::{ApprovalDecision, ApprovalRequest};
+
+    let ApprovalRequest::Capability { path, access, .. } = &entry.request else {
+        return;
+    };
+    let decision = match &entry.decision {
+        ApprovalDecision::Granted => "granted".green(),
+        ApprovalDecision::Denied { .. } => "denied".red(),
+        ApprovalDecision::Timeout => "timeout".red(),
+    };
+    let reason = match &entry.decision {
+        ApprovalDecision::Denied { reason } => format!(" reason={}", sanitize_for_terminal(reason)),
+        ApprovalDecision::Granted | ApprovalDecision::Timeout => String::new(),
+    };
+
+    eprintln!(
+        "    {} {} {} backend={} duration={}ms{}",
+        decision,
+        access,
+        sanitize_for_terminal(&path.display().to_string()),
+        sanitize_for_terminal(&entry.backend),
+        entry.duration_ms,
+        reason,
+    );
 }
 
 fn cmd_verify(args: AuditVerifyArgs) -> Result<()> {

--- a/crates/nono-cli/src/audit_event_reader.rs
+++ b/crates/nono-cli/src/audit_event_reader.rs
@@ -1,6 +1,7 @@
 use crate::audit_integrity::{
     AUDIT_EVENTS_FILENAME, AuditEventPayload, AuditEventRecord, CommandPolicyAuditEvent,
 };
+use nono::supervisor::AuditEntry;
 use nono::{NonoError, Result};
 use serde::Serialize;
 use std::fs::File;
@@ -80,4 +81,41 @@ pub(crate) fn command_policy_events_json(session_dir: &Path) -> Result<Vec<serde
         values.push(value);
     }
     Ok(values)
+}
+
+pub(crate) fn load_capability_decisions(session_dir: &Path) -> Result<Vec<AuditEntry>> {
+    let path = session_dir.join(AUDIT_EVENTS_FILENAME);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let file = File::open(&path).map_err(|e| {
+        NonoError::Snapshot(format!(
+            "Failed to open audit event log {}: {e}",
+            path.display()
+        ))
+    })?;
+    let reader = BufReader::new(file);
+    let mut events = Vec::new();
+    for (index, line) in reader.lines().enumerate() {
+        let line = line.map_err(|e| {
+            NonoError::Snapshot(format!(
+                "Failed to read audit event log {}: {e}",
+                path.display()
+            ))
+        })?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record: AuditEventRecord = serde_json::from_str(&line).map_err(|e| {
+            NonoError::Snapshot(format!(
+                "Failed to parse audit event record {} line {}: {e}",
+                path.display(),
+                index.saturating_add(1)
+            ))
+        })?;
+        if let AuditEventPayload::CapabilityDecision { entry } = record.event {
+            events.push(entry);
+        }
+    }
+    Ok(events)
 }

--- a/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
+++ b/crates/nono-cli/src/exec_strategy/supervisor_linux.rs
@@ -566,6 +566,7 @@ pub(super) fn handle_seccomp_notification(
         child_pid: child.as_raw() as u32,
         session_id: config.session_id.to_string(),
     };
+    let decision_started: Instant = Instant::now();
 
     let decision = match super::request_approval_with_relay_paused(config, &request, pty) {
         Ok(d) => {
@@ -591,10 +592,22 @@ pub(super) fn handle_seccomp_notification(
                     reason: DenialReason::BackendError,
                 },
             );
-            let _ = deny_notif(notify_fd, notif.id);
+            let decision = ApprovalDecision::Denied {
+                reason: format!("Approval backend error: {e}"),
+            };
+            let deny_result = deny_notif(notify_fd, notif.id);
+            let audit_result = record_capability_audit(config, request, decision_started, decision);
+            deny_result?;
+            audit_result?;
             return Ok(());
         }
     };
+    if let Err(audit_error) =
+        record_capability_audit(config, request, decision_started, decision.clone())
+    {
+        let _ = deny_notif(notify_fd, notif.id);
+        return Err(audit_error);
+    }
 
     // 9. Second TOCTOU check before acting on the decision
     if !notif_id_valid(notify_fd, notif.id)? {


### PR DESCRIPTION
## Linked Issue

Closes https://github.com/nolabs-ai/nono/issues/1524

## Summary

- Record seccomp-notify capability approval decisions in the session audit log.
- Show recorded file capability decisions in `nono audit show`.

Previously, `--capability-elevation` requests were visible in terminal diagnostics but absent from the audit trail.

## Agent Disclosure

This PR was generated with assistance from an AI coding agent.

Relevant repository guidance and implementation files consulted:

- `AGENTS.md`
- `crates/nono-cli/src/exec_strategy/supervisor_linux.rs`
- `crates/nono-cli/src/audit_commands.rs`
- `crates/nono-cli/src/audit_event_reader.rs`
- `crates/nono/src/audit.rs`
- `crates/nono/src/supervisor/types.rs`

I confirm that this PR follows the repository requirements, including security review considerations, formatting, tests, and DCO-signed commits.

## Test Plan

- `cargo test -p nono-cli`
- `cargo fmt --check`
- `git diff --check`
- Manually ran:

  ```bash
  nono run --allow-cwd --capability-elevation -- cat /etc/hostname
  nono audit show <session-id>
  ```

  Verified that `audit show` lists the recorded file capability decisions.


## Checklist

- [x] An issue exists and is linked above
- [x] Tests pass
- [x] Commits include DCO sign-off

