### PR TITLE
fix: allow config files for Claude

### DIFF
--- a/crates/nono-cli/src/package_status.rs
+++ b/crates/nono-cli/src/package_status.rs
@@ -40,13 +40,22 @@ impl OfficialPackStatusTarget {
     }
 }
 
-pub(crate) fn enforce_for_active_profile(profile_name: Option<&str>, silent: bool) -> Result<()> {
+/// Enforce official-pack status for the profile this run selected.
+///
+/// `cli_extends` carries `--extends`, which behaves as if those bases were
+/// prepended to the selected profile's `extends`, so a run that reaches a
+/// yanked pack only through `--extends` must be gated too.
+pub(crate) fn enforce_for_active_profile(
+    profile_name: Option<&str>,
+    cli_extends: &[String],
+    silent: bool,
+) -> Result<()> {
     let Some(profile_name) = profile_name else {
         return Ok(());
     };
 
     for target in OFFICIAL_PACK_STATUS_TARGETS {
-        if depends_on_official_pack_profile(*target, profile_name) {
+        if run_loads_official_pack(*target, profile_name, cli_extends) {
             enforce_official_pack_status(*target, silent)?;
         }
     }
@@ -122,22 +131,85 @@ fn yanked_message(key: &str, installed: &str, status: &PackageStatusResponse) ->
     message
 }
 
-fn depends_on_official_pack_profile(target: OfficialPackStatusTarget, name_or_path: &str) -> bool {
-    if is_official_package_ref(target, name_or_path) {
-        return true;
-    }
-    if is_official_profile_name(target, name_or_path) && !profile::is_user_override(name_or_path) {
-        return true;
-    }
-    depends_on_official_pack_profile_inner(target, name_or_path, &mut Vec::new())
+/// Returns `true` when this run launches Claude Code: the `nolabs-ai/claude`
+/// pack ref, any name the installed pack answers to (its `install_as` plus the
+/// manifest's aliases), the names the pack is published under while it is not
+/// installed yet, a user profile file named after one of those, or any profile
+/// whose `extends` chain reaches one of those.
+///
+/// `cli_extends` carries `--extends`, whose bases are resolved as if they
+/// were prepended to the selected profile's own `extends`.
+///
+/// This is deliberately broader than [`run_loads_official_pack`]: it gates the
+/// Claude Code sandbox preparation, which a profile needs because of what it
+/// launches, not because of where it came from.
+pub(crate) fn profile_selects_claude_code(name_or_path: &str, cli_extends: &[String]) -> bool {
+    reaches_official_pack_profile(
+        CLAUDE_PACK,
+        name_or_path,
+        cli_extends,
+        name_launches_official_pack,
+    )
 }
 
-fn depends_on_official_pack_profile_inner(
+/// Returns `true` when this run loads `target`'s own profile: the pack ref, a
+/// name the installed pack answers to, a name the pack is published under
+/// while it is not installed yet, or any profile whose `extends` chain reaches
+/// one of those.
+///
+/// Unlike [`profile_selects_claude_code`] this mirrors the resolver exactly, so
+/// a user profile file shadowing a published name is not the pack: that run
+/// never loads the pack, and the pack's registry status says nothing about it.
+fn run_loads_official_pack(
     target: OfficialPackStatusTarget,
     name_or_path: &str,
+    cli_extends: &[String],
+) -> bool {
+    reaches_official_pack_profile(target, name_or_path, cli_extends, name_loads_official_pack)
+}
+
+/// The pack a bare `--profile <name>` would resolve to, if any — matching the
+/// canonical `install_as` names and the manifest aliases alike.
+///
+/// Delegates to the resolver's own lookup rather than re-deriving it from a
+/// separate scan, so this answer cannot drift from the pack `load_profile_inner`
+/// would load — including the tie-break when two installed packs publish the
+/// same profile name.
+///
+/// Each call rescans the pack store (a `read_dir` per namespace plus a
+/// `package.json` read and parse per pack). Detection asks this once per node of
+/// every `extends` chain it walks, but the walk already pays the same scan per
+/// node inside [`profile::load_profile_extends`], so this at most doubles a cost
+/// bounded by chain length. Cache it in `profile` — behind the one lookup both
+/// sides use — if that ever shows up in a profile.
+fn pack_store_provider(name: &str) -> Option<String> {
+    profile::find_pack_store_profile(name).map(|(_, pack_key)| pack_key)
+}
+
+/// Walk `name_or_path` and the `--extends` bases, asking `name_matches` about
+/// each name and following every `extends` edge until one matches.
+fn reaches_official_pack_profile(
+    target: OfficialPackStatusTarget,
+    name_or_path: &str,
+    cli_extends: &[String],
+    name_matches: fn(OfficialPackStatusTarget, &str) -> bool,
+) -> bool {
+    let mut visited = Vec::new();
+    // `--extends` bases sit alongside the selected profile rather than under
+    // it, so each one needs its own walk. `visited` is shared: a name that
+    // fails to reach the pack fails for every root.
+    std::iter::once(name_or_path)
+        .chain(cli_extends.iter().map(String::as_str))
+        .any(|name| walk_extends_chain(target, name, name_matches, &mut visited))
+}
+
+fn walk_extends_chain(
+    target: OfficialPackStatusTarget,
+    name_or_path: &str,
+    name_matches: fn(OfficialPackStatusTarget, &str) -> bool,
     visited: &mut Vec<String>,
 ) -> bool {
-    if is_official_profile_name(target, name_or_path) {
+    if name_matches(target, name_or_path) {
         return true;
     }
     if visited.iter().any(|visited| visited == name_or_path) {
@@ -150,7 +222,50 @@ fn depends_on_official_pack_profile_inner(
     };
     bases
         .iter()
-        .any(|base| depends_on_official_pack_profile_inner(target, base, visited))
+        .any(|base| walk_extends_chain(target, base, name_matches, visited))
+}
+
+/// Returns `true` when this single name loads `target`'s own profile, ignoring
+/// `extends`.
+///
+/// Mirrors the resolver's precedence (`load_profile_inner`): pack ref, then
+/// user override, then the pack store, then the published names.
+fn name_loads_official_pack(target: OfficialPackStatusTarget, name: &str) -> bool {
+    if is_official_package_ref(target, name) {
+        return true;
+    }
+    // A user file shadows the pack, so this name loads that file, not the pack.
+    if profile::is_user_override(name) {
+        return false;
+    }
+    name_resolves_to_official_pack(target, name)
+}
+
+/// Returns `true` when this single name launches `target`'s agent, ignoring
+/// `extends`.
+///
+/// Differs from [`name_loads_official_pack`] on a user profile file named after
+/// the pack: `~/.config/nono/profiles/claude-code.json` shadows the pack, but it
+/// still launches Claude Code and still needs the Claude Code preparation.
+fn name_launches_official_pack(target: OfficialPackStatusTarget, name: &str) -> bool {
+    if is_official_package_ref(target, name) {
+        return true;
+    }
+    if profile::is_user_override(name) {
+        return is_official_profile_name(target, name);
+    }
+    name_resolves_to_official_pack(target, name)
+}
+
+/// The tail both questions share: the pack store, then the published names.
+fn name_resolves_to_official_pack(target: OfficialPackStatusTarget, name: &str) -> bool {
+    if let Some(pack_key) = pack_store_provider(name) {
+        // An installed pack owns the name it installs, even when that name is
+        // one the official pack publishes — `--profile claude` resolves to
+        // that pack, so this run is not the official one.
+        return pack_key == target.key();
+    }
+    is_official_profile_name(target, name)
 }
 
 fn is_official_profile_name(target: OfficialPackStatusTarget, name: &str) -> bool {
@@ -165,6 +280,42 @@ fn is_official_package_ref(target: OfficialPackStatusTarget, value: &str) -> boo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env::{with_isolated_config_home, write_user_profile};
+    use std::path::Path;
+
+    /// No `--extends` on the command line.
+    const NO_EXTENDS: &[String] = &[];
+
+    /// "Is this run launching Claude Code?" — gates the sandbox preparation.
+    fn selects_claude_code(name: &str) -> bool {
+        profile_selects_claude_code(name, NO_EXTENDS)
+    }
+
+    /// "Does this run load the official claude pack?" — gates the yanked-pack
+    /// check.
+    fn loads_claude_pack(name: &str) -> bool {
+        run_loads_official_pack(CLAUDE_PACK, name, NO_EXTENDS)
+    }
+
+    /// Install a fake pack providing one profile artifact under `install_as`,
+    /// also answering to `aliases`.
+    fn write_pack_profile(
+        config_home: &Path,
+        namespace: &str,
+        pack_name: &str,
+        install_as: &str,
+        aliases: &[&str],
+    ) {
+        crate::test_env::write_fake_pack(
+            config_home,
+            namespace,
+            pack_name,
+            install_as,
+            &format!(r#"{{ "meta": {{ "name": "{install_as}" }} }}"#),
+            aliases,
+            None,
+        );
+    }
 
     #[test]
     fn yanked_message_pins_latest_when_available() {
@@ -208,5 +359,197 @@ mod tests {
             CODEX_PACK,
             "nolabs-ai/codex-extra"
         ));
+    }
+
+    #[test]
+    fn claude_code_detection_covers_every_documented_profile_form() {
+        with_isolated_config_home(|_config_home| {
+            assert!(selects_claude_code("nolabs-ai/claude"));
+            assert!(selects_claude_code("nolabs-ai/claude@1.2.3"));
+            assert!(selects_claude_code("claude"));
+            assert!(selects_claude_code("claude-code"));
+
+            assert!(!selects_claude_code("default"));
+            assert!(!selects_claude_code("codex"));
+            assert!(!selects_claude_code("nolabs-ai/codex"));
+            assert!(!selects_claude_code("someone-else/claude"));
+        });
+    }
+
+    #[test]
+    fn claude_code_detection_follows_extends_chain_to_a_pack_ref() {
+        with_isolated_config_home(|config_home| {
+            write_user_profile(
+                config_home,
+                "my-agent",
+                r#"{
+                    "meta": { "name": "my-agent" },
+                    "extends": "nolabs-ai/claude"
+                }"#,
+            );
+
+            assert!(
+                selects_claude_code("my-agent"),
+                "a user profile extending the pack ref must be treated as Claude Code"
+            );
+        });
+    }
+
+    /// Aliases live in the pack manifest, not in `CLAUDE_PACK.profiles`, so
+    /// detection must ask the resolver instead of the hardcoded name list.
+    #[test]
+    fn claude_code_detection_covers_pack_manifest_aliases() {
+        with_isolated_config_home(|config_home| {
+            write_pack_profile(
+                config_home,
+                "nolabs-ai",
+                "claude",
+                "claude",
+                &["claude-code", "cc"],
+            );
+
+            assert!(
+                selects_claude_code("cc"),
+                "an alias the installed claude pack answers to must be treated as Claude Code"
+            );
+        });
+    }
+
+    /// A pack that happens to publish a profile named `claude` is not the
+    /// official pack, so its short name must not be mistaken for one.
+    #[test]
+    fn claude_code_detection_ignores_same_named_profile_from_another_pack() {
+        with_isolated_config_home(|config_home| {
+            write_pack_profile(config_home, "someone-else", "agent", "agent", &["kodu"]);
+
+            assert!(!selects_claude_code("kodu"));
+            assert!(!selects_claude_code("agent"));
+        });
+    }
+
+    /// An installed pack owns the name it installs, even when that name is one
+    /// the official pack is published under: `--profile claude` resolves to
+    /// this third-party pack (user file -> pack store -> built-in), so treating
+    /// it as Claude Code would relocate `~/.claude.json` for an unrelated
+    /// profile.
+    #[test]
+    fn third_party_pack_installing_the_claude_name_does_not_select_claude_code() {
+        with_isolated_config_home(|config_home| {
+            write_pack_profile(config_home, "someone-else", "agent", "claude", &["cc"]);
+
+            assert!(
+                !selects_claude_code("claude"),
+                "a third-party pack installed as `claude` must not be treated as Claude Code"
+            );
+            assert!(!selects_claude_code("cc"), "nor must one of its aliases");
+        });
+    }
+
+    /// The published-name fallback still has to fire once the official pack is
+    /// the one installed under that name.
+    #[test]
+    fn official_pack_installing_the_claude_name_selects_claude_code() {
+        with_isolated_config_home(|config_home| {
+            write_pack_profile(config_home, "nolabs-ai", "claude", "claude", &[]);
+
+            assert!(selects_claude_code("claude"));
+        });
+    }
+
+    /// A user profile file named after the pack shadows it, so the run never
+    /// loads the pack — but it is still a Claude Code run and still needs the
+    /// preparation. Regression for the repro in issue #1546, which writes
+    /// exactly these files.
+    #[test]
+    fn user_override_of_a_published_name_still_selects_claude_code() {
+        with_isolated_config_home(|config_home| {
+            for name in ["claude", "claude-code"] {
+                write_user_profile(
+                    config_home,
+                    name,
+                    &format!(r#"{{ "meta": {{ "name": "{name}" }}, "extends": "default" }}"#),
+                );
+
+                assert!(
+                    selects_claude_code(name),
+                    "a user profile named `{name}` still launches Claude Code"
+                );
+                assert!(
+                    !loads_claude_pack(name),
+                    "but it shadows the pack, so the run does not load the pack"
+                );
+            }
+        });
+    }
+
+    /// The override allowance is scoped to the names the pack publishes: an
+    /// unrelated user profile must not be dragged in.
+    #[test]
+    fn user_override_of_an_unrelated_name_does_not_select_claude_code() {
+        with_isolated_config_home(|config_home| {
+            write_user_profile(
+                config_home,
+                "my-agent",
+                r#"{ "meta": { "name": "my-agent" }, "extends": "default" }"#,
+            );
+
+            assert!(!selects_claude_code("my-agent"));
+            assert!(!loads_claude_pack("my-agent"));
+        });
+    }
+
+    #[test]
+    fn user_override_extending_the_pack_still_selects_claude_code() {
+        with_isolated_config_home(|config_home| {
+            write_user_profile(
+                config_home,
+                "claude",
+                r#"{ "meta": { "name": "claude" }, "extends": "nolabs-ai/claude" }"#,
+            );
+
+            assert!(
+                selects_claude_code("claude"),
+                "an override that extends the pack is still Claude Code"
+            );
+        });
+    }
+
+    /// `--extends` bases are resolved as if prepended to the selected
+    /// profile's own `extends`, so a run that only reaches the pack that way
+    /// still needs the Claude Code handling (and the pack status gate).
+    #[test]
+    fn cli_extends_reaching_the_pack_selects_claude_code() {
+        with_isolated_config_home(|config_home| {
+            write_user_profile(
+                config_home,
+                "vanilla",
+                r#"{ "meta": { "name": "vanilla" }, "extends": "default" }"#,
+            );
+            write_user_profile(
+                config_home,
+                "wraps-claude",
+                r#"{ "meta": { "name": "wraps-claude" }, "extends": "nolabs-ai/claude" }"#,
+            );
+
+            assert!(
+                !profile_selects_claude_code("vanilla", NO_EXTENDS),
+                "control: the selected profile alone does not reach the pack"
+            );
+            assert!(
+                profile_selects_claude_code("vanilla", &["nolabs-ai/claude".to_string()]),
+                "--extends naming the pack ref must be treated as Claude Code"
+            );
+            assert!(
+                profile_selects_claude_code("vanilla", &["wraps-claude".to_string()]),
+                "--extends whose own chain reaches the pack must be treated as Claude Code"
+            );
+            assert!(
+                !profile_selects_claude_code(
+                    "vanilla",
+                    &["default".to_string(), "vanilla".to_string()]
+                ),
+                "unrelated --extends bases must not be treated as Claude Code"
+            );
+        });
     }
 }

--- a/crates/nono-cli/src/package_status.rs
+++ b/crates/nono-cli/src/package_status.rs
@@ -9,18 +9,21 @@ use nono::{NonoError, Result};
 struct OfficialPackStatusTarget {
     namespace: &'static str,
     name: &'static str,
+    legacy_namespaces: &'static [&'static str],
     profiles: &'static [&'static str],
 }
 
 const CLAUDE_PACK: OfficialPackStatusTarget = OfficialPackStatusTarget {
     namespace: "nolabs-ai",
     name: "claude",
+    legacy_namespaces: &["always-further"],
     profiles: &["claude", "claude-code"],
 };
 
 const CODEX_PACK: OfficialPackStatusTarget = OfficialPackStatusTarget {
     namespace: "nolabs-ai",
     name: "codex",
+    legacy_namespaces: &[],
     profiles: &["codex"],
 };
 
@@ -31,6 +34,17 @@ impl OfficialPackStatusTarget {
         format!("{}/{}", self.namespace, self.name)
     }
 
+    /// Every namespace this pack has been published under, current one first.
+    fn namespaces(self) -> impl Iterator<Item = &'static str> {
+        std::iter::once(self.namespace).chain(self.legacy_namespaces.iter().copied())
+    }
+
+    /// Every `<namespace>/<name>` this pack has been published under.
+    fn keys(self) -> impl Iterator<Item = String> {
+        self.namespaces()
+            .map(move |ns| format!("{ns}/{}", self.name))
+    }
+
     fn package_ref(self) -> PackageRef {
         PackageRef {
             namespace: self.namespace.to_string(),
@@ -38,6 +52,14 @@ impl OfficialPackStatusTarget {
             version: None,
         }
     }
+}
+
+/// Namespaces the official claude pack has been published under.
+///
+/// Exposed so `profile` can gate legacy cleanup on the same list this module
+/// matches against, rather than keeping a second copy that can drift.
+pub(crate) fn official_claude_pack_namespaces() -> impl Iterator<Item = &'static str> {
+    CLAUDE_PACK.namespaces()
 }
 
 /// Enforce official-pack status for the profile this run selected.
@@ -263,7 +285,7 @@ fn name_resolves_to_official_pack(target: OfficialPackStatusTarget, name: &str) 
         // An installed pack owns the name it installs, even when that name is
         // one the official pack publishes — `--profile claude` resolves to
         // that pack, so this run is not the official one.
-        return pack_key == target.key();
+        return target.keys().any(|key| key == pack_key);
     }
     is_official_profile_name(target, name)
 }
@@ -273,8 +295,9 @@ fn is_official_profile_name(target: OfficialPackStatusTarget, name: &str) -> boo
 }
 
 fn is_official_package_ref(target: OfficialPackStatusTarget, value: &str) -> bool {
-    let key = target.key();
-    value == key || value.starts_with(&format!("{key}@"))
+    target
+        .keys()
+        .any(|key| value == key || value.starts_with(&format!("{key}@")))
 }
 
 #[cfg(test)]
@@ -359,6 +382,32 @@ mod tests {
             CODEX_PACK,
             "nolabs-ai/codex-extra"
         ));
+    }
+
+    /// The claude pack predates the org rename, so an install or an `extends`
+    /// written against the old namespace is still the official pack.
+    #[test]
+    fn legacy_namespace_refs_target_the_claude_pack() {
+        assert!(is_official_package_ref(
+            CLAUDE_PACK,
+            "always-further/claude"
+        ));
+        assert!(is_official_package_ref(
+            CLAUDE_PACK,
+            "always-further/claude@1.2.3"
+        ));
+        assert!(!is_official_package_ref(CODEX_PACK, "always-further/codex"));
+    }
+
+    #[test]
+    fn claude_pack_installed_under_the_legacy_namespace_selects_claude_code() {
+        with_isolated_config_home(|config_home| {
+            write_pack_profile(config_home, "always-further", "claude", "claude", &["cc"]);
+
+            assert!(selects_claude_code("claude"));
+            assert!(selects_claude_code("cc"));
+            assert!(loads_claude_pack("claude"));
+        });
     }
 
     #[test]

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -9403,17 +9403,7 @@ mod tests {
     where
         F: FnOnce(&Path) -> R,
     {
-        let _guard = match crate::test_env::ENV_LOCK.lock() {
-            Ok(g) => g,
-            Err(p) => p.into_inner(),
-        };
-        let tmp = tempdir().expect("tmpdir");
-        let config_dir = tmp.path().canonicalize().expect("canonicalize");
-        let _env = crate::test_env::EnvVarGuard::set_all(&[(
-            "XDG_CONFIG_HOME",
-            config_dir.to_str().expect("utf8"),
-        )]);
-        f(&config_dir)
+        crate::test_env::with_isolated_config_home(f)
     }
 
     /// Build a minimal pack store under `config_dir` (used as XDG_CONFIG_HOME).
@@ -9432,39 +9422,15 @@ mod tests {
         profile_json: &str,
         hook_file: Option<&str>,
     ) -> PathBuf {
-        let install_dir = config_dir
-            .join("nono")
-            .join("packages")
-            .join(ns)
-            .join(pack_name);
-        std::fs::create_dir_all(install_dir.join("profiles")).expect("create profiles dir");
-        if let Some(hf) = hook_file {
-            let hooks_dir = install_dir.join("hooks");
-            std::fs::create_dir_all(&hooks_dir).expect("create hooks dir");
-            std::fs::write(hooks_dir.join(hf), "#!/bin/sh\n").expect("write hook file");
-        }
-        // Write package.json manifest
-        let manifest = format!(
-            r#"{{
-              "schema_version": 1,
-              "name": "{pack_name}",
-              "artifacts": [{{
-                "type": "profile",
-                "path": "profiles/{install_as}.json",
-                "install_as": "{install_as}"
-              }}]
-            }}"#
-        );
-        std::fs::write(install_dir.join("package.json"), &manifest).expect("write package.json");
-        // Write profile JSON
-        std::fs::write(
-            install_dir
-                .join("profiles")
-                .join(format!("{install_as}.json")),
+        crate::test_env::write_fake_pack(
+            config_dir,
+            ns,
+            pack_name,
+            install_as,
             profile_json,
+            &[],
+            hook_file,
         )
-        .expect("write profile json");
-        install_dir
     }
 
     /// Test 1: A hook script starting with `$PACK_DIR` in a registry-pack profile

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -2756,7 +2756,7 @@ fn load_profile_inner(name_or_path: &str, cli_extends: &[String]) -> Result<Opti
         // bypassing the post-pull cleanup hook in `migration::check_and_run`.
         // Idempotent: silent no-op when no legacy artifacts exist, so safe
         // to fire on every claude resolution.
-        if is_always_further_claude_pack(&profile_path) {
+        if is_official_claude_pack(&profile_path) {
             crate::legacy_cleanup::check_and_offer_cleanup()?;
         }
         return Ok(Some(profile));
@@ -2778,15 +2778,19 @@ fn load_profile_inner(name_or_path: &str, cli_extends: &[String]) -> Result<Opti
     Ok(None)
 }
 
-/// True when `profile_path` lives inside `<package_store>/nolabs-ai/claude/`.
-/// Used to gate legacy-cleanup invocation on the canonical claude pack
-/// rather than any pack that happens to publish a profile named `claude`
-/// or `claude-code`.
-fn is_always_further_claude_pack(profile_path: &Path) -> bool {
+/// Returns `true` when `profile_path` lives inside `<package_store>/<ns>/claude/` for one of the
+/// namespaces the official claude pack has been published under. Used to gate legacy-cleanup
+/// invocation on the canonical claude pack rather than any pack that happens to publish a profile
+/// named `claude` or `claude-code`.
+///
+/// The namespace list comes from `package_status` so both modules agree on what counts as the
+/// official pack.
+fn is_official_claude_pack(profile_path: &Path) -> bool {
     let Ok(store) = crate::package::package_store_dir() else {
         return false;
     };
-    profile_path_is_in_pack(profile_path, &store, "always-further", "claude")
+    crate::package_status::official_claude_pack_namespaces()
+        .any(|ns| profile_path_is_in_pack(profile_path, &store, ns, "claude"))
 }
 
 /// Pure path-component matcher: does `profile_path` live under
@@ -4265,6 +4269,35 @@ mod tests {
             "always-further",
             "claude"
         ));
+    }
+
+    /// Wrapped in `with_config_env` so `package_store_dir()` returns the same
+    /// path here and inside `is_official_claude_pack`. It reads
+    /// `XDG_CONFIG_HOME` live on every call, so without holding `ENV_LOCK` a
+    /// parallel test swapping the env between the two reads would make them
+    /// disagree.
+    #[test]
+    fn official_claude_pack_matches_both_published_namespaces() {
+        with_config_env(|_config_dir| {
+            let store = crate::package::package_store_dir().expect("package store dir");
+
+            for ns in ["nolabs-ai", "always-further"] {
+                let path = store.join(ns).join("claude").join("profiles/claude.json");
+                assert!(
+                    is_official_claude_pack(&path),
+                    "{ns}/claude is the official claude pack"
+                );
+            }
+
+            let third_party = store
+                .join("someone-else")
+                .join("claude")
+                .join("profiles/claude.json");
+            assert!(
+                !is_official_claude_pack(&third_party),
+                "a third-party pack publishing a `claude` profile must not trigger legacy cleanup"
+            );
+        });
     }
 
     #[test]

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -2556,6 +2556,14 @@ pub fn load_profile_extends(name_or_path: &str) -> Option<Vec<String>> {
             .and_then(|p| p.extends);
     }
 
+    // Registry refs are not valid bare profile names, so resolve them from the
+    // pack store before the name check below rejects them.
+    if is_registry_ref(name_or_path) {
+        return find_pack_store_profile(name_or_path)
+            .and_then(|(profile_path, _)| parse_profile_file(&profile_path).ok())
+            .and_then(|p| p.extends);
+    }
+
     if !is_valid_profile_name(name_or_path) {
         return None;
     }
@@ -3001,7 +3009,16 @@ fn load_registry_profile(name_or_path: &str, cli_extends: &[String]) -> Result<P
     // Find the profile JSON in the installed pack
     for artifact in &manifest.artifacts {
         if artifact.artifact_type == crate::package::ArtifactType::Profile {
-            let install_name = artifact.install_as.as_deref().unwrap_or(&artifact.path);
+            let Some(install_name) = artifact.install_as.as_deref() else {
+                // `nono pull` rejects profile artifacts without `install_as`,
+                // so this only happens for a hand-built store.
+                tracing::warn!(
+                    "pack '{}' declares profile artifact '{}' without install_as; skipping",
+                    package_ref.key(),
+                    artifact.path
+                );
+                continue;
+            };
             let profile_path = install_dir
                 .join("profiles")
                 .join(format!("{install_name}.json"));
@@ -9879,6 +9896,93 @@ mod tests {
             after.source_pack.as_ref().map(PackageRef::key).as_deref(),
             Some("acme/widget-pack"),
             "absolute-path after hook must still have source_pack set"
+        );
+    }
+
+    #[test]
+    fn test_load_profile_extends_resolves_registry_refs_via_pack_store() {
+        let (from_ref, from_install_as) = with_config_env(|config_dir| {
+            build_fake_pack_store(
+                config_dir,
+                "acme",
+                "widget-pack",
+                "widget",
+                r#"{
+                    "meta": { "name": "widget" },
+                    "extends": ["node-dev", "default"]
+                }"#,
+                None,
+            );
+            (
+                load_profile_extends("acme/widget-pack"),
+                load_profile_extends("widget"),
+            )
+        });
+
+        assert_eq!(
+            from_ref.as_deref(),
+            Some(["node-dev".to_string(), "default".to_string()].as_slice()),
+            "registry ref must report the pack profile's bases"
+        );
+        assert_eq!(
+            from_ref, from_install_as,
+            "registry ref and install_as short name must agree"
+        );
+    }
+
+    #[test]
+    fn test_load_profile_extends_returns_none_for_unknown_registry_ref() {
+        let extends = with_config_env(|_config_dir| load_profile_extends("acme/not-installed"));
+        assert!(
+            extends.is_none(),
+            "an uninstalled pack ref has no resolvable bases"
+        );
+    }
+
+    #[test]
+    fn test_profile_artifact_without_install_as_is_rejected_by_load_and_extends() {
+        let (loaded, extends) = with_config_env(|config_dir| {
+            let install_dir = config_dir
+                .join("nono")
+                .join("packages")
+                .join("acme")
+                .join("no-install-as");
+            std::fs::create_dir_all(install_dir.join("profiles")).expect("create profiles dir");
+            std::fs::write(
+                install_dir.join("package.json"),
+                r#"{
+                  "schema_version": 1,
+                  "name": "no-install-as",
+                  "artifacts": [{
+                    "type": "profile",
+                    "path": "widget"
+                  }]
+                }"#,
+            )
+            .expect("write package.json");
+            std::fs::write(
+                install_dir.join("profiles").join("widget.json"),
+                r#"{
+                    "meta": { "name": "widget" },
+                    "extends": "nolabs-ai/claude"
+                }"#,
+            )
+            .expect("write pack profile");
+
+            (
+                load_profile_no_migrate("acme/no-install-as"),
+                load_profile_extends("acme/no-install-as"),
+            )
+        });
+
+        let err = loaded.expect_err("artifact without install_as must not resolve");
+        assert!(
+            err.to_string().contains("no profile found in pack"),
+            "expected a no-profile-found error, got: {err}"
+        );
+        assert!(
+            extends.is_none(),
+            "extends resolution must agree with the loader and report no bases"
         );
     }
 

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -708,6 +708,7 @@ fn prepare_profile_with_options(
         let profile = profile::load_profile_with_extends(profile_name, &args.extends)?;
         crate::package_status::enforce_for_active_profile(
             Some(profile_name),
+            &args.extends,
             options.hook_output_silent,
         )?;
         // If the profile was addressed by pack ref (e.g. --profile nolabs-ai/hermes),

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -6,6 +6,8 @@ use crate::config;
 use crate::credential_runtime::load_env_credentials;
 use crate::network_policy;
 use crate::output;
+#[cfg(unix)]
+use crate::package_status::profile_selects_claude_code;
 use crate::profile;
 use crate::profile::WorkdirAccess;
 use crate::profile_runtime::{prepare_profile, prepare_profile_for_preflight};
@@ -33,25 +35,6 @@ fn print_allow_domain_port_warnings(entries: &[String], context: &str, silent: b
     for warning in network_policy::collect_allow_domain_port_warnings(entries, context) {
         output::print_warning(&warning);
     }
-}
-
-/// Returns `true` if `profile_name` is `"claude-code"` or transitively extends it.
-fn is_claude_code_profile(profile_name: &str) -> bool {
-    fn check(name: &str, visited: &mut Vec<String>) -> bool {
-        if name == "claude-code" {
-            return true;
-        }
-        if visited.iter().any(|v| v == name) {
-            return false; // cycle — bail out
-        }
-        visited.push(name.to_string());
-        let bases = match profile::load_profile_extends(name) {
-            Some(bases) => bases,
-            None => return false,
-        };
-        bases.iter().any(|base| check(base, visited))
-    }
-    check(profile_name, &mut Vec::new())
 }
 
 fn collect_missing_cli_requested_paths(args: &SandboxArgs) -> Vec<String> {
@@ -333,7 +316,10 @@ pub(crate) fn should_auto_enable_claude_launch_services(
     cmd_args: &[std::ffi::OsString],
 ) -> bool {
     if args.allow_launch_services
-        || !args.profile.as_deref().is_some_and(is_claude_code_profile)
+        || !args
+            .profile
+            .as_deref()
+            .is_some_and(|profile| profile_selects_claude_code(profile, &args.extends))
         || !command_is_claude(program)
         || claude_session_has_non_browser_auth(cmd_args)
     {
@@ -1474,7 +1460,11 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
     print_allow_domain_port_warnings(&args.deny_proxy, "--deny-domain", silent);
 
     #[cfg(unix)]
-    if args.profile.as_deref().is_some_and(is_claude_code_profile) {
+    if args
+        .profile
+        .as_deref()
+        .is_some_and(|profile| profile_selects_claude_code(profile, &args.extends))
+    {
         let home = config::validated_home()?;
         let home_path = std::path::Path::new(&home);
 
@@ -1916,10 +1906,24 @@ mod tests {
         );
     }
 
+    /// Isolate every env var the Claude preflight decision reads. Callers must
+    /// hold `test_env::ENV_LOCK`.
+    ///
+    /// `XDG_CONFIG_HOME` is part of that set because the profile-name check
+    /// (`profile_selects_claude_code`) resolves the name against the user
+    /// profile dir and the pack store, both under the nono config dir. Leaving
+    /// it to the ambient environment lets a developer's own
+    /// `~/.config/nono/profiles/claude-code.json` decide these assertions.
     #[cfg(target_os = "macos")]
     fn claude_preflight_env(home: &Path, config_dir: &Path) -> crate::test_env::EnvVarGuard {
+        let xdg_config_home = home.join(".config");
+        fs::create_dir_all(&xdg_config_home).expect("mkdir XDG_CONFIG_HOME");
         let env = crate::test_env::EnvVarGuard::set_all(&[
             ("HOME", home.to_str().unwrap_or("/tmp")),
+            (
+                "XDG_CONFIG_HOME",
+                xdg_config_home.to_str().unwrap_or("/tmp/.config"),
+            ),
             (
                 "CLAUDE_CONFIG_DIR",
                 config_dir.to_str().unwrap_or("/tmp/.claude"),

--- a/crates/nono-cli/src/test_env.rs
+++ b/crates/nono-cli/src/test_env.rs
@@ -60,3 +60,91 @@ impl Drop for EnvVarGuard {
         }
     }
 }
+
+/// Run `f` with `$XDG_CONFIG_HOME` pointed at a fresh empty directory, so the
+/// user profile dir and the pack store start out empty and only contain what
+/// the test writes.
+pub(crate) fn with_isolated_config_home<F, R>(f: F) -> R
+where
+    F: FnOnce(&std::path::Path) -> R,
+{
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // Canonicalize: `resolve_user_config_dir` canonicalizes XDG_CONFIG_HOME,
+    // so hand back the same form the code under test will compute (on macOS
+    // the temp dir is under /var, a symlink to /private/var).
+    let config_home = tmp.path().canonicalize().expect("canonicalize temp dir");
+    let _env = EnvVarGuard::set_all(&[(
+        "XDG_CONFIG_HOME",
+        config_home.to_str().expect("utf-8 temp path"),
+    )]);
+    f(&config_home)
+}
+
+/// Install a fake pack under `config_home` providing one profile artifact
+/// installed as `install_as` and also answering to `aliases`.
+///
+/// Creates:
+///   `<config_home>/nono/packages/<ns>/<pack_name>/package.json`
+///   `<config_home>/nono/packages/<ns>/<pack_name>/profiles/<install_as>.json`
+///   `<config_home>/nono/packages/<ns>/<pack_name>/hooks/<hook_file>` (empty)
+///
+/// Returns the install directory.
+pub(crate) fn write_fake_pack(
+    config_home: &std::path::Path,
+    namespace: &str,
+    pack_name: &str,
+    install_as: &str,
+    profile_json: &str,
+    aliases: &[&str],
+    hook_file: Option<&str>,
+) -> std::path::PathBuf {
+    let install_dir = config_home
+        .join("nono")
+        .join("packages")
+        .join(namespace)
+        .join(pack_name);
+    std::fs::create_dir_all(install_dir.join("profiles")).expect("create profiles dir");
+    if let Some(hook_file) = hook_file {
+        let hooks_dir = install_dir.join("hooks");
+        std::fs::create_dir_all(&hooks_dir).expect("create hooks dir");
+        std::fs::write(hooks_dir.join(hook_file), "#!/bin/sh\n").expect("write hook file");
+    }
+    let aliases = aliases
+        .iter()
+        .map(|alias| format!("\"{alias}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    std::fs::write(
+        install_dir.join("package.json"),
+        format!(
+            r#"{{
+              "schema_version": 1,
+              "name": "{pack_name}",
+              "artifacts": [{{
+                "type": "profile",
+                "path": "profiles/{install_as}.json",
+                "install_as": "{install_as}",
+                "aliases": [{aliases}]
+              }}]
+            }}"#
+        ),
+    )
+    .expect("write package.json");
+    std::fs::write(
+        install_dir
+            .join("profiles")
+            .join(format!("{install_as}.json")),
+        profile_json,
+    )
+    .expect("write pack profile");
+    install_dir
+}
+
+/// Write a user profile to `<config_home>/nono/profiles/<name>.json`, the
+/// location that shadows both pack-store and built-in profiles of that name.
+pub(crate) fn write_user_profile(config_home: &std::path::Path, name: &str, profile_json: &str) {
+    let profiles = config_home.join("nono").join("profiles");
+    std::fs::create_dir_all(&profiles).expect("create profiles dir");
+    std::fs::write(profiles.join(format!("{name}.json")), profile_json).expect("write profile");
+}


### PR DESCRIPTION
## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Ref #1481
Closes #1546

## Summary
`load_profile_extends` now resolves registry refs correctly

Reuses `is_claude_code_profile` for sandbox preparation

## Test Plan
New tests

Reproduction steps for both issues

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
