### PR TITLE
docs(profile): add profile-drafts section to guide

### DIFF
--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -1027,7 +1027,76 @@ nono profile groups               # List available security groups
 nono profile diff <a> <b>         # Compare two profiles
 ```
 
-## 6. Variable Expansion
+## 6. Profile Drafts
+
+Profile drafts are a staging area for creating or editing profiles before they are applied. Drafts live in `~/.config/nono/profile-drafts/` (or `$XDG_CONFIG_HOME/nono/profile-drafts/`). The live profiles directory (`~/.config/nono/profiles/`) is read-only inside a running agent sandbox, so the draft workflow is the correct way for an agent to propose profile changes.
+
+### Creating a new profile via draft
+
+Write the profile JSON to the drafts directory using the profile name as the filename:
+
+```
+~/.config/nono/profile-drafts/my-agent.json
+```
+
+The `meta.name` field inside the JSON must match the filename (without `.json`). Then validate and promote:
+
+```
+nono profile validate --draft my-agent   # Validate the draft before promoting
+nono profile promote my-agent            # Show diff and prompt for confirmation
+nono profile promote --diff my-agent     # Preview the diff without applying
+nono profile promote --yes my-agent      # Apply without interactive confirmation
+```
+
+On success, `promote` atomically writes the profile to `~/.config/nono/profiles/my-agent.json` and deletes the draft file.
+
+### Editing an existing profile via draft
+
+When drafting a change to a profile that already exists, you must also create a `.base` file alongside the draft JSON. The `.base` file contains the SHA-256 hex digest of the current profile bytes. `promote` checks this hash to detect if the live profile changed while the draft was in progress.
+
+Steps:
+
+1. Read the current profile: `~/.config/nono/profiles/my-agent.json`
+2. Compute its SHA-256 hex digest and write it to `~/.config/nono/profile-drafts/my-agent.base`
+3. Write your modified profile JSON to `~/.config/nono/profile-drafts/my-agent.json`
+4. Validate and promote:
+
+```
+nono profile validate --draft my-agent
+nono profile promote my-agent
+```
+
+The `.base` file must contain exactly 64 lowercase hex characters. If the live profile was modified after the draft was created and the hash no longer matches, `promote` exits with:
+
+```
+draft base hash does not match current profile. The profile changed after the draft was written; regenerate or review the draft before promoting.
+```
+
+Reread the current profile, recompute the hash, and update your draft.
+
+### Extending a built-in or pack profile
+
+`promote` refuses to replace a built-in or pack-installed profile. Instead, draft a derived profile that extends it:
+
+```json
+{
+  "meta": { "name": "default-local", "version": "1", "description": "My customisations" },
+  "extends": "default"
+}
+```
+
+Draft name: `~/.config/nono/profile-drafts/default-local.json` (no `.base` needed — this is a new profile).
+
+Then start sessions with `nono run --profile default-local -- <command>`.
+
+### Summary of draft files
+
+| File | Purpose |
+|------|---------|
+| `~/.config/nono/profile-drafts/<name>.json` | Draft profile JSON |
+| `~/.config/nono/profile-drafts/<name>.base` | SHA-256 of live profile at draft creation time (required only when editing an existing profile) |
+
+## 7. Variable Expansion
 
 The following variables are expanded in all path fields (`filesystem.*`, including `filesystem.allow`, `filesystem.read`, `filesystem.write`, `filesystem.deny`, `filesystem.bypass_protection`, and `filesystem.suppress_save_prompt`), in `command_args`, and in the values of `environment.set_vars`.
 
@@ -1045,7 +1114,7 @@ The following variables are expanded in all path fields (`filesystem.*`, includi
 
 Always use these variables instead of hardcoded absolute paths to keep profiles portable across machines and users.
 
-## 7. Platform Predicates
+## 8. Platform Predicates
 
 Profile entries that list paths, group names, URL origins, or env credentials can be unconditional strings or conditional objects with `when`.
 
@@ -1073,7 +1142,7 @@ Profile entries that list paths, group names, URL origins, or env credentials ca
 
 Supported predicate forms include `linux`, `macos`, `linux:fedora`, `linux:rhel-like`, `linux:ubuntu:>=24.04`, `macos:>=15`, negation such as `!linux:nixos`, and arrays for any-of matching.
 
-## 8. Key Rules
+## 9. Key Rules
 
 - A profile with no `groups.include` has no deny rules. Always include appropriate deny groups for untrusted workloads.
 - `filesystem.bypass_protection` only removes the deny rule. It does not grant access. You must also add the path via `filesystem.allow`, `filesystem.read`, or `filesystem.write` (or the matching `*_file` variant).
@@ -1085,7 +1154,7 @@ Supported predicate forms include `linux`, `macos`, `linux:fedora`, `linux:rhel-
 - `network.block: true` blocks all network access. It cannot be combined with proxy settings.
 - `custom_credentials` upstream URLs must use HTTPS. HTTP is only accepted for loopback addresses (localhost, 127.0.0.1, ::1).
 
-## 9. Migration from previous schema
+## 10. Migration from previous schema
 
 Issue [#594](https://github.com/nolabs-ai/nono/issues/594) restructured the profile JSON schema. The old `policy.*` namespace has been dissolved into `filesystem`, `groups`, and `commands`; `security.groups` and `security.allowed_commands` have moved to top-level `groups.include` and `commands.allow`.
 


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1520

## Summary

Adds section 6 "Profile Drafts" to the profile authoring guide explaining the full draft workflow: creating new profiles, editing existing ones (including the .base hash file requirement), extending built-in/pack profiles via derived drafts, and all validate/promote command flags. Renumbers the subsequent sections 6–9 to 7–10.

@matglas

Please let me know if anything is missing :) 

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
