### PR TITLE
fix(exec): update `PWD` with `--workdir`

### DIFF
--- a/crates/nono-cli/src/exec_strategy.rs
+++ b/crates/nono-cli/src/exec_strategy.rs
@@ -42,7 +42,6 @@ use tracing::{debug, info, warn};
 pub(crate) use env_sanitization::is_dangerous_env_var;
 #[cfg(target_os = "linux")]
 pub(crate) use env_sanitization::is_env_var_allowed;
-use env_sanitization::should_skip_env_var;
 pub(crate) use env_sanitization::validate_env_var_patterns;
 pub(crate) use env_sanitization::validate_set_vars;
 
@@ -260,6 +259,10 @@ pub struct ExecConfig<'a> {
     pub cap_file: &'a std::path::Path,
     /// Directory the child process should start in.
     pub current_dir: &'a std::path::Path,
+    /// A child's `$PWD` that differs from the parent's.
+    pub child_pwd: Option<&'a std::path::Path>,
+    /// The inherited `$PWD`.
+    pub host_pwd: Option<&'a std::ffi::OsStr>,
     /// Whether to suppress diagnostic output.
     pub no_diagnostics: bool,
     /// Emit session diagnostics as JSON on stderr after the run.
@@ -390,30 +393,38 @@ pub fn execute_direct(config: &ExecConfig<'_>) -> Result<()> {
     cmd.env_clear();
     cmd.current_dir(config.current_dir);
 
+    const BLOCKED_EXTRA: &[&str] = &[
+        "NONO_CAP_FILE",
+        DETACHED_LAUNCH_ENV,
+        DETACHED_SESSION_ID_ENV,
+        DETACHED_CWD_PROMPT_RESPONSE_ENV,
+    ];
+
+    // `host_pwd` was resolved pre-sandbox; only the syscall-free policy gate is left
+    // to apply here, over this strategy's own filters.
+    let child_pwd = config.child_pwd.filter(|_| {
+        env_sanitization::pwd_rewrite_permitted(
+            &config.env_vars,
+            &config.set_vars,
+            BLOCKED_EXTRA,
+            config.denied_env_vars.as_deref(),
+            config.allowed_env_vars.as_deref(),
+        )
+    });
+
     for (key, value) in std::env::vars() {
-        if should_skip_env_var(
+        if !env_sanitization::env_var_survives_filters(
             &key,
             &config.env_vars,
-            &[
-                "NONO_CAP_FILE",
-                DETACHED_LAUNCH_ENV,
-                DETACHED_SESSION_ID_ENV,
-                DETACHED_CWD_PROMPT_RESPONSE_ENV,
-            ],
+            BLOCKED_EXTRA,
+            config.denied_env_vars.as_deref(),
+            config.allowed_env_vars.as_deref(),
         ) {
             continue;
         }
-        if let Some(ref denied) = config.denied_env_vars
-            && env_sanitization::is_env_var_denied(&key, denied)
-        {
-            continue;
-        }
-        if let Some(ref allowed) = config.allowed_env_vars
-            && !env_sanitization::is_env_var_allowed(&key, allowed)
-        {
-            continue;
-        }
-        cmd.env(&key, &value);
+        let value = env_sanitization::rewrite_workdir_env_var(&key, config.host_pwd, child_pwd)
+            .unwrap_or_else(|| value.as_ref());
+        cmd.env(&key, value);
     }
 
     cmd.args(cmd_args).env("NONO_CAP_FILE", config.cap_file);
@@ -572,33 +583,46 @@ pub fn execute_supervised<F: FnMut(i32) -> bool>(
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     let mut browser_shim: Option<BrowserShim> = None;
 
+    const BLOCKED_EXTRA: &[&str] = &[
+        "NONO_CAP_FILE",
+        "NONO_SUPERVISOR_PATH",
+        DETACHED_LAUNCH_ENV,
+        DETACHED_SESSION_ID_ENV,
+        DETACHED_CWD_PROMPT_RESPONSE_ENV,
+    ];
+
+    let child_pwd = config.child_pwd.filter(|_| {
+        env_sanitization::pwd_rewrite_permitted(
+            &config.env_vars,
+            &config.set_vars,
+            BLOCKED_EXTRA,
+            config.denied_env_vars.as_deref(),
+            config.allowed_env_vars.as_deref(),
+        )
+    });
+
     // Copy current environment, filtering dangerous and overridden vars
     for (key, value) in std::env::vars_os() {
         if let (Some(k), Some(v)) = (key.to_str(), value.to_str()) {
-            if should_skip_env_var(
+            if !env_sanitization::env_var_survives_filters(
                 k,
                 &config.env_vars,
-                &[
-                    "NONO_CAP_FILE",
-                    "NONO_SUPERVISOR_PATH",
-                    DETACHED_LAUNCH_ENV,
-                    DETACHED_SESSION_ID_ENV,
-                    DETACHED_CWD_PROMPT_RESPONSE_ENV,
-                ],
+                BLOCKED_EXTRA,
+                config.denied_env_vars.as_deref(),
+                config.allowed_env_vars.as_deref(),
             ) {
                 continue;
             }
-            if let Some(ref denied) = config.denied_env_vars
-                && env_sanitization::is_env_var_denied(k, denied)
-            {
-                continue;
-            }
-            if let Some(ref allowed) = config.allowed_env_vars
-                && !env_sanitization::is_env_var_allowed(k, allowed)
-            {
-                continue;
-            }
-            if let Ok(cstr) = CString::new(format!("{}={}", k, v)) {
+            // A rewritten working directory can be non-UTF-8 even when the
+            // inherited value was not, so assemble `KEY=VALUE` from raw bytes.
+            let replacement =
+                env_sanitization::rewrite_workdir_env_var(k, config.host_pwd, child_pwd);
+            let value_bytes = replacement.map_or_else(|| v.as_bytes(), OsStr::as_bytes);
+            let mut kv = Vec::with_capacity(k.len() + 1 + value_bytes.len());
+            kv.extend_from_slice(k.as_bytes());
+            kv.push(b'=');
+            kv.extend_from_slice(value_bytes);
+            if let Ok(cstr) = CString::new(kv) {
                 env_c.push(cstr);
             }
         }

--- a/crates/nono-cli/src/exec_strategy/env_sanitization.rs
+++ b/crates/nono-cli/src/exec_strategy/env_sanitization.rs
@@ -163,8 +163,90 @@ pub(crate) fn validate_set_vars(
     None
 }
 
+/// Replacement value for an inherited env var that names a working directory,
+/// or `None` to copy the inherited value through unchanged.
+///
+/// `child_pwd` is `Some` only when the child starts in a directory other than the
+/// one nono was launched from. `host_pwd` is `Some` only when the inherited `$PWD`
+/// was vouched for by [`trusted_host_pwd`].
+pub(super) fn rewrite_workdir_env_var<'a>(
+    key: &str,
+    host_pwd: Option<&'a std::ffi::OsStr>,
+    child_pwd: Option<&'a std::path::Path>,
+) -> Option<&'a std::ffi::OsStr> {
+    let child_pwd = child_pwd?;
+    let child_pwd = child_pwd.as_os_str();
+    if host_pwd == Some(child_pwd) {
+        return None;
+    }
+    match key {
+        "PWD" => Some(child_pwd),
+        "OLDPWD" => host_pwd,
+        _ => None,
+    }
+}
+
+/// Whether the working-directory rewrite may run at all for this session.
+///
+/// `set_vars` is injected after the inherited-env loop, so an operator-supplied
+/// `PWD` wins over any rewrite. Standing down keeps `$OLDPWD` from describing a
+/// move away from a directory that `$PWD` never names.
+pub(super) fn pwd_rewrite_permitted(
+    config_env_vars: &[(&str, &str)],
+    set_vars: &[(String, String)],
+    blocked_extra: &[&str],
+    denied_env_vars: Option<&[String]>,
+    allowed_env_vars: Option<&[String]>,
+) -> bool {
+    if set_vars.iter().any(|(key, _)| key == "PWD") {
+        return false;
+    }
+    env_var_survives_filters(
+        "PWD",
+        config_env_vars,
+        blocked_extra,
+        denied_env_vars,
+        allowed_env_vars,
+    )
+}
+
+/// The host `$PWD` eligible to drive `$OLDPWD` in [`rewrite_workdir_env_var`], or
+/// `None` when the inherited value cannot be trusted.
+pub(crate) fn host_pwd_before_sandbox(
+    launch_cwd: Option<&std::path::Path>,
+) -> Option<std::ffi::OsString> {
+    trusted_host_pwd(std::env::var_os("PWD"), launch_cwd)
+}
+
+/// The host `$PWD`, accepted only when it is a spelling of the directory nono was
+/// launched from.
+///
+/// Mirrors the guard in [`crate::sandbox_prepare`]'s `resolved_workdir`: a `$PWD` that
+/// does not canonicalise to `getcwd()` is stale or spoofed, and copying it into the
+/// child's `$OLDPWD` would tell the child it came from a directory it was never in.
+/// When `getcwd()` itself is unavailable there is nothing to validate against, so the
+/// value is rejected rather than trusted. Rejection only stands the `$OLDPWD` arm of
+/// the rewrite down; correcting `$PWD` needs no trust in the inherited value.
+fn trusted_host_pwd(
+    raw_pwd: Option<std::ffi::OsString>,
+    launch_cwd: Option<&std::path::Path>,
+) -> Option<std::ffi::OsString> {
+    let pwd = raw_pwd?;
+    // A non-UTF-8 value is dropped from the child environment, so a `PWD` spelt
+    // in one never reaches the child; rewriting `$OLDPWD` from it would claim a
+    // move away from a directory the child is never told it started in.
+    pwd.to_str()?;
+
+    let launch_cwd = launch_cwd?;
+    let path = std::path::Path::new(&pwd);
+    if !path.is_absolute() || path.canonicalize().ok()? != launch_cwd {
+        return None;
+    }
+    Some(pwd)
+}
+
 /// Decide whether an inherited env var should be dropped for sandbox execution.
-pub(super) fn should_skip_env_var(
+fn should_skip_env_var(
     key: &str,
     config_env_vars: &[(&str, &str)],
     blocked_extra: &[&str],
@@ -174,9 +256,35 @@ pub(super) fn should_skip_env_var(
         || is_dangerous_env_var(key)
 }
 
+/// Whether an inherited env var survives every environment filter and reaches the
+/// sandboxed child.
+pub(super) fn env_var_survives_filters(
+    key: &str,
+    config_env_vars: &[(&str, &str)],
+    blocked_extra: &[&str],
+    denied_env_vars: Option<&[String]>,
+    allowed_env_vars: Option<&[String]>,
+) -> bool {
+    if should_skip_env_var(key, config_env_vars, blocked_extra) {
+        return false;
+    }
+    if let Some(denied) = denied_env_vars
+        && is_env_var_denied(key, denied)
+    {
+        return false;
+    }
+    if let Some(allowed) = allowed_env_vars
+        && !is_env_var_allowed(key, allowed)
+    {
+        return false;
+    }
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsStr;
 
     // ============================================================================
     // 1Password env var blocklist — security-critical regression tests
@@ -453,5 +561,242 @@ mod tests {
     fn test_set_vars_empty_is_ok() {
         let set_vars: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         assert_eq!(validate_set_vars(&set_vars), None);
+    }
+
+    #[test]
+    fn test_workdir_vars_rewritten_when_child_relocates() {
+        let child = Some(std::path::Path::new("/tmp/foo"));
+        assert_eq!(
+            rewrite_workdir_env_var("PWD", Some(OsStr::new("/tmp/bar")), child),
+            Some(OsStr::new("/tmp/foo"))
+        );
+        assert_eq!(
+            rewrite_workdir_env_var("OLDPWD", Some(OsStr::new("/tmp/bar")), child),
+            Some(OsStr::new("/tmp/bar"))
+        );
+    }
+
+    #[test]
+    fn test_workdir_vars_inherited_when_child_stays_put() {
+        assert_eq!(
+            rewrite_workdir_env_var("PWD", Some(OsStr::new("/tmp/bar")), None),
+            None
+        );
+        assert_eq!(
+            rewrite_workdir_env_var("OLDPWD", Some(OsStr::new("/tmp/bar")), None),
+            None
+        );
+    }
+
+    #[test]
+    fn test_pwd_corrected_even_when_host_pwd_is_untrusted() {
+        let child = Some(std::path::Path::new("/tmp/foo"));
+        assert_eq!(
+            rewrite_workdir_env_var("PWD", None, child),
+            Some(OsStr::new("/tmp/foo"))
+        );
+    }
+
+    #[test]
+    fn test_rewrite_replaces_but_never_introduces() {
+        let child = Some(std::path::Path::new("/tmp/foo"));
+        assert_eq!(rewrite_workdir_env_var("OLDPWD", None, child), None);
+    }
+
+    #[test]
+    fn test_oldpwd_unchanged_when_pwd_is_correct() {
+        let child = Some(std::path::Path::new("/tmp/foo"));
+        assert_eq!(
+            rewrite_workdir_env_var("OLDPWD", Some(OsStr::new("/tmp/foo")), child),
+            None
+        );
+    }
+
+    #[test]
+    fn test_unrelated_keys_never_rewritten() {
+        let child = Some(std::path::Path::new("/tmp/foo"));
+        for key in ["HOME", "PWDX", "MYPWD", "pwd", ""] {
+            assert_eq!(
+                rewrite_workdir_env_var(key, Some(OsStr::new("/tmp/bar")), child),
+                None,
+                "key {key} should not be rewritten"
+            );
+        }
+    }
+
+    #[test]
+    fn test_non_utf8_workdir_round_trips() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let raw = b"/tmp/\xff\xfeinvalid";
+        let child = std::path::Path::new(OsStr::from_bytes(raw));
+        let rewritten = rewrite_workdir_env_var("PWD", Some(OsStr::new("/tmp/bar")), Some(child));
+        assert_eq!(rewritten.map(OsStr::as_bytes), Some(&raw[..]));
+    }
+
+    #[test]
+    fn test_pwd_dropped_by_policy_is_ineligible_for_rewrite() {
+        // A profile that strips `PWD` must not receive the same value as
+        // `$OLDPWD`, so filtering decides eligibility for both.
+        let denied = vec!["PWD".to_string()];
+        assert!(!env_var_survives_filters(
+            "PWD",
+            &[],
+            &[],
+            Some(&denied),
+            None
+        ));
+
+        let allowed_without_pwd = vec!["PATH".to_string(), "HOME".to_string()];
+        assert!(!env_var_survives_filters(
+            "PWD",
+            &[],
+            &[],
+            None,
+            Some(&allowed_without_pwd)
+        ));
+
+        let allowed_with_pwd = vec!["PWD".to_string()];
+        assert!(env_var_survives_filters(
+            "PWD",
+            &[],
+            &[],
+            None,
+            Some(&allowed_with_pwd)
+        ));
+        assert!(env_var_survives_filters("PWD", &[], &[], None, None));
+    }
+
+    #[test]
+    fn test_pwd_rewrite_stands_down_when_pwd_is_injected_or_filtered() {
+        assert!(pwd_rewrite_permitted(&[], &[], &[], None, None));
+
+        // `set_vars` lands after the inherited-env loop, so its `PWD` wins; the
+        // rewrite must not leave `$OLDPWD` describing a move `$PWD` denies.
+        let set_pwd = vec![("PWD".to_string(), "/injected".to_string())];
+        assert!(!pwd_rewrite_permitted(&[], &set_pwd, &[], None, None));
+
+        // An unrelated `set_vars` entry leaves the rewrite alone.
+        let set_other = vec![("EDITOR".to_string(), "vi".to_string())];
+        assert!(pwd_rewrite_permitted(&[], &set_other, &[], None, None));
+
+        // A `set_vars` `OLDPWD` overrides only that key; `PWD` still tracks the
+        // directory the child starts in.
+        let set_oldpwd = vec![("OLDPWD".to_string(), "/elsewhere".to_string())];
+        assert!(pwd_rewrite_permitted(&[], &set_oldpwd, &[], None, None));
+
+        // Credentials and env filters gate the rewrite the same way.
+        assert!(!pwd_rewrite_permitted(
+            &[("PWD", "/injected")],
+            &[],
+            &[],
+            None,
+            None
+        ));
+        let denied = vec!["PWD".to_string()];
+        assert!(!pwd_rewrite_permitted(&[], &[], &[], Some(&denied), None));
+    }
+
+    #[test]
+    fn test_trusted_host_pwd_accepts_a_spelling_of_the_launch_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let real = dir.path().join("real");
+        let link = dir.path().join("link");
+        std::fs::create_dir(&real).expect("create real dir");
+        std::os::unix::fs::symlink(&real, &link).expect("create symlink");
+        // `getcwd` reports the resolved path even when the shell's `$PWD` names
+        // the symlink, so the guard must accept the symlink spelling.
+        let launch_cwd = real.canonicalize().expect("canonicalize real dir");
+
+        assert_eq!(
+            trusted_host_pwd(Some(link.clone().into_os_string()), Some(&launch_cwd)),
+            Some(link.into_os_string()),
+            "a symlink spelling of the launch dir is the shell's logical `$PWD`"
+        );
+        assert_eq!(
+            trusted_host_pwd(Some(launch_cwd.clone().into_os_string()), Some(&launch_cwd)),
+            Some(launch_cwd.clone().into_os_string())
+        );
+    }
+
+    #[test]
+    fn test_trusted_host_pwd_rejects_untrustworthy_values() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let launch_cwd = dir.path().canonicalize().expect("canonicalize tempdir");
+        let elsewhere = launch_cwd.join("elsewhere");
+        std::fs::create_dir(&elsewhere).expect("create sibling dir");
+
+        // Unset: the child is never told a working directory, so there is
+        // nothing to rewrite and nothing to introduce.
+        assert_eq!(trusted_host_pwd(None, Some(&launch_cwd)), None);
+
+        // Non-UTF-8: dropped from the child environment, so it must not become
+        // the child's `$OLDPWD` either.
+        let non_utf8 = std::ffi::OsString::from_vec(b"/tmp/\xff\xfeinvalid".to_vec());
+        assert_eq!(trusted_host_pwd(Some(non_utf8), Some(&launch_cwd)), None);
+
+        // Stale or spoofed: resolves somewhere other than `getcwd`.
+        assert_eq!(
+            trusted_host_pwd(Some(elsewhere.into_os_string()), Some(&launch_cwd)),
+            None,
+            "a `$PWD` that does not canonicalise to `getcwd` is not the launch dir"
+        );
+
+        // Nonexistent, so it cannot be shown to name the launch dir.
+        let missing = launch_cwd.join("gone");
+        assert_eq!(
+            trusted_host_pwd(Some(missing.into_os_string()), Some(&launch_cwd)),
+            None
+        );
+
+        // Relative values cannot be compared against `getcwd` verbatim.
+        assert_eq!(
+            trusted_host_pwd(Some(std::ffi::OsString::from(".")), Some(&launch_cwd)),
+            None
+        );
+
+        // No `getcwd` means nothing to validate against, so the rewrite stands
+        // down rather than trusting the inherited value.
+        assert_eq!(
+            trusted_host_pwd(Some(launch_cwd.clone().into_os_string()), None),
+            None
+        );
+    }
+
+    #[test]
+    fn test_env_var_survives_filters_honors_overrides_and_blocklist() {
+        assert!(!env_var_survives_filters(
+            "PWD",
+            &[("PWD", "/injected")],
+            &[],
+            None,
+            None
+        ));
+        assert!(!env_var_survives_filters(
+            "NONO_CAP_FILE",
+            &[],
+            &["NONO_CAP_FILE"],
+            None,
+            None
+        ));
+        assert!(!env_var_survives_filters(
+            "LD_PRELOAD",
+            &[],
+            &[],
+            None,
+            None
+        ));
+        // Deny wins over an explicit allow entry for the same key.
+        let denied = vec!["GITHUB_*".to_string()];
+        let allowed = vec!["GITHUB_TOKEN".to_string()];
+        assert!(!env_var_survives_filters(
+            "GITHUB_TOKEN",
+            &[],
+            &[],
+            Some(&denied),
+            Some(&allowed)
+        ));
     }
 }

--- a/crates/nono-cli/src/execution_runtime.rs
+++ b/crates/nono-cli/src/execution_runtime.rs
@@ -137,6 +137,52 @@ pub(crate) fn execution_start_dir(
     }
 }
 
+/// A child's `$PWD` that differs from the parent's.
+fn child_pwd_for(
+    spelt: &std::path::Path,
+    requested_canonical: &std::path::Path,
+    start_dir: &std::path::Path,
+    launch_cwd: Option<&std::path::Path>,
+) -> Option<std::path::PathBuf> {
+    // `launch_cwd` comes from `getcwd`, so it is the resolved spelling of the
+    // invoking shell's logical `$PWD`.
+    if launch_cwd == Some(start_dir) {
+        return None;
+    }
+    if requested_canonical == start_dir
+        && let Some(logical) = logical_workdir(spelt, launch_cwd)
+    {
+        return Some(logical);
+    }
+    Some(start_dir.to_path_buf())
+}
+
+/// The `--workdir` spelling as an absolute path, with symlinks left unresolved.
+///
+/// A relative spelling is anchored to the launch directory the same way
+/// [`crate::sandbox_prepare`]'s `resolved_workdir` anchors one, so `--workdir ./link`
+/// and `--workdir /abs/cwd/link` reach the child as the same `$PWD`. Symlinks in the
+/// spelling survive, as a shell's logical `$PWD` does; `..` cannot be normalised away
+/// without resolving them, so such a spelling is discarded in favour of the directory
+/// the child actually starts in.
+fn logical_workdir(
+    spelt: &std::path::Path,
+    launch_cwd: Option<&std::path::Path>,
+) -> Option<std::path::PathBuf> {
+    let absolute = if spelt.is_absolute() {
+        spelt.to_path_buf()
+    } else {
+        launch_cwd?.join(spelt)
+    };
+    if absolute
+        .components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return None;
+    }
+    Some(absolute.components().collect())
+}
+
 fn recommended_builtin_profile(program: &Path) -> Option<&'static str> {
     let name = program.file_name()?.to_str()?;
     match name {
@@ -344,6 +390,14 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
     } else {
         execution_start_dir(&flags.workdir, &caps)?
     };
+    let launch_cwd = std::env::current_dir().ok();
+    let child_pwd = child_pwd_for(
+        &flags.workdir,
+        &requested_workdir,
+        &current_dir,
+        launch_cwd.as_deref(),
+    );
+    let host_pwd = exec_strategy::env_sanitization::host_pwd_before_sandbox(launch_cwd.as_deref());
     #[cfg(target_os = "linux")]
     let tool_sandbox_runtime = if let Some(command_policies) = flags
         .command_policies
@@ -611,6 +665,8 @@ pub(crate) fn execute_sandboxed(plan: LaunchPlan) -> Result<()> {
         env_vars,
         cap_file: &cap_file_path,
         current_dir: &current_dir,
+        child_pwd: child_pwd.as_deref(),
+        host_pwd: host_pwd.as_deref(),
         no_diagnostics: flags.no_diagnostics || flags.silent,
         diagnostics_json: flags.diagnostics_json,
         proxy_diagnostics: proxy_handle.as_ref().and_then(|handle| {
@@ -786,12 +842,153 @@ fn write_capability_state_file(
 #[cfg(test)]
 mod tests {
     use super::{
-        compute_executable_identity, recommended_builtin_profile,
+        child_pwd_for, compute_executable_identity, recommended_builtin_profile,
         validate_command_policy_execution_support,
     };
     use sha2::{Digest, Sha256};
     use std::fs;
     use std::path::Path;
+
+    #[test]
+    fn child_pwd_for_relative_workdir_is_absolute() {
+        // `--workdir ./my-project`: the spelling reaches us unresolved, so
+        // preferring it verbatim would hand the child a relative `$PWD`.
+        let pwd = child_pwd_for(
+            Path::new("./my-project"),
+            Path::new("/abs/cwd/my-project"),
+            Path::new("/abs/cwd/my-project"),
+            Some(Path::new("/abs/cwd")),
+        );
+        assert_eq!(pwd.as_deref(), Some(Path::new("/abs/cwd/my-project")));
+    }
+
+    #[test]
+    fn child_pwd_for_spells_relative_and_absolute_workdirs_alike() {
+        // `/abs/cwd/link` resolves elsewhere, so both spellings of the same
+        // directory must reach the child as the logical path, not the resolved
+        // one. Anchoring the relative spelling to the launch dir is what keeps
+        // the two forms from disagreeing.
+        let canonical = Path::new("/private/tmp/real");
+        for spelt in ["./link", "link", "/abs/cwd/link"] {
+            let pwd = child_pwd_for(
+                Path::new(spelt),
+                canonical,
+                canonical,
+                Some(Path::new("/abs/cwd")),
+            );
+            assert_eq!(
+                pwd.as_deref(),
+                Some(Path::new("/abs/cwd/link")),
+                "spelling {spelt} should reach the child as /abs/cwd/link"
+            );
+        }
+    }
+
+    #[test]
+    fn child_pwd_for_falls_back_when_the_launch_dir_is_unknown() {
+        // `getcwd` failed, so a relative spelling cannot be anchored and the
+        // child is told where it actually starts.
+        let canonical = Path::new("/private/tmp/real");
+        assert_eq!(
+            child_pwd_for(Path::new("./link"), canonical, canonical, None).as_deref(),
+            Some(canonical)
+        );
+        // An absolute spelling needs no anchor, so it still survives.
+        assert_eq!(
+            child_pwd_for(Path::new("/tmp/link"), canonical, canonical, None).as_deref(),
+            Some(Path::new("/tmp/link"))
+        );
+    }
+
+    #[test]
+    fn child_pwd_for_keeps_absolute_spelling_of_symlinked_workdir() {
+        // `--workdir /tmp/link` where the link resolves elsewhere: keep the
+        // logical path, as a shell would.
+        let pwd = child_pwd_for(
+            Path::new("/tmp/link"),
+            Path::new("/private/tmp/real"),
+            Path::new("/private/tmp/real"),
+            Some(Path::new("/abs/cwd")),
+        );
+        assert_eq!(pwd.as_deref(), Some(Path::new("/tmp/link")));
+    }
+
+    #[test]
+    fn child_pwd_for_uses_start_dir_when_workdir_is_not_covered() {
+        // `execution_start_dir` fell back to `/` because the capability set does
+        // not cover the requested directory; `$PWD` must name where the child
+        // actually lands.
+        let pwd = child_pwd_for(
+            Path::new("/abs/cwd/my-project"),
+            Path::new("/abs/cwd/my-project"),
+            Path::new("/"),
+            Some(Path::new("/abs/cwd")),
+        );
+        assert_eq!(pwd.as_deref(), Some(Path::new("/")));
+    }
+
+    #[test]
+    fn child_pwd_for_leaves_env_alone_when_child_stays_in_launch_dir() {
+        let start = Path::new("/private/tmp/project");
+        assert_eq!(
+            child_pwd_for(start, start, start, Some(start)),
+            None,
+            "same directory, no rewrite"
+        );
+
+        assert_eq!(
+            child_pwd_for(Path::new("."), start, start, Some(start)),
+            None
+        );
+    }
+
+    #[test]
+    fn child_pwd_for_normalizes_noise_in_the_workdir_spelling() {
+        // `/tmp/link` resolves elsewhere, so the expected values differ from the
+        // start dir: each case can only pass by normalizing the spelling, not by
+        // falling back to the directory the child actually lands in.
+        let canonical = Path::new("/private/tmp/real");
+        let cases = [
+            ("/tmp/./link/", "/tmp/link"),
+            ("/tmp//link", "/tmp/link"),
+            ("/tmp/link/.", "/tmp/link"),
+        ];
+        for (spelt, expected) in cases {
+            let pwd = child_pwd_for(
+                Path::new(spelt),
+                canonical,
+                canonical,
+                Some(Path::new("/abs/cwd")),
+            );
+            assert_eq!(
+                pwd.as_deref().map(Path::as_os_str),
+                Some(std::ffi::OsStr::new(expected)),
+                "spelling {spelt} should reach the child as {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn child_pwd_for_discards_parent_dir_spelling() {
+        // `..` cannot be normalized away without resolving symlinks, so the
+        // spelling is dropped in favour of where the child actually starts —
+        // including when the `..` only appears once the relative spelling has
+        // been anchored to the launch dir.
+        let canonical = Path::new("/private/tmp/real");
+        for spelt in ["/tmp/other/../link", "../link", "./other/../link"] {
+            let pwd = child_pwd_for(
+                Path::new(spelt),
+                canonical,
+                canonical,
+                Some(Path::new("/abs/cwd")),
+            );
+            assert_eq!(
+                pwd.as_deref(),
+                Some(canonical),
+                "spelling {spelt} should not reach the child"
+            );
+        }
+    }
 
     #[test]
     fn recommended_builtin_profile_matches_known_agent_commands() {

--- a/crates/nono-cli/tests/execution_strategy_run.rs
+++ b/crates/nono-cli/tests/execution_strategy_run.rs
@@ -39,15 +39,20 @@ fn setup_isolated_home(prefix: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
     (tmp, home, workspace)
 }
 
-fn run_nono(args: &[&str], home: &Path, cwd: &Path) -> Output {
-    nono_bin()
-        .args(args)
+fn nono_cmd(args: &[&str], home: &Path, cwd: &Path) -> Command {
+    let mut cmd = nono_bin();
+    cmd.args(args)
         .env("HOME", home)
         .env("XDG_CONFIG_HOME", home.join(".config"))
         .env("XDG_STATE_HOME", home.join(".local").join("state"))
         .env("NONO_NO_SAVE_PROMPT", "1")
         .env_remove("NONO_DETACHED_LAUNCH")
-        .current_dir(cwd)
+        .current_dir(cwd);
+    cmd
+}
+
+fn run_nono(args: &[&str], home: &Path, cwd: &Path) -> Output {
+    nono_cmd(args, home, cwd)
         .output()
         .expect("failed to run nono")
 }
@@ -569,5 +574,133 @@ fn command_policies_allows_compiled_binary_exec_in_writable_grant_dir() {
     assert!(
         stdout.contains("ok"),
         "expected binary output in stdout\nstdout: {stdout}\nstderr: {stderr}",
+    );
+}
+
+/// A granted project directory to hand the child via `--workdir`, plus a launch
+/// directory that is deliberately outside the capability set.
+struct WorkdirCase {
+    _tmp: tempfile::TempDir,
+    home: PathBuf,
+    profile: PathBuf,
+    launch: PathBuf,
+    project: PathBuf,
+}
+
+fn setup_workdir_case(prefix: &str) -> WorkdirCase {
+    let (tmp, home, workspace) = setup_isolated_home(prefix);
+    let launch = tmp.path().join("launch");
+    fs::create_dir_all(&launch).expect("create launch dir");
+
+    let profile = write_profile(
+        &home,
+        prefix,
+        &format!(
+            r#"{{
+                "meta": {{ "name": "{prefix}-test" }},
+                "filesystem": {{ "allow": ["{workspace}"] }},
+                "network": {{ "block": true }}
+            }}"#,
+            workspace = workspace.display()
+        ),
+    );
+
+    WorkdirCase {
+        _tmp: tmp,
+        home,
+        profile,
+        launch,
+        project: workspace,
+    }
+}
+
+/// The child's own `$PWD`, as reported by `/usr/bin/env`.
+fn child_pwd(stdout: &str) -> Option<&str> {
+    stdout.lines().find_map(|line| line.strip_prefix("PWD="))
+}
+
+/// Run `nono <subcommand> --workdir <project>` from the uncovered launch directory,
+/// exporting `host_pwd` as the inherited `$PWD`.
+fn run_workdir_case(case: &WorkdirCase, subcommand: &str, host_pwd: &Path) -> Output {
+    let mut args = vec![
+        subcommand,
+        "--profile",
+        case.profile.to_str().expect("profile path"),
+    ];
+    if subcommand == "run" {
+        args.push("--no-rollback");
+    }
+    args.extend([
+        "--workdir",
+        case.project.to_str().expect("project path"),
+        "--",
+        "/usr/bin/env",
+    ]);
+
+    nono_cmd(&args, &case.home, &case.launch)
+        .env("PWD", host_pwd)
+        .output()
+        .expect("failed to run nono")
+}
+
+/// `--workdir` must reach the child's `$PWD` even though nono was launched from a
+/// directory outside the capability set.
+#[test]
+fn direct_workdir_sets_child_pwd_from_uncovered_launch_dir() {
+    let case = setup_workdir_case("workdir-pwd-direct");
+    let output = run_workdir_case(&case, "wrap", &case.launch);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        child_pwd(&stdout),
+        case.project.to_str(),
+        "nono wrap --workdir must set the child's $PWD to the workdir\nstdout: {stdout}\nstderr: {stderr}",
+    );
+}
+
+#[test]
+fn supervised_workdir_sets_child_pwd_from_uncovered_launch_dir() {
+    let case = setup_workdir_case("workdir-pwd-supervised");
+    let output = run_workdir_case(&case, "run", &case.launch);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        child_pwd(&stdout),
+        case.project.to_str(),
+        "nono run --workdir must set the child's $PWD to the workdir\nstdout: {stdout}\nstderr: {stderr}",
+    );
+}
+
+#[test]
+fn direct_workdir_overrides_untrusted_host_pwd() {
+    let case = setup_workdir_case("workdir-pwd-stale-direct");
+    let output = run_workdir_case(&case, "wrap", &case.home);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        child_pwd(&stdout),
+        case.project.to_str(),
+        "a stale inherited $PWD must not suppress the correction\nstdout: {stdout}\nstderr: {stderr}",
+    );
+}
+
+#[test]
+fn supervised_workdir_overrides_untrusted_host_pwd() {
+    let case = setup_workdir_case("workdir-pwd-stale-supervised");
+    let output = run_workdir_case(&case, "run", &case.home);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        child_pwd(&stdout),
+        case.project.to_str(),
+        "a stale inherited $PWD must not suppress the correction\nstdout: {stdout}\nstderr: {stderr}",
     );
 }

--- a/docs/cli/usage/flags.mdx
+++ b/docs/cli/usage/flags.mdx
@@ -829,6 +829,8 @@ Working directory for `$WORKDIR` expansion in profiles (defaults to current dire
 nono run --profile always-further/claude --workdir ./my-project -- claude
 ```
 
+It also sets the directory the sandboxed process starts in, but only when the capability set covers that directory; otherwise the process starts in `/`. Whenever the directory the child starts in differs from the one nono was launched in — with or without this flag — the child's `$PWD` and `$OLDPWD` are rewritten to describe where it actually is. See [Environment Variable Filtering](/cli/features/environment).
+
 #### `--allow-cwd`
 
 Allow access to the current working directory without prompting. By default, nono prompts interactively for CWD sharing. The access level is determined by the profile's `[workdir]` config or defaults to read-only.


### PR DESCRIPTION
Updates the PWD environment variable of a child to use the workdir passed in.

## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1495

## Summary
Passes through any `--workdir` as the `PWD` environment variable for children.

## Test Plan
New tests and steps to reproduce fixed

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates

