### PR TITLE
ci: age out inactive issues with actions/stale

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -8,12 +8,13 @@
 # the `drop-triage-when-promoted` job runs on a schedule and reconciles state:
 # any open issue that has left the Backlog (status in PROMOTED_STATUSES) and
 # still carries the "triage" label gets it removed. This is idempotent.
+#
+# Stale issue grooming exists in stale.yml
 name: Project automation
 
 on:
   schedule:
     - cron: "*/10 * * * *" # triage reconcile
-    - cron: "30 6 * * 1" # weekly backlog grooming (Mondays 06:30 UTC)
   workflow_dispatch:
 
 permissions:
@@ -25,10 +26,6 @@ env:
   # Statuses that mean an issue has been triaged out of the Backlog.
   # The board columns are: Backlog | Blocked | In-Review | In-Progress | Todo | Done
   PROMOTED_STATUSES: "Todo,In-Progress,In-Review,Blocked,Done"
-  # Backlog grooming knobs.
-  STALE_DAYS: "90" # no activity for this long -> mark `stale`
-  CLOSE_GRACE_DAYS: "14" # after marking, wait this long before closing
-  EXEMPT_LABELS: "pinned,keep,roadmap,epic" # never groom issues with these labels
 
 jobs:
   # Remove the "triage" label once an issue has moved out of Backlog on the board.
@@ -108,114 +105,6 @@ jobs:
                 repo="${ref%#*}"; num="${ref##*#}"
                 echo "Removing 'triage' from $ref"
                 gh issue edit "$num" --repo "$repo" --remove-label "triage"
-              done
-
-            has_next=$(echo "$page" | jq -r '.data.organization.projectV2.items.pageInfo.hasNextPage')
-            cursor=$(echo "$page" | jq -r '.data.organization.projectV2.items.pageInfo.endCursor // ""')
-            [ "$has_next" = "true" ] || break
-          done
-
-  # Weekly grooming of the Backlog column: mark long-inactive issues `stale`,
-  # then close them after a grace period if still untouched.
-  #
-  # Prerequisite: a `stale` label must already exist in the repo(s) the board
-  # spans (gh cannot create labels on the fly).
-  groom-stale-backlog:
-    if: github.event.schedule == '30 6 * * 1' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Mark and close stale backlog issues
-        env:
-          # Same token as the triage job: Projects v2 Read + Issues Read & write.
-          GH_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          # shellcheck disable=SC2016  # $org/$number/$cursor are GraphQL variables, not shell variables
-          project_number=$(gh api graphql -f query='
-            query($org: String!) {
-              organization(login: $org) {
-                projectsV2(first: 50) { nodes { number title } }
-              }
-            }' -f org="$PROJECT_ORG" \
-            --jq ".data.organization.projectsV2.nodes[] | select(.title == \"$PROJECT_TITLE\") | .number")
-
-          if [ -z "$project_number" ]; then
-            echo "::error::Project '$PROJECT_TITLE' not found in org '$PROJECT_ORG'"
-            exit 1
-          fi
-          echo "Grooming Backlog of project #$project_number ($PROJECT_TITLE)"
-
-          # shellcheck disable=SC2016  # $org/$number/$cursor are GraphQL variables, not shell variables
-          query='
-            query($org: String!, $number: Int!, $cursor: String) {
-              organization(login: $org) {
-                projectV2(number: $number) {
-                  items(first: 100, after: $cursor) {
-                    pageInfo { hasNextPage endCursor }
-                    nodes {
-                      status: fieldValueByName(name: "Status") {
-                        ... on ProjectV2ItemFieldSingleSelectValue { name }
-                      }
-                      content {
-                        ... on Issue {
-                          number
-                          state
-                          updatedAt
-                          repository { nameWithOwner }
-                          labels(first: 50) { nodes { name } }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }'
-
-          now=$(date -u +%s)
-          stale_secs=$(( STALE_DAYS * 86400 ))
-          grace_secs=$(( CLOSE_GRACE_DAYS * 86400 ))
-
-          cursor=""
-          while : ; do
-            if [ -z "$cursor" ]; then
-              page=$(gh api graphql -F org="$PROJECT_ORG" -F number="$project_number" -F cursor=null -f query="$query")
-            else
-              page=$(gh api graphql -F org="$PROJECT_ORG" -F number="$project_number" -f cursor="$cursor" -f query="$query")
-            fi
-
-            echo "$page" | jq -r --arg exempt "$EXEMPT_LABELS" '
-              ($exempt | split(",")) as $ex
-              | .data.organization.projectV2.items.nodes[]
-              | select(.content.number != null)
-              | select(.content.state == "OPEN")
-              | select((.status.name // "") == "Backlog")
-              | { ref: "\(.content.repository.nameWithOwner)#\(.content.number)",
-                  updatedAt: .content.updatedAt,
-                  labels: [.content.labels.nodes[].name] }
-              | select((.labels | any(. as $l | $ex | index($l))) | not)
-              | [ .ref, .updatedAt, (if (.labels | index("stale")) then "stale" else "fresh" end) ]
-              | @tsv' \
-            | while IFS=$'\t' read -r ref updated marker; do
-                [ -n "$ref" ] || continue
-                repo="${ref%#*}"; num="${ref##*#}"
-                upd=$(date -u -d "$updated" +%s)
-                age=$(( now - upd ))
-                age_days=$(( age / 86400 ))
-                if [ "$marker" = "stale" ]; then
-                  if [ "$age" -ge "$grace_secs" ]; then
-                    echo "Closing $ref (no activity for ${age_days}d since marked stale)"
-                    gh issue close "$num" --repo "$repo" \
-                      --comment "Closing this backlog issue: no activity for ${age_days} days since it was marked \`stale\`. Comment to reopen if it's still relevant."
-                  fi
-                else
-                  if [ "$age" -ge "$stale_secs" ]; then
-                    echo "Marking $ref stale (inactive ${age_days}d)"
-                    gh issue edit "$num" --repo "$repo" --add-label "stale"
-                    gh issue comment "$num" --repo "$repo" \
-                      --body "This backlog issue has had no activity for ${age_days} days, so it's been labelled \`stale\`. It will be closed in ${CLOSE_GRACE_DAYS} days unless there's new activity or the \`stale\` label is removed."
-                  fi
-                fi
               done
 
             has_next=$(echo "$page" | jq -r '.data.organization.projectV2.items.pageInfo.hasNextPage')

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,71 @@
+# .github/workflows/stale.yml
+#
+# Ages inactive issues out of the backlog: 90 days idle -> `stale` label,
+# a further 14 days idle -> closed as not planned.
+#
+# Contributor-facing policy is documented in CONTRIBUTING.md ("Issue Lifecycle
+# and Stale Issues"); keep the two in sync when changing any threshold here.
+name: Stale issues
+
+on:
+  schedule:
+    - cron: "30 6 * * *" # daily 06:30 UTC
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Log what would be marked/closed without writing anything"
+        type: boolean
+        default: false
+
+permissions:
+  issues: write
+
+concurrency:
+  group: stale-issues
+  cancel-in-progress: false
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          days-before-issue-stale: 90
+          days-before-issue-close: 14
+          # -1 leaves pull requests alone.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+
+          stale-issue-label: stale
+          close-issue-reason: not_planned
+
+          stale-issue-message: >
+            This issue has had no activity for 90 days, so it has been labelled
+            `stale`. It will be closed in 14 days unless there is new activity.
+
+
+            If this is still relevant, comment saying so (or remove the `stale`
+            label) and it will be kept open. Closing is not a judgement on the
+            idea — a closed issue can be reopened at any time.
+
+          close-issue-message: >
+            Closing as stale: no activity in the 14 days since this was
+            labelled. Comment here to reopen if it is still relevant.
+
+          # Ways to keep an issue open regardless of activity.
+          exempt-all-issue-assignees: true
+          exempt-all-issue-milestones: true
+          exempt-issue-labels: keep
+
+          # Least recently updated first, so the operations budget goes to the
+          # issues most likely to be stale.
+          sort-by: updated
+          ascending: true
+          # Raised from the default 30 to cover a full pass over the backlog.
+          operations-per-run: 200
+
+          remove-issue-stale-when-updated: true
+          enable-statistics: true
+          debug-only: ${{ inputs.dry-run || false }}

--- a/.github/workflows/unstale.yml
+++ b/.github/workflows/unstale.yml
@@ -1,0 +1,38 @@
+# .github/workflows/unstale.yml
+#
+# Drops the `stale` label as soon as an issue shows a sign of life.
+#
+# stale.yml removes the label itself when an issue is merely commented on, but
+# it skips exempt issues entirely, so assigning/milestoning/`keep`-ing a stale
+# issue would otherwise leave the label stuck on it. This reacts to those
+# events directly.
+name: Unstale on activity
+
+on:
+  issues:
+    types: [assigned, milestoned, reopened, labeled]
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  remove-stale-label:
+    # Only act on labelled-stale issues, and only for a `keep` label when the
+    # trigger was a label being added — otherwise stale.yml adding `stale`
+    # would be undone here. Bot senders are ignored so the stale run cannot
+    # cancel its own work.
+    if: >
+      !github.event.issue.pull_request &&
+      github.event.sender.type != 'Bot' &&
+      contains(github.event.issue.labels.*.name, 'stale') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'keep')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove stale label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: gh issue edit "$ISSUE" --repo "$REPO" --remove-label stale

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,6 +231,47 @@ with a link to the PR.
 
 ---
 
+## Issue Lifecycle and Stale Issues
+
+Open issues are expected to represent work someone still intends to do. To keep
+the backlog an accurate signal rather than an archive, inactive issues are aged
+out automatically by
+[`.github/workflows/stale.yml`](./.github/workflows/stale.yml), which runs
+daily:
+
+1. An issue with **no activity for 90 days** gets the `stale` label and a
+   comment.
+2. If nothing happens for a further **14 days**, it is closed as `not planned`.
+
+**Never marked stale:**
+
+- issues with an assignee
+- issues in a milestone
+- issues labelled `keep`
+
+The `keep` label exists solely to opt out of this automation — it says nothing
+about priority. Pull requests are never marked stale.
+
+### If your issue gets labelled `stale`
+
+Any of the following keeps it open. The `stale` label is removed automatically
+in every case, by
+[`.github/workflows/unstale.yml`](./.github/workflows/unstale.yml):
+
+| What you do | Outcome |
+| --- | --- |
+| Comment on it | Stays open; the 90-day clock restarts |
+| Assign someone | Stays open for as long as it has an assignee |
+| Add it to a milestone | Stays open for as long as it is in one |
+| Apply `keep` | Stays open indefinitely |
+| Remove the `stale` label yourself | Stays open; the 90-day clock restarts |
+| Nothing | Closed as `not planned` once the 14 days are up |
+
+Closing is not a verdict on the idea. A closed issue can be reopened at any
+time, and reopening the original is preferred over filing a duplicate.
+
+---
+
 ## Scope: What nono Does and Does Not Do
 
 nono applies OS-enforced capability restrictions to sandbox AI agents and


### PR DESCRIPTION
## Linked Issue

Closes #1434 

## Summary


<!-- Briefly describe what this PR does and why. -->
- **`stale.yml`** — `actions/stale` v11, pinned to `4391f3da`. 90 days idle → `stale`;
    14 more → closed as `not planned`. Exempt: assignee, milestone, `keep`. PRs excluded
    via `days-before-pr-stale: -1`. `workflow_dispatch` takes a `dry-run` input that maps
    to `debug-only`.
- **`unstale.yml`** — removes `stale` on `assigned`/`milestoned`/`reopened`, and on
    `labeled` when the label is `keep`. `actions/stale` checks exemptions and returns
    before the code that removes the label, so an issue that becomes exempt while stale
    would otherwise keep the label forever. Bot senders are filtered so the stale run
    can't undo itself.
- **`project-automation.yml`** — drops the weekly `groom-stale-backlog` job, its cron,
    and its three env knobs. The triage reconcile job is unchanged.
- **`CONTRIBUTING.md`** — new "Issue Lifecycle and Stale Issues" section.
<!--
## Agent Disclosure (if applicable)

If this PR is generated by an AI agent, per CLAUDE.md you must include:
- A statement that the contributor is an agent.
- References to relevant files or sections consulted.
- Explicit confirmation of compliance with repository requirements.
-->

## Test Plan

<!-- How was this tested? Include relevant commands, test cases, or manual verification steps. -->

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
