### PR TITLE
fix(tool-sandbox): collapse command-not-found warnings into one summary line

### DIFF
--- a/crates/nono-cli/src/command_policy.rs
+++ b/crates/nono-cli/src/command_policy.rs
@@ -47,6 +47,35 @@ impl CommandPolicyFinding {
     }
 }
 
+/// Extracts the command name from a `command_not_found` finding's message
+/// (`"command policy '<name>' could not be resolved on PATH; skipping"`) by
+/// taking the text between the first pair of single quotes.
+fn command_not_found_name(message: &str) -> Option<&str> {
+    message.split('\'').nth(1)
+}
+
+/// Prints one collapsed summary line for all `command_not_found` warnings
+/// instead of one `eprintln!` per unresolved command. Most machines are
+/// missing only a handful of the many optional tools listed across the
+/// unified profile's `command_policies`, and a line-per-miss floods stderr
+/// on every launch (shadowfax#570). A no-op when there are no such warnings.
+pub(crate) fn print_command_not_found_summary(warnings: &[CommandPolicyFinding]) {
+    let names: Vec<&str> = warnings
+        .iter()
+        .filter(|w| w.code == "command_not_found")
+        .filter_map(|w| command_not_found_name(&w.message))
+        .collect();
+    if names.is_empty() {
+        return;
+    }
+    eprintln!(
+        "  [nono] Warning: {} command polic{} not found on PATH, skipping: {}",
+        names.len(),
+        if names.len() == 1 { "y" } else { "ies" },
+        names.join(", ")
+    );
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct CommandPolicyValidationReport {
     pub activation: CommandPolicyActivation,
@@ -3315,6 +3344,34 @@ mod tests {
         let mut permissions = fs::metadata(path).expect("stat executable").permissions();
         permissions.set_mode(0o755);
         fs::set_permissions(path, permissions).expect("make executable");
+    }
+
+    #[test]
+    fn command_not_found_name_extracts_quoted_command() {
+        assert_eq!(
+            command_not_found_name(
+                "command policy 'data-sniffer' could not be resolved on PATH; skipping"
+            ),
+            Some("data-sniffer")
+        );
+        assert_eq!(command_not_found_name("no quotes here"), None);
+    }
+
+    #[test]
+    fn print_command_not_found_summary_ignores_non_matching_codes() {
+        let warnings = vec![
+            CommandPolicyFinding::new(
+                "command_not_found",
+                "command policy 'glab' could not be resolved on PATH; skipping",
+            ),
+            CommandPolicyFinding::new("script_entrypoint", "unrelated finding"),
+        ];
+        let names: Vec<&str> = warnings
+            .iter()
+            .filter(|w| w.code == "command_not_found")
+            .filter_map(|w| command_not_found_name(&w.message))
+            .collect();
+        assert_eq!(names, vec!["glab"]);
     }
 
     #[test]

--- a/crates/nono-cli/src/command_policy.rs
+++ b/crates/nono-cli/src/command_policy.rs
@@ -3359,7 +3359,7 @@ mod tests {
 
     #[test]
     fn print_command_not_found_summary_ignores_non_matching_codes() {
-        let warnings = vec![
+        let warnings = [
             CommandPolicyFinding::new(
                 "command_not_found",
                 "command policy 'glab' could not be resolved on PATH; skipping",

--- a/crates/nono-cli/src/tool-sandbox/platform/linux.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/linux.rs
@@ -219,11 +219,7 @@ impl ResolvedToolSandboxPlan {
                 crate::command_policy::resolve_policy_command_binaries(config, path_env.clone())?
             }
         };
-        for w in &resolved.warnings {
-            if w.code == "command_not_found" {
-                eprintln!("  [nono] Warning: {}", w.message);
-            }
-        }
+        crate::command_policy::print_command_not_found_summary(&resolved.warnings);
         // Validate PATH/configured executable directories before using them
         // for deny-only resolution and the outer executable identity gate.
         // The gate allows non-controlled executables while excluding

--- a/crates/nono-cli/src/tool-sandbox/platform/macos.rs
+++ b/crates/nono-cli/src/tool-sandbox/platform/macos.rs
@@ -210,11 +210,7 @@ impl ResolvedToolSandboxPlan {
                 crate::command_policy::resolve_policy_command_binaries(config, path_env.clone())?
             }
         };
-        for w in &resolved.warnings {
-            if w.code == "command_not_found" {
-                eprintln!("  [nono] Warning: {}", w.message);
-            }
-        }
+        crate::command_policy::print_command_not_found_summary(&resolved.warnings);
         let exec_helpers = crate::command_policy::resolve_policy_exec_helpers(config)?;
         validate_controlled_exec_helper_immutability(config, &exec_helpers, outer_caps)?;
         let daemon_pid_source_helpers =


### PR DESCRIPTION
## Summary
- Every unresolved `command_policies` entry printed its own `[nono] Warning: command policy '<name>' could not be resolved on PATH; skipping` line on every launch. Since most machines only have a fraction of the many optional tools listed in a unified profile installed, this floods stderr with lines the user can't act on.
- Adds `command_policy::print_command_not_found_summary`, shared by the macOS and Linux tool-sandbox builders, that collapses all `command_not_found` findings into a single line, e.g. `[nono] Warning: 5 command policies not found on PATH, skipping: data-sniffer, dd-attest, dd-claude, glab, gt`.