### PR TITLE
docs(supervisor): clarify that capability elevation is disabled by default

### DIFF
--- a/docs/cli/features/supervisor.mdx
+++ b/docs/cli/features/supervisor.mdx
@@ -11,10 +11,10 @@ Supervised execution is the default for `nono run` and `nono shell`. No extra fl
 
 ```bash
 # Supervised by default
-nono run --profile always-further/claude -- claude
+nono run --profile nolabs-ai/claude -- claude
 
 # Enable rollback snapshots
-nono run --rollback --profile always-further/claude -- claude
+nono run --rollback --profile nolabs-ai/claude -- claude
 ```
 
 The execution model:
@@ -28,7 +28,23 @@ For the operational runtime workflow built on top of supervisor mode, see [Sessi
 
 ## Capability Expansion (Linux)
 
-On Linux, supervisor mode enables transparent capability expansion. When the sandboxed process tries to access a file outside its allowed paths, instead of getting `EPERM`, the supervisor intercepts the request and can grant access on the fly.
+Capability expansion is **disabled by default** and must be explicitly enabled. To turn it on, use one of:
+
+- CLI flag: `--capability-elevation`
+- Environment variable: `NONO_CAPABILITY_ELEVATION=1`
+- Profile setting: `security.capability_elevation = true`
+
+```bash
+# Enable via flag
+nono run --capability-elevation --profile nolabs-ai/claude -- claude
+
+# Enable via environment variable
+NONO_CAPABILITY_ELEVATION=1 nono run --profile nolabs-ai/claude -- claude
+```
+
+Without one of these, a sandboxed process that tries to access a path outside its granted set will receive `EPERM` as normal — no prompt will appear.
+
+When capability expansion is enabled, the supervisor intercepts the request and can grant access on the fly.
 
 ### How It Works
 


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1534 

## Summary

The supervisor docs implied that capability expansion was on by default as part of supervised execution. Separate the two concepts: supervised mode (fork+wait parent process) is the default; capability elevation (seccomp-notify + approval prompts) is opt-in.

Add explicit documentation of the three ways to enable it: --capability-elevation flag, NONO_CAPABILITY_ELEVATION env var, and security.capability_elevation profile setting, with examples.
<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
