### PR TITLE
fix(cli): point deprecated profile errors to nono pull

### DIFF
--- a/crates/nono-cli/src/package_status.rs
+++ b/crates/nono-cli/src/package_status.rs
@@ -62,6 +62,31 @@ pub(crate) fn official_claude_pack_namespaces() -> impl Iterator<Item = &'static
     CLAUDE_PACK.namespaces()
 }
 
+/// Canonical `<namespace>/<name>` for `nono pull` reinstall hints.
+///
+/// Legacy installs under a retired namespace (e.g. `always-further/claude`)
+/// are rewritten to the current published ref (`nolabs-ai/claude`), preserving
+/// an optional `@version` suffix. Other refs pass through unchanged.
+pub(crate) fn canonical_pull_ref(pack_ref: &str) -> String {
+    for target in OFFICIAL_PACK_STATUS_TARGETS {
+        if is_official_package_ref(*target, pack_ref) {
+            let version_suffix = pack_ref
+                .split_once('@')
+                .map(|(_, version)| format!("@{version}"))
+                .unwrap_or_default();
+            return format!("{}{version_suffix}", target.key());
+        }
+    }
+
+    const LEGACY_NAMESPACE: &str = "always-further/";
+    const CURRENT_NAMESPACE: &str = "nolabs-ai/";
+    if let Some(tail) = pack_ref.strip_prefix(LEGACY_NAMESPACE) {
+        format!("{CURRENT_NAMESPACE}{tail}")
+    } else {
+        pack_ref.to_string()
+    }
+}
+
 /// Enforce official-pack status for the profile this run selected.
 ///
 /// `cli_extends` carries `--extends`, which behaves as if those bases were
@@ -366,6 +391,32 @@ mod tests {
         assert!(is_official_profile_name(CODEX_PACK, "codex"));
         assert!(!is_official_profile_name(CLAUDE_PACK, "codex"));
         assert!(!is_official_profile_name(CODEX_PACK, "claude"));
+    }
+
+    #[test]
+    fn canonical_pull_ref_rewrites_legacy_claude_namespace() {
+        assert_eq!(
+            canonical_pull_ref("always-further/claude"),
+            "nolabs-ai/claude"
+        );
+        assert_eq!(
+            canonical_pull_ref("always-further/claude@1.2.3"),
+            "nolabs-ai/claude@1.2.3"
+        );
+        assert_eq!(canonical_pull_ref("nolabs-ai/claude"), "nolabs-ai/claude");
+        assert_eq!(canonical_pull_ref("acme/widget"), "acme/widget");
+    }
+
+    #[test]
+    fn canonical_pull_ref_rewrites_other_legacy_org_packs() {
+        assert_eq!(
+            canonical_pull_ref("always-further/codex"),
+            "nolabs-ai/codex"
+        );
+        assert_eq!(
+            canonical_pull_ref("always-further/opencode"),
+            "nolabs-ai/opencode"
+        );
     }
 
     #[test]

--- a/crates/nono-cli/src/profile_runtime.rs
+++ b/crates/nono-cli/src/profile_runtime.rs
@@ -1,4 +1,5 @@
 use crate::cli::SandboxArgs;
+use crate::package_status;
 use crate::{package, profile};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -124,6 +125,7 @@ fn verify_profile_packs(packs: &[String], profile: &profile::Profile) -> crate::
             )));
         }
         let (namespace, name) = (parts[0], parts[1]);
+        let pull_ref = package_status::canonical_pull_ref(pack_ref);
 
         let install_dir = package::package_install_dir(namespace, name)?;
         if !install_dir.exists() {
@@ -131,7 +133,7 @@ fn verify_profile_packs(packs: &[String], profile: &profile::Profile) -> crate::
                 "Pack '{}' declared by profile but not installed. \
                  Install it with: nono pull {}",
                 pack_ref,
-                pack_ref
+                pull_ref
             );
             continue;
         }
@@ -141,7 +143,7 @@ fn verify_profile_packs(packs: &[String], profile: &profile::Profile) -> crate::
                 package: pack_ref.clone(),
                 reason: format!(
                     "pack '{}' has no lockfile entry - reinstall with: nono pull {} --force",
-                    pack_ref, pack_ref
+                    pack_ref, pull_ref
                 ),
             }
         })?;
@@ -151,7 +153,7 @@ fn verify_profile_packs(packs: &[String], profile: &profile::Profile) -> crate::
             if !artifact_path.exists() {
                 return Err(nono::NonoError::PackageInstall(format!(
                     "pack '{}' is missing artifact '{}'. Reinstall with: nono pull {} --force",
-                    pack_ref, artifact_name, pack_ref
+                    pack_ref, artifact_name, pull_ref
                 )));
             }
 
@@ -172,7 +174,7 @@ fn verify_profile_packs(packs: &[String], profile: &profile::Profile) -> crate::
                      Expected: {}\n\
                      Found:    {}\n\
                      Reinstall with: nono pull {} --force",
-                    pack_ref, artifact_name, locked_artifact.sha256, hash, pack_ref
+                    pack_ref, artifact_name, locked_artifact.sha256, hash, pull_ref
                 )));
             }
         }
@@ -213,7 +215,7 @@ fn verify_profile_packs(packs: &[String], profile: &profile::Profile) -> crate::
                 package: pack_ref.clone(),
                 reason: format!(
                     "pack '{}' is missing .nono-trust.bundle - reinstall with: nono pull {} --force",
-                    pack_ref, pack_ref
+                    pack_ref, pull_ref
                 ),
             });
         }
@@ -226,7 +228,7 @@ fn verify_profile_packs(packs: &[String], profile: &profile::Profile) -> crate::
                 package: pack_ref.clone(),
                 reason: format!(
                     "pack '{}' has no signer identity in the lockfile - reinstall with: nono pull {} --force",
-                    pack_ref, pack_ref
+                    pack_ref, pull_ref
                 ),
             })?;
         verify_stored_bundles(&install_dir, &bundle_path, pack_ref, Some(pinned_signer))?;
@@ -246,6 +248,7 @@ fn verify_stored_bundles(
     pack_ref: &str,
     pinned_signer: Option<&str>,
 ) -> crate::Result<()> {
+    let pull_ref = package_status::canonical_pull_ref(pack_ref);
     let bundle_content = std::fs::read_to_string(bundle_path).map_err(|e| {
         nono::NonoError::PackageInstall(format!(
             "failed to read trust bundle for pack '{}': {}",
@@ -346,7 +349,7 @@ fn verify_stored_bundles(
             nono::NonoError::PackageInstall(format!(
                 "Sigstore verification failed for '{}' in pack '{}': {}\n\
                  Reinstall with: nono pull {} --force",
-                artifact_name, pack_ref, e, pack_ref
+                artifact_name, pack_ref, e, pull_ref
             ))
         })?;
 
@@ -374,7 +377,7 @@ fn verify_stored_bundles(
                     reason: format!(
                         "signer identity mismatch for '{}': bundle was signed by '{}' \
                          but lockfile pins '{}'. Reinstall with: nono pull {} --force",
-                        artifact_name, verified_uri, pinned, pack_ref
+                        artifact_name, verified_uri, pinned, pull_ref
                     ),
                 });
             }


### PR DESCRIPTION
## Linked Issue

Closes #1634

## Summary

- Add `canonical_pull_ref()` to rewrite legacy `always-further/<pack>` refs to `nolabs-ai/<pack>` (preserving optional `@version`) for reinstall hints.
- Use it in `profile_runtime.rs` everywhere pack verification errors suggest `nono pull … --force` or install commands.
- Fixes the mismatch where deprecated schema warnings already pointed at canonical keys, but the follow-on `PackageInstall` error still suggested `nono pull always-further/claude --force`.

## Agent Disclosure

This PR was prepared by an AI coding agent (Cursor) on behalf of @Frankie-Xu, per the Coding Agent Contribution Policy in `AGENTS.md` / `CLAUDE.md`.

Consulted: `crates/nono-cli/src/package_status.rs` (official pack legacy namespace list), `crates/nono-cli/src/profile_runtime.rs` (pack verification error paths), issue #1634 reproduction logs.

This is a message-only change; it does not relax sandbox policy, pack verification, or lockfile enforcement.

## Test Plan

- [x] `make ci` (clippy, fmt, lib/cli/doc tests, lint scripts)
- [x] Unit tests for `canonical_pull_ref` legacy → current namespace mapping
- [ ] Manual: profile with deprecated keys + legacy `always-further/claude` install → error suggests `nono pull nolabs-ai/claude --force`

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope

Made with [Cursor](https://cursor.com)