### PR TITLE
fix(proxy): bound per-line reads of the WebSocket upgrade response

### DIFF
--- a/crates/nono-proxy/src/external.rs
+++ b/crates/nono-proxy/src/external.rs
@@ -11,8 +11,9 @@ use crate::audit;
 use crate::config::ExternalProxyConfig;
 use crate::error::{ProxyError, Result};
 use crate::filter::ProxyFilter;
+use crate::line_reader;
 use crate::token;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 use tracing::debug;
 use zeroize::Zeroizing;
@@ -61,15 +62,18 @@ pub async fn connect_via_proxy(
 
     let mut buf_reader = BufReader::new(&mut proxy_stream);
     let mut response_line = String::new();
-    buf_reader
-        .read_line(&mut response_line)
-        .await
-        .map_err(|e| {
-            ProxyError::ExternalProxy(format!(
-                "failed to read response from external proxy: {}",
-                e
-            ))
-        })?;
+    line_reader::read_line_limited_string(
+        &mut buf_reader,
+        &mut response_line,
+        line_reader::MAX_LINE_SIZE,
+    )
+    .await
+    .map_err(|e| {
+        ProxyError::ExternalProxy(format!(
+            "failed to read response from external proxy: {}",
+            e
+        ))
+    })?;
 
     let status = parse_status_code(&response_line)?;
     if status != 200 {
@@ -82,7 +86,13 @@ pub async fn connect_via_proxy(
     // Drain headers up to the empty line.
     loop {
         let mut line = String::new();
-        buf_reader.read_line(&mut line).await.map_err(|e| {
+        line_reader::read_line_limited_string(
+            &mut buf_reader,
+            &mut line,
+            line_reader::MAX_LINE_SIZE,
+        )
+        .await
+        .map_err(|e| {
             ProxyError::ExternalProxy(format!("failed to drain proxy response headers: {}", e))
         })?;
         if line.trim().is_empty() {

--- a/crates/nono-proxy/src/lib.rs
+++ b/crates/nono-proxy/src/lib.rs
@@ -31,6 +31,7 @@ pub mod external;
 pub mod filter;
 pub mod forward;
 pub mod jwt_phantom;
+pub(crate) mod line_reader;
 pub mod oauth2;
 pub mod oauth_capture;
 pub mod pool;

--- a/crates/nono-proxy/src/line_reader.rs
+++ b/crates/nono-proxy/src/line_reader.rs
@@ -1,0 +1,143 @@
+//! Bounded line reading shared by proxy paths that read untrusted
+//! line-oriented data (request/status lines, headers, chunk-size and trailer
+//! lines) from a client, upstream, or external proxy socket. Without a bound,
+//! a peer that never sends a newline can make `read_line` grow its buffer
+//! without limit and OOM the proxy.
+
+use tokio::io::{AsyncBufRead, AsyncBufReadExt};
+
+/// Cap on a single line read via [`read_line_limited`] / [`read_line_limited_string`].
+pub(crate) const MAX_LINE_SIZE: usize = 8 * 1024;
+
+/// Read one line from `reader`, erroring once `max_len` bytes buffer without a
+/// newline. `Ok(None)` on clean EOF; otherwise mirrors `read_line`'s semantics.
+pub(crate) async fn read_line_limited<R>(
+    reader: &mut R,
+    max_len: usize,
+) -> std::io::Result<Option<Vec<u8>>>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut buf = Vec::new();
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            return Ok((!buf.is_empty()).then_some(buf));
+        }
+        if let Some(pos) = available.iter().position(|&b| b == b'\n') {
+            if buf.len().saturating_add(pos).saturating_add(1) > max_len {
+                reader.consume(pos + 1);
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "line exceeded maximum length",
+                ));
+            }
+            buf.extend_from_slice(&available[..=pos]);
+            reader.consume(pos + 1);
+            return Ok(Some(buf));
+        }
+        if buf.len().saturating_add(available.len()) > max_len {
+            let consumed = available.len();
+            reader.consume(consumed);
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "line exceeded maximum length",
+            ));
+        }
+        let consumed = available.len();
+        buf.extend_from_slice(available);
+        reader.consume(consumed);
+    }
+}
+
+/// String-returning wrapper matching `AsyncBufReadExt::read_line`'s calling
+/// convention (appends to `buf`, returns bytes read, 0 means EOF), for call
+/// sites that parse the line as UTF-8 text.
+pub(crate) async fn read_line_limited_string<R>(
+    reader: &mut R,
+    buf: &mut String,
+    max_len: usize,
+) -> std::io::Result<usize>
+where
+    R: AsyncBufRead + Unpin,
+{
+    match read_line_limited(reader, max_len).await? {
+        None => Ok(0),
+        Some(bytes) => {
+            let len = bytes.len();
+            let text = String::from_utf8(bytes).map_err(|_| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, "line is not valid UTF-8")
+            })?;
+            buf.push_str(&text);
+            Ok(len)
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncWriteExt, BufReader};
+
+    #[tokio::test]
+    async fn read_line_limited_returns_none_on_clean_eof() {
+        let (client, server) = tokio::io::duplex(64);
+        drop(client);
+        let mut reader = BufReader::new(server);
+        assert_eq!(read_line_limited(&mut reader, 64).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn read_line_limited_rejects_line_over_max_len_without_newline() {
+        let (mut client, server) = tokio::io::duplex(MAX_LINE_SIZE * 2);
+        let mut reader = BufReader::new(server);
+        client
+            .write_all(&vec![b'a'; MAX_LINE_SIZE + 1])
+            .await
+            .unwrap();
+        let result = read_line_limited(&mut reader, MAX_LINE_SIZE).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn read_line_limited_string_returns_zero_on_clean_eof() {
+        let (client, server) = tokio::io::duplex(64);
+        drop(client);
+        let mut reader = BufReader::new(server);
+        let mut buf = String::new();
+        assert_eq!(
+            read_line_limited_string(&mut reader, &mut buf, 64)
+                .await
+                .unwrap(),
+            0
+        );
+        assert!(buf.is_empty());
+    }
+
+    #[tokio::test]
+    async fn read_line_limited_string_reads_a_line() {
+        let (mut client, server) = tokio::io::duplex(64);
+        client.write_all(b"hello\r\n").await.unwrap();
+        let mut reader = BufReader::new(server);
+        let mut buf = String::new();
+        let n = read_line_limited_string(&mut reader, &mut buf, 64)
+            .await
+            .unwrap();
+        assert_eq!(n, 7);
+        assert_eq!(buf, "hello\r\n");
+    }
+
+    #[tokio::test]
+    async fn read_line_limited_string_rejects_invalid_utf8() {
+        let (mut client, server) = tokio::io::duplex(64);
+        client.write_all(&[0xff, 0xfe, b'\n']).await.unwrap();
+        let mut reader = BufReader::new(server);
+        let mut buf = String::new();
+        assert!(
+            read_line_limited_string(&mut reader, &mut buf, 64)
+                .await
+                .is_err()
+        );
+    }
+}

--- a/crates/nono-proxy/src/server.rs
+++ b/crates/nono-proxy/src/server.rs
@@ -16,6 +16,7 @@ use crate::error::{ProxyError, Result};
 use crate::external;
 use crate::filter::ProxyFilter;
 use crate::forward::{self, AuditCtx, UpstreamScheme, UpstreamSpec, UpstreamStrategy};
+use crate::line_reader;
 use crate::oauth_capture::OAuthCaptureStore;
 use crate::pool::UpstreamPool;
 use crate::reverse;
@@ -26,7 +27,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
 use tokio::sync::watch;
 use tracing::{debug, info, warn};
@@ -1372,7 +1373,12 @@ async fn handle_connection(mut stream: tokio::net::TcpStream, state: &ProxyState
     // to prevent data loss (BufReader may read ahead into the body).
     let mut buf_reader = BufReader::new(&mut stream);
     let mut first_line = String::new();
-    buf_reader.read_line(&mut first_line).await?;
+    line_reader::read_line_limited_string(
+        &mut buf_reader,
+        &mut first_line,
+        line_reader::MAX_LINE_SIZE,
+    )
+    .await?;
 
     if first_line.is_empty() {
         return Ok(()); // Client disconnected
@@ -1382,7 +1388,12 @@ async fn handle_connection(mut stream: tokio::net::TcpStream, state: &ProxyState
     let mut header_bytes = Vec::new();
     loop {
         let mut line = String::new();
-        let n = buf_reader.read_line(&mut line).await?;
+        let n = line_reader::read_line_limited_string(
+            &mut buf_reader,
+            &mut line,
+            line_reader::MAX_LINE_SIZE,
+        )
+        .await?;
         if n == 0 || line.trim().is_empty() {
             break;
         }
@@ -1514,14 +1525,24 @@ async fn handle_connection(mut stream: tokio::net::TcpStream, state: &ProxyState
                                     // the same connection.
                                     let mut buf_reader = BufReader::new(&mut stream);
                                     let mut retry_line = String::new();
-                                    buf_reader.read_line(&mut retry_line).await?;
+                                    line_reader::read_line_limited_string(
+                                        &mut buf_reader,
+                                        &mut retry_line,
+                                        line_reader::MAX_LINE_SIZE,
+                                    )
+                                    .await?;
                                     if retry_line.is_empty() {
                                         return Ok(()); // client disconnected
                                     }
                                     let mut retry_headers = Vec::new();
                                     loop {
                                         let mut line = String::new();
-                                        let n = buf_reader.read_line(&mut line).await?;
+                                        let n = line_reader::read_line_limited_string(
+                                            &mut buf_reader,
+                                            &mut line,
+                                            line_reader::MAX_LINE_SIZE,
+                                        )
+                                        .await?;
                                         if n == 0 || line.trim().is_empty() {
                                             break;
                                         }

--- a/crates/nono-proxy/src/tls_intercept/handle.rs
+++ b/crates/nono-proxy/src/tls_intercept/handle.rs
@@ -18,13 +18,14 @@ use crate::credential::CredentialStore;
 use crate::error::{ProxyError, Result};
 use crate::filter::ProxyFilter;
 use crate::forward::{self, AuditCtx, UpstreamScheme, UpstreamSpec, UpstreamStrategy};
+use crate::line_reader;
 use crate::oauth_capture::OAuthCaptureStore;
 use crate::reverse;
 use crate::route::RouteStore;
 use crate::tls_intercept::cert_cache::CertCache;
 use crate::tls_intercept::{acceptor, h2_forward, websocket};
 use std::sync::Arc;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 use tokio_rustls::TlsAcceptor;
 use tracing::{debug, warn};
@@ -306,7 +307,12 @@ where
 {
     let mut buf_reader = BufReader::new(&mut *stream);
     let mut first_line = String::new();
-    buf_reader.read_line(&mut first_line).await?;
+    line_reader::read_line_limited_string(
+        &mut buf_reader,
+        &mut first_line,
+        line_reader::MAX_LINE_SIZE,
+    )
+    .await?;
     if first_line.is_empty() {
         return Ok(None);
     }
@@ -314,7 +320,12 @@ where
     let mut header_bytes = Vec::new();
     loop {
         let mut line = String::new();
-        let n = buf_reader.read_line(&mut line).await?;
+        let n = line_reader::read_line_limited_string(
+            &mut buf_reader,
+            &mut line,
+            line_reader::MAX_LINE_SIZE,
+        )
+        .await?;
         if n == 0 || line.trim().is_empty() {
             break;
         }

--- a/crates/nono-proxy/src/tls_intercept/http1.rs
+++ b/crates/nono-proxy/src/tls_intercept/http1.rs
@@ -1,8 +1,9 @@
 //! Strict HTTP/1 head parsing and single-response framing for TLS interception.
 
 use crate::error::{ProxyError, Result};
+use crate::line_reader;
 use std::time::Duration;
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 
 const MAX_RESPONSE_BODY: u64 = 16 * 1024 * 1024;
 const RESPONSE_BODY_TIMEOUT: Duration = Duration::from_secs(30);
@@ -188,7 +189,10 @@ where
     let mut total = 0u64;
     loop {
         let mut size_line = String::new();
-        if reader.read_line(&mut size_line).await? == 0 {
+        if line_reader::read_line_limited_string(reader, &mut size_line, line_reader::MAX_LINE_SIZE)
+            .await?
+            == 0
+        {
             return Err(ProxyError::HttpParse(
                 "truncated chunked response".to_string(),
             ));
@@ -216,7 +220,14 @@ where
         }
         loop {
             let mut trailer = String::new();
-            if reader.read_line(&mut trailer).await? == 0 {
+            if line_reader::read_line_limited_string(
+                reader,
+                &mut trailer,
+                line_reader::MAX_LINE_SIZE,
+            )
+            .await?
+                == 0
+            {
                 return Err(ProxyError::HttpParse(
                     "truncated chunked trailers".to_string(),
                 ));

--- a/crates/nono-proxy/src/tls_intercept/websocket.rs
+++ b/crates/nono-proxy/src/tls_intercept/websocket.rs
@@ -2,11 +2,12 @@
 
 use super::http1::{self, HeaderField};
 use crate::error::{ProxyError, Result};
+use crate::line_reader::{MAX_LINE_SIZE, read_line_limited};
 use crate::reverse;
 use base64::Engine as _;
 use sha1::{Digest, Sha1};
 use std::time::Duration;
-use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+use tokio::io::{AsyncRead, BufReader};
 
 const MAX_HEADER_SIZE: usize = 64 * 1024;
 const UPSTREAM_HEADER_TIMEOUT: Duration = Duration::from_secs(30);
@@ -38,29 +39,29 @@ where
 {
     let read = async {
         let mut reader = BufReader::new(&mut *upstream);
-        let mut status_line = String::new();
-        if reader.read_line(&mut status_line).await? == 0 {
-            return Err(ProxyError::UpstreamConnect {
+        let status_line_bytes = read_line_limited(&mut reader, MAX_LINE_SIZE)
+            .await?
+            .ok_or_else(|| ProxyError::UpstreamConnect {
                 host: host.to_string(),
                 reason: "upstream closed before sending an upgrade response".to_string(),
-            });
-        }
+            })?;
+        let status_line = String::from_utf8(status_line_bytes).map_err(|_| {
+            ProxyError::HttpParse("malformed upstream status line: invalid UTF-8".to_string())
+        })?;
         let status = parse_status_line(&status_line)?;
         let mut header_bytes = Vec::new();
         loop {
-            let mut line = String::new();
-            let count = reader.read_line(&mut line).await?;
-            if count == 0 {
-                return Err(ProxyError::UpstreamConnect {
+            let line = read_line_limited(&mut reader, MAX_LINE_SIZE)
+                .await?
+                .ok_or_else(|| ProxyError::UpstreamConnect {
                     host: host.to_string(),
                     reason: "upstream closed before terminating upgrade response headers"
                         .to_string(),
-                });
-            }
-            if line == "\r\n" || line == "\n" {
+                })?;
+            if line == b"\r\n" || line == b"\n" {
                 break;
             }
-            header_bytes.extend_from_slice(line.as_bytes());
+            header_bytes.extend_from_slice(&line);
             if header_bytes.len() > MAX_HEADER_SIZE {
                 return Err(ProxyError::UpstreamConnect {
                     host: host.to_string(),
@@ -117,4 +118,63 @@ pub(crate) fn is_valid_response(status: u16, header_bytes: &[u8], client_key: &s
             .iter()
             .any(|value| value.eq_ignore_ascii_case("websocket"))
         && matches!(http1::values(&fields, "sec-websocket-accept").as_slice(), [accept] if *accept == expected)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncWriteExt;
+
+    // Regression test: an upstream that never terminates the status line must
+    // be rejected immediately by the per-line size cap, not left to grow an
+    // unbounded buffer until the 30s connect timeout (or OOM) kicks in.
+    #[tokio::test]
+    async fn read_response_rejects_unterminated_status_line() {
+        let (mut client, server) = tokio::io::duplex(MAX_LINE_SIZE * 2);
+        client
+            .write_all(&vec![b'a'; MAX_LINE_SIZE + 1])
+            .await
+            .unwrap();
+        client.flush().await.unwrap();
+
+        let mut server = server;
+        let result = read_response(&mut server, "example.com").await;
+        assert!(result.is_err());
+    }
+
+    // Regression test: a single header line with no terminator that exceeds
+    // the per-line cap must be rejected without buffering it in full, even
+    // though it's still under the cumulative MAX_HEADER_SIZE budget.
+    #[tokio::test]
+    async fn read_response_rejects_unterminated_header_line() {
+        let (mut client, server) = tokio::io::duplex(MAX_LINE_SIZE * 2);
+        client
+            .write_all(b"HTTP/1.1 101 Switching Protocols\r\n")
+            .await
+            .unwrap();
+        client
+            .write_all(&vec![b'a'; MAX_LINE_SIZE + 1])
+            .await
+            .unwrap();
+        client.flush().await.unwrap();
+
+        let mut server = server;
+        let result = read_response(&mut server, "example.com").await;
+        assert!(result.is_err());
+    }
+
+    // An oversized line whose `\n` lands in the same `fill_buf` chunk must still
+    // be rejected: capping only the no-newline branch would let it through.
+    #[tokio::test]
+    async fn read_line_limited_rejects_newline_terminated_line_over_max_len() {
+        let (mut client, server) = tokio::io::duplex(4096);
+        client.write_all(b"aaaaaaaaaa\n").await.unwrap();
+        client.flush().await.unwrap();
+        drop(client);
+
+        let mut reader = BufReader::new(server);
+        let result = read_line_limited(&mut reader, 5).await;
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
Closes #1616

`read_line` grows its buffer until it sees a newline, so an upstream that
streams bytes without one made the proxy allocate for the full 30s header
timeout. `MAX_HEADER_SIZE` only applied once a whole line had been buffered,
and never to the status line at all.

Adds `MAX_LINE_SIZE` (8 KiB) and a `read_line_limited` helper over
`AsyncBufRead` that errors with `InvalidData` once that many bytes accumulate,
checking the cap on both the newline-found and no-newline branches.
`MAX_HEADER_SIZE` still bounds the cumulative total.

Contributed by an agent on behalf of @kipz.

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope
