### PR TITLE
fix(proxy): honor host:port deny entries under wildcard allow

### DIFF
--- a/crates/nono-cli/src/credential_runtime.rs
+++ b/crates/nono-cli/src/credential_runtime.rs
@@ -12,7 +12,7 @@ fn parse_env_credential_map_args(values: &[String]) -> Result<Vec<(String, Strin
     }
 
     let mut pairs = Vec::with_capacity(values.len() / 2);
-    for chunk in values.chunks_exact(2) {
+    for chunk in values.as_chunks::<2>().0 {
         let credential_ref = chunk[0].trim();
         let env_var = chunk[1].trim();
 

--- a/crates/nono-cli/src/network_policy.rs
+++ b/crates/nono-cli/src/network_policy.rs
@@ -350,6 +350,9 @@ pub fn build_proxy_config(
 /// Expand `--deny-domain` entries: if an entry matches a group name in the
 /// network policy, expand it to the group's hosts and suffixes. Otherwise
 /// treat it as a literal hostname.
+///
+/// Unlike [`expand_proxy_allow`], `host:port` is kept intact — stripping it
+/// would widen a deny to every port on that host.
 pub fn expand_proxy_deny(policy: &NetworkPolicy, entries: &[String]) -> Vec<String> {
     let mut result = Vec::new();
     for entry in entries {
@@ -364,11 +367,7 @@ pub fn expand_proxy_deny(policy: &NetworkPolicy, entries: &[String]) -> Vec<Stri
                 result.push(wildcard);
             }
         } else {
-            let host = entry
-                .rsplit_once(':')
-                .and_then(|(h, p)| p.parse::<u16>().ok().map(|_| h))
-                .unwrap_or(entry.as_str());
-            result.push(host.to_string());
+            result.push(entry.clone());
         }
     }
     result
@@ -481,6 +480,13 @@ pub fn partition_allow_domain(
     Ok((plain_hosts, endpoint_routes))
 }
 
+/// Warn about `:port` suffixes on **allow**-side entries only.
+///
+/// `expand_proxy_allow` still strips ports (see its doc comment for the
+/// compatibility reason), so a port on an allow entry is genuinely ignored
+/// and worth flagging. Deny entries are not affected: `expand_proxy_deny`
+/// preserves the port and the filter honors it, so callers must not route
+/// `deny_domain`/`--deny-domain` entries through this function.
 pub fn collect_allow_domain_port_warnings(entries: &[String], source: &str) -> Vec<String> {
     entries
         .iter()
@@ -1499,13 +1505,55 @@ mod tests {
     }
 
     #[test]
-    fn test_expand_proxy_deny_strips_port() {
+    fn test_expand_proxy_deny_preserves_port() {
+        // Unlike expand_proxy_allow, deny entries keep their :port suffix so
+        // the filter can deny only that port rather than the whole host.
         let json = embedded_network_policy_json();
         let policy = load_network_policy(json).unwrap();
 
         let entries = vec!["evil.com:443".to_string()];
         let denied = expand_proxy_deny(&policy, &entries);
-        assert_eq!(denied, vec!["evil.com"]);
+        assert_eq!(denied, vec!["evil.com:443"]);
+    }
+
+    #[test]
+    fn test_expand_proxy_deny_host_port_does_not_affect_other_ports() {
+        // A host:port deny must not widen to a bare-host deny that also
+        // blocks unrelated ports (e.g. a credential route on a different port).
+        let json = embedded_network_policy_json();
+        let policy = load_network_policy(json).unwrap();
+
+        let entries = vec!["127.0.0.1:8975".to_string()];
+        let denied = expand_proxy_deny(&policy, &entries);
+        assert_eq!(denied, vec!["127.0.0.1:8975"]);
+        assert!(!denied.contains(&"127.0.0.1".to_string()));
+    }
+
+    #[test]
+    fn test_expand_proxy_allow_still_strips_port() {
+        // Deliberately unlike expand_proxy_deny: allow keeps matching every
+        // port on a host, for compatibility.
+        let json = embedded_network_policy_json();
+        let policy = load_network_policy(json).unwrap();
+
+        let entries = vec!["evil.com:443".to_string()];
+        let allowed = expand_proxy_allow(&policy, &entries);
+        assert_eq!(allowed, vec!["evil.com"]);
+    }
+
+    #[test]
+    fn test_build_proxy_config_denied_host_port_entry_propagated() {
+        // A host:port deny entry must reach ProxyConfig.denied_hosts intact.
+        let json = embedded_network_policy_json();
+        let policy = load_network_policy(json).unwrap();
+        let profile_name = policy.profiles.keys().next().unwrap().clone();
+        let resolved = resolve_network_profile(&policy, &profile_name).unwrap();
+
+        let entries = vec!["127.0.0.1:8975".to_string()];
+        let denied_hosts = expand_proxy_deny(&policy, &entries);
+        let config = build_proxy_config(&resolved, &[], &denied_hosts);
+
+        assert_eq!(config.denied_hosts, vec!["127.0.0.1:8975".to_string()]);
     }
 
     #[test]

--- a/crates/nono-cli/src/pack_update_hint.rs
+++ b/crates/nono-cli/src/pack_update_hint.rs
@@ -217,13 +217,9 @@ fn refresh_helper_args(stale: &[(String, String)]) -> Vec<String> {
 }
 
 fn parse_refresh_helper_args(args: Vec<String>) -> Option<Vec<(String, String)>> {
-    let mut chunks = args.chunks_exact(2);
-    let stale = chunks
-        .by_ref()
-        .map(|chunk| (chunk[0].clone(), chunk[1].clone()))
-        .collect();
-    if chunks.remainder().is_empty() {
-        Some(stale)
+    let (chunks, remainder) = args.as_chunks::<2>();
+    if remainder.is_empty() {
+        Some(chunks.iter().map(|[a, b]| (a.clone(), b.clone())).collect())
     } else {
         None
     }

--- a/crates/nono-cli/src/sandbox_prepare.rs
+++ b/crates/nono-cli/src/sandbox_prepare.rs
@@ -1537,8 +1537,8 @@ pub(crate) fn prepare_sandbox(args: &SandboxArgs, silent: bool) -> Result<Prepar
         .collect();
     print_allow_domain_port_warnings(&profile_allow_domain_strs, "profile allow_domain", silent);
     print_allow_domain_port_warnings(&args.allow_proxy, "--allow-domain", silent);
-    print_allow_domain_port_warnings(&profile_deny_domain, "profile deny_domain", silent);
-    print_allow_domain_port_warnings(&args.deny_proxy, "--deny-domain", silent);
+    // deny_domain entries keep their :port suffix through expand_proxy_deny
+    // (see its doc comment), so no "port is ignored" warning applies here.
 
     #[cfg(unix)]
     if args

--- a/crates/nono-proxy/src/filter.rs
+++ b/crates/nono-proxy/src/filter.rs
@@ -7,7 +7,7 @@
 use crate::config::{is_proxy_denied_metadata_ip, parse_host_ip_literal};
 use crate::error::Result;
 use nono::net_filter::{FilterResult, HostFilter};
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use tracing::debug;
 
 /// Result of a filter check including resolved socket addresses.
@@ -123,13 +123,32 @@ impl ProxyFilter {
             .unwrap_or_else(|| self.inner.check_host(host, resolved_ips))
     }
 
+    /// Checks deny (incl. `host:port`) before the allowlist, so a wildcard
+    /// `allow_domain: ["*"]` can't shadow a port-scoped deny entry.
     fn check_host_result(&self, host: &str, port: u16, resolved_ips: &[IpAddr]) -> FilterResult {
+        // Normalize before appending the port: a raw trailing dot would land
+        // mid-string (e.g. "evil.com.:443"), past where normalization looks.
+        let normalized_host = HostFilter::normalize_authority_host(host);
+        // Bracket IPv6 literals so their embedded colons can't be mistaken
+        // for the port separator (e.g. "[::1]:8975", not "::1:8975").
+        let host_port = if normalized_host.parse::<Ipv6Addr>().is_ok() {
+            format!("[{normalized_host}]:{port}")
+        } else {
+            format!("{normalized_host}:{port}")
+        };
+
+        if let Some(deny) = self.inner.check_deny(&host_port) {
+            return deny;
+        }
+        if let Some(deny) = self.inner.check_deny(host) {
+            return deny;
+        }
+
         let result = self.inner.check_host(host, resolved_ips);
         if !matches!(result, FilterResult::DenyNotAllowed { .. }) {
             return result;
         }
 
-        let host_port = format!("{host}:{port}");
         self.inner.check_host(&host_port, resolved_ips)
     }
 
@@ -214,6 +233,58 @@ mod tests {
         // bare domain must NOT match wildcard
         let result = filter.check_host_with_ips("ads.example.com", &public_ip);
         assert!(result.is_allowed());
+    }
+
+    #[test]
+    fn test_proxy_filter_denied_host_port_honored_under_wildcard_allow() {
+        // A port-scoped deny must hold under a wildcard allow, without
+        // affecting other ports on the same host.
+        let filter =
+            ProxyFilter::new(&["*".to_string()]).with_denied_hosts(&["127.0.0.1:8975".to_string()]);
+        let loopback = vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))];
+
+        let result = filter.check_host_result("127.0.0.1", 8975, &loopback);
+        assert!(!result.is_allowed(), "denied port must not be allowed");
+        assert!(matches!(result, FilterResult::DenyHost { .. }));
+
+        let result = filter.check_host_result("127.0.0.1", 8787, &loopback);
+        assert!(
+            result.is_allowed(),
+            "unrelated port on the same host must remain allowed"
+        );
+    }
+
+    #[test]
+    fn test_proxy_filter_denied_host_port_honored_for_trailing_dot_fqdn() {
+        // A trailing-dot FQDN must not bypass a port-scoped deny via
+        // unnormalized host:port construction (see check_host_result).
+        let filter =
+            ProxyFilter::new(&["*".to_string()]).with_denied_hosts(&["evil.com:443".to_string()]);
+
+        let result = filter.check_host_result("evil.com.", 443, &[]);
+        assert!(
+            !result.is_allowed(),
+            "trailing-dot form must still be denied"
+        );
+        assert!(matches!(result, FilterResult::DenyHost { .. }));
+    }
+
+    #[test]
+    fn test_proxy_filter_denied_host_port_honored_for_ipv6_literal() {
+        // An IPv6 host:port deny must match the bracketed authority form,
+        // not "::1:8975" (ambiguous with the port separator).
+        let filter =
+            ProxyFilter::new(&["*".to_string()]).with_denied_hosts(&["[::1]:8975".to_string()]);
+
+        let result = filter.check_host_result("::1", 8975, &[]);
+        assert!(!result.is_allowed(), "IPv6 host:port form must be denied");
+        assert!(matches!(result, FilterResult::DenyHost { .. }));
+
+        let result = filter.check_host_result("::1", 8787, &[]);
+        assert!(
+            result.is_allowed(),
+            "unrelated port on the same IPv6 host must remain allowed"
+        );
     }
 
     #[test]

--- a/crates/nono/src/net_filter.rs
+++ b/crates/nono/src/net_filter.rs
@@ -315,6 +315,38 @@ impl HostFilter {
         }
     }
 
+    /// Check only the deny list, skipping the allowlist (which a wildcard
+    /// `*` would otherwise satisfy before a port-scoped deny is checked).
+    pub fn check_deny(&self, host: &str) -> Option<FilterResult> {
+        // Infallible: deny_hosts/deny_suffixes are populated via the same
+        // fallback (normalize_entry), so a fallible lookup here could miss
+        // an entry that IDNA rejects (e.g. a host:port or IPv6 literal).
+        let lower_host = normalize_entry(host);
+
+        if self.deny_hosts.contains(&lower_host) {
+            return Some(FilterResult::DenyHost {
+                host: host.to_string(),
+            });
+        }
+
+        for suffix in &self.deny_suffixes {
+            if lower_host.ends_with(suffix.as_str()) && lower_host.len() > suffix.len() {
+                return Some(FilterResult::DenyHost {
+                    host: host.to_string(),
+                });
+            }
+        }
+
+        None
+    }
+
+    /// Normalize a host before embedding it in a `host:port` string, so a
+    /// trailing dot can't land past where normalization looks for it.
+    #[must_use]
+    pub fn normalize_authority_host(host: &str) -> String {
+        normalize_entry(host)
+    }
+
     /// Number of allowed hosts (exact + wildcard)
     #[must_use]
     pub fn allowed_count(&self) -> usize {
@@ -564,6 +596,30 @@ mod tests {
     }
 
     #[test]
+    fn test_check_deny_matches_host_port_entry() {
+        let filter = HostFilter::allow_all().with_denied_hosts(&["127.0.0.1:8975".to_string()]);
+
+        // The deny-only check must match the exact host:port string...
+        assert!(matches!(
+            filter.check_deny("127.0.0.1:8975"),
+            Some(FilterResult::DenyHost { .. })
+        ));
+        // ...but not the bare host, since the deny entry is port-scoped.
+        assert!(filter.check_deny("127.0.0.1").is_none());
+        // ...and not an unrelated port on the same host.
+        assert!(filter.check_deny("127.0.0.1:8787").is_none());
+    }
+
+    #[test]
+    fn test_check_deny_ignores_allowlist() {
+        // check_deny only ever returns a deny verdict or None; it never
+        // consults the allowlist, unlike check_host.
+        let filter = HostFilter::new(&["good.com".to_string()]);
+        assert!(filter.check_deny("good.com").is_none());
+        assert!(filter.check_deny("anything-else.com").is_none());
+    }
+
+    #[test]
     fn test_allowed_count() {
         let filter = HostFilter::new(&[
             "api.openai.com".to_string(),
@@ -721,5 +777,17 @@ mod tests {
         let filter = HostFilter::new(&["*.googleapis.com".to_string()]);
         let result = filter.check_host("storage.googleapis.com.", &public_ip());
         assert!(result.is_allowed());
+    }
+
+    #[test]
+    fn test_check_deny_matches_idna_invalid_entry() {
+        // deny_hosts stores entries via the infallible normalize_entry
+        // fallback, so check_deny must use the same fallback rather than
+        // silently treating an IDNA-invalid lookup key as "not denied".
+        let filter = HostFilter::allow_all().with_denied_hosts(&["xn--zz:443".to_string()]);
+        assert!(matches!(
+            filter.check_deny("xn--zz:443"),
+            Some(FilterResult::DenyHost { .. })
+        ));
     }
 }


### PR DESCRIPTION
## Linked Issue

Closes #1708

## Summary

`ProxyFilter::check_host_result` only checked a `host:port` deny entry as a fallback after a bare-host `DenyNotAllowed`, which a wildcard `allow_domain: ["*"]` never reaches. This reorders deny checks (host:port, then bare host) before the allow-list result. Also stops `expand_proxy_deny` from stripping `:port` off deny entries (allow-side stripping is unchanged, for compatibility), and normalizes the host before building `host:port` so a trailing-dot hostname can't bypass a port-scoped deny.

## Agent Disclosure

Written by an AI coding agent (Claude) on behalf of the repository owner. Consulted `AGENTS.md`, `CLAUDE.md`, and the four files this PR touches.

## Test Plan

Added unit tests covering wildcard-allow + port-scoped deny, trailing-dot bypass, and deny/allow port-stripping asymmetry. `make fmt && make ci` clean. Verified end-to-end against a real sandboxed process.

## Checklist

- [x] An issue exists and is linked above
- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([CLAUDE.md](CLAUDE.md)) and is covered by tests
- [ ] Public-facing changes are paired with documentation updates

## Agent Compliance Check

- [x] I am not prohibited from contributing under this policy
- [x] An issue already exists
- [x] I disclosed that I am an agent in the issue discussion
- [x] I described my intent and approach in the issue discussion
- [x] I reviewed repository coding and security rules for the affected area
- [x] I provided required attribution for reused or adapted code
- [x] I did not use forbidden patterns such as unwrap/expect
- [x] I used NonoError where required
- [x] I validated and canonicalized all relevant paths
- [x] This PR matches the approved or disclosed issue scope