### PR TITLE
fix(macos): group-sourced keychain caps must not bypass deny_keychains_macos

### DIFF
--- a/crates/nono-cli/src/policy.rs
+++ b/crates/nono-cli/src/policy.rs
@@ -882,7 +882,14 @@ pub fn apply_macos_keychain_db_exception(caps: &mut CapabilitySet) {
     let mut explicit_paths: HashMap<PathBuf, AccessMode> = HashMap::new();
     let mut keychain_roots: HashMap<PathBuf, AccessMode> = HashMap::new();
 
-    for cap in caps.fs_capabilities().iter().filter(|cap| cap.is_file) {
+    // Only user-intent grants trigger the exception. Group-sourced caps must not
+    // emit specific-op allows — they land after the deny_keychains_macos rules
+    // and would win under Seatbelt last-rule-wins, reopening the keychain.
+    for cap in caps
+        .fs_capabilities()
+        .iter()
+        .filter(|cap| cap.is_file && cap.source.is_user_intent())
+    {
         if !is_keychain_db(&cap.resolved) {
             continue;
         }
@@ -3078,6 +3085,38 @@ mod tests {
             )),
             "expected metadata keychain DB file-write-data rule (to override specific deny), got: {}",
             rules
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_apply_macos_keychain_db_exception_ignores_group_sourced_caps() {
+        // Group-sourced keychain caps must not trigger the exception.
+        let mut caps = CapabilitySet::new();
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".to_string());
+        let login_db = PathBuf::from(home).join("Library/Keychains/login.keychain-db");
+        caps.add_fs(FsCapability {
+            original: login_db.clone(),
+            resolved: login_db.clone(),
+            access: AccessMode::ReadWrite,
+            is_file: true,
+            source: CapabilitySource::Group("claude_code_macos".to_string()),
+        });
+
+        apply_macos_keychain_db_exception(&mut caps);
+
+        let rules = caps.platform_rules().join("\n");
+        assert!(
+            !rules.contains("file-read-data"),
+            "group-sourced cap must not generate file-read-data exception rule, got: {rules}"
+        );
+        assert!(
+            !rules.contains("file-write-data"),
+            "group-sourced cap must not generate file-write-data exception rule, got: {rules}"
+        );
+        assert!(
+            rules.is_empty(),
+            "group-sourced cap must not generate any exception rules, got: {rules}"
         );
     }
 

--- a/crates/nono/src/sandbox/macos.rs
+++ b/crates/nono/src/sandbox/macos.rs
@@ -12,7 +12,7 @@ use crate::error::{NonoError, Result};
 use crate::sandbox::SupportInfo;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::ptr;
 use tracing::{debug, info};
 
@@ -279,9 +279,35 @@ fn has_explicit_keychain_db_access(caps: &CapabilitySet) -> bool {
         false
     };
 
-    caps.fs_capabilities()
-        .iter()
-        .any(|cap| is_keychain_db(&cap.original) || is_keychain_db(&cap.resolved))
+    // Collect all known keychain DB paths for coverage checks below.
+    let all_keychain_dbs: Vec<PathBuf> = user_keychain_dbs
+        .as_ref()
+        .map(|dbs| dbs.to_vec())
+        .unwrap_or_default()
+        .into_iter()
+        .chain(system_keychain_dbs.iter().cloned())
+        .collect();
+
+    // Only user-intent grants unlock Mach IPC to keychain daemons. Group grants
+    // must not suppress the secd/securityd denies — Mach IPC bypasses file-level
+    // rules, so a group-sourced keychain cap would reopen access even when
+    // deny_keychains_macos is active.
+    //
+    // A directory grant covering a keychain DB also counts — e.g. a profile that
+    // allows ~/Library/Keychains (directory) covers login.keychain-db within it.
+    caps.fs_capabilities().iter().any(|cap| {
+        if !cap.source.is_user_intent() {
+            return false;
+        }
+        if cap.is_file {
+            is_keychain_db(&cap.original) || is_keychain_db(&cap.resolved)
+        } else {
+            // Directory grant: check if it covers any known keychain DB.
+            all_keychain_dbs
+                .iter()
+                .any(|db| db.starts_with(&cap.resolved) || db.starts_with(&cap.original))
+        }
+    })
 }
 
 /// Escape a path for use in Seatbelt profile strings.
@@ -874,7 +900,6 @@ pub fn apply(caps: &CapabilitySet) -> Result<()> {
     let profile = generate_profile(caps)?;
 
     debug!("Generated Seatbelt profile ({} bytes)", profile.len());
-
     let profile_cstr = CString::new(profile)
         .map_err(|e| NonoError::SandboxInit(format!("Invalid profile string: {}", e)))?;
 
@@ -1472,6 +1497,58 @@ mod tests {
             resolved: metadata_keychain_db,
             access: AccessMode::Read,
             is_file: true,
+            source: CapabilitySource::Profile,
+        });
+
+        let profile = generate_profile(&caps).unwrap();
+
+        assert!(!profile.contains("(deny mach-lookup (global-name \"com.apple.SecurityServer\"))"));
+        assert!(!profile.contains("(deny mach-lookup (global-name \"com.apple.securityd\"))"));
+        assert!(
+            !profile.contains("(deny mach-lookup (global-name \"com.apple.security.keychaind\"))")
+        );
+        assert!(!profile.contains("(deny mach-lookup (global-name \"com.apple.secd\"))"));
+        assert!(!profile.contains("(deny mach-lookup (global-name \"com.apple.security.agent\"))"));
+    }
+
+    #[test]
+    fn test_generate_profile_group_sourced_keychain_does_not_suppress_mach_deny() {
+        // Group-sourced keychain caps must not suppress Mach IPC denies.
+        let mut caps = CapabilitySet::new();
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".to_string());
+        let keychain = PathBuf::from(home).join("Library/Keychains/login.keychain-db");
+        caps.add_fs(FsCapability {
+            original: keychain.clone(),
+            resolved: keychain,
+            access: AccessMode::ReadWrite,
+            is_file: true,
+            source: CapabilitySource::Group("claude_code_macos".to_string()),
+        });
+
+        let profile = generate_profile(&caps).unwrap();
+
+        assert!(profile.contains("(deny mach-lookup (global-name \"com.apple.SecurityServer\"))"));
+        assert!(profile.contains("(deny mach-lookup (global-name \"com.apple.securityd\"))"));
+        assert!(
+            profile.contains("(deny mach-lookup (global-name \"com.apple.security.keychaind\"))")
+        );
+        assert!(profile.contains("(deny mach-lookup (global-name \"com.apple.secd\"))"));
+        assert!(profile.contains("(deny mach-lookup (global-name \"com.apple.security.agent\"))"));
+    }
+
+    #[test]
+    fn test_generate_profile_directory_grant_covering_keychain_suppresses_mach_deny() {
+        // A profile-level directory grant covering ~/Library/Keychains must suppress
+        // Mach IPC denies, the same as an explicit file grant for login.keychain-db.
+        // Regression: nolabs-ai/claude grants the Keychains directory, not individual files.
+        let mut caps = CapabilitySet::new();
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".to_string());
+        let keychains_dir = PathBuf::from(home).join("Library/Keychains");
+        caps.add_fs(FsCapability {
+            original: keychains_dir.clone(),
+            resolved: keychains_dir,
+            access: AccessMode::ReadWrite,
+            is_file: false,
             source: CapabilitySource::Profile,
         });
 

--- a/docs/cli/internals/security-model.mdx
+++ b/docs/cli/internals/security-model.mdx
@@ -196,11 +196,23 @@ Security implication:
 
 This was chosen as a compatibility tradeoff for the Claude profile. Users who need a tighter boundary should use a custom profile instead of relying on the pack-provided `claude-code` profile.
 
-For users who want the Claude profile shape without macOS keychain access, nono also provides:
+For users who want the Claude profile shape without macOS keychain access, you need to create a full custom profile rather than a simple extension. The keychain access in `nolabs-ai/claude` comes from `filesystem.allow` and `filesystem.bypass_protection` entries in the pack profile itself — not from the `claude_code_macos` group — so excluding the group alone is not sufficient.
 
-- `claude-no-kc`
+The correct approach:
 
-That profile keeps the normal Claude filesystem/runtime allowances but does not relax the macOS keychain deny for `~/Library/Keychains`.
+1. Inspect the current pack profile:
+   ```bash
+   nono profile show --raw nolabs-ai/claude
+   ```
+
+2. Copy all `filesystem.allow`, `filesystem.read`, `filesystem.allow_file`, and group entries into a new local profile, omitting `$HOME/Library/Keychains` from `filesystem.allow` and removing it from `filesystem.bypass_protection` entirely.
+
+3. Save the profile and run with it:
+   ```bash
+   nono run --profile claude-no-kc -- claude
+   ```
+
+The `deny_keychains_macos` required group is always active in every profile. Without the `filesystem.allow` + `filesystem.bypass_protection` pair for `~/Library/Keychains`, the deny wins and keychain access is fully blocked at both the file level and via Mach IPC.
 
 ## The fd Injection Model
 

--- a/docs/cli/internals/security-model.mdx
+++ b/docs/cli/internals/security-model.mdx
@@ -202,7 +202,7 @@ The correct approach:
 
 1. Inspect the current pack profile:
    ```bash
-   nono profile show --raw nolabs-ai/claude
+   nono profile show --raw nolabs-ai/claude --json
    ```
 
 2. Copy all `filesystem.allow`, `filesystem.read`, `filesystem.allow_file`, and group entries into a new local profile, omitting `$HOME/Library/Keychains` from `filesystem.allow` and removing it from `filesystem.bypass_protection` entirely.


### PR DESCRIPTION


## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1519 
Closes #1494

cc @levbishop and @Eric-Arellano please let me know what you think

## Summary

Including the claude_code_macos group was silently reopening keychain access even when deny_keychains_macos was active, via two paths:

- apply_macos_keychain_db_exception emitted specific-op Seatbelt allow rules for group-sourced caps, which landed after the deny and won under last-rule-wins
- has_explicit_keychain_db_access returned true for group-sourced caps, suppressing Mach IPC denies for secd/securityd — which bypass file level rules entirely

Both are now gated on is_user_intent(). Also extends the DB access check to match directory caps covering a keychain DB path, not just exact file matches — otherwise the nolabs-ai/claude packs directory grant failed the check and broke OAuth.
<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
