### PR TITLE
feat(remote): add remote session connect and ps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,6 +2776,7 @@ dependencies = [
  "criterion",
  "dirs",
  "dns-lookup",
+ "futures-util",
  "globset",
  "ignore",
  "itoa",
@@ -2802,6 +2803,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "toml 1.1.3+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
@@ -4721,6 +4723,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4969,6 +4987,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.2",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5122,6 +5159,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8-zero"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4994,7 +4994,7 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.2",
+ "http 1.5.0",
  "httparse",
  "log",
  "rand 0.9.5",

--- a/crates/nono-cli/Cargo.toml
+++ b/crates/nono-cli/Cargo.toml
@@ -73,7 +73,9 @@ keyring = { version = "3", optional = true, default-features = false }
 
 # Keyless (Sigstore/Fulcio/Rekor) signing for instruction file attestation
 sigstore-sign = "0.11.0"
-tokio = { version = "1", features = ["rt"] }
+tokio = { version = "1", features = ["io-std", "macros", "rt-multi-thread", "signal"] }
+tokio-tungstenite = { version = "0.28", default-features = false, features = ["connect", "rustls-tls-native-roots"] }
+futures-util = "0.3"
 
 ureq = { version = "3", features = ["platform-verifier", "socks-proxy"] }
 semver = "1"

--- a/crates/nono-cli/src/app_runtime.rs
+++ b/crates/nono-cli/src/app_runtime.rs
@@ -68,9 +68,34 @@ fn dispatch_command(
         Commands::Platform(args) => run_command_with_update(update_handle, silent, || {
             platform_client::run_platform(args)
         }),
-        Commands::Ps(args) => {
-            run_command_with_update(update_handle, silent, || session_commands::run_ps(&args))
-        }
+        Commands::Connect(args) => run_command_with_update(update_handle, silent, || {
+            #[cfg(unix)]
+            {
+                crate::connect_client::run_connect(args)
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = args;
+                Err(nono::NonoError::UnsupportedPlatform(
+                    "remote terminal attach currently requires a Unix terminal".to_string(),
+                ))
+            }
+        }),
+        Commands::Ps(args) => run_command_with_update(update_handle, silent, || {
+            if args.remote {
+                #[cfg(unix)]
+                {
+                    return crate::connect_client::run_remote_ps(&args);
+                }
+                #[cfg(not(unix))]
+                {
+                    return Err(nono::NonoError::UnsupportedPlatform(
+                        "remote session listing is not implemented on this platform".to_string(),
+                    ));
+                }
+            }
+            session_commands::run_ps(&args)
+        }),
         Commands::Stop(args) => {
             run_command_with_update(update_handle, silent, || session_commands::run_stop(&args))
         }

--- a/crates/nono-cli/src/audit_client.rs
+++ b/crates/nono-cli/src/audit_client.rs
@@ -2,11 +2,9 @@
 
 use crate::cli::{AuditStatusArgs, AuditSyncArgs};
 use crate::platform_client::{
-    PlatformState, REQUEST_PROTOCOL_V1, canonical_request_v1, endpoint_url, http_agent,
-    load_signing_key, load_state, write_json_secure,
+    PlatformState, REQUEST_PROTOCOL_V1, endpoint_url, http_agent, load_state, sign_request_v1,
+    write_json_secure,
 };
-use aws_lc_rs::rand::SystemRandom;
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use nono::audit::{
     AUDIT_EVENTS_FILENAME, canonical_session_digest_payload, compute_session_digest,
     verify_audit_log,
@@ -14,11 +12,10 @@ use nono::audit::{
 use nono::undo::{SessionMetadata, SnapshotManager};
 use nono::{NonoError, Result};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 use uuid::Uuid;
 
 const OUTBOX_DIRNAME: &str = "audit-outbox";
@@ -328,21 +325,13 @@ fn deliver_queued(state: &PlatformState, path: &Path, queued: &QueuedAudit) -> R
         .path()
         .to_string();
     let body = queued.wire_body()?;
-    let body_digest = format!("sha256:{}", sha256_hex(body.as_bytes()));
-    let timestamp = current_timestamp_ms()?.to_string();
-    let request_id = queued.ingest_id().to_string();
-    let canonical = canonical_request_v1(
+    let signed = sign_request_v1(
+        state,
         "POST",
         &request_path,
-        &state.subject_id,
-        &timestamp,
-        &request_id,
-        &body_digest,
-    );
-    let key_pair = load_signing_key(state)?;
-    let signature = key_pair
-        .sign(&SystemRandom::new(), canonical.as_bytes())
-        .map_err(|_| NonoError::KeystoreAccess("failed to sign audit request".to_string()))?;
+        queued.ingest_id(),
+        body.as_bytes(),
+    )?;
 
     let mut response = http_agent(Duration::from_secs(15))
         .post(&endpoint)
@@ -352,13 +341,10 @@ fn deliver_queued(state: &PlatformState, path: &Path, queued: &QueuedAudit) -> R
         .header("Content-Type", "application/json")
         .header("X-Nono-Protocol-Version", REQUEST_PROTOCOL_V1)
         .header("X-Nono-Subject-Id", &state.subject_id)
-        .header("X-Nono-Timestamp", &timestamp)
-        .header("X-Nono-Request-Id", &request_id)
-        .header("X-Nono-Content-SHA256", &body_digest)
-        .header(
-            "X-Nono-Signature",
-            format!("p256-sha256={}", URL_SAFE_NO_PAD.encode(signature.as_ref())),
-        )
+        .header("X-Nono-Timestamp", &signed.timestamp)
+        .header("X-Nono-Request-Id", &signed.request_id)
+        .header("X-Nono-Content-SHA256", &signed.body_digest)
+        .header("X-Nono-Signature", &signed.signature)
         .send(&body)
         .map_err(|error| NonoError::Snapshot(format!("audit ingest request failed: {error}")))?;
     if !response.status().is_success() {
@@ -523,22 +509,6 @@ fn outbox_path(ingest_id: Uuid) -> Result<PathBuf> {
 
 fn outbox_dir() -> Result<PathBuf> {
     Ok(crate::state_paths::user_state_dir()?.join(OUTBOX_DIRNAME))
-}
-
-fn current_timestamp_ms() -> Result<u128> {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_millis())
-        .map_err(|error| NonoError::Snapshot(format!("system clock is before Unix epoch: {error}")))
-}
-
-fn sha256_hex(bytes: &[u8]) -> String {
-    let digest = Sha256::digest(bytes);
-    let mut encoded = String::with_capacity(digest.len() * 2);
-    for byte in digest {
-        encoded.push_str(&format!("{byte:02x}"));
-    }
-    encoded
 }
 
 #[cfg(test)]

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -41,6 +41,7 @@ const STYLES: Styles = Styles::plain().header(Style::new().bold());
   stop       Stop a running sandbox session
   detach     Detach from an interactive runtime session
   attach     Attach to a detached runtime session
+  connect    Connect this terminal to a session hosted by nono-console
   logs       View runtime session event logs
   inspect    Show detailed runtime session state
   session    Manage runtime session storage
@@ -307,7 +308,7 @@ pub enum Commands {
 ")]
     Trust(TrustArgs),
 
-    /// List running sandboxed sessions
+    /// List local or remote sandboxed sessions
     #[command(help_template = "\
 {about}
 
@@ -322,6 +323,12 @@ pub enum Commands {
 
     # Show all sessions (including exited)
     nono ps --all
+
+    # Show sessions hosted by the enrolled tenant's nono-console
+    nono ps --remote
+
+    # Show all remote sessions as JSON
+    nono ps --remote --all --json
 
     # JSON output
     nono ps --json
@@ -399,6 +406,29 @@ IN-BAND DETACH:
 "
     )]
     Attach(AttachArgs),
+
+    /// Connect this terminal to a session hosted by nono-console
+    #[command(
+        help_template = "\
+{about}
+
+\x1b[1mUSAGE\x1b[0m
+  nono connect [session|url] [flags]
+
+{all-args}
+{after-help}",
+        after_help = "EXAMPLES:
+    # Discover the enrolled tenant's console, list live sessions, then choose one
+    nono connect
+
+    # Attach directly by global session ID
+    nono connect local:host:abc123
+
+    # Escape hatch: use a complete WebSocket attach URL
+    nono connect wss://console.example.com/api/v1/sessions/local:host:abc123/terminal
+"
+    )]
+    Connect(ConnectArgs),
 
     /// View event log for a session
     #[command(help_template = "\
@@ -2663,6 +2693,18 @@ pub enum SessionCommands {
 
 #[derive(Parser, Debug)]
 pub struct PsArgs {
+    /// List sessions hosted by the enrolled tenant's nono-console
+    #[arg(long)]
+    pub remote: bool,
+
+    /// nono-console origin override (valid only with --remote)
+    #[arg(long, requires = "remote")]
+    pub console: Option<String>,
+
+    /// Explicit console token-file override (valid only with --remote)
+    #[arg(long, value_name = "PATH", requires = "remote")]
+    pub token_file: Option<PathBuf>,
+
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
@@ -2696,6 +2738,24 @@ pub struct DetachArgs {
 pub struct AttachArgs {
     /// Session ID, prefix, or name
     pub session: String,
+}
+
+#[derive(Parser, Debug)]
+pub struct ConnectArgs {
+    /// Session name/global ID, or a complete ws(s) terminal URL
+    pub target: Option<String>,
+
+    /// nono-console origin; defaults to signed discovery from device enrollment
+    #[arg(long, env = "NONO_CONSOLE_URL")]
+    pub console: Option<String>,
+
+    /// Explicit token-file override; normally browser authorization is automatic
+    #[arg(long, env = "NONO_CONNECT_TOKEN_FILE")]
+    pub token_file: Option<PathBuf>,
+
+    /// Spectate without sending terminal input (reserved until console fan-out lands)
+    #[arg(long)]
+    pub read_only: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -4273,6 +4333,40 @@ mod tests {
     }
 
     #[test]
+    fn test_ps_remote_flags_parse() {
+        let cli = Cli::try_parse_from([
+            "nono",
+            "ps",
+            "--remote",
+            "--all",
+            "--json",
+            "--console",
+            "https://console.example.com",
+            "--token-file",
+            "/tmp/console-token",
+        ])
+        .expect("ps remote flags must parse");
+        let Commands::Ps(args) = cli.command else {
+            panic!("expected Commands::Ps");
+        };
+        assert!(args.remote);
+        assert!(args.all);
+        assert!(args.json);
+        assert_eq!(args.console.as_deref(), Some("https://console.example.com"));
+        assert_eq!(
+            args.token_file.as_deref(),
+            Some(std::path::Path::new("/tmp/console-token"))
+        );
+    }
+
+    #[test]
+    fn test_ps_console_requires_remote() {
+        let result =
+            Cli::try_parse_from(["nono", "ps", "--console", "https://console.example.com"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_profile_schema_with_output() {
         let cli = Cli::parse_from(["nono", "profile", "schema", "-o", "/tmp/schema.json"]);
         match cli.command {
@@ -4422,6 +4516,7 @@ mod tests {
         "stop",
         "detach",
         "attach",
+        "connect",
         "logs",
         "inspect",
         "session",

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -2738,6 +2738,10 @@ pub struct DetachArgs {
 pub struct AttachArgs {
     /// Session ID, prefix, or name
     pub session: String,
+
+    /// Emit the private nono-console attach-helper readiness protocol
+    #[arg(long, hide = true)]
+    pub bridge_status: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/crates/nono-cli/src/cli_bootstrap.rs
+++ b/crates/nono-cli/src/cli_bootstrap.rs
@@ -227,6 +227,7 @@ fn cli_verbosity(cli: &Cli) -> u8 {
         | Commands::Trust(_)
         | Commands::Audit(_)
         | Commands::Platform(_)
+        | Commands::Connect(_)
         | Commands::Pull(_)
         | Commands::Remove(_)
         | Commands::Update(_)

--- a/crates/nono-cli/src/connect_client.rs
+++ b/crates/nono-cli/src/connect_client.rs
@@ -343,6 +343,12 @@ fn load_cached_authorization(
 
 fn authorize_device(state: &crate::platform_client::PlatformState) -> Result<Zeroizing<String>> {
     let mut response = signed_post(state, "/api/v1/auth/device/code", &[], None)?;
+    if matches!(response.status().as_u16(), 401 | 403) {
+        return Err(NonoError::ActionRequired(
+            "platform authentication failed; renew the platform enrollment and try again"
+                .to_string(),
+        ));
+    }
     require_success(&response, "starting human authorization")?;
     let body = read_response(&mut response, "device authorization response")?;
     let code: DeviceCodeResponse = serde_json::from_str(&body).map_err(|error| {

--- a/crates/nono-cli/src/connect_client.rs
+++ b/crates/nono-cli/src/connect_client.rs
@@ -31,6 +31,7 @@ const DEVICE_AUTH_PROTOCOL_V1: &str = "1";
 const DEVICE_AUTH_VERIFICATION_PATH: &str = "/platform/device";
 const DEVICE_AUTH_CACHE_FILENAME: &str = "platform-console-auth.json";
 const DEFAULT_DETACH_SEQUENCE: &[u8] = &[0x1d, b'd'];
+const WEBSOCKET_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 static REMOTE_EXIT_CODE: AtomicI32 = AtomicI32::new(0);
 
 #[derive(Debug, Deserialize)]
@@ -132,6 +133,12 @@ enum ServerControl {
     },
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AttachOutcome {
+    Detached,
+    SessionExited,
+}
+
 pub(crate) fn run_connect(args: ConnectArgs) -> Result<()> {
     if args.read_only {
         return Err(NonoError::ActionRequired(
@@ -157,7 +164,11 @@ pub(crate) fn run_connect(args: ConnectArgs) -> Result<()> {
         .map_err(|error| {
             NonoError::ConfigParse(format!("could not start connect runtime: {error}"))
         })?;
-    runtime.block_on(attach(attach_url, token, detach_sequence))
+    match runtime.block_on(attach(attach_url, token, detach_sequence))? {
+        AttachOutcome::Detached => eprintln!("\nDetached from remote session."),
+        AttachOutcome::SessionExited => {}
+    }
+    Ok(())
 }
 
 /// List sessions visible through the enrolled tenant's nono-console.
@@ -955,7 +966,11 @@ fn terminal_url(console: &Url, session_id: &str) -> Result<Url> {
     Ok(url)
 }
 
-async fn attach(url: Url, token: Zeroizing<String>, detach_sequence: Vec<u8>) -> Result<()> {
+async fn attach(
+    url: Url,
+    token: Zeroizing<String>,
+    detach_sequence: Vec<u8>,
+) -> Result<AttachOutcome> {
     let mut request = url
         .as_str()
         .into_client_request()
@@ -968,9 +983,15 @@ async fn attach(url: Url, token: Zeroizing<String>, detach_sequence: Vec<u8>) ->
         HeaderValue::from_static("nono.terminal.v1"),
     );
 
-    let (socket, response) = tokio_tungstenite::connect_async(request)
-        .await
-        .map_err(|error| NonoError::ConfigParse(format!("terminal connection failed: {error}")))?;
+    let (socket, response) = tokio::time::timeout(
+        WEBSOCKET_CONNECT_TIMEOUT,
+        tokio_tungstenite::connect_async(request),
+    )
+    .await
+    .map_err(|_| {
+        NonoError::ConfigParse("terminal connection timed out after 15 seconds".to_string())
+    })?
+    .map_err(|error| NonoError::ConfigParse(format!("terminal connection failed: {error}")))?;
     let selected_protocol = response
         .headers()
         .get(SEC_WEBSOCKET_PROTOCOL)
@@ -997,7 +1018,7 @@ async fn attach(url: Url, token: Zeroizing<String>, detach_sequence: Vec<u8>) ->
                 let read = read.map_err(NonoError::Io)?;
                 if read == 0 {
                     send_detach(&mut ws_tx).await?;
-                    return Ok(());
+                    return Ok(AttachOutcome::Detached);
                 }
                 let matched = matcher.push(&input[..read]);
                 if !matched.forward.is_empty() {
@@ -1007,7 +1028,7 @@ async fn attach(url: Url, token: Zeroizing<String>, detach_sequence: Vec<u8>) ->
                 }
                 if matched.detach {
                     send_detach(&mut ws_tx).await?;
-                    return Ok(());
+                    return Ok(AttachOutcome::Detached);
                 }
             }
             _ = resize.recv() => {
@@ -1029,7 +1050,9 @@ async fn attach(url: Url, token: Zeroizing<String>, detach_sequence: Vec<u8>) ->
                             }
                             let _ = (cols, rows);
                         }
-                        Ok(ServerControl::SessionExited { exit_code: Some(0) }) => return Ok(()),
+                        Ok(ServerControl::SessionExited { exit_code: Some(0) }) => {
+                            return Ok(AttachOutcome::SessionExited);
+                        }
                         Ok(ServerControl::SessionExited { exit_code: Some(code) }) => {
                             if code < 0 {
                                 return Err(NonoError::ConfigParse(
@@ -1038,7 +1061,7 @@ async fn attach(url: Url, token: Zeroizing<String>, detach_sequence: Vec<u8>) ->
                                 ));
                             }
                             REMOTE_EXIT_CODE.store(code, Ordering::Release);
-                            return Ok(());
+                            return Ok(AttachOutcome::SessionExited);
                         }
                         Ok(ServerControl::SessionExited { exit_code: None }) => {
                             return Err(NonoError::ConfigParse(
@@ -1122,6 +1145,7 @@ impl RawTerminal {
 
 impl Drop for RawTerminal {
     fn drop(&mut self) {
+        crate::pty_proxy::restore_terminal_modes_after_attach();
         let stdin = io::stdin();
         let _ = nix::sys::termios::tcsetattr(
             &stdin,
@@ -1155,39 +1179,114 @@ struct DetachMatch {
 
 struct DetachMatcher {
     sequence: Vec<u8>,
-    pending: Vec<u8>,
+    pending_match_len: usize,
+    pending_escape: Vec<u8>,
 }
 
 impl DetachMatcher {
     fn new(sequence: Vec<u8>) -> Self {
         Self {
             sequence,
-            pending: Vec::new(),
+            pending_match_len: 0,
+            pending_escape: Vec::new(),
         }
     }
 
     fn push(&mut self, input: &[u8]) -> DetachMatch {
         let mut forward = Vec::with_capacity(input.len());
-        for &byte in input {
-            self.pending.push(byte);
-            while !self.sequence.starts_with(&self.pending) {
-                forward.push(self.pending.remove(0));
-                if self.pending.is_empty() {
-                    break;
+        for (index, &byte) in input.iter().enumerate() {
+            if !self.pending_escape.is_empty() {
+                self.pending_escape.push(byte);
+                let Some(&expected) = self.sequence.get(self.pending_match_len) else {
+                    self.flush_pending(&mut forward);
+                    continue;
+                };
+                match crate::pty_proxy::match_enhanced_key_sequence(&self.pending_escape, expected)
+                {
+                    crate::pty_proxy::EnhancedKeyMatch::Pending => {
+                        if self.pending_escape.len()
+                            > crate::pty_proxy::MAX_ENHANCED_KEY_SEQUENCE_LEN
+                        {
+                            self.flush_pending(&mut forward);
+                        }
+                    }
+                    crate::pty_proxy::EnhancedKeyMatch::Matched => {
+                        self.pending_escape.clear();
+                        self.pending_match_len += 1;
+                        if self.pending_match_len == self.sequence.len() {
+                            self.pending_match_len = 0;
+                            return DetachMatch {
+                                forward,
+                                detach: true,
+                            };
+                        }
+                    }
+                    crate::pty_proxy::EnhancedKeyMatch::Invalid => {
+                        self.flush_pending(&mut forward);
+                    }
+                }
+                continue;
+            }
+
+            if self.sequence.is_empty() {
+                forward.push(byte);
+                continue;
+            }
+
+            if byte == self.sequence[self.pending_match_len] {
+                self.pending_match_len += 1;
+                if self.pending_match_len == self.sequence.len() {
+                    self.pending_match_len = 0;
+                    return DetachMatch {
+                        forward,
+                        detach: true,
+                    };
+                }
+                continue;
+            }
+
+            if byte == b'\x1b'
+                && input.get(index + 1).copied() == Some(b'[')
+                && self
+                    .sequence
+                    .get(self.pending_match_len)
+                    .copied()
+                    .is_some_and(crate::pty_proxy::detach_key_supports_enhanced_match)
+            {
+                self.pending_escape.push(byte);
+                continue;
+            }
+
+            if self.pending_match_len > 0 {
+                forward.extend_from_slice(&self.sequence[..self.pending_match_len]);
+                self.pending_match_len = 0;
+                if byte == self.sequence[0] {
+                    self.pending_match_len = 1;
+                    continue;
                 }
             }
-            if self.pending == self.sequence {
-                self.pending.clear();
-                return DetachMatch {
-                    forward,
-                    detach: true,
-                };
-            }
+            forward.push(byte);
         }
         DetachMatch {
             forward,
             detach: false,
         }
+    }
+
+    fn flush_pending(&mut self, forward: &mut Vec<u8>) {
+        if self.pending_match_len > 0 {
+            forward.extend_from_slice(&self.sequence[..self.pending_match_len]);
+            self.pending_match_len = 0;
+        }
+        forward.extend_from_slice(&self.pending_escape);
+        self.pending_escape.clear();
+    }
+}
+
+#[cfg(test)]
+impl DetachMatcher {
+    fn pending_bytes(&self) -> bool {
+        self.pending_match_len > 0 || !self.pending_escape.is_empty()
     }
 }
 
@@ -1306,12 +1405,46 @@ mod tests {
         let first = matcher.push(b"abc\x1d");
         assert_eq!(first.forward, b"abc");
         assert!(!first.detach);
+        assert!(matcher.pending_bytes());
         let mismatch = matcher.push(b"x");
         assert_eq!(mismatch.forward, b"\x1dx");
         assert!(!mismatch.detach);
         let matched = matcher.push(b"z\x1ddtail");
         assert_eq!(matched.forward, b"z");
         assert!(matched.detach);
+    }
+
+    #[test]
+    fn detach_matcher_accepts_csi_u_control_prefix() {
+        let mut matcher = DetachMatcher::new(vec![0x1d, b'd']);
+        let matched = matcher.push(b"\x1b[93;5ud");
+        assert!(matched.forward.is_empty());
+        assert!(matched.detach);
+        assert!(!matcher.pending_bytes());
+    }
+
+    #[test]
+    fn detach_matcher_accepts_chunked_csi_u_control_prefix() {
+        let mut matcher = DetachMatcher::new(vec![0x1d, b'd']);
+        let first = matcher.push(b"\x1b[93;");
+        assert!(first.forward.is_empty());
+        assert!(!first.detach);
+        assert!(matcher.pending_bytes());
+        let second = matcher.push(b"5u");
+        assert!(second.forward.is_empty());
+        assert!(!second.detach);
+        let third = matcher.push(b"d");
+        assert!(third.forward.is_empty());
+        assert!(third.detach);
+    }
+
+    #[test]
+    fn detach_matcher_forwards_unrelated_csi_u_input() {
+        let mut matcher = DetachMatcher::new(vec![0x1d, b'd']);
+        let unmatched = matcher.push(b"\x1b[99;5u");
+        assert_eq!(unmatched.forward, b"\x1b[99;5u");
+        assert!(!unmatched.detach);
+        assert!(!matcher.pending_bytes());
     }
 
     #[test]

--- a/crates/nono-cli/src/connect_client.rs
+++ b/crates/nono-cli/src/connect_client.rs
@@ -1,0 +1,1334 @@
+//! Terminal-native remote attach client for nono-console.
+//!
+//! The open wire contract is documented in `docs/protocols/remote-attach-v1.md`.
+//! Human authentication is deliberately separate from device enrollment. This
+//! explicit protected file or `NONO_CONNECT_TOKEN`. Otherwise an enrolled
+//! device runs browser-approved human authorization, caches a device-bound
+//! opaque credential, and exchanges it for a short-lived console bearer token.
+
+use std::io::{self, IsTerminal, Write};
+use std::path::Path;
+use std::sync::atomic::{AtomicI32, Ordering};
+
+use futures_util::{SinkExt, StreamExt};
+use nono::{NonoError, Result};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::{
+    HeaderValue,
+    header::{AUTHORIZATION, SEC_WEBSOCKET_PROTOCOL},
+};
+use tokio_tungstenite::tungstenite::protocol::Message;
+use url::Url;
+use zeroize::Zeroizing;
+
+use crate::cli::{ConnectArgs, PsArgs};
+
+const RESPONSE_LIMIT_BYTES: u64 = 1024 * 1024;
+const DISCOVERY_PROTOCOL_V1: &str = "1";
+const DEVICE_AUTH_PROTOCOL_V1: &str = "1";
+const DEVICE_AUTH_VERIFICATION_PATH: &str = "/platform/device";
+const DEVICE_AUTH_CACHE_FILENAME: &str = "platform-console-auth.json";
+const DEFAULT_DETACH_SEQUENCE: &[u8] = &[0x1d, b'd'];
+static REMOTE_EXIT_CODE: AtomicI32 = AtomicI32::new(0);
+
+#[derive(Debug, Deserialize)]
+struct ListSessionsResponse {
+    sessions: Vec<RemoteSession>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ConsoleDiscoveryResponse {
+    protocol_version: String,
+    tenant_id: String,
+    console_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeviceCodeResponse {
+    protocol_version: String,
+    device_code: String,
+    user_code: String,
+    verification_path: String,
+    expires_in: u64,
+    interval: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct DevicePollRequest<'a> {
+    protocol_version: &'static str,
+    device_code: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct DevicePollResponse {
+    protocol_version: String,
+    status: String,
+    credential: Option<String>,
+    expires_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeviceAccessTokenResponse {
+    protocol_version: String,
+    access_token: String,
+    token_type: String,
+    expires_in: u64,
+    tenant_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CachedDeviceAuthorization {
+    protocol_version: String,
+    platform_url: String,
+    tenant_id: String,
+    subject_id: String,
+    credential: String,
+    expires_at: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct RemoteSession {
+    global_session_id: String,
+    backend_status: String,
+    record: Option<RemoteSessionRecord>,
+    agent: Option<RemoteAgent>,
+    repo: Option<RemoteRepo>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct RemoteSessionRecord {
+    name: Option<String>,
+    status: String,
+    command: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct RemoteAgent {
+    name: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct RemoteRepo {
+    full_name: String,
+    base_branch: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ServerControl {
+    Attached {
+        protocol_version: String,
+        cols: u16,
+        rows: u16,
+    },
+    SessionExited {
+        exit_code: Option<i32>,
+    },
+    Error {
+        code: Option<String>,
+        message: String,
+    },
+}
+
+pub(crate) fn run_connect(args: ConnectArgs) -> Result<()> {
+    if args.read_only {
+        return Err(NonoError::ActionRequired(
+            "read-only remote attach is not implemented yet; console fan-out must land first"
+                .to_string(),
+        ));
+    }
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return Err(NonoError::ActionRequired(
+            "nono connect requires an interactive terminal".to_string(),
+        ));
+    }
+
+    let token = load_token(args.token_file.as_deref())?;
+    let attach_url = resolve_attach_url(args.target.as_deref(), args.console.as_deref(), &token)?;
+    validate_transport_url(&attach_url)?;
+    let detach_sequence = crate::launch_runtime::load_configured_detach_sequence()?
+        .unwrap_or_else(|| DEFAULT_DETACH_SEQUENCE.to_vec());
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| {
+            NonoError::ConfigParse(format!("could not start connect runtime: {error}"))
+        })?;
+    runtime.block_on(attach(attach_url, token, detach_sequence))
+}
+
+/// List sessions visible through the enrolled tenant's nono-console.
+pub(crate) fn run_remote_ps(args: &PsArgs) -> Result<()> {
+    // Resolve the environment equivalents here rather than through clap. That
+    // keeps a globally configured remote console from affecting local `nono ps`.
+    let token_file_env = args
+        .token_file
+        .is_none()
+        .then(|| std::env::var_os("NONO_CONNECT_TOKEN_FILE"))
+        .flatten()
+        .map(std::path::PathBuf::from);
+    let token_file = args.token_file.as_deref().or(token_file_env.as_deref());
+    let token = load_token(token_file)?;
+    let console_env = if args.console.is_none() {
+        match std::env::var("NONO_CONSOLE_URL") {
+            Ok(value) => Some(value),
+            Err(std::env::VarError::NotPresent) => None,
+            Err(error) => {
+                return Err(NonoError::ConfigParse(format!(
+                    "could not read NONO_CONSOLE_URL: {error}"
+                )));
+            }
+        }
+    } else {
+        None
+    };
+    let console = match args.console.as_deref().or(console_env.as_deref()) {
+        Some(console) => validate_console_url(console)?,
+        None => discover_console()?,
+    };
+    let sessions = filter_remote_sessions(fetch_sessions(&console, &token)?, args.all);
+
+    if args.json {
+        let json = serde_json::to_string_pretty(&sessions).map_err(|error| {
+            NonoError::ConfigParse(format!("JSON serialization failed: {error}"))
+        })?;
+        println!("{json}");
+        return Ok(());
+    }
+
+    print_remote_sessions(&sessions, args.all)
+}
+
+/// Return the non-zero hosted process status recorded by `run_connect`.
+/// The CLI executes one top-level command, so a process-local atomic keeps this
+/// outcome out of the public `nono::NonoError` / FFI contract.
+pub(crate) fn take_remote_exit_code() -> Option<i32> {
+    match REMOTE_EXIT_CODE.swap(0, Ordering::AcqRel) {
+        0 => None,
+        code => Some(code),
+    }
+}
+
+fn resolve_attach_url(target: Option<&str>, console: Option<&str>, token: &str) -> Result<Url> {
+    if let Some(target) = target
+        && let Ok(url) = Url::parse(target)
+        && matches!(url.scheme(), "ws" | "wss")
+    {
+        validate_direct_attach_url(&url)?;
+        return Ok(url);
+    }
+
+    let console_url = match console {
+        Some(console) => validate_console_url(console)?,
+        None => discover_console()?,
+    };
+    let session = match target {
+        Some(value) => select_named_session(&list_live_sessions(&console_url, token)?, value)?,
+        None => select_interactively(&list_live_sessions(&console_url, token)?)?,
+    };
+    terminal_url(&console_url, &session.global_session_id)
+}
+
+fn load_token(path: Option<&Path>) -> Result<Zeroizing<String>> {
+    let value = match path {
+        Some(path) => {
+            let metadata = std::fs::metadata(path).map_err(|source| NonoError::ConfigRead {
+                path: path.to_path_buf(),
+                source,
+            })?;
+            if metadata.len() > 64 * 1024 {
+                return Err(NonoError::ConfigParse(
+                    "connect token file exceeds 64 KiB".to_string(),
+                ));
+            }
+            if !metadata.is_file() {
+                return Err(NonoError::ConfigParse(
+                    "connect token path must be a regular file".to_string(),
+                ));
+            }
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                if metadata.permissions().mode() & 0o077 != 0 {
+                    return Err(NonoError::ActionRequired(
+                        "connect token file must not be readable or writable by group/other (use mode 0600)"
+                            .to_string(),
+                    ));
+                }
+            }
+            std::fs::read_to_string(path).map_err(|source| NonoError::ConfigRead {
+                path: path.to_path_buf(),
+                source,
+            })?
+        }
+        None => match std::env::var("NONO_CONNECT_TOKEN") {
+            Ok(value) => value,
+            Err(std::env::VarError::NotPresent) => return acquire_console_access_token(),
+            Err(error) => {
+                return Err(NonoError::ConfigParse(format!(
+                    "could not read NONO_CONNECT_TOKEN: {error}"
+                )));
+            }
+        },
+    };
+    let token = value.trim();
+    if token.is_empty() || token.contains(|character: char| character.is_ascii_whitespace()) {
+        return Err(NonoError::ConfigParse(
+            "connect token is empty or contains whitespace".to_string(),
+        ));
+    }
+    Ok(Zeroizing::new(token.to_string()))
+}
+
+fn acquire_console_access_token() -> Result<Zeroizing<String>> {
+    let state = crate::platform_client::load_state()?.ok_or_else(|| {
+        NonoError::ActionRequired(
+            "human authorization requires platform enrollment; run `nono platform enroll` or provide --token-file"
+                .to_string(),
+        )
+    })?;
+    if state.subject_kind != "device" {
+        return Err(NonoError::ActionRequired(
+            "human authorization requires a device enrollment; workload identities cannot authorize terminal access"
+                .to_string(),
+        ));
+    }
+    if let Some(cached) = load_cached_authorization(&state)?
+        && let Some(token) = exchange_console_access_token(&state, &cached.credential)?
+    {
+        return Ok(token);
+    }
+    authorize_device(&state)
+}
+
+fn load_cached_authorization(
+    state: &crate::platform_client::PlatformState,
+) -> Result<Option<CachedDeviceAuthorization>> {
+    let path = device_auth_cache_path()?;
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(NonoError::ConfigRead { path, source }),
+    };
+    let cached: CachedDeviceAuthorization = serde_json::from_str(&contents).map_err(|error| {
+        NonoError::ConfigParse(format!("invalid device authorization cache: {error}"))
+    })?;
+    let expires_at = chrono::DateTime::parse_from_rfc3339(&cached.expires_at).map_err(|error| {
+        NonoError::ConfigParse(format!("invalid device authorization expiry: {error}"))
+    })?;
+    if cached.protocol_version != DEVICE_AUTH_PROTOCOL_V1
+        || cached.platform_url != state.platform_url
+        || cached.tenant_id != state.tenant_id
+        || cached.subject_id != state.subject_id
+        || expires_at <= chrono::Utc::now()
+    {
+        return Ok(None);
+    }
+    Ok(Some(cached))
+}
+
+fn authorize_device(state: &crate::platform_client::PlatformState) -> Result<Zeroizing<String>> {
+    let mut response = signed_post(state, "/api/v1/auth/device/code", &[], None)?;
+    require_success(&response, "starting human authorization")?;
+    let body = read_response(&mut response, "device authorization response")?;
+    let code: DeviceCodeResponse = serde_json::from_str(&body).map_err(|error| {
+        NonoError::ConfigParse(format!("invalid device authorization response: {error}"))
+    })?;
+    if code.protocol_version != DEVICE_AUTH_PROTOCOL_V1
+        || code.verification_path != DEVICE_AUTH_VERIFICATION_PATH
+        || code.expires_in == 0
+        || code.expires_in > 15 * 60
+        || code.interval == 0
+        || code.interval > 30
+    {
+        return Err(NonoError::ConfigParse(
+            "platform returned an unsupported device authorization contract".to_string(),
+        ));
+    }
+    let verification_url =
+        crate::platform_client::endpoint_url(&state.platform_url, &code.verification_path)?;
+    eprintln!("Authorize this terminal in your browser:");
+    eprintln!("  {verification_url}");
+    eprintln!("  Code: {}", code.user_code);
+    if let Err(error) = open_browser(&verification_url) {
+        eprintln!("  Browser could not be opened automatically: {error}");
+    }
+
+    let started = std::time::Instant::now();
+    loop {
+        if started.elapsed() >= std::time::Duration::from_secs(code.expires_in) {
+            return Err(NonoError::ActionRequired(
+                "human authorization expired; run `nono connect` again".to_string(),
+            ));
+        }
+        std::thread::sleep(std::time::Duration::from_secs(code.interval));
+        let request = DevicePollRequest {
+            protocol_version: DEVICE_AUTH_PROTOCOL_V1,
+            device_code: &code.device_code,
+        };
+        let body = serde_json::to_vec(&request).map_err(|error| {
+            NonoError::ConfigParse(format!("could not encode device poll: {error}"))
+        })?;
+        let mut response = signed_post(state, "/api/v1/auth/device/poll", &body, None)?;
+        require_success(&response, "polling human authorization")?;
+        let response_body = read_response(&mut response, "device poll response")?;
+        let poll: DevicePollResponse = serde_json::from_str(&response_body).map_err(|error| {
+            NonoError::ConfigParse(format!("invalid device poll response: {error}"))
+        })?;
+        if poll.protocol_version != DEVICE_AUTH_PROTOCOL_V1 {
+            return Err(NonoError::ConfigParse(
+                "platform returned an unsupported device poll protocol".to_string(),
+            ));
+        }
+        match poll.status.as_str() {
+            "authorization_pending" => continue,
+            "access_denied" => {
+                return Err(NonoError::ActionRequired(
+                    "human authorization was denied".to_string(),
+                ));
+            }
+            "expired" => {
+                return Err(NonoError::ActionRequired(
+                    "human authorization expired; run `nono connect` again".to_string(),
+                ));
+            }
+            "authorized" => {
+                let credential = poll.credential.ok_or_else(|| {
+                    NonoError::ConfigParse("authorized response omitted its credential".to_string())
+                })?;
+                let expires_at = poll.expires_at.ok_or_else(|| {
+                    NonoError::ConfigParse("authorized response omitted its expiry".to_string())
+                })?;
+                chrono::DateTime::parse_from_rfc3339(&expires_at).map_err(|error| {
+                    NonoError::ConfigParse(format!("invalid device authorization expiry: {error}"))
+                })?;
+                let cached = CachedDeviceAuthorization {
+                    protocol_version: DEVICE_AUTH_PROTOCOL_V1.to_string(),
+                    platform_url: state.platform_url.clone(),
+                    tenant_id: state.tenant_id.clone(),
+                    subject_id: state.subject_id.clone(),
+                    credential,
+                    expires_at,
+                };
+                crate::platform_client::write_json_secure(&device_auth_cache_path()?, &cached)?;
+                let token = exchange_console_access_token(state, &cached.credential)?
+                    .ok_or_else(|| {
+                        NonoError::ActionRequired(
+                            "the new human authorization could not be exchanged; run `nono connect` again"
+                                .to_string(),
+                        )
+                    })?;
+                eprintln!("Terminal authorized.");
+                return Ok(token);
+            }
+            _ => {
+                return Err(NonoError::ConfigParse(
+                    "platform returned an unknown device authorization status".to_string(),
+                ));
+            }
+        }
+    }
+}
+
+fn exchange_console_access_token(
+    state: &crate::platform_client::PlatformState,
+    credential: &str,
+) -> Result<Option<Zeroizing<String>>> {
+    let mut response = signed_post(
+        state,
+        "/api/v1/auth/device/access-token",
+        &[],
+        Some(credential),
+    )?;
+    if matches!(response.status().as_u16(), 401 | 403) {
+        return Ok(None);
+    }
+    require_success(&response, "exchanging human authorization")?;
+    let body = read_response(&mut response, "console access response")?;
+    let access: DeviceAccessTokenResponse = serde_json::from_str(&body).map_err(|error| {
+        NonoError::ConfigParse(format!("invalid console access response: {error}"))
+    })?;
+    if access.protocol_version != DEVICE_AUTH_PROTOCOL_V1
+        || access.token_type != "Bearer"
+        || access.tenant_id != state.tenant_id
+        || access.expires_in == 0
+        || access.expires_in > 5 * 60
+    {
+        return Err(NonoError::ConfigParse(
+            "platform returned an unsupported console access contract".to_string(),
+        ));
+    }
+    validate_token(access.access_token).map(Some)
+}
+
+fn signed_post(
+    state: &crate::platform_client::PlatformState,
+    path: &str,
+    body: &[u8],
+    bearer: Option<&str>,
+) -> Result<ureq::http::Response<ureq::Body>> {
+    let endpoint = crate::platform_client::endpoint_url(&state.platform_url, path)?;
+    let request_path = Url::parse(&endpoint)
+        .map_err(|error| NonoError::ConfigParse(format!("invalid platform endpoint: {error}")))?
+        .path()
+        .to_string();
+    let signed = crate::platform_client::sign_request_v1(
+        state,
+        "POST",
+        &request_path,
+        uuid::Uuid::now_v7(),
+        body,
+    )?;
+    let mut request = crate::platform_client::http_agent(std::time::Duration::from_secs(15))
+        .post(&endpoint)
+        .config()
+        .http_status_as_error(false)
+        .build()
+        .header("Content-Type", "application/json")
+        .header(
+            "X-Nono-Protocol-Version",
+            crate::platform_client::REQUEST_PROTOCOL_V1,
+        )
+        .header("X-Nono-Subject-Id", &state.subject_id)
+        .header("X-Nono-Timestamp", &signed.timestamp)
+        .header("X-Nono-Request-Id", &signed.request_id)
+        .header("X-Nono-Content-SHA256", &signed.body_digest)
+        .header("X-Nono-Signature", &signed.signature);
+    if let Some(credential) = bearer {
+        request = request.header("Authorization", &format!("Bearer {credential}"));
+    }
+    request.send(body).map_err(|error| {
+        NonoError::ConfigParse(format!("platform authorization request failed: {error}"))
+    })
+}
+
+fn require_success(response: &ureq::http::Response<ureq::Body>, operation: &str) -> Result<()> {
+    if response.status().is_success() {
+        Ok(())
+    } else {
+        Err(NonoError::ConfigParse(format!(
+            "platform returned HTTP {} while {operation}",
+            response.status().as_u16()
+        )))
+    }
+}
+
+fn read_response(response: &mut ureq::http::Response<ureq::Body>, name: &str) -> Result<String> {
+    response
+        .body_mut()
+        .with_config()
+        .limit(RESPONSE_LIMIT_BYTES)
+        .read_to_string()
+        .map_err(|error| NonoError::ConfigParse(format!("invalid {name}: {error}")))
+}
+
+fn validate_token(value: String) -> Result<Zeroizing<String>> {
+    let token = value.trim();
+    if token.is_empty() || token.contains(|character: char| character.is_ascii_whitespace()) {
+        return Err(NonoError::ConfigParse(
+            "connect token is empty or contains whitespace".to_string(),
+        ));
+    }
+    Ok(Zeroizing::new(token.to_string()))
+}
+
+fn device_auth_cache_path() -> Result<std::path::PathBuf> {
+    Ok(crate::state_paths::user_state_dir()?.join(DEVICE_AUTH_CACHE_FILENAME))
+}
+
+fn open_browser(url: &str) -> std::result::Result<(), String> {
+    #[cfg(target_os = "macos")]
+    let result = std::process::Command::new("open").arg(url).status();
+    #[cfg(target_os = "linux")]
+    let result = std::process::Command::new("xdg-open").arg(url).status();
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    let result: std::result::Result<std::process::ExitStatus, std::io::Error> =
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "browser launch unsupported",
+        ));
+    match result {
+        Ok(status) if status.success() => Ok(()),
+        Ok(status) => Err(format!("browser opener exited with {status}")),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+fn validate_console_url(value: &str) -> Result<Url> {
+    let url = Url::parse(value)
+        .map_err(|error| NonoError::ConfigParse(format!("invalid console URL: {error}")))?;
+    if url.cannot_be_a_base() || !matches!(url.scheme(), "http" | "https") {
+        return Err(NonoError::ConfigParse(
+            "console URL must use http:// or https://".to_string(),
+        ));
+    }
+    if url.scheme() == "http" && !is_loopback(&url) {
+        return Err(NonoError::ConfigParse(
+            "console URL must use HTTPS; HTTP is allowed only for loopback development".to_string(),
+        ));
+    }
+    if !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(NonoError::ConfigParse(
+            "console URL must not contain credentials, query parameters, or fragments".to_string(),
+        ));
+    }
+    Ok(url)
+}
+
+fn discover_console() -> Result<Url> {
+    let state = crate::platform_client::load_state()?.ok_or_else(|| {
+        NonoError::ActionRequired(
+            "console discovery requires platform enrollment; run `nono platform enroll` or pass --console"
+                .to_string(),
+        )
+    })?;
+    if state.subject_kind != "device" {
+        return Err(NonoError::ActionRequired(
+            "console discovery requires a device enrollment; workload identities cannot authorize human terminal access"
+                .to_string(),
+        ));
+    }
+    let endpoint = crate::platform_client::endpoint_url(&state.platform_url, "/api/v1/console")?;
+    let request_path = Url::parse(&endpoint)
+        .map_err(|error| NonoError::ConfigParse(format!("invalid discovery endpoint: {error}")))?
+        .path()
+        .to_string();
+    let signed = crate::platform_client::sign_request_v1(
+        &state,
+        "GET",
+        &request_path,
+        uuid::Uuid::now_v7(),
+        &[],
+    )?;
+    let mut response = crate::platform_client::http_agent(std::time::Duration::from_secs(15))
+        .get(&endpoint)
+        .config()
+        .http_status_as_error(false)
+        .build()
+        .header(
+            "X-Nono-Protocol-Version",
+            crate::platform_client::REQUEST_PROTOCOL_V1,
+        )
+        .header("X-Nono-Subject-Id", &state.subject_id)
+        .header("X-Nono-Timestamp", &signed.timestamp)
+        .header("X-Nono-Request-Id", &signed.request_id)
+        .header("X-Nono-Content-SHA256", &signed.body_digest)
+        .header("X-Nono-Signature", &signed.signature)
+        .call()
+        .map_err(|error| NonoError::ConfigParse(format!("console discovery failed: {error}")))?;
+    if !response.status().is_success() {
+        return Err(NonoError::ConfigParse(format!(
+            "platform returned HTTP {} while discovering nono-console",
+            response.status().as_u16()
+        )));
+    }
+    let body = response
+        .body_mut()
+        .with_config()
+        .limit(RESPONSE_LIMIT_BYTES)
+        .read_to_string()
+        .map_err(|error| NonoError::ConfigParse(format!("invalid discovery response: {error}")))?;
+    validate_discovery_response(&state, &body)
+}
+
+fn validate_discovery_response(
+    state: &crate::platform_client::PlatformState,
+    body: &str,
+) -> Result<Url> {
+    let response: ConsoleDiscoveryResponse = serde_json::from_str(body)
+        .map_err(|error| NonoError::ConfigParse(format!("invalid discovery response: {error}")))?;
+    if response.protocol_version != DISCOVERY_PROTOCOL_V1 {
+        return Err(NonoError::ConfigParse(
+            "platform returned an unsupported console discovery protocol".to_string(),
+        ));
+    }
+    if response.tenant_id != state.tenant_id {
+        return Err(NonoError::ConfigParse(
+            "platform console discovery tenant does not match local enrollment".to_string(),
+        ));
+    }
+    validate_console_url(&response.console_url)
+}
+
+fn validate_transport_url(url: &Url) -> Result<()> {
+    if url.scheme() == "wss" || (url.scheme() == "ws" && is_loopback(url)) {
+        Ok(())
+    } else {
+        Err(NonoError::ConfigParse(
+            "remote attach must use WSS; WS is allowed only for loopback development".to_string(),
+        ))
+    }
+}
+
+fn validate_direct_attach_url(url: &Url) -> Result<()> {
+    if !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(NonoError::ConfigParse(
+            "attach URLs must not contain credentials, query parameters, or fragments".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn is_loopback(url: &Url) -> bool {
+    matches!(url.host_str(), Some("localhost" | "127.0.0.1" | "::1"))
+}
+
+fn fetch_sessions(console: &Url, token: &str) -> Result<Vec<RemoteSession>> {
+    let endpoint = console_endpoint(console, "/api/v1/sessions")?;
+    let agent = crate::platform_client::http_agent(std::time::Duration::from_secs(15));
+    let authorization = format!("Bearer {token}");
+    let mut response = agent
+        .get(endpoint.as_str())
+        .config()
+        .http_status_as_error(false)
+        .build()
+        .header("Authorization", &authorization)
+        .call()
+        .map_err(|error| NonoError::ConfigParse(format!("console request failed: {error}")))?;
+    if !response.status().is_success() {
+        let status = response.status().as_u16();
+        return Err(NonoError::ConfigParse(format!(
+            "console returned HTTP {status} while listing sessions"
+        )));
+    }
+    let body = response
+        .body_mut()
+        .with_config()
+        .limit(RESPONSE_LIMIT_BYTES)
+        .read_to_string()
+        .map_err(|error| NonoError::ConfigParse(format!("invalid session response: {error}")))?;
+    let response: ListSessionsResponse = serde_json::from_str(&body)
+        .map_err(|error| NonoError::ConfigParse(format!("invalid session response: {error}")))?;
+    Ok(response.sessions)
+}
+
+fn list_live_sessions(console: &Url, token: &str) -> Result<Vec<RemoteSession>> {
+    Ok(fetch_sessions(console, token)?
+        .into_iter()
+        .filter(is_live_session)
+        .collect())
+}
+
+fn is_live_session(session: &RemoteSession) -> bool {
+    session.backend_status == "ready"
+        && session
+            .record
+            .as_ref()
+            .is_some_and(|record| record.status == "running")
+}
+
+fn filter_remote_sessions(mut sessions: Vec<RemoteSession>, all: bool) -> Vec<RemoteSession> {
+    if !all {
+        sessions.retain(is_live_session);
+    }
+    sessions.sort_by(|left, right| {
+        remote_name(left)
+            .cmp(remote_name(right))
+            .then_with(|| left.global_session_id.cmp(&right.global_session_id))
+    });
+    sessions
+}
+
+fn print_remote_sessions(sessions: &[RemoteSession], all: bool) -> Result<()> {
+    if sessions.is_empty() {
+        if all {
+            eprintln!("No remote sessions found.");
+        } else {
+            eprintln!("No live remote sessions. Use --all to include inactive sessions.");
+        }
+        return Ok(());
+    }
+
+    struct Row {
+        session: String,
+        name: String,
+        status: String,
+        agent: String,
+        repo: String,
+    }
+
+    let rows = sessions
+        .iter()
+        .map(|session| Row {
+            session: session.global_session_id.clone(),
+            name: remote_name(session).to_string(),
+            status: remote_status(session).to_string(),
+            agent: remote_agent(session).to_string(),
+            repo: remote_repo(session),
+        })
+        .collect::<Vec<_>>();
+    let session_width = rows
+        .iter()
+        .map(|row| row.session.len())
+        .max()
+        .unwrap_or("SESSION".len())
+        .max("SESSION".len());
+    let name_width = rows
+        .iter()
+        .map(|row| row.name.len())
+        .max()
+        .unwrap_or("NAME".len())
+        .max("NAME".len())
+        .min(28);
+    let status_width = rows
+        .iter()
+        .map(|row| row.status.len())
+        .max()
+        .unwrap_or("STATUS".len())
+        .max("STATUS".len())
+        .min(16);
+    let agent_width = rows
+        .iter()
+        .map(|row| row.agent.len())
+        .max()
+        .unwrap_or("AGENT".len())
+        .max("AGENT".len())
+        .min(20);
+
+    println!(
+        "{:<session_width$} {:<name_width$} {:<status_width$} {:<agent_width$} REPOSITORY",
+        "SESSION", "NAME", "STATUS", "AGENT"
+    );
+    for row in rows {
+        println!(
+            "{:<session_width$} {:<name_width$} {:<status_width$} {:<agent_width$} {}",
+            row.session,
+            crate::command_display::truncate_chars(&row.name, name_width),
+            crate::command_display::truncate_chars(&row.status, status_width),
+            crate::command_display::truncate_chars(&row.agent, agent_width),
+            row.repo,
+        );
+    }
+    Ok(())
+}
+
+fn remote_name(session: &RemoteSession) -> &str {
+    session
+        .record
+        .as_ref()
+        .and_then(|record| record.name.as_deref())
+        .unwrap_or("-")
+}
+
+fn remote_status(session: &RemoteSession) -> &str {
+    session
+        .record
+        .as_ref()
+        .map(|record| record.status.as_str())
+        .unwrap_or(&session.backend_status)
+}
+
+fn remote_agent(session: &RemoteSession) -> &str {
+    session
+        .agent
+        .as_ref()
+        .map(|agent| agent.name.as_str())
+        .or_else(|| {
+            session
+                .record
+                .as_ref()
+                .and_then(|record| record.command.first().map(String::as_str))
+        })
+        .unwrap_or("-")
+}
+
+fn remote_repo(session: &RemoteSession) -> String {
+    session
+        .repo
+        .as_ref()
+        .map(|repo| format!("{}#{}", repo.full_name, repo.base_branch))
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn select_named_session(sessions: &[RemoteSession], target: &str) -> Result<RemoteSession> {
+    let matches = sessions
+        .iter()
+        .filter(|session| {
+            session.global_session_id == target
+                || session.global_session_id.starts_with(target)
+                || session
+                    .record
+                    .as_ref()
+                    .and_then(|record| record.name.as_deref())
+                    == Some(target)
+        })
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [session] => Ok(clone_session(session)),
+        [] => Err(NonoError::SessionNotFound(target.to_string())),
+        _ => Err(NonoError::ConfigParse(format!(
+            "remote session selector '{target}' is ambiguous"
+        ))),
+    }
+}
+
+fn select_interactively(sessions: &[RemoteSession]) -> Result<RemoteSession> {
+    if sessions.is_empty() {
+        return Err(NonoError::ActionRequired(
+            "the console has no live sessions visible to this user".to_string(),
+        ));
+    }
+    for (index, session) in sessions.iter().enumerate() {
+        let record = session.record.as_ref();
+        let name = record
+            .and_then(|value| value.name.as_deref())
+            .unwrap_or(&session.global_session_id);
+        let agent = session
+            .agent
+            .as_ref()
+            .map(|value| value.name.as_str())
+            .or_else(|| record.and_then(|value| value.command.first().map(String::as_str)))
+            .unwrap_or("unknown");
+        let repo = session
+            .repo
+            .as_ref()
+            .map(|value| format!("{}#{}", value.full_name, value.base_branch))
+            .unwrap_or_else(|| "(no repo)".to_string());
+        println!("  {}.  {:<28} {:<14} {repo}", index + 1, name, agent);
+    }
+    print!("> ");
+    io::stdout().flush().map_err(NonoError::Io)?;
+    let mut choice = String::new();
+    io::stdin().read_line(&mut choice).map_err(NonoError::Io)?;
+    let index = choice
+        .trim()
+        .parse::<usize>()
+        .ok()
+        .and_then(|value| value.checked_sub(1))
+        .ok_or_else(|| NonoError::ConfigParse("invalid session selection".to_string()))?;
+    sessions
+        .get(index)
+        .map(clone_session)
+        .ok_or_else(|| NonoError::ConfigParse("session selection is out of range".to_string()))
+}
+
+fn clone_session(session: &RemoteSession) -> RemoteSession {
+    RemoteSession {
+        global_session_id: session.global_session_id.clone(),
+        backend_status: session.backend_status.clone(),
+        record: session.record.as_ref().map(|record| RemoteSessionRecord {
+            name: record.name.clone(),
+            status: record.status.clone(),
+            command: record.command.clone(),
+        }),
+        agent: session.agent.as_ref().map(|agent| RemoteAgent {
+            name: agent.name.clone(),
+        }),
+        repo: session.repo.as_ref().map(|repo| RemoteRepo {
+            full_name: repo.full_name.clone(),
+            base_branch: repo.base_branch.clone(),
+        }),
+    }
+}
+
+fn console_endpoint(console: &Url, path: &str) -> Result<Url> {
+    let mut url = console.clone();
+    let joined = format!(
+        "{}/{}",
+        url.path().trim_end_matches('/'),
+        path.trim_start_matches('/')
+    );
+    url.set_path(&joined);
+    Ok(url)
+}
+
+fn terminal_url(console: &Url, session_id: &str) -> Result<Url> {
+    let path = format!(
+        "/api/v1/sessions/{}/terminal",
+        urlencoding::encode(session_id)
+    );
+    let mut url = console_endpoint(console, &path)?;
+    let websocket_scheme = if url.scheme() == "https" { "wss" } else { "ws" };
+    url.set_scheme(websocket_scheme)
+        .map_err(|_| NonoError::ConfigParse("could not construct terminal URL".to_string()))?;
+    Ok(url)
+}
+
+async fn attach(url: Url, token: Zeroizing<String>, detach_sequence: Vec<u8>) -> Result<()> {
+    let mut request = url
+        .as_str()
+        .into_client_request()
+        .map_err(|error| NonoError::ConfigParse(format!("invalid terminal request: {error}")))?;
+    let authorization = HeaderValue::from_str(&format!("Bearer {}", token.as_str()))
+        .map_err(|_| NonoError::ConfigParse("invalid connect token".to_string()))?;
+    request.headers_mut().insert(AUTHORIZATION, authorization);
+    request.headers_mut().insert(
+        "Sec-WebSocket-Protocol",
+        HeaderValue::from_static("nono.terminal.v1"),
+    );
+
+    let (socket, response) = tokio_tungstenite::connect_async(request)
+        .await
+        .map_err(|error| NonoError::ConfigParse(format!("terminal connection failed: {error}")))?;
+    let selected_protocol = response
+        .headers()
+        .get(SEC_WEBSOCKET_PROTOCOL)
+        .and_then(|value| value.to_str().ok());
+    if selected_protocol != Some("nono.terminal.v1") {
+        return Err(NonoError::ConfigParse(
+            "console did not negotiate the required nono.terminal.v1 protocol".to_string(),
+        ));
+    }
+    let (mut ws_tx, mut ws_rx) = socket.split();
+    let mut stdin = tokio::io::stdin();
+    let mut stdout = tokio::io::stdout();
+    let mut input = vec![0_u8; 8192];
+    let mut matcher = DetachMatcher::new(detach_sequence);
+    let _terminal = RawTerminal::enter()?;
+    let (cols, rows) = terminal_size();
+    send_resize(&mut ws_tx, cols, rows).await?;
+    let mut resize = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change())
+        .map_err(NonoError::Io)?;
+
+    loop {
+        tokio::select! {
+            read = stdin.read(&mut input) => {
+                let read = read.map_err(NonoError::Io)?;
+                if read == 0 {
+                    send_detach(&mut ws_tx).await?;
+                    return Ok(());
+                }
+                let matched = matcher.push(&input[..read]);
+                if !matched.forward.is_empty() {
+                    ws_tx.send(Message::Binary(matched.forward.into()))
+                        .await
+                        .map_err(ws_error)?;
+                }
+                if matched.detach {
+                    send_detach(&mut ws_tx).await?;
+                    return Ok(());
+                }
+            }
+            _ = resize.recv() => {
+                let (cols, rows) = terminal_size();
+                send_resize(&mut ws_tx, cols, rows).await?;
+            }
+            message = ws_rx.next() => match message {
+                Some(Ok(Message::Binary(bytes))) => {
+                    stdout.write_all(&bytes).await.map_err(NonoError::Io)?;
+                    stdout.flush().await.map_err(NonoError::Io)?;
+                }
+                Some(Ok(Message::Text(text))) => {
+                    match serde_json::from_str::<ServerControl>(text.as_str()) {
+                        Ok(ServerControl::Attached { protocol_version, cols, rows }) => {
+                            if protocol_version != "1" {
+                                return Err(NonoError::ConfigParse(format!(
+                                    "console selected unsupported terminal protocol {protocol_version}"
+                                )));
+                            }
+                            let _ = (cols, rows);
+                        }
+                        Ok(ServerControl::SessionExited { exit_code: Some(0) }) => return Ok(()),
+                        Ok(ServerControl::SessionExited { exit_code: Some(code) }) => {
+                            if code < 0 {
+                                return Err(NonoError::ConfigParse(
+                                    "remote session returned an invalid negative exit status"
+                                        .to_string(),
+                                ));
+                            }
+                            REMOTE_EXIT_CODE.store(code, Ordering::Release);
+                            return Ok(());
+                        }
+                        Ok(ServerControl::SessionExited { exit_code: None }) => {
+                            return Err(NonoError::ConfigParse(
+                                "remote session ended without an exit status".to_string(),
+                            ));
+                        }
+                        Ok(ServerControl::Error { code, message }) => {
+                            let prefix = code.map(|value| format!("{value}: ")).unwrap_or_default();
+                            return Err(NonoError::ConfigParse(format!("{prefix}{message}")));
+                        }
+                        Err(error) => {
+                            return Err(NonoError::ConfigParse(format!(
+                                "invalid terminal control frame: {error}"
+                            )));
+                        }
+                    }
+                }
+                Some(Ok(Message::Ping(bytes))) => {
+                    ws_tx.send(Message::Pong(bytes)).await.map_err(ws_error)?;
+                }
+                Some(Ok(Message::Pong(_))) | Some(Ok(Message::Frame(_))) => {}
+                Some(Ok(Message::Close(_))) | None => {
+                    return Err(NonoError::ConfigParse(
+                        "terminal connection closed without a session-ended event".to_string(),
+                    ));
+                }
+                Some(Err(error)) => return Err(ws_error(error)),
+            }
+        }
+    }
+}
+
+fn ws_error(error: tokio_tungstenite::tungstenite::Error) -> NonoError {
+    NonoError::ConfigParse(format!("terminal connection failed: {error}"))
+}
+
+async fn send_resize<S>(sink: &mut S, cols: u16, rows: u16) -> Result<()>
+where
+    S: futures_util::Sink<Message, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
+{
+    let message = serde_json::json!({
+        "type": "resize",
+        "protocol_version": "1",
+        "cols": cols,
+        "rows": rows,
+    });
+    sink.send(Message::Text(message.to_string().into()))
+        .await
+        .map_err(ws_error)
+}
+
+async fn send_detach<S>(sink: &mut S) -> Result<()>
+where
+    S: futures_util::Sink<Message, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
+{
+    let message = serde_json::json!({ "type": "detach", "protocol_version": "1" });
+    sink.send(Message::Text(message.to_string().into()))
+        .await
+        .map_err(ws_error)
+}
+
+struct RawTerminal {
+    original: nix::sys::termios::Termios,
+}
+
+impl RawTerminal {
+    fn enter() -> Result<Self> {
+        use nix::sys::termios::{SetArg, cfmakeraw, tcgetattr, tcsetattr};
+        let stdin = io::stdin();
+        let original = tcgetattr(&stdin).map_err(|error| {
+            NonoError::ConfigParse(format!("could not read terminal mode: {error}"))
+        })?;
+        let mut raw = original.clone();
+        cfmakeraw(&mut raw);
+        tcsetattr(&stdin, SetArg::TCSANOW, &raw).map_err(|error| {
+            NonoError::ConfigParse(format!("could not enter raw terminal mode: {error}"))
+        })?;
+        Ok(Self { original })
+    }
+}
+
+impl Drop for RawTerminal {
+    fn drop(&mut self) {
+        let stdin = io::stdin();
+        let _ = nix::sys::termios::tcsetattr(
+            &stdin,
+            nix::sys::termios::SetArg::TCSANOW,
+            &self.original,
+        );
+    }
+}
+
+fn terminal_size() -> (u16, u16) {
+    let mut size = nix::libc::winsize {
+        ws_row: 0,
+        ws_col: 0,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    // SAFETY: TIOCGWINSZ only writes the fixed-size `winsize` structure.
+    let result =
+        unsafe { nix::libc::ioctl(nix::libc::STDOUT_FILENO, nix::libc::TIOCGWINSZ, &mut size) };
+    if result == 0 && size.ws_col > 0 && size.ws_row > 0 {
+        (size.ws_col, size.ws_row)
+    } else {
+        (80, 24)
+    }
+}
+
+struct DetachMatch {
+    forward: Vec<u8>,
+    detach: bool,
+}
+
+struct DetachMatcher {
+    sequence: Vec<u8>,
+    pending: Vec<u8>,
+}
+
+impl DetachMatcher {
+    fn new(sequence: Vec<u8>) -> Self {
+        Self {
+            sequence,
+            pending: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, input: &[u8]) -> DetachMatch {
+        let mut forward = Vec::with_capacity(input.len());
+        for &byte in input {
+            self.pending.push(byte);
+            while !self.sequence.starts_with(&self.pending) {
+                forward.push(self.pending.remove(0));
+                if self.pending.is_empty() {
+                    break;
+                }
+            }
+            if self.pending == self.sequence {
+                self.pending.clear();
+                return DetachMatch {
+                    forward,
+                    detach: true,
+                };
+            }
+        }
+        DetachMatch {
+            forward,
+            detach: false,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transport_refuses_cleartext_off_loopback() {
+        assert!(
+            validate_transport_url(&Url::parse("wss://console.example/terminal").unwrap()).is_ok()
+        );
+        assert!(
+            validate_transport_url(&Url::parse("ws://127.0.0.1:8080/terminal").unwrap()).is_ok()
+        );
+        assert!(
+            validate_transport_url(&Url::parse("ws://console.example/terminal").unwrap()).is_err()
+        );
+    }
+
+    #[test]
+    fn console_subpath_is_preserved() {
+        let console = validate_console_url("https://example.test/nono").unwrap();
+        let url = terminal_url(&console, "local:host:session").unwrap();
+        assert_eq!(
+            url.as_str(),
+            "wss://example.test/nono/api/v1/sessions/local%3Ahost%3Asession/terminal"
+        );
+    }
+
+    #[test]
+    fn discovery_fixture_matches_enrollment_and_rejects_tenant_mismatch() {
+        let state = crate::platform_client::PlatformState {
+            protocol_version: "1".to_string(),
+            platform_url: "https://platform.example.com".to_string(),
+            tenant_id: "019f0000-0000-7000-8000-000000000001".to_string(),
+            subject_id: "019f0000-0000-7000-8000-000000000002".to_string(),
+            subject_kind: "device".to_string(),
+            management_mode: "audit_only".to_string(),
+            key_algorithm: "ecdsa_p256_sha256_fixed".to_string(),
+            key_ref: "keystore:test".to_string(),
+            enrolled_at: "2026-08-12T00:00:00Z".to_string(),
+        };
+        let fixture = include_str!("../../../tests/fixtures/console-discovery-v1.json");
+        assert_eq!(
+            validate_discovery_response(&state, fixture)
+                .unwrap()
+                .as_str(),
+            "https://console.example.com/"
+        );
+        let mut wrong_tenant = state;
+        wrong_tenant.tenant_id = "019f0000-0000-7000-8000-000000000099".to_string();
+        assert!(validate_discovery_response(&wrong_tenant, fixture).is_err());
+    }
+
+    #[test]
+    fn device_authorization_fixture_matches_client_contract() {
+        let fixture = include_str!("../../../tests/fixtures/device-auth-v1.json");
+        let response: DeviceCodeResponse = serde_json::from_str(fixture).unwrap();
+        assert_eq!(response.protocol_version, DEVICE_AUTH_PROTOCOL_V1);
+        assert_eq!(response.verification_path, DEVICE_AUTH_VERIFICATION_PATH);
+        assert_eq!(response.expires_in, 600);
+        assert_eq!(response.interval, 5);
+    }
+
+    #[test]
+    fn remote_ps_filters_live_sessions_and_sorts_by_name() {
+        let sessions = vec![
+            remote_session("session-exited", Some("zinc"), "ready", "exited"),
+            remote_session("session-b", Some("birch"), "ready", "running"),
+            remote_session("session-a", Some("alder"), "ready", "running"),
+            remote_session("session-starting", Some("cedar"), "starting", "running"),
+        ];
+
+        let live = filter_remote_sessions(sessions, false);
+        assert_eq!(live.len(), 2);
+        assert_eq!(remote_name(&live[0]), "alder");
+        assert_eq!(remote_name(&live[1]), "birch");
+
+        let all = filter_remote_sessions(
+            vec![
+                remote_session("session-exited", Some("zinc"), "ready", "exited"),
+                remote_session("session-a", Some("alder"), "ready", "running"),
+            ],
+            true,
+        );
+        assert_eq!(all.len(), 2);
+        assert_eq!(remote_status(&all[1]), "exited");
+    }
+
+    fn remote_session(
+        id: &str,
+        name: Option<&str>,
+        backend_status: &str,
+        record_status: &str,
+    ) -> RemoteSession {
+        RemoteSession {
+            global_session_id: id.to_string(),
+            backend_status: backend_status.to_string(),
+            record: Some(RemoteSessionRecord {
+                name: name.map(str::to_string),
+                status: record_status.to_string(),
+                command: vec!["claude".to_string()],
+            }),
+            agent: Some(RemoteAgent {
+                name: "Claude Code".to_string(),
+            }),
+            repo: None,
+        }
+    }
+
+    #[test]
+    fn detach_matcher_preserves_partial_and_mismatched_input() {
+        let mut matcher = DetachMatcher::new(vec![0x1d, b'd']);
+        let first = matcher.push(b"abc\x1d");
+        assert_eq!(first.forward, b"abc");
+        assert!(!first.detach);
+        let mismatch = matcher.push(b"x");
+        assert_eq!(mismatch.forward, b"\x1dx");
+        assert!(!mismatch.detach);
+        let matched = matcher.push(b"z\x1ddtail");
+        assert_eq!(matched.forward, b"z");
+        assert!(matched.detach);
+    }
+
+    #[test]
+    fn direct_attach_url_rejects_url_credentials_and_queries() {
+        assert!(
+            validate_direct_attach_url(
+                &Url::parse("wss://console.example/terminal?token=secret").unwrap()
+            )
+            .is_err()
+        );
+        assert!(
+            validate_direct_attach_url(
+                &Url::parse("wss://user:secret@console.example/terminal").unwrap()
+            )
+            .is_err()
+        );
+        assert!(validate_console_url("https://console.example?token=secret").is_err());
+        assert!(validate_console_url("https://user@console.example").is_err());
+    }
+}

--- a/crates/nono-cli/src/main.rs
+++ b/crates/nono-cli/src/main.rs
@@ -20,6 +20,8 @@ mod command_policy;
 mod command_runtime;
 mod completions;
 mod config;
+#[cfg(unix)]
+mod connect_client;
 mod credential_runtime;
 mod deprecated_policy;
 mod deprecated_schema;
@@ -134,6 +136,12 @@ fn main() {
 
     let cli_result = run_cli(cli);
     tool_sandbox::log_main_total();
+    #[cfg(unix)]
+    if cli_result.is_ok()
+        && let Some(code) = connect_client::take_remote_exit_code()
+    {
+        std::process::exit(code.clamp(1, 255));
+    }
     if let Err(e) = cli_result {
         if let nono::NonoError::ActionRequired(message) = &e {
             eprintln!("{message}");

--- a/crates/nono-cli/src/platform_client.rs
+++ b/crates/nono-cli/src/platform_client.rs
@@ -12,12 +12,14 @@ use base64::{
 };
 use nono::{NonoError, Result};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
 use zeroize::Zeroizing;
 
 pub(crate) const REQUEST_PROTOCOL_V1: &str = "1";
@@ -314,6 +316,62 @@ pub(crate) fn canonical_request_v1(
     format!(
         "nono-request-v1\n{method}\n{path}\n{subject_id}\n{timestamp_ms}\n{request_id}\n{body_digest}"
     )
+}
+
+#[derive(Debug)]
+pub(crate) struct SignedRequestHeaders {
+    pub(crate) timestamp: String,
+    pub(crate) request_id: String,
+    pub(crate) body_digest: String,
+    pub(crate) signature: String,
+}
+
+pub(crate) fn sign_request_v1(
+    state: &PlatformState,
+    method: &str,
+    path: &str,
+    request_id: Uuid,
+    body: &[u8],
+) -> Result<SignedRequestHeaders> {
+    let timestamp = current_timestamp_ms()?.to_string();
+    let request_id = request_id.to_string();
+    let body_digest = format!("sha256:{}", sha256_hex(body));
+    let canonical = canonical_request_v1(
+        method,
+        path,
+        &state.subject_id,
+        &timestamp,
+        &request_id,
+        &body_digest,
+    );
+    let key_pair = load_signing_key(state)?;
+    let signature = key_pair
+        .sign(&SystemRandom::new(), canonical.as_bytes())
+        .map_err(|_| NonoError::KeystoreAccess("failed to sign platform request".to_string()))?;
+    Ok(SignedRequestHeaders {
+        timestamp,
+        request_id,
+        body_digest,
+        signature: format!("p256-sha256={}", URL_SAFE_NO_PAD.encode(signature.as_ref())),
+    })
+}
+
+fn current_timestamp_ms() -> Result<u128> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .map_err(|error| {
+            NonoError::ConfigParse(format!("system clock is before Unix epoch: {error}"))
+        })
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        encoded.push_str(&format!("{byte:02x}"));
+    }
+    encoded
 }
 
 pub(crate) fn endpoint_url(platform_url: &str, path: &str) -> Result<String> {

--- a/crates/nono-cli/src/pty_proxy.rs
+++ b/crates/nono-cli/src/pty_proxy.rs
@@ -39,7 +39,7 @@ const RESIZE_MESSAGE_LEN: usize = 4;
 const SCROLLBACK_LIMIT_BYTES: usize = 8 * 1024 * 1024;
 const VT_SCROLLBACK_ROWS: usize = 10_000;
 const DEFAULT_DETACH_SEQUENCE: [u8; 2] = [0x1d, b'd'];
-const MAX_ENHANCED_KEY_SEQUENCE_LEN: usize = 32;
+pub(crate) const MAX_ENHANCED_KEY_SEQUENCE_LEN: usize = 32;
 const ATTACH_ACK_OK: u8 = 0;
 const ATTACH_ACK_BUSY: u8 = 1;
 const ATTACH_ACK_DENIED: u8 = 2;
@@ -1263,17 +1263,17 @@ impl PtyProxy {
     }
 }
 
-enum EnhancedKeyMatch {
+pub(crate) enum EnhancedKeyMatch {
     Pending,
     Matched,
     Invalid,
 }
 
-fn detach_key_supports_enhanced_match(key: u8) -> bool {
+pub(crate) fn detach_key_supports_enhanced_match(key: u8) -> bool {
     key.is_ascii_graphic() || key == b' ' || control_key_candidates(key).is_some()
 }
 
-fn match_enhanced_key_sequence(bytes: &[u8], expected_key: u8) -> EnhancedKeyMatch {
+pub(crate) fn match_enhanced_key_sequence(bytes: &[u8], expected_key: u8) -> EnhancedKeyMatch {
     if bytes.is_empty() {
         return EnhancedKeyMatch::Pending;
     }
@@ -1387,6 +1387,16 @@ fn control_key_candidates(expected_key: u8) -> Option<[u32; 2]> {
         ]),
         _ => None,
     }
+}
+
+/// Reset terminal input-reporting modes after a terminal-native attach client.
+///
+/// A hosted application may enable kitty CSI-u keyboard reporting, mouse
+/// tracking, or bracketed paste. Termios restoration alone does not disable
+/// those terminal-emulator modes, so a returning shell would otherwise receive
+/// encoded input such as `\x1b[99;5u` for Ctrl-C.
+pub(crate) fn restore_terminal_modes_after_attach() {
+    let _ = write_all_fd(libc::STDOUT_FILENO, TERMINAL_RESTORE_NORMAL);
 }
 
 fn compose_replay_body(
@@ -2392,6 +2402,16 @@ fn print_detach_notice(session_id: Option<&str>) {
 /// mid-shutdown when we connected) to give a clean "session exited" message
 /// instead of a raw "Broken pipe" error.
 pub fn attach_to_session(session_id: &str) -> Result<()> {
+    attach_to_session_with_ready(session_id, || {})
+}
+
+/// Attach and invoke `on_ready` only after the supervisor accepted this client
+/// as its active writer. nono-console uses this boundary to avoid announcing a
+/// WebSocket attachment before the underlying writer slot is actually held.
+pub fn attach_to_session_with_ready<F>(session_id: &str, on_ready: F) -> Result<()>
+where
+    F: FnOnce(),
+{
     let stream = match connect_to_session(session_id) {
         Err(NonoError::SessionGone) => {
             // The supervisor may have been mid-shutdown. Wait briefly and
@@ -2403,6 +2423,7 @@ pub fn attach_to_session(session_id: &str) -> Result<()> {
         other => other?,
     };
     wait_for_attach_ready(stream.as_raw_fd(), timeouts::pty_attach_timeout_ms())?;
+    on_ready();
     attach_to_stream(stream, Some(session_id))
 }
 

--- a/crates/nono-cli/src/session.rs
+++ b/crates/nono-cli/src/session.rs
@@ -95,6 +95,9 @@ impl SessionGuard {
     pub fn set_exited(&mut self, exit_code: i32) {
         self.record.status = SessionStatus::Exited;
         self.record.exit_code = Some(exit_code);
+        if let Err(e) = update_session_file(&self.path, &self.record) {
+            warn!("Failed to persist session exit status: {}", e);
+        }
     }
 }
 
@@ -1157,6 +1160,41 @@ mod tests {
         let loaded = load_session_file(&file_path).expect("load");
         assert_eq!(loaded.status, SessionStatus::Exited);
         assert_eq!(loaded.exit_code, Some(-1));
+    }
+
+    #[test]
+    fn session_guard_persists_real_exit_code_before_drop() {
+        let dir = tempdir().expect("tempdir");
+        #[cfg(unix)]
+        make_private_dir(dir.path());
+        let path = dir.path().join("guard-exit.json");
+        let record = SessionRecord {
+            session_id: "guard-exit".to_string(),
+            name: None,
+            supervisor_pid: 300,
+            child_pid: 301,
+            started: "2026-08-12T00:00:00+00:00".to_string(),
+            started_epoch: 77777,
+            status: SessionStatus::Running,
+            attachment: SessionAttachment::Detached,
+            exit_code: None,
+            command: vec!["test".to_string()],
+            profile: None,
+            workdir: PathBuf::from("/tmp"),
+            network: "blocked".to_string(),
+            rollback_session: None,
+        };
+        write_session_file(&path, &record).expect("write initial session");
+        let mut guard = SessionGuard {
+            record,
+            path: path.clone(),
+        };
+
+        guard.set_exited(7);
+
+        let persisted = load_session_file(&path).expect("load persisted session");
+        assert_eq!(persisted.status, SessionStatus::Exited);
+        assert_eq!(persisted.exit_code, Some(7));
     }
 
     #[test]

--- a/crates/nono-cli/src/session_commands.rs
+++ b/crates/nono-cli/src/session_commands.rs
@@ -14,6 +14,10 @@ use std::io::{BufRead, Seek, SeekFrom};
 use std::path::Path;
 use tracing::debug;
 
+const BRIDGE_STATUS_READY: &str = "\x1b]777;nono-attach-v1=ready\x07";
+const BRIDGE_STATUS_BUSY: &str = "\x1b]777;nono-attach-v1=busy\x07";
+const BRIDGE_STATUS_GONE: &str = "\x1b]777;nono-attach-v1=gone\x07";
+
 /// Refuse to run if we're inside a nono sandbox.
 ///
 /// Commands that send signals or delete files (stop, prune) must not run
@@ -320,6 +324,11 @@ pub fn run_attach(args: &AttachArgs) -> Result<()> {
     let record = session::load_session(&args.session)?;
 
     if record.status == SessionStatus::Exited {
+        if args.bridge_status {
+            eprint!("{BRIDGE_STATUS_GONE}");
+            let _ = std::io::Write::flush(&mut std::io::stderr());
+            return Ok(());
+        }
         match record.exit_code {
             Some(code) => {
                 eprintln!(
@@ -335,13 +344,20 @@ pub fn run_attach(args: &AttachArgs) -> Result<()> {
     }
 
     if !session::is_process_alive(record.supervisor_pid, record.started_epoch) {
+        if args.bridge_status {
+            eprint!("{BRIDGE_STATUS_GONE}");
+            let _ = std::io::Write::flush(&mut std::io::stderr());
+            return Ok(());
+        }
         return Err(NonoError::ConfigParse(format!(
             "Session {} supervisor (PID {}) is no longer running",
             record.session_id, record.supervisor_pid
         )));
     }
 
-    eprintln!("[nono] Attaching to session {}...", record.session_id);
+    if !args.bridge_status {
+        eprintln!("[nono] Attaching to session {}...", record.session_id);
+    }
 
     if record.status == SessionStatus::Paused {
         return Err(NonoError::ConfigParse(format!(
@@ -350,8 +366,21 @@ pub fn run_attach(args: &AttachArgs) -> Result<()> {
         )));
     }
 
-    match crate::pty_proxy::attach_to_session(&record.session_id) {
+    let result = if args.bridge_status {
+        crate::pty_proxy::attach_to_session_with_ready(&record.session_id, || {
+            eprint!("{BRIDGE_STATUS_READY}");
+            let _ = std::io::Write::flush(&mut std::io::stderr());
+        })
+    } else {
+        crate::pty_proxy::attach_to_session(&record.session_id)
+    };
+    match result {
         Err(NonoError::AttachBusy) => {
+            if args.bridge_status {
+                eprint!("{BRIDGE_STATUS_BUSY}");
+                let _ = std::io::Write::flush(&mut std::io::stderr());
+                return Ok(());
+            }
             eprintln!(
                 "[nono] Session {} already has an active attached client.",
                 record.session_id
@@ -359,6 +388,11 @@ pub fn run_attach(args: &AttachArgs) -> Result<()> {
             Ok(())
         }
         Err(NonoError::SessionGone) => {
+            if args.bridge_status {
+                eprint!("{BRIDGE_STATUS_GONE}");
+                let _ = std::io::Write::flush(&mut std::io::stderr());
+                return Ok(());
+            }
             eprintln!(
                 "[nono] Session {} exited before attach could complete.",
                 record.session_id

--- a/docs/protocols/remote-attach-v1.md
+++ b/docs/protocols/remote-attach-v1.md
@@ -1,0 +1,308 @@
+# Remote terminal attach protocol v1
+
+This document specifies the open WebSocket contract used by `nono connect` to
+discover nono-console and attach a local terminal to a hosted session. It does
+not define session launch, fleet policy, or local sandbox enforcement.
+
+## Console discovery
+
+When `--console` is absent, an enrolled device asks its configured platform for
+the nono-console origin:
+
+```text
+GET /api/v1/console
+X-Nono-Protocol-Version: 1
+X-Nono-Subject-Id: <enrolled device UUID>
+X-Nono-Timestamp: <Unix milliseconds>
+X-Nono-Request-Id: <one-time UUID>
+X-Nono-Content-SHA256: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+X-Nono-Signature: p256-sha256=<base64url signature>
+```
+
+The content digest is SHA-256 of the empty request body. The P-256 signature
+covers the existing canonical enrolled-request payload:
+
+```text
+nono-request-v1
+GET
+<exact request path>
+<subject id>
+<timestamp>
+<request id>
+<body digest>
+```
+
+The platform accepts active enrolled devices only, derives the tenant from the
+authenticated subject, enforces bounded freshness, and durably consumes the
+request ID once. Missing, modified, stale, replayed, workload-signed, or
+revoked-subject requests fail closed.
+
+A successful response is:
+
+```json
+{
+  "protocol_version": "1",
+  "tenant_id": "019f0000-0000-7000-8000-000000000001",
+  "console_url": "https://console.example.com"
+}
+```
+
+The client requires `protocol_version: "1"` and requires `tenant_id` to equal
+its protected enrollment state. `console_url` must be an absolute `https://`
+origin without credentials, query parameters, or fragments. Plain `http://` is
+accepted only for an explicit loopback address. A URL path prefix is preserved.
+
+Discovery authenticates a device and selects infrastructure; it does not prove
+human identity and does not authorize session listing or attachment. Those
+operations still require a separate human access token. `--console` remains an
+explicit development and support override.
+
+## Human device authorization
+
+When no explicit human token is configured, an enrolled device obtains a
+revocable CLI authorization without copying the browser session cookie. All
+CLI requests below use the same enrolled-request signature headers as console
+discovery, with the exact method, path, request body digest, and a fresh
+one-time request UUID.
+
+The device starts the flow with an empty signed request:
+
+```text
+POST /api/v1/auth/device/code
+```
+
+The platform returns protocol version `1`, a high-entropy `device_code`, a
+short `user_code`, `verification_path: "/platform/device"`, `expires_in: 600`,
+and a bounded polling `interval`. The CLI constructs the verification URL from
+its enrolled platform origin; it never trusts the HTTP Host header as a public
+origin.
+
+After normal browser authentication, the human submits the displayed code:
+
+```text
+POST /api/v1/auth/device/authorize
+{"protocol_version":"1","user_code":"ABCD-EFGH","decision":"approve"}
+```
+
+The platform resolves both user and tenant from the authenticated browser
+session. Approval succeeds only when that tenant equals the enrolled device's
+tenant. A denial uses `decision: "deny"` and is terminal.
+
+The CLI polls with a signed JSON request:
+
+```text
+POST /api/v1/auth/device/poll
+{"protocol_version":"1","device_code":"<secret>"}
+```
+
+Pending responses carry `status: "authorization_pending"`. The first approved
+poll durably creates the authorization and returns `status: "authorized"`, a
+random opaque `credential`, and its expiry. A retry during the original
+ten-minute code lifetime returns that same credential so a lost HTTP response
+does not strand the approval. Expired, denied, modified, replayed,
+wrong-device, wrong-tenant, workload-signed, or revoked-device requests fail
+closed without revealing whether another tenant's code exists.
+
+The credential is not a console token. It is bound server-side to the human,
+tenant, and enrolled device, is stored only as a digest by the platform, and
+may be cached locally in a mode-0600 state file. Before each connection the CLI
+uses a fresh signed request and presents the credential in the Authorization
+header:
+
+```text
+POST /api/v1/auth/device/access-token
+Authorization: Bearer <opaque CLI authorization>
+```
+
+The platform rechecks the active device, user, tenant, membership, and current
+role, then returns a new five-minute, `nono-console`-audience access token. A
+copied cache file is insufficient without the enrolled device key. Explicit
+`--token-file` and `NONO_CONNECT_TOKEN` values remain operator overrides and do
+not enter this flow.
+
+After a newly approved credential has been cached and successfully exchanged,
+the CLI reports `Terminal authorized.` A cached authorization is normally
+silent. `nono ps --remote` performs the same authorization and discovery flow,
+lists the sessions visible to that human, and exits successfully without
+attaching a terminal.
+
+## Session listing
+
+The CLI lists the authenticated human's console sessions with:
+
+```text
+GET /api/v1/sessions
+Authorization: Bearer <short-lived console access token>
+```
+
+The response is an object containing a `sessions` array. Each entry includes a
+globally unique `global_session_id`, the backend status, and optional runtime,
+agent, and repository metadata. The fields consumed by protocol v1 are:
+
+```json
+{
+  "sessions": [
+    {
+      "global_session_id": "local:host:019f0000-0000-7000-8000-000000000003",
+      "backend_status": "ready",
+      "record": {
+        "name": "tall-edge",
+        "status": "running",
+        "command": ["claude"]
+      },
+      "agent": { "name": "Claude Code" },
+      "repo": null
+    }
+  ]
+}
+```
+
+Additive fields are allowed. By default `nono ps --remote` and the interactive
+`nono connect` picker show only entries whose backend is `ready` and whose
+runtime record is `running`. `nono ps --remote --all` retains inactive entries;
+`--json` emits the client-consumed protocol fields for automation. Listing and
+attaching accept the same `--console` / `NONO_CONSOLE_URL` discovery override
+and `--token-file` / `NONO_CONNECT_TOKEN_FILE` credential override.
+
+## Authentication and transport
+
+The client connects to:
+
+```text
+GET /api/v1/sessions/{global_session_id}/terminal
+Upgrade: websocket
+Sec-WebSocket-Protocol: nono.terminal.v1
+Authorization: Bearer <human access token>
+```
+
+Authentication is never carried in the URL. The bearer token identifies a
+human subject, tenant, scopes, expiry, and token/session ID. Device enrollment
+is a distinct identity and must not be treated as proof of a human identity.
+A later hardening revision may additionally bind the upgrade to the enrolled
+device key without replacing human authorization.
+
+Non-loopback connections must use `wss://` with normal certificate validation.
+A client may trust a configured private CA, but must not offer an insecure TLS
+mode. Plain `ws://` is permitted only for explicit loopback development.
+
+The client offers `nono.terminal.v1` as the WebSocket subprotocol. A server that
+does not support v1 rejects the upgrade rather than silently selecting another
+protocol.
+
+## Frames
+
+Binary frames are raw PTY bytes:
+
+- client to server: keyboard/input bytes;
+- server to client: PTY output bytes.
+
+Text frames are UTF-8 JSON control messages. Every client control message
+carries `protocol_version: "1"`. Unknown message types or unsupported versions
+produce an `error` control frame; malformed frames never widen access.
+
+### Resize
+
+Client to server, sent once after connection and whenever the local terminal
+size changes:
+
+```json
+{
+  "type": "resize",
+  "protocol_version": "1",
+  "cols": 120,
+  "rows": 40
+}
+```
+
+Both dimensions are unsigned 16-bit values and must be non-zero.
+
+### Detach
+
+Client to server:
+
+```json
+{
+  "type": "detach",
+  "protocol_version": "1"
+}
+```
+
+Detach closes this attachment only. It must not stop the hosted session.
+
+### Attached
+
+Server to client after the backend attachment is ready:
+
+```json
+{
+  "type": "attached",
+  "protocol_version": "1",
+  "cols": 120,
+  "rows": 40
+}
+```
+
+The client must not describe the session as attached before receiving this
+message.
+
+### Session ended
+
+Server to client when the hosted session has ended:
+
+```json
+{
+  "type": "session_exited",
+  "exit_code": 2
+}
+```
+
+`exit_code` is the hosted session process status, not the status of an
+intermediate attach helper. It may be null only when the backend genuinely
+cannot establish the outcome. A command-line client should return success for
+zero, the reported non-zero status where its operating system supports it, and
+failure for an unknown outcome.
+
+### Error
+
+Server to client before closing an established WebSocket:
+
+```json
+{
+  "type": "error",
+  "code": "attach_busy",
+  "message": "session already has a writer"
+}
+```
+
+Messages must not include credentials, authorization headers, captured input,
+or other secrets.
+
+## Session listing
+
+The interactive picker uses the console's existing authenticated endpoint:
+
+```text
+GET /api/v1/sessions
+Authorization: Bearer <human access token>
+```
+
+The client displays only live sessions returned for the token's server-derived
+tenant. A browser-controlled tenant value is never accepted.
+
+## Read-only and multiple attachments
+
+The reserved query `?mode=read_only` requests a watcher that cannot send PTY
+input. A server without fan-out support must reject this mode explicitly.
+For writable attachments v1 permits exactly one writer; a second writer is
+refused with `attach_busy`. Writer stealing is not implicit.
+
+## Current implementation boundary
+
+The implementation supports one writable attachment. Enrolled devices discover
+the configured console origin and, unless an explicit token override is used,
+complete browser-approved human authorization and exchange the cached,
+device-bound credential for a short-lived console bearer token. Device-key
+upgrade binding, private CA bundles, dedicated authorization management, and
+read-only fan-out are follow-up work. These absences must be surfaced to the
+caller and must not be replaced with an unenrolled shared secret or an insecure
+TLS flag.

--- a/docs/protocols/remote-attach-v1.md
+++ b/docs/protocols/remote-attach-v1.md
@@ -228,6 +228,10 @@ Client to server:
 ```
 
 Detach closes this attachment only. It must not stop the hosted session.
+Terminal-native clients recognize the configured detach sequence in both
+traditional control-byte form and modern CSI-u keyboard encoding. On return,
+they restore termios and terminal-emulator keyboard, mouse, focus, and paste
+modes before handing control back to the local shell.
 
 ### Attached
 

--- a/tests/fixtures/console-discovery-v1.json
+++ b/tests/fixtures/console-discovery-v1.json
@@ -1,0 +1,5 @@
+{
+  "protocol_version": "1",
+  "tenant_id": "019f0000-0000-7000-8000-000000000001",
+  "console_url": "https://console.example.com"
+}

--- a/tests/fixtures/device-auth-v1.json
+++ b/tests/fixtures/device-auth-v1.json
@@ -1,0 +1,8 @@
+{
+  "protocol_version": "1",
+  "device_code": "v1_test_device_code_0123456789",
+  "user_code": "ABCD-EFGH",
+  "verification_path": "/platform/device",
+  "expires_in": 600,
+  "interval": 5
+}


### PR DESCRIPTION
Introduce `nono connect` command to attach this terminal to remote sessions hosted by `nono-console`.

Also adds a `--remote` flag to `nono ps` to list sessions hosted by the enrolled tenant's `nono-console`. This allows users to inspect and interact with sessions running on their remote infrastructure.

Key changes include:
- New `nono connect` command for interactive terminal attachment.
- `nono ps --remote` for listing remote sessions.
- New `connect_client` module for WebSocket-based communication with the console.
- Updates to `Cargo.toml` to include `tokio-tungstenite` and `futures-util` for WebSocket client functionality.
- Refactor of platform request signing logic, moving `current_timestamp_ms` and `sha256_hex` into `platform_client` and introducing a reusable `sign_request_v1` function.
- Terminal attachment currently requires a Unix-like platform.
- New protocol documentation at `docs/protocols/remote-attach-v1.md`.

Signed-off-by: Luke Hinds <lukehinds@gmail.com>

<!--
## Agent Compliance Check (Required for AI/Automated PRs)
- [ ] I am not prohibited from contributing under this policy
- [ ] An issue already exists
- [ ] I disclosed that I am an agent in the issue discussion
- [ ] I described my intent and approach in the issue discussion
- [ ] I reviewed repository coding and security rules for the affected area
- [ ] I provided required attribution for reused or adapted code
- [ ] I did not use forbidden patterns such as unwrap/expect
- [ ] I used NonoError where required
- [ ] I validated and canonicalized all relevant paths
- [ ] This PR matches the approved or disclosed issue scope
-->
