### PR TITLE
fix(query): dont widen grant suggestions to $HOME or XDG roots

### DIFF
--- a/crates/nono-cli/src/capability_ext.rs
+++ b/crates/nono-cli/src/capability_ext.rs
@@ -7,6 +7,7 @@ use crate::cli::SandboxArgs;
 use crate::policy;
 use crate::profile::{Profile, expand_vars};
 use crate::protected_paths::{self, ProtectedRoots};
+use crate::query_ext::is_sensitive_root;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use crate::tool_sandbox::dynamic_providers::expand_dynamic_tokens;
 
@@ -185,6 +186,7 @@ fn add_cli_unix_socket_caps(
                     caps.add_fs(cap);
                 }
             } else if let Some(parent) = path.parent()
+                && !is_sensitive_root(parent)
                 && let Some(cap) = try_new_dir(
                     parent,
                     AccessMode::ReadWrite,
@@ -861,6 +863,7 @@ impl CapabilitySetExt for CapabilitySet {
                         caps.add_fs(cap);
                     }
                 } else if let Some(parent) = path.parent()
+                    && !is_sensitive_root(parent)
                     && let Some(mut cap) = try_new_dir(parent, AccessMode::ReadWrite, &label)?
                 {
                     cap.source = CapabilitySource::Profile;

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -757,8 +757,8 @@ pub(crate) fn suggested_flag_parts(path: &Path, requested: AccessMode) -> (&'sta
     let target = if path.exists() || path.is_dir() || path.parent().is_none() {
         path.to_path_buf()
     } else if let Some(parent) = path.parent() {
-        // Never suggest granting access to the root filesystem
-        if parent == Path::new("/") {
+        if is_sensitive_root(parent) {
+            // Never widen to a sensitive top-level directory; suggest the exact path instead.
             path.to_path_buf()
         } else {
             parent.to_path_buf()
@@ -767,7 +767,66 @@ pub(crate) fn suggested_flag_parts(path: &Path, requested: AccessMode) -> (&'sta
         path.to_path_buf()
     };
 
+    // When the target is an exact file path (not widened to a directory), use
+    // file-specific flags regardless of whether the file currently exists.
+    let flag = if target == path && !path.is_dir() {
+        match requested {
+            AccessMode::Read => "--read-file",
+            AccessMode::Write => "--write-file",
+            AccessMode::ReadWrite => "--allow-file",
+        }
+    } else {
+        flag
+    };
+
     (flag, target)
+}
+
+/// Returns true for directories that should never be used as a widened grant target:
+/// the filesystem root, the user's home directory, and XDG base directories.
+fn is_sensitive_root(path: &Path) -> bool {
+    if path == Path::new("/") {
+        return true;
+    }
+
+    if let Some(home) = dirs::home_dir()
+        && path == home
+    {
+        return true;
+    }
+
+    // XDG base directories (use env vars with standard defaults).
+    let xdg_roots: Vec<PathBuf> = [
+        std::env::var("XDG_CONFIG_HOME")
+            .ok()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                dirs::home_dir()
+                    .map(|h| h.join(".config"))
+                    .unwrap_or_default()
+            }),
+        std::env::var("XDG_DATA_HOME")
+            .ok()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                dirs::home_dir()
+                    .map(|h| h.join(".local/share"))
+                    .unwrap_or_default()
+            }),
+        std::env::var("XDG_STATE_HOME")
+            .ok()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                dirs::home_dir()
+                    .map(|h| h.join(".local/state"))
+                    .unwrap_or_default()
+            }),
+    ]
+    .into_iter()
+    .filter(|p| !p.as_os_str().is_empty())
+    .collect();
+
+    xdg_roots.iter().any(|root| path == root)
 }
 
 #[cfg(test)]
@@ -1229,5 +1288,55 @@ mod tests {
     #[test]
     fn test_path_matches_empty_rules_allows_all() {
         assert!(path_matches_endpoint_rules("/any/path", &[]));
+    }
+
+    // suggested_flag_parts: non-existent file directly under $HOME must not widen to ~/
+    #[test]
+    fn test_suggested_flag_parts_home_dir_file() {
+        let home = dirs::home_dir().expect("home dir required for this test");
+        let nonexistent = home.join("nono-blocked.txt");
+        // File must not exist for the widening path to be triggered.
+        assert!(!nonexistent.exists());
+
+        let (flag, target) = suggested_flag_parts(&nonexistent, AccessMode::Write);
+        assert_eq!(
+            flag, "--write-file",
+            "should suggest a file grant, not a directory grant"
+        );
+        assert_eq!(
+            target, nonexistent,
+            "should not widen to the home directory"
+        );
+    }
+
+    // suggested_flag_parts: non-existent file under XDG_CONFIG_HOME must not widen to that root
+    #[test]
+    fn test_suggested_flag_parts_xdg_config_home_file() {
+        let home = dirs::home_dir().expect("home dir required for this test");
+        let xdg_config = std::env::var("XDG_CONFIG_HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| home.join(".config"));
+        let nonexistent = xdg_config.join("nono-blocked.txt");
+        assert!(!nonexistent.exists());
+
+        let (flag, target) = suggested_flag_parts(&nonexistent, AccessMode::Write);
+        assert_eq!(flag, "--write-file");
+        assert_eq!(target, nonexistent, "should not widen to XDG_CONFIG_HOME");
+    }
+
+    // suggested_flag_parts: non-existent file under a nested project subdir should still widen
+    // to the parent (this is the intentional behavior we must not regress).
+    #[test]
+    fn test_suggested_flag_parts_nested_subdir_widens() {
+        // Use a temp dir that is guaranteed to exist so we get a real parent, but the
+        // file inside it does not exist.
+        let dir = tempdir().expect("tempdir");
+        let nonexistent = dir.path().join("dist").join("bundle.js");
+        assert!(!nonexistent.exists());
+
+        let (flag, target) = suggested_flag_parts(&nonexistent, AccessMode::Write);
+        // The parent "dist" doesn't exist either, so it widens to it — that is correct.
+        assert_eq!(flag, "--write");
+        assert_eq!(target, dir.path().join("dist"));
     }
 }

--- a/crates/nono-cli/src/query_ext.rs
+++ b/crates/nono-cli/src/query_ext.rs
@@ -784,24 +784,29 @@ pub(crate) fn suggested_flag_parts(path: &Path, requested: AccessMode) -> (&'sta
 
 /// Returns true for directories that should never be used as a widened grant target:
 /// the filesystem root, the user's home directory, and XDG base directories.
-fn is_sensitive_root(path: &Path) -> bool {
+///
+/// All candidate roots are canonicalized before comparison so that symlinked home
+/// directories (e.g. macOS `/Users/foo` → `/private/Users/foo`) match the
+/// canonicalized `path` that arrives from `suggested_flag_parts`.
+pub(crate) fn is_sensitive_root(path: &Path) -> bool {
     if path == Path::new("/") {
         return true;
     }
 
     if let Some(home) = dirs::home_dir()
-        && path == home
+        && try_canonicalize(&home) == path
     {
         return true;
     }
 
     // XDG base directories (use env vars with standard defaults).
+    let home = dirs::home_dir();
     let xdg_roots: Vec<PathBuf> = [
         std::env::var("XDG_CONFIG_HOME")
             .ok()
             .map(PathBuf::from)
             .unwrap_or_else(|| {
-                dirs::home_dir()
+                home.as_deref()
                     .map(|h| h.join(".config"))
                     .unwrap_or_default()
             }),
@@ -809,7 +814,7 @@ fn is_sensitive_root(path: &Path) -> bool {
             .ok()
             .map(PathBuf::from)
             .unwrap_or_else(|| {
-                dirs::home_dir()
+                home.as_deref()
                     .map(|h| h.join(".local/share"))
                     .unwrap_or_default()
             }),
@@ -817,13 +822,22 @@ fn is_sensitive_root(path: &Path) -> bool {
             .ok()
             .map(PathBuf::from)
             .unwrap_or_else(|| {
-                dirs::home_dir()
+                home.as_deref()
                     .map(|h| h.join(".local/state"))
+                    .unwrap_or_default()
+            }),
+        std::env::var("XDG_CACHE_HOME")
+            .ok()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                home.as_deref()
+                    .map(|h| h.join(".cache"))
                     .unwrap_or_default()
             }),
     ]
     .into_iter()
     .filter(|p| !p.as_os_str().is_empty())
+    .map(|p| try_canonicalize(&p))
     .collect();
 
     xdg_roots.iter().any(|root| path == root)

--- a/tests/integration/test_policy_queries.sh
+++ b/tests/integration/test_policy_queries.sh
@@ -32,7 +32,7 @@ expect_output_contains "sensitive path is denied" "\"reason\": \"sensitive_path\
 expect_output_contains "non-granted path is denied" "\"reason\": \"path_not_granted\"" \
     "$NONO_BIN" --silent why --json --path "$DENIED_PATH" --op read
 
-expect_output_contains "non-granted path suggests exact flag" "\"suggested_flag\": \"--read $HOME\"" \
+expect_output_contains "non-granted path suggests exact flag" "\"suggested_flag\": \"--read-file $DENIED_PATH\"" \
     "$NONO_BIN" --silent why --json --path "$DENIED_PATH" --op read
 
 expect_output_contains "allow grants write for matching path" "\"status\": \"allowed\"" \


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1505

## Summary

When a denied write targets a non-existent file directly under $HOME, $XDG_CONFIG_HOME, $XDG_DATA_HOME, or $XDG_STATE_HOME, suggest the exact file grant (--write-file <path>) instead of widening to the parent directory. The existing root (/) guard is extended to cover these sensitive top-level directories.

Fixes the Linux side effect too: a narrow file grant wont overlap required deny groups, so saved profiles no longer fail to start.

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
