### PR TITLE
docs(cli): fix curl command for fetching latest version

### DIFF
--- a/docs/cli/getting_started/installation.mdx
+++ b/docs/cli/getting_started/installation.mdx
@@ -14,12 +14,12 @@ nono --version
 
 ### Debian/Ubuntu
 
-Download the `.deb` package from [GitHub Releases](https://github.com/always-further/nono/releases):
+Download the `.deb` package from [GitHub Releases](https://github.com/nolabs-ai/nono/releases):
 
 ```bash
-VERSION=$(curl -sI https://github.com/always-further/nono/releases/latest | grep -i location | grep -oP 'v\K[0-9a-zA-Z.-]+')
+VERSION=$(curl -sIL https://github.com/nolabs-ai/nono/releases/latest | grep -i location | grep -oP 'v\K[0-9a-zA-Z.-]+')
 ARCH=$(dpkg --print-architecture)
-wget https://github.com/always-further/nono/releases/download/v${VERSION}/nono-cli_${VERSION}_${ARCH}.deb
+wget https://github.com/nolabs-ai/nono/releases/download/v${VERSION}/nono-cli_${VERSION}_${ARCH}.deb
 sudo dpkg -i nono-cli_${VERSION}_${ARCH}.deb
 nono --version
 ```
@@ -41,12 +41,12 @@ nono --version
 
 ### Manual RPM (RHEL/openSUSE and fallback)
 
-Download the `.rpm` package from [GitHub Releases](https://github.com/always-further/nono/releases):
+Download the `.rpm` package from [GitHub Releases](https://github.com/nolabs-ai/nono/releases):
 
 ```bash
-VERSION=$(curl -sI https://github.com/always-further/nono/releases/latest | grep -i location | grep -oP 'v\K[0-9a-zA-Z.-]+')
+VERSION=$(curl -sIL https://github.com/nolabs-ai/nono/releases/latest | grep -i location | grep -oP 'v\K[0-9a-zA-Z.-]+')
 ARCH=$(uname -m)
-wget https://github.com/always-further/nono/releases/download/v${VERSION}/nono-cli-${VERSION}-1.${ARCH}.rpm
+wget https://github.com/nolabs-ai/nono/releases/download/v${VERSION}/nono-cli-${VERSION}-1.${ARCH}.rpm
 sudo dnf install ./nono-cli-${VERSION}-1.${ARCH}.rpm
 nono --version
 ```


### PR DESCRIPTION
The current command in the installation docs for Debian/Ubuntu doesn't find the version, because it looks for it on the /latest url.

This change adds the `-L` flag, which instructs curl to follow the 301 redirect header. Then you get the url with the appropriate version to grep for.

Example runs:
```sh
$ curl -sI https://github.com/always-further/nono/releases/latest | grep -i location
location: https://github.com/nolabs-ai/nono/releases/latest

$ curl -sIL https://github.com/always-further/nono/releases/latest | grep -i location
location: https://github.com/nolabs-ai/nono/releases/latest
location: https://github.com/nolabs-ai/nono/releases/tag/v0.71.0

$ curl -sIL https://github.com/always-further/nono/releases/latest | grep -i location | grep -oP 'v\K[0-9a-zA-Z.-]+'
0.71.0
```

## Linked Issue

<!-- Every PR must reference an existing issue. PRs without a linked issue will not be reviewed. -->

Closes #1568

## Summary

<!-- Briefly describe what this PR does and why. -->

<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates

I just did an online patch of the docs, can I skip the DCO for it?
<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
