### PR TITLE
test(audit): add per-variant golden vectors for AuditEventPayload

### DIFF
--- a/crates/nono/src/audit.rs
+++ b/crates/nono/src/audit.rs
@@ -1941,4 +1941,212 @@ mod tests {
             )
         );
     }
+
+    /// Golden vectors for each `AuditEventPayload` variant, shared with nono-py.
+    ///
+    /// Each case pins the exact JSON emitted by `serde_json::to_string` and the
+    /// corresponding alpha leaf hash.  If this test fails the wire format diverged
+    /// across language bindings -- fix the divergence, never the vector.
+    ///
+    /// Companion test in nono-py: `tests/test_audit.py::TestAuditEventPayloadGoldenVectors`
+    #[test]
+    fn audit_event_payload_golden_vectors() {
+        use crate::AccessMode;
+        use crate::supervisor::{ApprovalDecision, ApprovalRequest, UrlOpenRequest};
+        use crate::undo::{NetworkAuditDecision, NetworkAuditEvent, NetworkAuditMode};
+        use std::path::PathBuf;
+        use std::time::{Duration, UNIX_EPOCH};
+
+        fn check(
+            label: &str,
+            payload: &AuditEventPayload,
+            expected_json: &str,
+            expected_leaf: &str,
+        ) {
+            let json = serde_json::to_string(payload).unwrap();
+            assert_eq!(json, expected_json, "{label}: JSON mismatch");
+            let leaf = hash_event(json.as_bytes());
+            assert_eq!(
+                leaf.to_string(),
+                expected_leaf,
+                "{label}: leaf hash mismatch"
+            );
+        }
+
+        check(
+            "SessionStarted",
+            &AuditEventPayload::SessionStarted {
+                started: "2026-04-21T20:00:00Z".to_string(),
+                command: vec!["claude".to_string()],
+                redaction_policy: None,
+            },
+            r#"{"type":"session_started","started":"2026-04-21T20:00:00Z","command":["claude"]}"#,
+            "c33fec3894d439b2cb313e7b24d142d8a87ce4e839e8c8e66851d14ad7595c69",
+        );
+
+        check(
+            "SessionEnded",
+            &AuditEventPayload::SessionEnded {
+                ended: "2026-04-21T20:00:01Z".to_string(),
+                exit_code: 0,
+            },
+            r#"{"type":"session_ended","ended":"2026-04-21T20:00:01Z","exit_code":0}"#,
+            "076e559e44135ff9a3d27403d1d6ad389bb04542956a064fc23acb37824c70bb",
+        );
+
+        // Note: AuditEntry.timestamp (SystemTime) serializes as
+        // {"secs_since_epoch":N,"nanos_since_epoch":M}.  ApprovalDecision uses
+        // untagged enum serialization, producing {"Denied":{"reason":"..."}}.
+        check(
+            "CapabilityDecision",
+            &AuditEventPayload::CapabilityDecision {
+                entry: crate::supervisor::AuditEntry {
+                    timestamp: UNIX_EPOCH + Duration::from_secs(5),
+                    request: ApprovalRequest::Capability {
+                        request_id: "req-1".to_string(),
+                        path: PathBuf::from("/tmp/example"),
+                        access: AccessMode::ReadWrite,
+                        reason: Some("need scratch space".to_string()),
+                        child_pid: 42,
+                        session_id: "sess-1".to_string(),
+                    },
+                    decision: ApprovalDecision::Denied {
+                        reason: "outside policy".to_string(),
+                    },
+                    backend: "terminal".to_string(),
+                    duration_ms: 12,
+                },
+            },
+            concat!(
+                r#"{"type":"capability_decision","entry":{"timestamp":{"secs_since_epoch":5,"nanos_since_epoch":0},"#,
+                r#""request":{"capability_type":"capability","request_id":"req-1","path":"/tmp/example","#,
+                r#""access":"ReadWrite","reason":"need scratch space","child_pid":42,"session_id":"sess-1"},"#,
+                r#""decision":{"Denied":{"reason":"outside policy"}},"backend":"terminal","duration_ms":12}}"#,
+            ),
+            "fb0ff01abb9de69f3c50deb6b828a25d941d7541856d81b8fa3da84b95aa125a",
+        );
+
+        // Note: UrlOpen.error has no skip_serializing_if, so None serializes as null.
+        check(
+            "UrlOpen",
+            &AuditEventPayload::UrlOpen {
+                request: UrlOpenRequest {
+                    request_id: "open-1".to_string(),
+                    url: "https://example.com/callback".to_string(),
+                    child_pid: 42,
+                    session_id: "sess-1".to_string(),
+                },
+                success: true,
+                error: None,
+            },
+            concat!(
+                r#"{"type":"url_open","request":{"request_id":"open-1","#,
+                r#""url":"https://example.com/callback","child_pid":42,"session_id":"sess-1"},"#,
+                r#""success":true,"error":null}"#,
+            ),
+            "ce74e0fa39cd9c9f74ba3eaf509cf88d2b39b771360f646fae3e385c1ca37f2d",
+        );
+
+        check(
+            "Network",
+            &AuditEventPayload::Network {
+                event: Box::new(NetworkAuditEvent {
+                    timestamp_unix_ms: 5,
+                    mode: NetworkAuditMode::Reverse,
+                    decision: NetworkAuditDecision::Deny,
+                    route_id: None,
+                    auth_mechanism: None,
+                    auth_outcome: None,
+                    managed_credential_active: None,
+                    injection_mode: None,
+                    denial_category: None,
+                    endpoint_policy_action: None,
+                    endpoint_policy_rule: None,
+                    approval_backend: None,
+                    credential_capture_action: None,
+                    credential_capture_name: None,
+                    credential_capture_command: None,
+                    credential_capture_argv: None,
+                    credential_capture_exit_status: None,
+                    credential_capture_duration_ms: None,
+                    credential_capture_stdout_bytes: None,
+                    credential_capture_stderr: None,
+                    credential_capture_cache_scope: None,
+                    credential_capture_output_format: None,
+                    credential_capture_header_names: None,
+                    credential_capture_stdin_mode: None,
+                    credential_capture_interactive: None,
+                    spiffe_context: None,
+                    target: "api.example.com".to_string(),
+                    upstream: None,
+                    port: Some(443),
+                    method: Some("POST".to_string()),
+                    path: Some("/v1/chat".to_string()),
+                    status: Some(403),
+                    reason: Some("policy".to_string()),
+                }),
+            },
+            concat!(
+                r#"{"type":"network","event":{"timestamp_unix_ms":5,"mode":"reverse","decision":"deny","#,
+                r#""target":"api.example.com","port":443,"method":"POST","path":"/v1/chat","status":403,"reason":"policy"}}"#,
+            ),
+            "629b456dfbf72482f4c68050d40978bdd644947584605f1df4d39346b67875f8",
+        );
+
+        check(
+            "SandboxRuntime",
+            &AuditEventPayload::SandboxRuntime {
+                event: SandboxRuntimeAuditEvent {
+                    timestamp: "2026-04-21T20:00:00Z".to_string(),
+                    platform: "macOS".to_string(),
+                    landlock_abi: None,
+                    landlock_execute_enforced: None,
+                    tool_sandbox_active: false,
+                },
+            },
+            concat!(
+                r#"{"type":"sandbox_runtime","event":{"timestamp":"2026-04-21T20:00:00Z","#,
+                r#""platform":"macOS","tool_sandbox_active":false}}"#,
+            ),
+            "de97a52ba94e3201c97dc53ebc51e901ef7b3c965c6bb336365e2fa367522109",
+        );
+
+        // Note: CommandPolicy.reason has no skip_serializing_if, so None -> null.
+        // env_display uses skip_serializing_if = "Vec::is_empty" so [] is omitted.
+        check(
+            "CommandPolicy",
+            &AuditEventPayload::CommandPolicy {
+                event: Box::new(CommandPolicyAuditEvent {
+                    timestamp: "2026-04-21T20:00:00Z".to_string(),
+                    session_id: Some("sess-1".to_string()),
+                    command: "git".to_string(),
+                    caller: "session".to_string(),
+                    caller_kind: None,
+                    caller_command: None,
+                    caller_pid: None,
+                    shim_pid: None,
+                    session_root_pid: None,
+                    decision: "allow".to_string(),
+                    reason: None,
+                    stdio_mode: "piped".to_string(),
+                    argv_hash: "aabbcc".to_string(),
+                    env_name_hash: "ddeeff".to_string(),
+                    cwd_hash: "001122".to_string(),
+                    argv_display: vec!["git".to_string(), "status".to_string()],
+                    env_names_display: vec![],
+                    env_display: vec![],
+                    cwd_display: "/home/user".to_string(),
+                    exit_code: Some(0),
+                    stdio: None,
+                }),
+            },
+            concat!(
+                r#"{"type":"command_policy","event":{"timestamp":"2026-04-21T20:00:00Z","session_id":"sess-1","#,
+                r#""command":"git","caller":"session","decision":"allow","reason":null,"stdio_mode":"piped","#,
+                r#""argv_hash":"aabbcc","env_name_hash":"ddeeff","cwd_hash":"001122","#,
+                r#""argv_display":["git","status"],"env_names_display":[],"cwd_display":"/home/user","exit_code":0}}"#,
+            ),
+            "ae7caf84865bfd686729a67a04fc3fd6af72dbd700eb77403d9f338491c4815d",
+        );
+    }
 }


### PR DESCRIPTION
Closes #1522

## Summary

The existing `rust_compatibility_golden_vectors` test (`audit.rs:1903`) pins the session-digest hex, ledger chain-hash, and Merkle proof serialization.  It does not pin the serialized form of any `AuditEventPayload` variant.

A serde-attribute change on the enum or any nested type would produce different leaf hashes in all language bindings without failing the current test.  The new test catches this class of silent regression.

## What this PR does

Adds `audit_event_payload_golden_vectors` to `crates/nono/src/audit.rs`.

For each `AuditEventPayload` variant the test asserts:
- the exact JSON string produced by `serde_json::to_string`
- the alpha leaf hash produced by `hash_event` on those bytes

Variants covered (all seven current variants):

| Variant | Notable format detail pinned |
|---------|------------------------------|
| `SessionStarted` | tag key `"session_started"`, `redaction_policy` omitted when None |
| `SessionEnded` | `exit_code` is an integer, not a string |
| `CapabilityDecision` | `AuditEntry.timestamp` as `{"secs_since_epoch":N,"nanos_since_epoch":M}` |
| `UrlOpen` | `error: null` (no `skip_serializing_if`; None does NOT become absent) |
| `Network` | all skip-serializing_if fields absent when None |
| `SandboxRuntime` | optional Landlock fields absent when None |
| `CommandPolicy` | `reason: null` (no `skip_serializing_if`), `env_display` absent when empty |

No production code is changed.  No existing tests are modified.

## Test plan

- `cargo test --package nono --lib audit::tests::audit_event_payload_golden_vectors`: passes
- `make ci` (clippy + fmt-check + tests + audit + doc-lint): passes

## Agent disclosure

This PR was prepared by an AI agent (Claude Sonnet) acting under human direction per the project's agent contribution policy.

- An issue exists: #1522
- Intent and approach were disclosed in the issue before any code change
- No forbidden patterns used: no `.unwrap()` or `.expect()` outside the test module's existing `#[allow(clippy::unwrap_used)]` scope
- No `NonoError` required: test-only addition with no error-path logic
- Paths: no path handling in this change
- This PR matches the disclosed issue scope

## Agent compliance check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists (#1522)
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (test fixtures follow patterns already in `verifier_round_trips_all_current_audit_event_payload_variants` at audit.rs:1516)
- [x] I did not use forbidden patterns such as unwrap/expect (within existing test-module allow)
- [x] `NonoError` is not applicable (no error-path code)
- [x] No path validation required (no filesystem paths in this change)
- [x] This PR matches the approved or disclosed issue scope
