### PR TITLE
fix(cli): preserve open URL policy when network is blocked

### DIFF
--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -162,6 +162,7 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     let trust = &flags.trust;
     let network = &flags.network;
     let proxy = network.proxy_options();
+    let open_url = network.open_url_options();
     let session = &flags.session;
     let tool_sandbox_active = flags
         .command_policies
@@ -672,7 +673,7 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
                 session,
                 rollback,
                 trust,
-                proxy,
+                open_url,
                 proxy_handle: proxy_handle.as_ref(),
                 executable_identity: executable_identity.as_ref(),
                 audit_signer: audit_signer.as_ref(),

--- a/crates/nono-cli/src/launch_runtime.rs
+++ b/crates/nono-cli/src/launch_runtime.rs
@@ -195,8 +195,9 @@ pub(crate) enum NetworkIntent {
     #[default]
     Unrestricted,
     /// `--block-net` or profile `network.block` with no active proxy override:
-    /// outbound connections are denied by the OS sandbox.
-    BlockAll,
+    /// outbound connections are denied by the OS sandbox. URL-opening requests
+    /// are handled by the supervisor and may still carry their own allowlist.
+    BlockAll { open_url: Option<OpenUrlIntent> },
     /// Proxy-activating features are configured. Proxy starts only if
     /// `ProxyLaunchOptions::is_active()` — custom credentials alone do not.
     ProxyFiltered(Box<ProxyLaunchOptions>),
@@ -211,6 +212,14 @@ impl NetworkIntent {
         match self {
             Self::ProxyFiltered(opts) => Some(opts),
             _ => None,
+        }
+    }
+
+    pub(crate) fn open_url_options(&self) -> Option<&OpenUrlIntent> {
+        match self {
+            Self::BlockAll { open_url } => open_url.as_ref(),
+            Self::ProxyFiltered(opts) => opts.open_url.as_ref(),
+            Self::Unrestricted => None,
         }
     }
 }
@@ -673,6 +682,23 @@ mod tests {
             command: Vec::new(),
             help: None,
         }
+    }
+
+    #[test]
+    fn blocked_network_preserves_open_url_options_without_proxy_activation() {
+        let intent = NetworkIntent::BlockAll {
+            open_url: Some(OpenUrlIntent {
+                origins: vec!["https://example.com".to_string()],
+                allow_localhost: true,
+                allow_launch_services: false,
+            }),
+        };
+
+        assert!(!intent.is_proxy_active());
+        assert!(intent.proxy_options().is_none());
+        let open_url = intent.open_url_options().expect("open URL options");
+        assert_eq!(open_url.origins, ["https://example.com"]);
+        assert!(open_url.allow_localhost);
     }
 
     #[test]

--- a/crates/nono-cli/src/proxy_runtime.rs
+++ b/crates/nono-cli/src/proxy_runtime.rs
@@ -1461,6 +1461,18 @@ pub(crate) fn prepare_proxy_launch_options(
         network_profile.is_some() || !allow_domain.is_empty() || !deny_domain.is_empty();
     let has_credentials = !credentials.is_empty();
     let would_activate = has_domain_filter || has_credentials || upstream_proxy_addr.is_some();
+    let open_url = if !prepared.open_url_origins.is_empty()
+        || prepared.open_url_allow_localhost
+        || prepared.allow_launch_services_active
+    {
+        Some(OpenUrlIntent {
+            origins: prepared.open_url_origins.clone(),
+            allow_localhost: prepared.open_url_allow_localhost,
+            allow_launch_services: prepared.allow_launch_services_active,
+        })
+    } else {
+        None
+    };
 
     // Normal launch validation rejects hard-block plus proxy-mode inputs before
     // this fallback can choose BlockAll or strict filtering.
@@ -1478,7 +1490,7 @@ pub(crate) fn prepare_proxy_launch_options(
                 );
             }
         }
-        return Ok(NetworkIntent::BlockAll);
+        return Ok(NetworkIntent::BlockAll { open_url });
     }
 
     let strict_filter = prepared.profile_network_block;
@@ -1553,19 +1565,6 @@ pub(crate) fn prepare_proxy_launch_options(
         Some(TlsInterceptIntent {
             ca_validity: tls_options.ca_validity,
             ca_env_vars: tls_options.ca_env_vars,
-        })
-    } else {
-        None
-    };
-
-    let open_url = if !prepared.open_url_origins.is_empty()
-        || prepared.open_url_allow_localhost
-        || prepared.allow_launch_services_active
-    {
-        Some(OpenUrlIntent {
-            origins: prepared.open_url_origins.clone(),
-            allow_localhost: prepared.open_url_allow_localhost,
-            allow_launch_services: prepared.allow_launch_services_active,
         })
     } else {
         None

--- a/crates/nono-cli/src/supervised_runtime.rs
+++ b/crates/nono-cli/src/supervised_runtime.rs
@@ -1,7 +1,7 @@
 use crate::audit_attestation::AuditSigner;
 use crate::audit_integrity::AuditRecorder;
 use crate::launch_runtime::{
-    ProxyLaunchOptions, RollbackLaunchOptions, SessionLaunchOptions, TrustLaunchOptions,
+    OpenUrlIntent, RollbackLaunchOptions, SessionLaunchOptions, TrustLaunchOptions,
 };
 use crate::rollback_runtime::{
     AuditState, RollbackExitContext, create_audit_state, finalize_supervised_exit,
@@ -31,7 +31,7 @@ pub(crate) struct SupervisedRuntimeContext<'a> {
     pub(crate) session: &'a SessionLaunchOptions,
     pub(crate) rollback: &'a RollbackLaunchOptions,
     pub(crate) trust: &'a TrustLaunchOptions,
-    pub(crate) proxy: Option<&'a ProxyLaunchOptions>,
+    pub(crate) open_url: Option<&'a OpenUrlIntent>,
     pub(crate) proxy_handle: Option<&'a nono_proxy::server::ProxyHandle>,
     pub(crate) executable_identity: Option<&'a ExecutableIdentity>,
     pub(crate) audit_signer: Option<&'a AuditSigner>,
@@ -193,7 +193,7 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
         session,
         rollback,
         trust,
-        proxy,
+        open_url,
         proxy_handle,
         executable_identity,
         audit_signer,
@@ -283,21 +283,12 @@ pub(crate) fn execute_supervised_runtime(ctx: SupervisedRuntimeContext<'_>) -> R
         session_id: &supervisor_session_id,
         attach_initial_client: !session.detached_start,
         detach_sequence: session.detach_sequence.as_deref(),
-        open_url_origins: proxy
-            .and_then(|p| p.open_url.as_ref())
-            .map(|o| o.origins.as_slice())
-            .unwrap_or(&[]),
-        open_url_allow_localhost: proxy
-            .and_then(|p| p.open_url.as_ref())
-            .map(|o| o.allow_localhost)
-            .unwrap_or(false),
+        open_url_origins: open_url.map(|o| o.origins.as_slice()).unwrap_or(&[]),
+        open_url_allow_localhost: open_url.map(|o| o.allow_localhost).unwrap_or(false),
         audit_recorder: audit_recorder.clone(),
         network_audit_events: supervisor_network_audit_events.as_ref(),
         redaction_policy,
-        allow_launch_services_active: proxy
-            .and_then(|p| p.open_url.as_ref())
-            .map(|o| o.allow_launch_services)
-            .unwrap_or(false),
+        allow_launch_services_active: open_url.map(|o| o.allow_launch_services).unwrap_or(false),
         #[cfg(target_os = "linux")]
         proxy_port: match caps.network_mode() {
             nono::NetworkMode::ProxyOnly { port, .. } => *port,


### PR DESCRIPTION
## Linked Issue

Closes https://github.com/nolabs-ai/nono/issues/1528

## Summary

When `network.block` was enabled, the resolved `NetworkIntent::BlockAll` discarded the profile's `open_urls` configuration.

As a result, the supervisor received an empty URL allowlist and rejected origins that were explicitly configured in `open_urls.allow_origins`.

This PR:

- preserves URL origins and localhost settings in `NetworkIntent::BlockAll`;
- passes the URL configuration independently to `SupervisorConfig`;
- keeps sandbox network access fully blocked;
- does not activate the regular network proxy merely because `open_urls` is configured;
- adds a regression test covering blocked network mode with URL allowlist settings.

## Agent Disclosure

This PR was prepared with assistance from an AI coding agent.

The following repository materials were consulted:

- `AGENTS.md`
- `CLAUDE.md`
- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/pull_request_template.md`
- recent signed-off commits in the repository
- the reproduction record in `report/history_202607290745.md`

The affected implementation areas were reviewed in:

- `crates/nono-cli/src/proxy_runtime.rs`
- `crates/nono-cli/src/launch_runtime.rs`
- `crates/nono-cli/src/execution_runtime.rs`
- `crates/nono-cli/src/supervised_runtime.rs`

The change follows the repository requirements:

- network blocking remains fail-closed;
- no new `unwrap()` or `expect()` was added to production code;
- the existing proxy activation behavior is preserved;
- the commit includes a DCO sign-off;
- the change is limited to the reported URL configuration propagation bug.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo test -p nono-cli blocked_network_preserves_open_url_options_without_proxy_activation`
- `cargo test -p nono-cli --test url_open_integration`

Manual reproduction using the profile and command from the linked issue was also performed.

Before the fix, the audit event was:

```text
Origin https://example.com is not in the profile's open_urls.allow_origins list
```

After the fix, the origin validation succeeds and the request proceeds to the browser opener. The headless test environment then terminates the browser opener after timeout, producing:

```text
Failed to open URL in browser: Browser opener exited with status: signal: 15 (SIGTERM)
```

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using DCO
- [x] All new code follows the project's coding standards and is covered by tests
- [x] Public-facing changes are paired with documentation updates (not applicable: this is a focused bugfix with no interface or configuration syntax change)
```