### PR TITLE
fix(cli): let child profiles override inherited allow_http2

### DIFF
--- a/crates/nono-cli/data/nono-profile.schema.json
+++ b/crates/nono-cli/data/nono-profile.schema.json
@@ -888,8 +888,11 @@
           "description": "Block network access. Network is allowed by default; set to true to deny all outbound traffic."
         },
         "allow_http2": {
-          "type": "boolean",
-          "description": "Allow HTTP/2 to upstream servers via ALPN negotiation. Defaults to false (HTTP/1.1 with keep-alive). Equivalent to the --allow-http2 CLI flag."
+          "oneOf": [
+            { "type": "boolean" },
+            { "type": "null" }
+          ],
+          "description": "Allow HTTP/2 to upstream servers via ALPN negotiation. When omitted on a root profile, defaults to false (HTTP/1.1 with keep-alive). Absent inherits the parent profile; true/false override; null clears an inherited true. Equivalent to the --allow-http2 CLI flag, which is OR'd with the resolved profile value at launch."
         },
         "network_profile": {
           "oneOf": [

--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -64,7 +64,7 @@ Inherit from another profile by name:
 - Scalar fields: child overrides base.
 - Array fields (`groups.include`, `groups.exclude`, `commands.allow`, `commands.deny`, `filesystem.*`, `allow_domain`, `deny_domain`, `open_port`, `open_port_range`, `listen_port`, `listen_port_range`, `no_proxy`, `rollback.*`, `upstream_bypass`): child values are appended to base values and deduplicated. To remove inherited entries, use `groups.exclude` for groups; there is no mechanism to remove inherited filesystem paths. For `allow_domain` entries with endpoint rules, rules for the same domain are merged (appended) rather than replaced. `deny_domain` entries are additive — child profiles can only add more denies, never remove inherited ones.
 - Map fields (`env_credentials`, `hooks`, `custom_credentials`): child entries are merged into base; child keys override matching base keys.
-- `network_profile` supports three-state inheritance via `InheritableValue`: absent = inherit base value, `null` = explicitly clear, string = override. This is the only field that supports null-clearing.
+- `network_profile` and `network.allow_http2` support three-state inheritance via `InheritableValue`: absent = inherit base value, `null` = explicitly clear, explicit value = override. `allow_http2: false` therefore overrides an inherited `true`. The CLI `--allow-http2` flag is still OR'd with the resolved profile value at launch and cannot disable a resolved `true`.
 - `open_urls`: if the child provides the field (even as `{}`), it replaces the base entirely. If absent, the base value is inherited. Setting to `null` in JSON is equivalent to omitting it (both inherit the base).
 - `workdir`: child overrides base unless child is `"none"` (which inherits the base value instead).
 
@@ -357,7 +357,7 @@ Here `read` only ever matches `.ts`/`.tsx` files, so it can never overlap `.env`
 | Field                   | Type                              | Default  | Description |
 |-------------------------|-----------------------------------|----------|-------------|
 | `block`                 | boolean                           | `false`  | Block all network access. |
-| `allow_http2`           | boolean                           | `false`  | Allow HTTP/2 to upstream servers via ALPN negotiation. Default is HTTP/1.1 with keep-alive. Equivalent to `--allow-http2`. |
+| `allow_http2`           | boolean or null                   | inherit (`false`) | Allow HTTP/2 to upstream servers via ALPN negotiation. Absent inherits the parent; `true`/`false` override; `null` clears an inherited `true` back to HTTP/1.1. A root profile that omits the field uses HTTP/1.1. Equivalent to `--allow-http2`, which is still OR'd with the resolved value at launch. |
 | `network_profile`       | string or null                    | inherit  | Name from `network-policy.json` for proxy filtering. Set to `null` to clear inherited value. |
 | `allow_domain`          | array of string or object         | `[]`     | Additional domains to allow through the proxy. Entries can be plain strings (CONNECT tunnel) or objects with endpoint rules (TLS-intercepted L7 filtering). Aliases: `proxy_allow`, `allow_proxy`. |
 | `deny_domain`           | array of string                   | `[]`     | Domains to block through the proxy regardless of the allowlist. Evaluated before `allow_domain`. Supports wildcard subdomains (`*.ads.example.com`). Equivalent to `--deny-domain`. |

--- a/crates/nono-cli/src/profile/mod.rs
+++ b/crates/nono-cli/src/profile/mod.rs
@@ -1589,10 +1589,16 @@ pub struct NetworkConfig {
     #[serde(default)]
     pub block: bool,
     /// Allow HTTP/2 to upstream servers via ALPN negotiation.
-    /// When `false` (default), the proxy negotiates HTTP/1.1 with keep-alive
-    /// connection pooling. Equivalent to the `--allow-http2` CLI flag.
-    #[serde(default)]
-    pub allow_http2: bool,
+    ///
+    /// Three-state inheritance (same as `network_profile`):
+    /// absent = inherit the parent, `null` = clear an inherited `true` back
+    /// to HTTP/1.1, explicit `true`/`false` = override. A root profile that
+    /// omits the field resolves to `false` (HTTP/1.1 with keep-alive).
+    ///
+    /// Equivalent to `--allow-http2`, which is still OR'd with the *resolved*
+    /// profile value at launch and cannot disable a resolved `true`.
+    #[serde(default, skip_serializing_if = "InheritableValue::is_inherit")]
+    pub allow_http2: InheritableValue<bool>,
     /// Network proxy profile name (from network-policy.json).
     /// When set, outbound traffic is filtered through the proxy.
     ///
@@ -1714,6 +1720,14 @@ pub enum TlsCaLifecycle {
 impl NetworkConfig {
     pub fn resolved_network_profile(&self) -> Option<&str> {
         self.network_profile.as_ref().map(String::as_str)
+    }
+
+    /// Returns whether HTTP/2 is enabled after profile inheritance.
+    ///
+    /// Only an explicit `true` enables HTTP/2. Absent, `null` (clear), and
+    /// explicit `false` all resolve to the default (HTTP/1.1).
+    pub fn resolved_allow_http2(&self) -> bool {
+        matches!(self.allow_http2, InheritableValue::Set(true))
     }
 
     /// Returns the resolved credentials list, defaulting to empty if unset.
@@ -3649,7 +3663,7 @@ fn merge_profiles(base: Profile, child: Profile) -> Profile {
         },
         network: NetworkConfig {
             block: base.network.block || child.network.block,
-            allow_http2: base.network.allow_http2 || child.network.allow_http2,
+            allow_http2: child.network.allow_http2.merge(base.network.allow_http2),
             network_profile: child
                 .network
                 .network_profile
@@ -6448,7 +6462,7 @@ mod tests {
             },
             network: NetworkConfig {
                 block: false,
-                allow_http2: false,
+                allow_http2: InheritableValue::Inherit,
                 network_profile: InheritableValue::Set("base-net".to_string()),
                 allow_domain: vec![AllowDomainEntry::Plain("base.example.com".to_string())],
                 deny_domain: vec![],
@@ -6540,7 +6554,7 @@ mod tests {
             },
             network: NetworkConfig {
                 block: false,
-                allow_http2: false,
+                allow_http2: InheritableValue::Inherit,
                 network_profile: InheritableValue::Inherit,
                 allow_domain: vec![AllowDomainEntry::Plain("child.example.com".to_string())],
                 deny_domain: vec![],
@@ -6973,6 +6987,66 @@ mod tests {
 
         let merged = merge_profiles(base, child);
         assert_eq!(merged.network.resolved_network_profile(), None);
+    }
+
+    fn profile_with_allow_http2(value: InheritableValue<bool>) -> Profile {
+        Profile {
+            network: NetworkConfig {
+                allow_http2: value,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_merge_profiles_allow_http2_parent_true_child_absent_inherits() {
+        let merged = merge_profiles(
+            profile_with_allow_http2(InheritableValue::Set(true)),
+            profile_with_allow_http2(InheritableValue::Inherit),
+        );
+        assert_eq!(merged.network.allow_http2, InheritableValue::Set(true));
+        assert!(merged.network.resolved_allow_http2());
+    }
+
+    #[test]
+    fn test_merge_profiles_allow_http2_parent_true_child_false_overrides() {
+        let merged = merge_profiles(
+            profile_with_allow_http2(InheritableValue::Set(true)),
+            profile_with_allow_http2(InheritableValue::Set(false)),
+        );
+        assert_eq!(merged.network.allow_http2, InheritableValue::Set(false));
+        assert!(!merged.network.resolved_allow_http2());
+    }
+
+    #[test]
+    fn test_merge_profiles_allow_http2_parent_false_child_true_overrides() {
+        let merged = merge_profiles(
+            profile_with_allow_http2(InheritableValue::Set(false)),
+            profile_with_allow_http2(InheritableValue::Set(true)),
+        );
+        assert_eq!(merged.network.allow_http2, InheritableValue::Set(true));
+        assert!(merged.network.resolved_allow_http2());
+    }
+
+    #[test]
+    fn test_merge_profiles_allow_http2_null_clears_inherited_true() {
+        let merged = merge_profiles(
+            profile_with_allow_http2(InheritableValue::Set(true)),
+            profile_with_allow_http2(InheritableValue::Clear),
+        );
+        assert_eq!(merged.network.allow_http2, InheritableValue::Clear);
+        assert!(!merged.network.resolved_allow_http2());
+    }
+
+    #[test]
+    fn test_merge_profiles_allow_http2_multi_level_child_false_overrides() {
+        let grandparent = profile_with_allow_http2(InheritableValue::Set(true));
+        let parent = profile_with_allow_http2(InheritableValue::Inherit);
+        let child = profile_with_allow_http2(InheritableValue::Set(false));
+        let merged = merge_profiles(merge_profiles(grandparent, parent), child);
+        assert_eq!(merged.network.allow_http2, InheritableValue::Set(false));
+        assert!(!merged.network.resolved_allow_http2());
     }
 
     #[test]
@@ -8063,6 +8137,75 @@ mod tests {
     }
 
     #[test]
+    fn test_allow_http2_deserialization_distinguishes_absent_null_true_false() {
+        let absent: Profile = serde_json::from_str(r#"{ "meta": { "name": "absent" } }"#)
+            .expect("parse absent profile");
+        assert_eq!(absent.network.allow_http2, InheritableValue::Inherit);
+        assert!(!absent.network.resolved_allow_http2());
+
+        let cleared: Profile = serde_json::from_str(
+            r#"{
+                "meta": { "name": "cleared" },
+                "network": { "allow_http2": null }
+            }"#,
+        )
+        .expect("parse cleared allow_http2");
+        assert_eq!(cleared.network.allow_http2, InheritableValue::Clear);
+        assert!(!cleared.network.resolved_allow_http2());
+
+        let enabled: Profile = serde_json::from_str(
+            r#"{
+                "meta": { "name": "enabled" },
+                "network": { "allow_http2": true }
+            }"#,
+        )
+        .expect("parse allow_http2 true");
+        assert_eq!(enabled.network.allow_http2, InheritableValue::Set(true));
+        assert!(enabled.network.resolved_allow_http2());
+
+        let disabled: Profile = serde_json::from_str(
+            r#"{
+                "meta": { "name": "disabled" },
+                "network": { "allow_http2": false }
+            }"#,
+        )
+        .expect("parse allow_http2 false");
+        assert_eq!(disabled.network.allow_http2, InheritableValue::Set(false));
+        assert!(!disabled.network.resolved_allow_http2());
+    }
+
+    #[test]
+    fn test_allow_http2_round_trip_preserves_absent_null_and_bool() {
+        let cases = [
+            (InheritableValue::Inherit, None),
+            (InheritableValue::Clear, Some(serde_json::Value::Null)),
+            (
+                InheritableValue::Set(true),
+                Some(serde_json::Value::Bool(true)),
+            ),
+            (
+                InheritableValue::Set(false),
+                Some(serde_json::Value::Bool(false)),
+            ),
+        ];
+        for (stored, expected_json) in cases {
+            let mut profile = Profile::default();
+            profile.meta.name = "round-trip".to_string();
+            profile.network.allow_http2 = stored.clone();
+            let json = serde_json::to_value(&profile).expect("serialize profile");
+            let actual = json.pointer("/network/allow_http2").cloned();
+            assert_eq!(actual, expected_json, "serialize {stored:?}");
+            let reparsed: Profile =
+                serde_json::from_value(json).expect("deserialized profile must round-trip");
+            assert_eq!(
+                reparsed.network.resolved_allow_http2(),
+                matches!(stored, InheritableValue::Set(true))
+            );
+            assert_eq!(reparsed.network.allow_http2, stored);
+        }
+    }
+
+    #[test]
     fn test_top_level_schema_field_allowed_in_profile() {
         let profile: Profile = serde_json::from_str(
             r#"{
@@ -8503,6 +8646,70 @@ mod tests {
             profile.groups.include.contains(&"mise_manager".to_string()),
             "expected groups from mise-dev to still be inherited",
         );
+    }
+
+    #[test]
+    fn test_extends_allow_http2_child_false_overrides_inherited_true() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::write(
+            dir.path().join("h2-grand.json"),
+            r#"{
+                "meta": { "name": "h2-grand" },
+                "network": { "allow_http2": true }
+            }"#,
+        )
+        .expect("write grandparent profile");
+        std::fs::write(
+            dir.path().join("h2-parent.json"),
+            r#"{
+                "meta": { "name": "h2-parent" },
+                "extends": "h2-grand"
+            }"#,
+        )
+        .expect("write parent profile");
+        let child_path = dir.path().join("h2-child.json");
+        std::fs::write(
+            &child_path,
+            r#"{
+                "meta": { "name": "h2-child" },
+                "extends": "h2-parent",
+                "network": { "allow_http2": false }
+            }"#,
+        )
+        .expect("write child profile");
+
+        let profile = load_from_file(&child_path, &[]).expect("load child with extends");
+        assert_eq!(profile.network.allow_http2, InheritableValue::Set(false));
+        assert!(
+            !profile.network.resolved_allow_http2(),
+            "child allow_http2:false must override inherited true"
+        );
+    }
+
+    #[test]
+    fn test_extends_allow_http2_child_absent_inherits_true() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::write(
+            dir.path().join("h2-base.json"),
+            r#"{
+                "meta": { "name": "h2-base" },
+                "network": { "allow_http2": true }
+            }"#,
+        )
+        .expect("write base profile");
+        let child_path = dir.path().join("h2-absent.json");
+        std::fs::write(
+            &child_path,
+            r#"{
+                "meta": { "name": "h2-absent" },
+                "extends": "h2-base"
+            }"#,
+        )
+        .expect("write child profile");
+
+        let profile = load_from_file(&child_path, &[]).expect("load child with extends");
+        assert_eq!(profile.network.allow_http2, InheritableValue::Set(true));
+        assert!(profile.network.resolved_allow_http2());
     }
 
     #[test]

--- a/crates/nono-cli/src/proxy_command.rs
+++ b/crates/nono-cli/src/proxy_command.rs
@@ -357,8 +357,9 @@ fn build_launch_options(args: &ProxyArgs) -> Result<ProxyLaunchOptions> {
     };
 
     // Enable HTTP/2 to upstreams when requested via the CLI flag or the
-    // profile's `network.allow_http2`, mirroring the sandboxed `run` path.
-    let enable_h2 = args.allow_http2 || network.map(|n| n.allow_http2).unwrap_or(false);
+    // resolved profile `network.allow_http2`, mirroring the sandboxed `run`
+    // path. This OR is CLI-vs-resolved-profile, not profile-to-profile merge.
+    let enable_h2 = args.allow_http2 || network.map(|n| n.resolved_allow_http2()).unwrap_or(false);
 
     Ok(ProxyLaunchOptions {
         domain_filter,
@@ -655,6 +656,65 @@ mod tests {
             .map(crate::profile::AllowDomainEntry::domain)
             .collect();
         assert_eq!(domains, vec!["solo.example.com"]);
+    }
+
+    #[test]
+    fn profile_allow_http2_false_overrides_inherited_true() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env = cleared_env();
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::write(
+            dir.path().join("h2-base.json"),
+            r#"{
+                "meta": { "name": "h2-base" },
+                "network": { "allow_http2": true }
+            }"#,
+        )
+        .expect("write base profile");
+        let child_path = dir.path().join("h2-child.json");
+        std::fs::write(
+            &child_path,
+            r#"{
+                "meta": { "name": "h2-child" },
+                "extends": "h2-base",
+                "network": { "allow_http2": false }
+            }"#,
+        )
+        .expect("write child profile");
+
+        let args = parse_args(&["--profile", child_path.to_str().expect("valid utf8")]);
+        let opts = build_launch_options(&args).expect("child profile is valid");
+        assert!(
+            !opts.enable_h2,
+            "child allow_http2:false must disable inherited HTTP/2"
+        );
+    }
+
+    #[test]
+    fn allow_http2_flag_ors_with_resolved_profile_false() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env = cleared_env();
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("h2-off.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "h2-off" },
+                "network": { "allow_http2": false }
+            }"#,
+        )
+        .expect("write profile");
+
+        let args = parse_args(&[
+            "--profile",
+            profile_path.to_str().expect("valid utf8"),
+            "--allow-http2",
+        ]);
+        let opts = build_launch_options(&args).expect("CLI flag with profile false is valid");
+        assert!(
+            opts.enable_h2,
+            "CLI --allow-http2 must still enable HTTP/2 when the resolved profile is false"
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -1759,7 +1759,7 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
     // Capture the profile's `network.allow_http2` intent alongside the CLI flag.
     let profile_allow_http2 = loaded_profile
         .as_ref()
-        .map(|p| p.network.allow_http2)
+        .map(|p| p.network.resolved_allow_http2())
         .unwrap_or(false);
     let allow_http2_requested = args.allow_http2 || profile_allow_http2;
 

--- a/crates/nono-cli/tests/schema_shape.rs
+++ b/crates/nono-cli/tests/schema_shape.rs
@@ -91,6 +91,27 @@ fn test_schema_network_config_matches_rust_model() {
 }
 
 #[test]
+fn test_schema_allow_http2_accepts_boolean_or_null() {
+    let schema = load_schema();
+    let allow_http2 = schema
+        .pointer("/$defs/NetworkConfig/properties/allow_http2")
+        .unwrap_or_else(|| panic!("NetworkConfig.allow_http2 must exist"));
+    let one_of = allow_http2
+        .get("oneOf")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("allow_http2 must be oneOf boolean|null"));
+    let types = one_of
+        .iter()
+        .filter_map(|entry| entry.get("type").and_then(Value::as_str))
+        .collect::<BTreeSet<_>>();
+    let expected = ["boolean", "null"].into_iter().collect::<BTreeSet<_>>();
+    assert_eq!(
+        types, expected,
+        "allow_http2 must accept boolean override and null-clear like network_profile"
+    );
+}
+
+#[test]
 fn test_schema_top_level_profile_matches_rust_model() {
     let schema = load_schema();
     assert_properties_at(

--- a/docs/cli/features/networking.mdx
+++ b/docs/cli/features/networking.mdx
@@ -476,7 +476,9 @@ By default, the proxy uses HTTP/1.1 with keep-alive connection pooling for all u
 nono run --profile claude-code --allow-http2 -- claude
 ```
 
-It can also be set in a profile with `network.allow_http2`, which both `nono run` and `nono proxy` honor.
+It can also be set in a profile with `network.allow_http2`, which both `nono run` and `nono proxy` honor. A child profile can set `"allow_http2": false` (or `null`) to override an inherited `true`; omitting the field keeps the parent's value.
+
+The `--allow-http2` CLI flag is still combined with the **resolved** profile value using OR: the flag can enable HTTP/2 but cannot disable a profile that resolved `true`.
 
 When enabled:
 


### PR DESCRIPTION
## Linked Issue

Closes #1632

## Summary

Fix profile inheritance for `network.allow_http2`: the field was OR-merged (`base || child`), so any ancestor with `allow_http2: true` permanently forced HTTP/2 on all descendants. A child setting `"allow_http2": false` was silently ignored.

This PR changes `allow_http2` to `InheritableValue<bool>` (same three-state model as `network_profile`): absent inherits, explicit `true`/`false` overrides, `null` clears an inherited `true`. Call sites use `resolved_allow_http2()`; the CLI `--allow-http2` flag is still OR'd with the resolved profile value at launch (unchanged).

Files consulted: `crates/nono-cli/src/profile/mod.rs` (`merge_profiles`, `InheritableValue`), `sandbox_prepare.rs`, `proxy_command.rs`, `nono-profile.schema.json`, `profile-authoring-guide.md`, `docs/cli/features/networking.mdx`.

## Agent Disclosure

This PR is submitted by an AI coding agent (Cursor AI) on behalf of @Frankie-Xu, per `AGENTS.md` / `CLAUDE.md`. Intent and approach were disclosed in https://github.com/nolabs-ai/nono/issues/1632#issuecomment-5345061642. The change is CLI profile merge only; no library policy changes. This contribution complies with repository coding and security requirements.

## Test Plan

- [x] `make ci` (clippy, fmt-check, tests, cargo audit, lint-aliases, lint-docs) — passed locally on macOS
- [x] Unit tests for merge semantics (inherit / override / null-clear / multi-level)
- [x] Integration tests via `extends` profile loading
- [x] `proxy_command` tests: child `false` overrides inherited `true`; CLI `--allow-http2` still ORs with resolved profile `false`
- [x] Schema shape test: `allow_http2` accepts boolean or null

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates

## Agent Compliance Check (Required for AI/Automated PRs)

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope

Made with [Cursor](https://cursor.com)