### PR TITLE
fix(deps): bump aws-lc-rs to 1.17.3 for hardened RPM builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",

--- a/crates/nono-cli/Cargo.toml
+++ b/crates/nono-cli/Cargo.toml
@@ -61,7 +61,7 @@ chrono = { version = "0.4", features = ["serde"] }
 itoa = "1"
 
 # Signing key PKCS#8 serialization (already transitive via sigstore-verify)
-aws-lc-rs = "1"
+aws-lc-rs = "1.17.3"
 
 # Keystore access for trust signing keys (optional). Linux uses the pure-Rust
 # zbus Secret Service backend (see linux target deps), so no libdbus is linked.


### PR DESCRIPTION
aws-lc-sys 0.42.0, pulled in since v0.67.0, fails to build under RPM hardened flags, breaking the Fedora COPR builds:

    relocation R_X86_64_32 against `.rodata' can not be used when
    making a PIE object; recompile with -fPIE
    failed to set dynamic section sizes: bad value

Its memcmp_invalid_stripped_check probe compiles with only -O3, deliberately ignoring CFLAGS, but still appends LDFLAGS. RPM hardening splits PIE across the two: CFLAGS carries redhat-hardened-cc1 (adds -fPIE, dropped) while LDFLAGS carries redhat-hardened-ld (forces -pie, applied). The object is then built non-PIE and linked as PIE.

Fixed upstream in aws-lc-sys 0.43.0 (aws/aws-lc-rs#1168): the probe keeps cc-rs's computed flags, only runs for the GCC versions actually affected by GCC bug 95189, and no longer aborts the build when it fails to compile. Take it via aws-lc-rs 1.17.3; 1.17.2 carries the same fix but is yanked. The manifest floor is raised to match so a re-resolve cannot land back on 0.42.0.

Verified by building nono-cli with CFLAGS/LDFLAGS from rpm --eval: 0.42.0 reproduces the reported failure, 0.43.0 builds clean and the workspace test suite passes.

Fixes #1447

## Linked Issue

Closes #1447 

## Summary

aws-lc-sys 0.42.0, pulled in since v0.67.0, fails to build under RPM hardened flags, breaking the Fedora COPR builds:

## Agent Disclosure (if applicable)

## Test Plan

Local build and my copr fork https://copr.fedorainfracloud.org/coprs/mnohime/nono/build/10793414/ passed

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates

