### PR TITLE
feat(cli): support --extends on nono proxy

### DIFF
--- a/crates/nono-cli/data/profile-authoring-guide.md
+++ b/crates/nono-cli/data/profile-authoring-guide.md
@@ -56,10 +56,11 @@ Inherit from another profile by name:
 
 - Inheritance chain max depth: 10.
 - The CLI `--extends <PROFILE>` flag composes a selected `--profile` for one
-  invocation. It is repeatable and prepends its bases to the profile JSON's
-  `extends` list, preserving left-to-right merge order while keeping the
-  selected profile as the final override layer. Inherited grants can widen
-  sandbox permissions.
+  invocation on profile-consuming commands such as `nono run`, `nono wrap`,
+  `nono why`, and `nono proxy`. It is repeatable and prepends its bases to the
+  profile JSON's `extends` list, preserving left-to-right merge order while
+  keeping the selected profile as the final override layer. Inherited grants
+  can widen sandbox permissions.
 - Scalar fields: child overrides base.
 - Array fields (`groups.include`, `groups.exclude`, `commands.allow`, `commands.deny`, `filesystem.*`, `allow_domain`, `deny_domain`, `open_port`, `open_port_range`, `listen_port`, `listen_port_range`, `no_proxy`, `rollback.*`, `upstream_bypass`): child values are appended to base values and deduplicated. To remove inherited entries, use `groups.exclude` for groups; there is no mechanism to remove inherited filesystem paths. For `allow_domain` entries with endpoint rules, rules for the same domain are merged (appended) rather than replaced. `deny_domain` entries are additive — child profiles can only add more denies, never remove inherited ones.
 - Map fields (`env_credentials`, `hooks`, `custom_credentials`): child entries are merged into base; child keys override matching base keys.

--- a/crates/nono-cli/src/cli.rs
+++ b/crates/nono-cli/src/cli.rs
@@ -227,6 +227,7 @@ pub enum Commands {
   nono proxy --port 8080 --no-auth             # Open loopback proxy (no token required)
   nono proxy --allow-domain github.com         # Allowlist a host
   nono proxy --profile my-profile              # Load network settings from a profile
+  nono proxy -p default --extends extra-domains # Compose profile layers for this run
 ")]
     Proxy(Box<ProxyArgs>),
 
@@ -1539,6 +1540,15 @@ pub struct ProxyArgs {
         help_heading = "PROXY"
     )]
     pub profile: Option<String>,
+
+    /// Extend the selected profile with an additional base profile for this invocation
+    #[arg(
+        long,
+        value_name = "PROFILE",
+        requires = "profile",
+        help_heading = "PROXY"
+    )]
+    pub extends: Vec<String>,
 
     /// Maximum concurrent client connections (0 = unlimited). Raise this when
     /// driving highly parallel clients such as `docker pull`, which opens many
@@ -3223,6 +3233,54 @@ mod tests {
         match cli.command {
             Commands::Why(args) => assert_eq!(args.extends, vec!["base".to_string()]),
             _ => panic!("Expected Why command"),
+        }
+    }
+
+    #[test]
+    fn test_proxy_extends_parse() {
+        let cli = Cli::parse_from([
+            "nono",
+            "proxy",
+            "--profile",
+            "default",
+            "--extends",
+            "extra-domains",
+        ]);
+        match cli.command {
+            Commands::Proxy(args) => {
+                assert_eq!(args.profile.as_deref(), Some("default"));
+                assert_eq!(args.extends, vec!["extra-domains".to_string()]);
+            }
+            _ => panic!("Expected Proxy command"),
+        }
+    }
+
+    #[test]
+    fn test_proxy_extends_requires_profile() {
+        let result = Cli::try_parse_from(["nono", "proxy", "--extends", "base"]);
+        assert!(result.is_err(), "--extends without --profile should fail");
+    }
+
+    #[test]
+    fn test_proxy_extends_repeated_preserves_order() {
+        let cli = Cli::parse_from([
+            "nono",
+            "proxy",
+            "--profile",
+            "agent",
+            "--extends",
+            "linux-host-compat",
+            "--extends",
+            "extra-domains",
+        ]);
+        match cli.command {
+            Commands::Proxy(args) => {
+                assert_eq!(
+                    args.extends,
+                    vec!["linux-host-compat".to_string(), "extra-domains".to_string()]
+                );
+            }
+            _ => panic!("Expected Proxy command"),
         }
     }
 

--- a/crates/nono-cli/src/proxy_command.rs
+++ b/crates/nono-cli/src/proxy_command.rs
@@ -197,7 +197,7 @@ fn load_preloaded_ca(
 /// proxy) — matching `proxy_runtime::resolve_effective_proxy_settings`.
 fn build_launch_options(args: &ProxyArgs) -> Result<ProxyLaunchOptions> {
     let loaded = match args.profile {
-        Some(ref name) => Some(profile::load_profile(name)?),
+        Some(ref name) => Some(profile::load_profile_with_extends(name, &args.extends)?),
         None => None,
     };
     let network = loaded.as_ref().map(|p| &p.network);
@@ -582,6 +582,79 @@ mod tests {
         let args = parse_args(&["--profile", profile_path.to_str().expect("valid utf8")]);
         let opts = build_launch_options(&args).expect("profile with allow_http2 is valid");
         assert!(opts.enable_h2);
+    }
+
+    #[test]
+    fn profile_extends_merges_allow_domain() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env = cleared_env();
+        let dir = tempfile::tempdir().expect("tmpdir");
+        std::fs::write(
+            dir.path().join("extra-domains.json"),
+            r#"{
+                "meta": { "name": "extra-domains" },
+                "network": { "allow_domain": ["extra.example.com"] }
+            }"#,
+        )
+        .expect("write extra profile");
+        let child_path = dir.path().join("child.json");
+        std::fs::write(
+            &child_path,
+            r#"{
+                "meta": { "name": "child" },
+                "network": { "allow_domain": ["child.example.com"] }
+            }"#,
+        )
+        .expect("write child profile");
+
+        let args = parse_args(&[
+            "--profile",
+            child_path.to_str().expect("valid utf8"),
+            "--extends",
+            "extra-domains",
+        ]);
+        let opts = build_launch_options(&args).expect("profile with --extends is valid");
+        let filter = opts
+            .domain_filter
+            .expect("merged allow_domain produces domain filter");
+        let domains: Vec<&str> = filter
+            .allow_domain
+            .iter()
+            .map(crate::profile::AllowDomainEntry::domain)
+            .collect();
+        assert_eq!(
+            domains,
+            vec!["extra.example.com", "child.example.com"],
+            "CLI --extends base must merge before selected profile overrides"
+        );
+    }
+
+    #[test]
+    fn profile_without_extends_is_unchanged() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env = cleared_env();
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let profile_path = dir.path().join("solo.json");
+        std::fs::write(
+            &profile_path,
+            r#"{
+                "meta": { "name": "solo" },
+                "network": { "allow_domain": ["solo.example.com"] }
+            }"#,
+        )
+        .expect("write profile");
+
+        let args = parse_args(&["--profile", profile_path.to_str().expect("valid utf8")]);
+        let opts = build_launch_options(&args).expect("profile without --extends is valid");
+        let filter = opts
+            .domain_filter
+            .expect("allow_domain produces domain filter");
+        let domains: Vec<&str> = filter
+            .allow_domain
+            .iter()
+            .map(crate::profile::AllowDomainEntry::domain)
+            .collect();
+        assert_eq!(domains, vec!["solo.example.com"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `--extends <PROFILE>` to `nono proxy`, matching the existing `nono run --extends` semantics (repeatable, requires `--profile`).
- Wire profile loading through `profile::load_profile_with_extends` in `proxy_command::build_launch_options`, reusing the same compose/merge path as `run`/`wrap`/`why`.
- Add unit tests for CLI parsing, `allow_domain` merge via extends, and regression without `--extends`; update profile authoring guide.

Closes #1678

## Approach

`ProxyArgs` gains an `extends: Vec<String>` field with identical clap attributes to `SandboxArgs`. When `--profile` is set, the proxy startup path calls `load_profile_with_extends(name, &args.extends)` instead of `load_profile(name)`. CLI `--extends` bases are prepended to the profile JSON's `extends` list before inheritance resolution — same precedence as `nono run`.

No library-layer policy changes; this is CLI-only profile composition.

## Test plan

- [x] `cargo test -p nono-cli proxy_extends` — CLI parsing (requires profile, order preserved)
- [x] `cargo test -p nono-cli profile_extends_merges` — sibling profile merge of `allow_domain`
- [x] `cargo test -p nono-cli profile_without_extends` — regression without flag
- [x] Manual: `nono proxy -p default --extends extra-domains` accepts flag (profile-not-found is expected without the profile installed)
- [x] `make ci` — clippy + fmt pass; one unrelated flaky test (`shell_dry_run_rejects_block_net_with_upstream_proxy`) failed once on temp-path overlap, passes on rerun

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists (#1678)
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code (reuses existing `load_profile_with_extends`)
- [x] I did not use forbidden patterns such as unwrap/expect (test `.expect()` on locks/paths follows existing test conventions)
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths (no new path handling; reuses profile loader)
- [x] This PR matches the approved or disclosed issue scope

**Contributor disclosure:** This PR was prepared by an AI coding agent (Cursor) acting as a contribution assistant for Frankie-Xu.

## References

- Issue: #1678
- Reused: `profile::load_profile_with_extends` (`crates/nono-cli/src/profile/mod.rs`)
- Reference implementation: `SandboxArgs.extends` + `command_runtime.rs` / `profile_runtime.rs`

Made with [Cursor](https://cursor.com)